### PR TITLE
fix(tutorial): don't let ora swallow stdin after stage 3

### DIFF
--- a/.changeset/cli-version-dynamic.md
+++ b/.changeset/cli-version-dynamic.md
@@ -1,9 +1,0 @@
----
-"@some-useful-agents/cli": patch
----
-
-Two CLI fixes:
-
-1. **`sua --version` now reports the real version.** Previously hardcoded as `0.1.0`; now read from the CLI package's own `package.json` at runtime so it stays in sync with releases automatically.
-
-2. **Tutorial `explain` prompts no longer hallucinate commands.** The prompt sent to Claude/Codex now includes the exact CLI command surface, so deep-dive answers use real commands like `sua agent list` instead of invented ones like `sua list`.

--- a/.changeset/tutorial-ora-stdin.md
+++ b/.changeset/tutorial-ora-stdin.md
@@ -1,0 +1,5 @@
+---
+"@some-useful-agents/cli": patch
+---
+
+Fix tutorial silently exiting after stage 3. ora's default `discardStdin: true` was fighting with readline: after the spinner stopped, stdin was left in a state that made subsequent `rl.question` calls fail silently, so the tutorial never reached stages 4 and 5. All ora calls in the tutorial now pass `discardStdin: false`. Also wraps each stage in a try/catch that logs errors before re-throwing, so future silent failures are visible.

--- a/packages/cli/src/commands/tutorial.ts
+++ b/packages/cli/src/commands/tutorial.ts
@@ -43,14 +43,24 @@ async function runTutorial(): Promise<void> {
 
   try {
     printHeader();
-    await stage1(ctx);
-    await stage2(ctx);
-    await stage3(ctx);
-    await stage4(ctx);
-    await stage5(ctx);
+    await runStage(1, () => stage1(ctx));
+    await runStage(2, () => stage2(ctx));
+    await runStage(3, () => stage3(ctx));
+    await runStage(4, () => stage4(ctx));
+    await runStage(5, () => stage5(ctx));
     printOutro();
   } finally {
     rl.close();
+  }
+}
+
+async function runStage(n: number, fn: () => Promise<void>): Promise<void> {
+  try {
+    await fn();
+  } catch (err) {
+    console.error(chalk.red(`\n[stage ${n}] failed: ${(err as Error).message}`));
+    if ((err as Error).stack) console.error(chalk.dim((err as Error).stack));
+    throw err;
   }
 }
 
@@ -96,7 +106,7 @@ async function pause(ctx: Ctx, stageTopic: string): Promise<void> {
 async function doExplain(ctx: Ctx, topic: string): Promise<void> {
   if (!ctx.llm) return;
   const prompt = buildExplainPrompt(topic);
-  const spinner = ora(`Asking ${ctx.llm}...`).start();
+  const spinner = ora({ text: `Asking ${ctx.llm}...`, discardStdin: false }).start();
   const result = await invokeLlm({ prompt, provider: ctx.llm, timeoutMs: 60_000 });
   spinner.stop();
   if (result.exitCode !== 0) {
@@ -178,7 +188,7 @@ async function stage3(ctx: Ctx): Promise<void> {
   }
 
   const provider = await createProvider(ctx.config);
-  const spinner = ora('Running hello...').start();
+  const spinner = ora({ text: 'Running hello...', discardStdin: false }).start();
   try {
     const run = await provider.submitRun({ agent, triggeredBy: 'cli' });
     let current = run;
@@ -229,7 +239,7 @@ async function stage4(ctx: Ctx): Promise<void> {
   }
 
   const provider = await createProvider(ctx.config);
-  const spinner = ora('curl icanhazdadjoke.com...').start();
+  const spinner = ora({ text: 'curl icanhazdadjoke.com...', discardStdin: false }).start();
   try {
     const run = await provider.submitRun({ agent, triggeredBy: 'cli' });
     let current = run;


### PR DESCRIPTION
## Problem
Tutorial silently exits after stage 3. Users press Enter at the "Press Enter to continue" pause and return to the shell prompt, never reaching stages 4 (build dad-joke) and 5 (schedule).

## Root cause
ora's default `discardStdin: true` puts stdin into raw mode while spinning and returns it in a state where the next `rl.question()` call fails silently. Stage 3 is the first stage with a spinner, which is why the silent exit only happens there.

## Fix
- Pass `discardStdin: false` to every ora call in the tutorial (3 sites)
- Wrap each stage in a try/catch that logs errors + stack trace before re-throwing, so future silent failures are visible rather than clean-exiting

## Context
This was a stray commit from PR #15 that didn't make it in before that PR merged. Same code, just a cleaner standalone PR so it can ship as 0.3.2.

## Testing locally
Ran `sua tutorial` end-to-end; all 5 stages complete and print the dad joke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)