### PR TITLE
feat: Phase 1 core modules and CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,5 +21,6 @@
   "devDependencies": {
     "typescript": "^5.8.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "type": "module"
 }

--- a/packages/cli/src/commands/cancel.ts
+++ b/packages/cli/src/commands/cancel.ts
@@ -1,0 +1,30 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { LocalProvider } from '@some-useful-agents/core';
+import { loadConfig, getDbPath } from '../config.js';
+
+export const cancelCommand = new Command('cancel')
+  .description('Cancel a running agent')
+  .argument('<runId>', 'Run ID')
+  .action(async (runId: string) => {
+    const config = loadConfig();
+    const provider = new LocalProvider(getDbPath(config));
+    await provider.initialize();
+
+    try {
+      const run = await provider.getRun(runId);
+      if (!run) {
+        console.error(chalk.red(`Run "${runId}" not found.`));
+        process.exit(1);
+      }
+      if (run.status !== 'running' && run.status !== 'pending') {
+        console.log(chalk.yellow(`Run is already ${run.status}.`));
+        return;
+      }
+
+      await provider.cancelRun(runId);
+      console.log(chalk.green(`Cancelled run ${chalk.dim(runId.slice(0, 8))}.`));
+    } finally {
+      await provider.shutdown();
+    }
+  });

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,0 +1,102 @@
+import { Command } from 'commander';
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import chalk from 'chalk';
+import { loadConfig, getAgentDirs } from '../config.js';
+import { loadAgents } from '@some-useful-agents/core';
+
+interface Check {
+  name: string;
+  run: () => { ok: boolean; message: string };
+}
+
+export const doctorCommand = new Command('doctor')
+  .description('Check prerequisites and system health')
+  .action(() => {
+    const config = loadConfig();
+
+    const checks: Check[] = [
+      {
+        name: 'Node.js >= 22.5',
+        run: () => {
+          const version = process.versions.node;
+          const [major, minor] = version.split('.').map(Number);
+          const ok = major > 22 || (major === 22 && minor >= 5);
+          return { ok, message: ok ? `v${version}` : `v${version} (need >= 22.5)` };
+        },
+      },
+      {
+        name: 'npm available',
+        run: () => {
+          try {
+            const version = execSync('npm --version', { encoding: 'utf-8' }).trim();
+            return { ok: true, message: `v${version}` };
+          } catch {
+            return { ok: false, message: 'not found' };
+          }
+        },
+      },
+      {
+        name: 'Claude Code CLI',
+        run: () => {
+          try {
+            const version = execSync('claude --version', { encoding: 'utf-8' }).trim();
+            return { ok: true, message: version };
+          } catch {
+            return { ok: false, message: 'not found (needed for claude-code agents)' };
+          }
+        },
+      },
+      {
+        name: 'Docker available',
+        run: () => {
+          if (config.provider !== 'temporal') {
+            return { ok: true, message: 'skipped (not using temporal provider)' };
+          }
+          try {
+            execSync('docker info', { encoding: 'utf-8', stdio: 'pipe' });
+            return { ok: true, message: 'running' };
+          } catch {
+            return { ok: false, message: 'not running (needed for temporal provider)' };
+          }
+        },
+      },
+      {
+        name: 'Agents directory',
+        run: () => {
+          const dirs = getAgentDirs(config);
+          const { agents, warnings } = loadAgents({ directories: dirs.runnable });
+          if (agents.size === 0 && warnings.length > 0) {
+            return { ok: false, message: `No agents found (${warnings.length} warning(s))` };
+          }
+          return { ok: agents.size > 0, message: `${agents.size} agent(s) found` };
+        },
+      },
+      {
+        name: 'Config file',
+        run: () => {
+          const exists = existsSync('sua.config.json');
+          return { ok: exists, message: exists ? 'found' : 'not found (run "sua init")' };
+        },
+      },
+    ];
+
+    console.log(chalk.bold('\nsome-useful-agents doctor\n'));
+
+    let allOk = true;
+    for (const check of checks) {
+      const result = check.run();
+      const icon = result.ok ? chalk.green('✓') : chalk.red('✗');
+      const msg = result.ok ? chalk.dim(result.message) : chalk.red(result.message);
+      console.log(`  ${icon} ${check.name} ${msg}`);
+      if (!result.ok) allOk = false;
+    }
+
+    console.log('');
+    if (allOk) {
+      console.log(chalk.green('All checks passed.'));
+    } else {
+      console.log(chalk.yellow('Some checks failed. See above.'));
+      process.exit(1);
+    }
+  });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,40 @@
+import { Command } from 'commander';
+import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import chalk from 'chalk';
+
+export const initCommand = new Command('init')
+  .description('Initialize some-useful-agents in the current directory')
+  .action(() => {
+    const configPath = join(process.cwd(), 'sua.config.json');
+
+    if (existsSync(configPath)) {
+      console.log(chalk.yellow('sua.config.json already exists. Skipping.'));
+      return;
+    }
+
+    const config = {
+      provider: 'local',
+      agentsDir: './agents',
+      dataDir: './data',
+      mcpPort: 3003,
+    };
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+    console.log(chalk.green('Created sua.config.json'));
+
+    // Ensure directories exist
+    const agentsLocal = join(config.agentsDir, 'local');
+    if (!existsSync(agentsLocal)) {
+      mkdirSync(agentsLocal, { recursive: true });
+      console.log(chalk.green(`Created ${agentsLocal}/`));
+    }
+
+    if (!existsSync(config.dataDir)) {
+      mkdirSync(config.dataDir, { recursive: true });
+      console.log(chalk.green(`Created ${config.dataDir}/`));
+    }
+
+    console.log(chalk.dim('\nRun "sua agent list" to see available agents.'));
+    console.log(chalk.dim('Run "sua agent run hello-shell" to test your first agent.'));
+  });

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -1,0 +1,43 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import Table from 'cli-table3';
+import { loadAgents } from '@some-useful-agents/core';
+import { loadConfig, getAgentDirs } from '../config.js';
+
+export const listCommand = new Command('list')
+  .description('List available agents')
+  .option('--catalog', 'Show community catalog agents')
+  .action((options) => {
+    const config = loadConfig();
+    const dirs = getAgentDirs(config);
+
+    const directories = options.catalog ? dirs.catalog : dirs.runnable;
+    const label = options.catalog ? 'Community Catalog' : 'Available Agents';
+
+    const { agents, warnings } = loadAgents({ directories });
+
+    for (const w of warnings) {
+      console.error(chalk.yellow(`Warning: ${w.file}: ${w.message}`));
+    }
+
+    if (agents.size === 0) {
+      console.log(chalk.dim(`No agents found. ${options.catalog ? '' : 'Run "sua init" to get started.'}`));
+      return;
+    }
+
+    const table = new Table({
+      head: [chalk.bold('Name'), chalk.bold('Type'), chalk.bold('Description')],
+    });
+
+    for (const [, agent] of agents) {
+      table.push([
+        chalk.cyan(agent.name),
+        agent.type === 'shell' ? chalk.green('shell') : chalk.magenta('claude-code'),
+        agent.description ?? chalk.dim('(no description)'),
+      ]);
+    }
+
+    console.log(`\n${chalk.bold(label)}\n`);
+    console.log(table.toString());
+    console.log(chalk.dim(`\n${agents.size} agent(s)`));
+  });

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -1,0 +1,24 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { LocalProvider } from '@some-useful-agents/core';
+import { loadConfig, getDbPath } from '../config.js';
+
+export const logsCommand = new Command('logs')
+  .description('Show logs for a run')
+  .argument('<runId>', 'Run ID')
+  .action(async (runId: string) => {
+    const config = loadConfig();
+    const provider = new LocalProvider(getDbPath(config));
+    await provider.initialize();
+
+    try {
+      const logs = await provider.getRunLogs(runId);
+      if (!logs || logs === '(no output)') {
+        console.log(chalk.dim('No output for this run.'));
+      } else {
+        console.log(logs);
+      }
+    } finally {
+      await provider.shutdown();
+    }
+  });

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,0 +1,58 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import { loadAgents, LocalProvider } from '@some-useful-agents/core';
+import { loadConfig, getAgentDirs, getDbPath } from '../config.js';
+
+export const runCommand = new Command('run')
+  .description('Run an agent')
+  .argument('<name>', 'Agent name')
+  .option('--verbose', 'Show detailed output')
+  .action(async (name: string, options) => {
+    const config = loadConfig();
+    const dirs = getAgentDirs(config);
+    const { agents } = loadAgents({ directories: dirs.runnable });
+
+    const agent = agents.get(name);
+    if (!agent) {
+      console.error(chalk.red(`Agent "${name}" not found.`));
+      console.error(chalk.dim('Run "sua agent list" to see available agents.'));
+      process.exit(1);
+    }
+
+    const provider = new LocalProvider(getDbPath(config));
+    await provider.initialize();
+
+    const spinner = ora(`Running ${chalk.cyan(name)}...`).start();
+
+    try {
+      const run = await provider.submitRun({ agent, triggeredBy: 'cli' });
+      spinner.text = `Running ${chalk.cyan(name)} (${chalk.dim(run.id.slice(0, 8))})...`;
+
+      // Poll for completion
+      let current = run;
+      while (current.status === 'running' || current.status === 'pending') {
+        await new Promise(r => setTimeout(r, 250));
+        const updated = await provider.getRun(run.id);
+        if (updated) current = updated;
+      }
+
+      if (current.status === 'completed') {
+        spinner.succeed(`${chalk.cyan(name)} completed`);
+        if (current.result) {
+          console.log(chalk.dim('\n--- output ---'));
+          console.log(current.result.trimEnd());
+          console.log(chalk.dim('--- end ---'));
+        }
+      } else {
+        spinner.fail(`${chalk.cyan(name)} ${current.status}`);
+        if (current.error) {
+          console.error(chalk.red(current.error));
+        }
+      }
+
+      console.log(chalk.dim(`\nRun ID: ${current.id}`));
+    } finally {
+      await provider.shutdown();
+    }
+  });

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,0 +1,69 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import Table from 'cli-table3';
+import { LocalProvider } from '@some-useful-agents/core';
+import { loadConfig, getDbPath } from '../config.js';
+
+const STATUS_COLORS: Record<string, (s: string) => string> = {
+  completed: chalk.green,
+  running: chalk.blue,
+  pending: chalk.yellow,
+  failed: chalk.red,
+  cancelled: chalk.gray,
+};
+
+export const statusCommand = new Command('status')
+  .description('Show run status')
+  .argument('[runId]', 'Specific run ID (shows all recent if omitted)')
+  .option('-n, --limit <n>', 'Number of recent runs to show', '10')
+  .action(async (runId?: string, options?: { limit: string }) => {
+    const config = loadConfig();
+    const provider = new LocalProvider(getDbPath(config));
+    await provider.initialize();
+
+    try {
+      if (runId) {
+        const run = await provider.getRun(runId);
+        if (!run) {
+          console.error(chalk.red(`Run "${runId}" not found.`));
+          process.exit(1);
+        }
+
+        const colorFn = STATUS_COLORS[run.status] ?? chalk.white;
+        console.log(`\n${chalk.bold('Run')} ${chalk.dim(run.id)}`);
+        console.log(`  Agent:     ${chalk.cyan(run.agentName)}`);
+        console.log(`  Status:    ${colorFn(run.status)}`);
+        console.log(`  Started:   ${run.startedAt}`);
+        if (run.completedAt) console.log(`  Completed: ${run.completedAt}`);
+        if (run.exitCode !== undefined) console.log(`  Exit code: ${run.exitCode}`);
+        if (run.error) console.log(`  Error:     ${chalk.red(run.error)}`);
+      } else {
+        const limit = parseInt(options?.limit ?? '10', 10);
+        const runs = await provider.listRuns({ limit });
+
+        if (runs.length === 0) {
+          console.log(chalk.dim('No runs yet.'));
+          return;
+        }
+
+        const table = new Table({
+          head: [chalk.bold('ID'), chalk.bold('Agent'), chalk.bold('Status'), chalk.bold('Started')],
+        });
+
+        for (const run of runs) {
+          const colorFn = STATUS_COLORS[run.status] ?? chalk.white;
+          table.push([
+            chalk.dim(run.id.slice(0, 8)),
+            chalk.cyan(run.agentName),
+            colorFn(run.status),
+            run.startedAt,
+          ]);
+        }
+
+        console.log(`\n${chalk.bold('Recent Runs')}\n`);
+        console.log(table.toString());
+      }
+    } finally {
+      await provider.shutdown();
+    }
+  });

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,0 +1,43 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+export interface SuaConfig {
+  provider: 'local' | 'temporal';
+  agentsDir: string;
+  dataDir: string;
+  mcpPort: number;
+}
+
+const DEFAULT_CONFIG: SuaConfig = {
+  provider: 'local',
+  agentsDir: './agents',
+  dataDir: './data',
+  mcpPort: 3003,
+};
+
+export function loadConfig(): SuaConfig {
+  const configPath = join(process.cwd(), 'sua.config.json');
+  if (!existsSync(configPath)) {
+    return DEFAULT_CONFIG;
+  }
+
+  try {
+    const raw = readFileSync(configPath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    return { ...DEFAULT_CONFIG, ...parsed };
+  } catch {
+    return DEFAULT_CONFIG;
+  }
+}
+
+export function getAgentDirs(config: SuaConfig): { runnable: string[]; catalog: string[] } {
+  const base = resolve(config.agentsDir);
+  return {
+    runnable: [join(base, 'examples'), join(base, 'local')],
+    catalog: [join(base, 'community')],
+  };
+}
+
+export function getDbPath(config: SuaConfig): string {
+  return join(resolve(config.dataDir), 'runs.db');
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,2 +1,32 @@
 #!/usr/bin/env node
-// CLI entry point — implementation in Phase 1 branch
+
+import { Command } from 'commander';
+import { listCommand } from './commands/list.js';
+import { runCommand } from './commands/run.js';
+import { statusCommand } from './commands/status.js';
+import { logsCommand } from './commands/logs.js';
+import { cancelCommand } from './commands/cancel.js';
+import { initCommand } from './commands/init.js';
+import { doctorCommand } from './commands/doctor.js';
+
+const program = new Command();
+
+program
+  .name('sua')
+  .description('some-useful-agents — a local-first agent playground')
+  .version('0.1.0');
+
+const agent = program
+  .command('agent')
+  .description('Manage and run agents');
+
+agent.addCommand(listCommand);
+agent.addCommand(runCommand);
+agent.addCommand(statusCommand);
+agent.addCommand(logsCommand);
+agent.addCommand(cancelCommand);
+
+program.addCommand(initCommand);
+program.addCommand(doctorCommand);
+
+program.parse();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,5 +17,6 @@
     "typescript": "^5.8.0",
     "@types/uuid": "^10.0.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "type": "module"
 }

--- a/packages/core/src/agent-executor.ts
+++ b/packages/core/src/agent-executor.ts
@@ -1,0 +1,140 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import type { AgentDefinition } from './types.js';
+
+export interface ExecutionResult {
+  result: string;
+  exitCode: number;
+  error?: string;
+}
+
+export interface ExecutionHandle {
+  promise: Promise<ExecutionResult>;
+  kill: () => void;
+}
+
+export function executeAgent(agent: AgentDefinition): ExecutionHandle {
+  if (agent.type === 'shell') {
+    return executeShellAgent(agent);
+  }
+  return executeClaudeCodeAgent(agent);
+}
+
+function executeShellAgent(agent: AgentDefinition): ExecutionHandle {
+  if (!agent.command) {
+    throw new Error(`Shell agent "${agent.name}" has no command`);
+  }
+
+  let child: ChildProcess;
+  let killed = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const promise = new Promise<ExecutionResult>((resolve) => {
+    const env = { ...process.env, ...(agent.env ?? {}) };
+
+    child = spawn('bash', ['-c', agent.command!], {
+      cwd: agent.workingDirectory ?? process.cwd(),
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout!.on('data', (data: Buffer) => { stdout += data.toString(); });
+    child.stderr!.on('data', (data: Buffer) => { stderr += data.toString(); });
+
+    const timeoutMs = (agent.timeout ?? 300) * 1000;
+    timer = setTimeout(() => {
+      killed = true;
+      child.kill('SIGTERM');
+      setTimeout(() => { if (!child.killed) child.kill('SIGKILL'); }, 5000);
+    }, timeoutMs);
+
+    child.on('close', (code) => {
+      if (timer) clearTimeout(timer);
+      if (killed) {
+        resolve({ result: stdout, exitCode: 124, error: `Agent timed out after ${agent.timeout ?? 300}s` });
+      } else {
+        resolve({
+          result: stdout,
+          exitCode: code ?? 1,
+          error: code !== 0 ? stderr || `Process exited with code ${code}` : undefined,
+        });
+      }
+    });
+
+    child.on('error', (err) => {
+      if (timer) clearTimeout(timer);
+      resolve({ result: '', exitCode: 127, error: err.message });
+    });
+  });
+
+  return {
+    promise,
+    kill: () => { killed = true; child?.kill('SIGTERM'); },
+  };
+}
+
+function executeClaudeCodeAgent(agent: AgentDefinition): ExecutionHandle {
+  if (!agent.prompt) {
+    throw new Error(`Claude-code agent "${agent.name}" has no prompt`);
+  }
+
+  let child: ChildProcess;
+  let killed = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const promise = new Promise<ExecutionResult>((resolve) => {
+    const args = ['--print', agent.prompt!];
+    if (agent.model) { args.push('--model', agent.model); }
+    if (agent.maxTurns) { args.push('--max-turns', String(agent.maxTurns)); }
+    if (agent.allowedTools?.length) { args.push('--allowedTools', agent.allowedTools.join(',')); }
+
+    const env = { ...process.env, ...(agent.env ?? {}) };
+
+    child = spawn('claude', args, {
+      cwd: agent.workingDirectory ?? process.cwd(),
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout!.on('data', (data: Buffer) => { stdout += data.toString(); });
+    child.stderr!.on('data', (data: Buffer) => { stderr += data.toString(); });
+
+    const timeoutMs = (agent.timeout ?? 300) * 1000;
+    timer = setTimeout(() => {
+      killed = true;
+      child.kill('SIGTERM');
+    }, timeoutMs);
+
+    child.on('close', (code) => {
+      if (timer) clearTimeout(timer);
+      if (killed) {
+        resolve({ result: stdout, exitCode: 124, error: `Agent timed out after ${agent.timeout ?? 300}s` });
+      } else {
+        resolve({
+          result: stdout,
+          exitCode: code ?? 1,
+          error: code !== 0 ? stderr || `Claude exited with code ${code}` : undefined,
+        });
+      }
+    });
+
+    child.on('error', (err) => {
+      if (timer) clearTimeout(timer);
+      if (err.message.includes('ENOENT')) {
+        resolve({ result: '', exitCode: 127, error: 'Claude Code CLI not found. Install it: https://docs.anthropic.com/en/docs/claude-code' });
+      } else {
+        resolve({ result: '', exitCode: 127, error: err.message });
+      }
+    });
+  });
+
+  return {
+    promise,
+    kill: () => { killed = true; child?.kill('SIGTERM'); },
+  };
+}

--- a/packages/core/src/agent-loader.ts
+++ b/packages/core/src/agent-loader.ts
@@ -1,3 +1,84 @@
-// Agent loader — implementation in Phase 1 branch
-// Reads agents/ directory, validates YAML with zod, returns AgentDefinition map
-export {};
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, extname } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import { agentDefinitionSchema } from './schema.js';
+import type { AgentDefinition } from './types.js';
+
+export interface LoadAgentsOptions {
+  directories: string[];
+  onWarning?: (file: string, message: string) => void;
+}
+
+export interface LoadAgentsResult {
+  agents: Map<string, AgentDefinition>;
+  warnings: Array<{ file: string; message: string }>;
+}
+
+export function loadAgents(options: LoadAgentsOptions): LoadAgentsResult {
+  const agents = new Map<string, AgentDefinition>();
+  const warnings: Array<{ file: string; message: string }> = [];
+
+  const warn = (file: string, message: string) => {
+    warnings.push({ file, message });
+    options.onWarning?.(file, message);
+  };
+
+  for (const dir of options.directories) {
+    if (!existsSync(dir)) {
+      warn(dir, `Directory does not exist: ${dir}`);
+      continue;
+    }
+
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch (err) {
+      warn(dir, `Cannot read directory: ${(err as Error).message}`);
+      continue;
+    }
+
+    for (const entry of entries) {
+      const ext = extname(entry).toLowerCase();
+      if (ext !== '.yaml' && ext !== '.yml') continue;
+
+      const filePath = join(dir, entry);
+      let raw: string;
+      try {
+        raw = readFileSync(filePath, 'utf-8');
+      } catch (err) {
+        warn(filePath, `Cannot read file: ${(err as Error).message}`);
+        continue;
+      }
+
+      if (!raw.trim()) {
+        warn(filePath, 'Empty file');
+        continue;
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = parseYaml(raw);
+      } catch (err) {
+        warn(filePath, `Invalid YAML: ${(err as Error).message}`);
+        continue;
+      }
+
+      const result = agentDefinitionSchema.safeParse(parsed);
+      if (!result.success) {
+        const issues = result.error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join(', ');
+        warn(filePath, `Validation failed: ${issues}`);
+        continue;
+      }
+
+      const agent = result.data as AgentDefinition;
+
+      if (agents.has(agent.name)) {
+        warn(filePath, `Duplicate agent name "${agent.name}" (overwriting previous)`);
+      }
+
+      agents.set(agent.name, agent);
+    }
+  }
+
+  return { agents, warnings };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,3 +2,5 @@ export * from './types.js';
 export * from './schema.js';
 export * from './agent-loader.js';
 export * from './run-store.js';
+export * from './agent-executor.js';
+export * from './local-provider.js';

--- a/packages/core/src/local-provider.ts
+++ b/packages/core/src/local-provider.ts
@@ -1,0 +1,91 @@
+import { randomUUID } from 'node:crypto';
+import type { Provider, AgentDefinition, Run, RunStatus } from './types.js';
+import { RunStore } from './run-store.js';
+import { executeAgent, type ExecutionHandle } from './agent-executor.js';
+
+export class LocalProvider implements Provider {
+  name = 'local';
+  private store: RunStore;
+  private running = new Map<string, ExecutionHandle>();
+
+  constructor(dbPath: string) {
+    this.store = new RunStore(dbPath);
+  }
+
+  async initialize(): Promise<void> {
+    // No-op for local provider
+  }
+
+  async shutdown(): Promise<void> {
+    for (const [id, handle] of this.running) {
+      handle.kill();
+      this.store.updateRun(id, {
+        status: 'cancelled',
+        completedAt: new Date().toISOString(),
+        error: 'Provider shutting down',
+      });
+    }
+    this.running.clear();
+    this.store.close();
+  }
+
+  async submitRun(request: { agent: AgentDefinition; triggeredBy: Run['triggeredBy'] }): Promise<Run> {
+    const run: Run = {
+      id: randomUUID(),
+      agentName: request.agent.name,
+      status: 'running',
+      startedAt: new Date().toISOString(),
+      triggeredBy: request.triggeredBy,
+    };
+
+    this.store.createRun(run);
+
+    const handle = executeAgent(request.agent);
+    this.running.set(run.id, handle);
+
+    handle.promise.then((result) => {
+      this.running.delete(run.id);
+
+      const status: RunStatus = result.exitCode === 0 ? 'completed' : 'failed';
+      this.store.updateRun(run.id, {
+        status,
+        completedAt: new Date().toISOString(),
+        result: result.result,
+        exitCode: result.exitCode,
+        error: result.error,
+      });
+    });
+
+    return run;
+  }
+
+  async getRun(runId: string): Promise<Run | null> {
+    return this.store.getRun(runId);
+  }
+
+  async listRuns(filter?: { agentName?: string; status?: RunStatus; limit?: number }): Promise<Run[]> {
+    return this.store.listRuns(filter);
+  }
+
+  async cancelRun(runId: string): Promise<void> {
+    const handle = this.running.get(runId);
+    if (handle) {
+      handle.kill();
+      this.running.delete(runId);
+      this.store.updateRun(runId, {
+        status: 'cancelled',
+        completedAt: new Date().toISOString(),
+        error: 'Cancelled by user',
+      });
+    }
+  }
+
+  async getRunLogs(runId: string): Promise<string> {
+    const run = this.store.getRun(runId);
+    if (!run) return '';
+    const parts: string[] = [];
+    if (run.result) parts.push(run.result);
+    if (run.error) parts.push(`[ERROR] ${run.error}`);
+    return parts.join('\n') || '(no output)';
+  }
+}

--- a/packages/core/src/run-store.ts
+++ b/packages/core/src/run-store.ts
@@ -1,3 +1,119 @@
-// Run store — implementation in Phase 1 branch
-// SQLite-backed run persistence using node:sqlite with WAL mode
-export {};
+import { DatabaseSync } from 'node:sqlite';
+
+type SqlValue = string | number | null | bigint | Uint8Array;
+import { mkdirSync, existsSync } from 'node:fs';
+import { dirname } from 'node:path';
+import type { Run, RunStatus } from './types.js';
+
+export class RunStore {
+  private db: DatabaseSync;
+
+  constructor(dbPath: string) {
+    const dir = dirname(dbPath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+
+    this.db = new DatabaseSync(dbPath);
+    this.db.exec('PRAGMA journal_mode = WAL');
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS runs (
+        id TEXT PRIMARY KEY,
+        agentName TEXT NOT NULL,
+        status TEXT NOT NULL,
+        startedAt TEXT NOT NULL,
+        completedAt TEXT,
+        result TEXT,
+        exitCode INTEGER,
+        error TEXT,
+        triggeredBy TEXT NOT NULL
+      )
+    `);
+    this.db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_runs_agent ON runs(agentName);
+      CREATE INDEX IF NOT EXISTS idx_runs_status ON runs(status);
+    `);
+  }
+
+  createRun(run: Run): void {
+    const stmt = this.db.prepare(`
+      INSERT INTO runs (id, agentName, status, startedAt, completedAt, result, exitCode, error, triggeredBy)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    stmt.run(run.id, run.agentName, run.status, run.startedAt,
+      run.completedAt ?? null, run.result ?? null, run.exitCode ?? null,
+      run.error ?? null, run.triggeredBy);
+  }
+
+  getRun(id: string): Run | null {
+    const stmt = this.db.prepare('SELECT * FROM runs WHERE id = ?');
+    const row = stmt.get(id) as Record<string, unknown> | undefined;
+    if (!row) return null;
+    return this.rowToRun(row);
+  }
+
+  updateRun(id: string, updates: Partial<Pick<Run, 'status' | 'completedAt' | 'result' | 'exitCode' | 'error'>>): void {
+    const fields: string[] = [];
+    const values: SqlValue[] = [];
+
+    if (updates.status !== undefined) { fields.push('status = ?'); values.push(updates.status); }
+    if (updates.completedAt !== undefined) { fields.push('completedAt = ?'); values.push(updates.completedAt); }
+    if (updates.result !== undefined) { fields.push('result = ?'); values.push(updates.result); }
+    if (updates.exitCode !== undefined) { fields.push('exitCode = ?'); values.push(updates.exitCode); }
+    if (updates.error !== undefined) { fields.push('error = ?'); values.push(updates.error); }
+
+    if (fields.length === 0) return;
+
+    values.push(id);
+    const stmt = this.db.prepare(`UPDATE runs SET ${fields.join(', ')} WHERE id = ?`);
+    stmt.run(...values);
+  }
+
+  listRuns(filter?: { agentName?: string; status?: RunStatus; limit?: number }): Run[] {
+    let sql = 'SELECT * FROM runs';
+    const conditions: string[] = [];
+    const values: SqlValue[] = [];
+
+    if (filter?.agentName) {
+      conditions.push('agentName = ?');
+      values.push(filter.agentName);
+    }
+    if (filter?.status) {
+      conditions.push('status = ?');
+      values.push(filter.status);
+    }
+
+    if (conditions.length > 0) {
+      sql += ' WHERE ' + conditions.join(' AND ');
+    }
+
+    sql += ' ORDER BY startedAt DESC';
+
+    if (filter?.limit) {
+      sql += ' LIMIT ?';
+      values.push(filter.limit);
+    }
+
+    const stmt = this.db.prepare(sql);
+    const rows = stmt.all(...values) as Record<string, unknown>[];
+    return rows.map(row => this.rowToRun(row));
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  private rowToRun(row: Record<string, unknown>): Run {
+    return {
+      id: row.id as string,
+      agentName: row.agentName as string,
+      status: row.status as RunStatus,
+      startedAt: row.startedAt as string,
+      completedAt: row.completedAt as string | undefined,
+      result: row.result as string | undefined,
+      exitCode: row.exitCode as number | undefined,
+      error: row.error as string | undefined,
+      triggeredBy: row.triggeredBy as Run['triggeredBy'],
+    };
+  }
+}

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -16,5 +16,6 @@
     "typescript": "^5.8.0",
     "@types/express": "^5.0.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "type": "module"
 }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "typescript": "^5.8.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "type": "module"
 }

--- a/packages/temporal-provider/package.json
+++ b/packages/temporal-provider/package.json
@@ -14,5 +14,6 @@
   "devDependencies": {
     "typescript": "^5.8.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "type": "module"
 }


### PR DESCRIPTION
## Summary
- Implement agent-loader (YAML parsing + zod validation from `agents/` directory)
- Implement SQLite run-store (`node:sqlite` built-in with WAL mode, zero native deps)
- Implement AgentExecutor (shared shell/claude-code execution logic)
- Implement LocalProvider (ties executor + run-store together)
- Implement all CLI commands: `list`, `run`, `status`, `logs`, `cancel`, `init`, `doctor`
- Rich CLI output with chalk, ora, cli-table3
- All packages set to ESM (`"type": "module"`)

## Smoke tested
- `sua agent list` — shows hello-shell and hello-claude
- `sua agent run hello-shell` — executes, prints output, records run in SQLite
- `sua agent status` — shows run history table
- `sua doctor` — checks Node version, npm, Claude CLI, Docker, agents dir, config

## Test plan
- [ ] Add 35 unit test cases across schema, loader, store, provider, CLI
- [ ] Add GitHub Actions CI (lint + build + validate agents)
- [ ] Add vitest config

🤖 Generated with [Claude Code](https://claude.com/claude-code)