### PR TITLE
feat: Phase 2a — MCP server and agent chaining

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3193,6 +3193,7 @@
       "license": "MIT",
       "dependencies": {
         "@some-useful-agents/core": "*",
+        "@some-useful-agents/mcp-server": "*",
         "chalk": "^5.4.0",
         "cli-table3": "^0.6.5",
         "commander": "^13.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@some-useful-agents/core": "*",
+    "@some-useful-agents/mcp-server": "*",
     "commander": "^13.1.0",
     "chalk": "^5.4.0",
     "ora": "^8.2.0",

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1,0 +1,33 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { join, resolve } from 'node:path';
+import { loadConfig, getAgentDirs, getDbPath } from '../config.js';
+
+export const mcpCommand = new Command('mcp')
+  .description('MCP server management');
+
+mcpCommand
+  .command('start')
+  .description('Start the MCP server')
+  .option('-p, --port <port>', 'Port to listen on')
+  .action(async (options) => {
+    const config = loadConfig();
+    const port = options.port ? parseInt(options.port, 10) : config.mcpPort;
+    const dirs = getAgentDirs(config);
+    const dbPath = getDbPath(config);
+
+    // Dynamic import to avoid loading MCP deps when not needed
+    const { startMcpServer } = await import('@some-useful-agents/mcp-server');
+
+    console.log(chalk.bold('Starting MCP server...'));
+    console.log(chalk.dim(`  Port:   ${port}`));
+    console.log(chalk.dim(`  Agents: ${dirs.runnable.join(', ')}`));
+    console.log(chalk.dim(`  DB:     ${dbPath}`));
+    console.log('');
+
+    await startMcpServer({
+      port,
+      agentDirs: dirs.runnable,
+      dbPath,
+    });
+  });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,6 +8,7 @@ import { logsCommand } from './commands/logs.js';
 import { cancelCommand } from './commands/cancel.js';
 import { initCommand } from './commands/init.js';
 import { doctorCommand } from './commands/doctor.js';
+import { mcpCommand } from './commands/mcp.js';
 
 const program = new Command();
 
@@ -28,5 +29,6 @@ agent.addCommand(cancelCommand);
 
 program.addCommand(initCommand);
 program.addCommand(doctorCommand);
+program.addCommand(mcpCommand);
 
 program.parse();

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -5,7 +5,8 @@
     "rootDir": "src"
   },
   "references": [
-    { "path": "../core" }
+    { "path": "../core" },
+    { "path": "../mcp-server" }
   ],
   "include": ["src"]
 }

--- a/packages/core/src/chain-executor.ts
+++ b/packages/core/src/chain-executor.ts
@@ -1,0 +1,71 @@
+import type { AgentDefinition, Run } from './types.js';
+import type { Provider } from './types.js';
+import { resolveExecutionOrder, resolveTemplate } from './chain-resolver.js';
+
+export interface ChainResult {
+  runs: Run[];
+  outputs: Map<string, { result: string; exitCode: number }>;
+  skipped: string[];
+}
+
+/**
+ * Execute a chain of agents in dependency order.
+ * Stops on first failure, marks downstream agents as skipped.
+ */
+export async function executeChain(
+  agents: Map<string, AgentDefinition>,
+  provider: Provider,
+  triggeredBy: Run['triggeredBy'],
+  pollInterval = 250,
+): Promise<ChainResult> {
+  const order = resolveExecutionOrder(agents);
+  const outputs = new Map<string, { result: string; exitCode: number }>();
+  const runs: Run[] = [];
+  const skipped: string[] = [];
+  let failed = false;
+
+  for (const agent of order) {
+    if (failed) {
+      skipped.push(agent.name);
+      continue;
+    }
+
+    // Resolve input template if present
+    let resolvedAgent = agent;
+    if (agent.input) {
+      const resolvedInput = resolveTemplate(agent.input, outputs);
+      // For claude-code agents, append to prompt. For shell agents, set as env var.
+      if (agent.type === 'claude-code' && agent.prompt) {
+        resolvedAgent = { ...agent, prompt: `${agent.prompt}\n\nInput: ${resolvedInput}` };
+      } else if (agent.type === 'shell') {
+        resolvedAgent = {
+          ...agent,
+          env: { ...(agent.env ?? {}), SUA_CHAIN_INPUT: resolvedInput },
+        };
+      }
+    }
+
+    const run = await provider.submitRun({ agent: resolvedAgent, triggeredBy });
+
+    // Poll for completion
+    let current = run;
+    while (current.status === 'running' || current.status === 'pending') {
+      await new Promise(r => setTimeout(r, pollInterval));
+      const updated = await provider.getRun(run.id);
+      if (updated) current = updated;
+    }
+
+    runs.push(current);
+
+    if (current.status === 'completed') {
+      outputs.set(agent.name, {
+        result: current.result ?? '',
+        exitCode: current.exitCode ?? 0,
+      });
+    } else {
+      failed = true;
+    }
+  }
+
+  return { runs, outputs, skipped };
+}

--- a/packages/core/src/chain-resolver.test.ts
+++ b/packages/core/src/chain-resolver.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { resolveExecutionOrder, resolveTemplate, CycleError, MissingDependencyError } from './chain-resolver.js';
+import type { AgentDefinition } from './types.js';
+
+function agent(name: string, deps?: string[]): AgentDefinition {
+  return { name, type: 'shell', command: `echo ${name}`, dependsOn: deps };
+}
+
+describe('resolveExecutionOrder', () => {
+  it('returns single agent with no dependencies', () => {
+    const agents = new Map([['a', agent('a')]]);
+    const order = resolveExecutionOrder(agents);
+    expect(order.map(a => a.name)).toEqual(['a']);
+  });
+
+  it('resolves linear dependency chain', () => {
+    const agents = new Map([
+      ['c', agent('c', ['b'])],
+      ['b', agent('b', ['a'])],
+      ['a', agent('a')],
+    ]);
+    const order = resolveExecutionOrder(agents);
+    const names = order.map(a => a.name);
+    expect(names.indexOf('a')).toBeLessThan(names.indexOf('b'));
+    expect(names.indexOf('b')).toBeLessThan(names.indexOf('c'));
+  });
+
+  it('resolves diamond dependency', () => {
+    const agents = new Map([
+      ['d', agent('d', ['b', 'c'])],
+      ['b', agent('b', ['a'])],
+      ['c', agent('c', ['a'])],
+      ['a', agent('a')],
+    ]);
+    const order = resolveExecutionOrder(agents);
+    const names = order.map(a => a.name);
+    expect(names.indexOf('a')).toBeLessThan(names.indexOf('b'));
+    expect(names.indexOf('a')).toBeLessThan(names.indexOf('c'));
+    expect(names.indexOf('b')).toBeLessThan(names.indexOf('d'));
+    expect(names.indexOf('c')).toBeLessThan(names.indexOf('d'));
+  });
+
+  it('throws CycleError on circular dependency', () => {
+    const agents = new Map([
+      ['a', agent('a', ['b'])],
+      ['b', agent('b', ['a'])],
+    ]);
+    expect(() => resolveExecutionOrder(agents)).toThrow(CycleError);
+  });
+
+  it('throws CycleError on self-reference', () => {
+    const agents = new Map([['a', agent('a', ['a'])]]);
+    expect(() => resolveExecutionOrder(agents)).toThrow(CycleError);
+  });
+
+  it('throws MissingDependencyError for nonexistent dependency', () => {
+    const agents = new Map([['a', agent('a', ['missing'])]]);
+    expect(() => resolveExecutionOrder(agents)).toThrow(MissingDependencyError);
+  });
+
+  it('handles agents with no dependsOn field', () => {
+    const agents = new Map([
+      ['a', { name: 'a', type: 'shell' as const, command: 'echo a' }],
+      ['b', { name: 'b', type: 'shell' as const, command: 'echo b' }],
+    ]);
+    const order = resolveExecutionOrder(agents);
+    expect(order.length).toBe(2);
+  });
+});
+
+describe('resolveTemplate', () => {
+  it('resolves result template', () => {
+    const outputs = new Map([['fetch', { result: 'hello', exitCode: 0 }]]);
+    expect(resolveTemplate('got: {{outputs.fetch.result}}', outputs)).toBe('got: hello');
+  });
+
+  it('resolves exitCode template', () => {
+    const outputs = new Map([['fetch', { result: '', exitCode: 42 }]]);
+    expect(resolveTemplate('code: {{outputs.fetch.exitCode}}', outputs)).toBe('code: 42');
+  });
+
+  it('resolves multiple templates', () => {
+    const outputs = new Map([
+      ['a', { result: 'foo', exitCode: 0 }],
+      ['b', { result: 'bar', exitCode: 0 }],
+    ]);
+    expect(resolveTemplate('{{outputs.a.result}} and {{outputs.b.result}}', outputs)).toBe('foo and bar');
+  });
+
+  it('returns empty string for missing agent output', () => {
+    const outputs = new Map<string, { result: string; exitCode: number }>();
+    expect(resolveTemplate('got: {{outputs.missing.result}}', outputs)).toBe('got: ');
+  });
+
+  it('passes through non-template text', () => {
+    const outputs = new Map<string, { result: string; exitCode: number }>();
+    expect(resolveTemplate('plain text', outputs)).toBe('plain text');
+  });
+});

--- a/packages/core/src/chain-resolver.ts
+++ b/packages/core/src/chain-resolver.ts
@@ -1,0 +1,88 @@
+import type { AgentDefinition } from './types.js';
+
+export class CycleError extends Error {
+  constructor(public readonly cycle: string[]) {
+    super(`Circular dependency detected: ${cycle.join(' -> ')}`);
+    this.name = 'CycleError';
+  }
+}
+
+export class MissingDependencyError extends Error {
+  constructor(public readonly agent: string, public readonly missing: string) {
+    super(`Agent "${agent}" depends on "${missing}" which does not exist`);
+    this.name = 'MissingDependencyError';
+  }
+}
+
+/**
+ * Topological sort of agents based on dependsOn fields.
+ * Returns agents in execution order (dependencies first).
+ * Throws CycleError if circular dependencies exist.
+ * Throws MissingDependencyError if a dependency doesn't exist.
+ */
+export function resolveExecutionOrder(agents: Map<string, AgentDefinition>): AgentDefinition[] {
+  // Validate all dependencies exist
+  for (const [name, agent] of agents) {
+    for (const dep of agent.dependsOn ?? []) {
+      if (!agents.has(dep)) {
+        throw new MissingDependencyError(name, dep);
+      }
+    }
+  }
+
+  const sorted: AgentDefinition[] = [];
+  const visited = new Set<string>();
+  const visiting = new Set<string>();
+
+  function visit(name: string, path: string[]) {
+    if (visited.has(name)) return;
+    if (visiting.has(name)) {
+      const cycleStart = path.indexOf(name);
+      throw new CycleError([...path.slice(cycleStart), name]);
+    }
+
+    visiting.add(name);
+    path.push(name);
+
+    const agent = agents.get(name)!;
+    for (const dep of agent.dependsOn ?? []) {
+      visit(dep, [...path]);
+    }
+
+    visiting.delete(name);
+    visited.add(name);
+    sorted.push(agent);
+  }
+
+  for (const name of agents.keys()) {
+    visit(name, []);
+  }
+
+  return sorted;
+}
+
+/**
+ * Resolve template strings like {{outputs.agent-name.result}}
+ * against a map of completed agent outputs.
+ */
+export function resolveTemplate(
+  template: string,
+  outputs: Map<string, { result: string; exitCode: number }>
+): string {
+  return template.replace(/\{\{outputs\.([a-z0-9-]+)\.(result|exitCode)\}\}/g, (_, agentName, field) => {
+    const output = outputs.get(agentName);
+    if (!output) return '';
+    if (field === 'result') return output.result;
+    if (field === 'exitCode') return String(output.exitCode);
+    return '';
+  });
+}
+
+const MAX_CHAIN_DEPTH = 20;
+
+export function validateChainDepth(agents: Map<string, AgentDefinition>): void {
+  const order = resolveExecutionOrder(agents);
+  if (order.length > MAX_CHAIN_DEPTH) {
+    throw new Error(`Chain exceeds maximum depth of ${MAX_CHAIN_DEPTH} agents (has ${order.length})`);
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,3 +4,5 @@ export * from './agent-loader.js';
 export * from './run-store.js';
 export * from './agent-executor.js';
 export * from './local-provider.js';
+export * from './chain-resolver.js';
+export * from './chain-executor.js';

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,1 +1,90 @@
-// MCP server entry point — implementation in Phase 2a branch
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { createServer } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { LocalProvider, loadAgents } from '@some-useful-agents/core';
+import { registerTools } from './tools.js';
+
+export interface McpServerOptions {
+  port: number;
+  agentDirs: string[];
+  dbPath: string;
+}
+
+export async function startMcpServer(options: McpServerOptions): Promise<void> {
+  const provider = new LocalProvider(options.dbPath);
+  await provider.initialize();
+
+  const server = new McpServer({
+    name: 'some-useful-agents',
+    version: '0.1.0',
+  });
+
+  registerTools(server, provider, options.agentDirs);
+
+  const transports = new Map<string, StreamableHTTPServerTransport>();
+
+  const httpServer = createServer(async (req, res) => {
+    const url = new URL(req.url ?? '/', `http://localhost:${options.port}`);
+
+    if (url.pathname === '/mcp') {
+      if (req.method === 'POST') {
+        const sessionId = req.headers['mcp-session-id'] as string | undefined;
+        let transport: StreamableHTTPServerTransport;
+
+        if (sessionId && transports.has(sessionId)) {
+          transport = transports.get(sessionId)!;
+        } else {
+          const newSessionId = randomUUID();
+          transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: () => newSessionId,
+          });
+          transports.set(newSessionId, transport);
+          await server.connect(transport);
+        }
+
+        await transport.handleRequest(req, res);
+      } else if (req.method === 'GET') {
+        const sessionId = req.headers['mcp-session-id'] as string | undefined;
+        if (sessionId && transports.has(sessionId)) {
+          const transport = transports.get(sessionId)!;
+          await transport.handleRequest(req, res);
+        } else {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'No session. Send a POST first.' }));
+        }
+      } else if (req.method === 'DELETE') {
+        const sessionId = req.headers['mcp-session-id'] as string | undefined;
+        if (sessionId && transports.has(sessionId)) {
+          const transport = transports.get(sessionId)!;
+          await transport.handleRequest(req, res);
+          transports.delete(sessionId);
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      } else {
+        res.writeHead(405);
+        res.end();
+      }
+    } else if (url.pathname === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok', sessions: transports.size }));
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  });
+
+  httpServer.listen(options.port, () => {
+    console.log(`MCP server listening on http://localhost:${options.port}/mcp`);
+    console.log(`Health check: http://localhost:${options.port}/health`);
+  });
+
+  process.on('SIGINT', async () => {
+    console.log('\nShutting down...');
+    await provider.shutdown();
+    httpServer.close();
+    process.exit(0);
+  });
+}

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -1,0 +1,113 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Provider } from '@some-useful-agents/core';
+import { loadAgents } from '@some-useful-agents/core';
+
+export function registerTools(server: McpServer, provider: Provider, agentDirs: string[]): void {
+
+  server.tool(
+    'list-agents',
+    'List available agent definitions',
+    {},
+    async () => {
+      const { agents } = loadAgents({ directories: agentDirs });
+      const list = Array.from(agents.values()).map(a => ({
+        name: a.name,
+        type: a.type,
+        description: a.description ?? '',
+      }));
+      return { content: [{ type: 'text' as const, text: JSON.stringify(list, null, 2) }] };
+    }
+  );
+
+  server.tool(
+    'run-agent',
+    'Start an agent run',
+    { name: z.string().describe('Agent name to run') },
+    async ({ name }) => {
+      const { agents } = loadAgents({ directories: agentDirs });
+      const agent = agents.get(name);
+      if (!agent) {
+        return { content: [{ type: 'text' as const, text: `Agent "${name}" not found.` }], isError: true };
+      }
+
+      const run = await provider.submitRun({ agent, triggeredBy: 'mcp' });
+
+      // Wait for completion (with timeout)
+      const timeout = (agent.timeout ?? 300) * 1000 + 5000;
+      const start = Date.now();
+      let current = run;
+      while ((current.status === 'running' || current.status === 'pending') && Date.now() - start < timeout) {
+        await new Promise(r => setTimeout(r, 500));
+        const updated = await provider.getRun(run.id);
+        if (updated) current = updated;
+      }
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify({
+            id: current.id,
+            status: current.status,
+            result: current.result,
+            error: current.error,
+            exitCode: current.exitCode,
+          }, null, 2),
+        }],
+        isError: current.status === 'failed',
+      };
+    }
+  );
+
+  server.tool(
+    'get-status',
+    'Get the status of a run',
+    { runId: z.string().describe('Run ID') },
+    async ({ runId }) => {
+      const run = await provider.getRun(runId);
+      if (!run) {
+        return { content: [{ type: 'text' as const, text: `Run "${runId}" not found.` }], isError: true };
+      }
+      return { content: [{ type: 'text' as const, text: JSON.stringify(run, null, 2) }] };
+    }
+  );
+
+  server.tool(
+    'get-logs',
+    'Get logs for a run',
+    { runId: z.string().describe('Run ID') },
+    async ({ runId }) => {
+      const logs = await provider.getRunLogs(runId);
+      return { content: [{ type: 'text' as const, text: logs || '(no output)' }] };
+    }
+  );
+
+  server.tool(
+    'cancel-agent',
+    'Cancel a running agent',
+    { runId: z.string().describe('Run ID to cancel') },
+    async ({ runId }) => {
+      await provider.cancelRun(runId);
+      return { content: [{ type: 'text' as const, text: `Cancelled run ${runId}` }] };
+    }
+  );
+
+  server.tool(
+    'list-runs',
+    'List recent runs',
+    {
+      agentName: z.string().optional().describe('Filter by agent name'),
+      limit: z.number().optional().default(20).describe('Max results'),
+    },
+    async ({ agentName, limit }) => {
+      const runs = await provider.listRuns({ agentName, limit });
+      const summary = runs.map(r => ({
+        id: r.id,
+        agent: r.agentName,
+        status: r.status,
+        started: r.startedAt,
+      }));
+      return { content: [{ type: 'text' as const, text: JSON.stringify(summary, null, 2) }] };
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- MCP server with streamable HTTP transport on configurable port (default 3003)
- 6 MCP tools: `list-agents`, `run-agent`, `get-status`, `get-logs`, `cancel-agent`, `list-runs`
- Agent chaining: DAG resolution with cycle detection, template-based output piping (`{{outputs.agent.result}}`)
- Chain executor: sequential execution, stop-on-failure, skip downstream agents
- `sua mcp start` CLI command with `--port` option
- Health check endpoint at `/health`

## Testing
- 12 new tests for chain resolver (topological sort, cycles, self-reference, missing deps, templates)
- 42 total tests passing
- Smoke tested: MCP server starts, health check returns OK

## How to test
```bash
# Start MCP server
sua mcp start

# In another terminal, check health
curl http://localhost:3003/health
```

Configure Claude Code to connect: add `http://localhost:3003/mcp` as a streamable HTTP MCP server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)