### PR TITLE
fix: add repository fields to each package for OIDC provenance

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,5 +32,14 @@
     "dist",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gregmeyer/some-useful-agents.git",
+    "directory": "packages/cli"
+  },
+  "homepage": "https://github.com/gregmeyer/some-useful-agents#readme",
+  "bugs": {
+    "url": "https://github.com/gregmeyer/some-useful-agents/issues"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,5 +26,14 @@
     "dist",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gregmeyer/some-useful-agents.git",
+    "directory": "packages/core"
+  },
+  "homepage": "https://github.com/gregmeyer/some-useful-agents#readme",
+  "bugs": {
+    "url": "https://github.com/gregmeyer/some-useful-agents/issues"
+  }
 }

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -25,5 +25,14 @@
     "dist",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gregmeyer/some-useful-agents.git",
+    "directory": "packages/dashboard"
+  },
+  "homepage": "https://github.com/gregmeyer/some-useful-agents#readme",
+  "bugs": {
+    "url": "https://github.com/gregmeyer/some-useful-agents/issues"
+  }
 }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -24,5 +24,14 @@
     "dist",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gregmeyer/some-useful-agents.git",
+    "directory": "packages/mcp-server"
+  },
+  "homepage": "https://github.com/gregmeyer/some-useful-agents#readme",
+  "bugs": {
+    "url": "https://github.com/gregmeyer/some-useful-agents/issues"
+  }
 }

--- a/packages/temporal-provider/package.json
+++ b/packages/temporal-provider/package.json
@@ -27,5 +27,14 @@
     "dist",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gregmeyer/some-useful-agents.git",
+    "directory": "packages/temporal-provider"
+  },
+  "homepage": "https://github.com/gregmeyer/some-useful-agents#readme",
+  "bugs": {
+    "url": "https://github.com/gregmeyer/some-useful-agents/issues"
+  }
 }


### PR DESCRIPTION
## Problem
The v0.2.0 release publish failed with:

\`\`\`
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match
"https://github.com/gregmeyer/some-useful-agents" from provenance
\`\`\`

npm Trusted Publishing signs provenance with the GitHub repo URL via OIDC, then verifies the package's `package.json` declares the same repository. Without it, publish is rejected even though trusted publishing itself worked.

## Fix
Added `repository`, `homepage`, and `bugs` fields to each of the 5 packages. The `repository.directory` field points to the package subdirectory in the monorepo (npm convention).

## Side benefit
npm's package pages will now link to the source repo and issue tracker, improving discoverability.

## What happens after merge
The release workflow triggers. With no pending changesets, the `changesets/action@v1` falls into its "Attempting to publish any unpublished packages" path. It sees 0.2.0 isn't on npm yet for any of these packages and retries the publish (via OIDC, same as before). The repository field matches, provenance verifies, all 5 publish.

Verified locally: only `0.1.0` exists on npm for each package; the previous failed publish didn't reserve 0.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)