### PR TITLE
fix(ci): --force npm upgrade in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,10 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
-      # npm CLI >= 11.5.1 is required for trusted publishing
+      # npm CLI >= 11.5.1 is required for trusted publishing.
+      # --force bypasses the bundled-deps mismatch when upgrading npm in-place.
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@latest --force
 
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
## Problem
The release workflow failed on the first run with:
```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
```

This is a well-known npm self-upgrade bug: Node 22.22.2 ships with npm 10.9.7, and running `npm install -g npm@latest` in-place gets confused about its own bundled dependencies mid-install.

## Fix
Add `--force` to bypass the bundled-deps check. The upgrade is still needed because Trusted Publishing requires npm >= 11.5.1.

## Testing
Minimal change. CI's `build-and-test` job will verify nothing else broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)