### PR TITLE
docs+fix: suppress SQLite warning, update README, expand ROADMAP

### DIFF
--- a/.changeset/suppress-warning-roadmap-readme.md
+++ b/.changeset/suppress-warning-roadmap-readme.md
@@ -1,0 +1,11 @@
+---
+"@some-useful-agents/cli": patch
+---
+
+Three small but visible improvements:
+
+1. **Suppress the `node:sqlite` ExperimentalWarning.** Every `sua` command was printing `(node:XXXX) ExperimentalWarning: SQLite is an experimental feature...` because we use the built-in `node:sqlite` module. The CLI now filters that specific warning while letting every other warning through. When the minimum Node version eventually moves to 24+, where sqlite is stable, this becomes a no-op.
+
+2. **Rewrite the README.** Reflects the v0.3 command surface (including `sua tutorial`, `sua schedule`, `sua secrets`), shows a real agent YAML with chaining + scheduling + secrets, notes known-weak security spots with links to ADRs, and points at the ROADMAP + ADR dir.
+
+3. **Expand ROADMAP.md.** Added daemon mode / unattended operation, tutorial resume, parallel agents / swarms, and a formal security audit as explicit "Next" items.

--- a/README.md
+++ b/README.md
@@ -1,119 +1,166 @@
 # some-useful-agents
 
-A local-first agent playground. Author, schedule, and report on agents running on your machine.
+A local-first agent playground. Author agents in YAML, run them from the CLI or MCP, schedule them on cron, chain them into pipelines, and share them with the community.
 
-Define agents in YAML, run them via CLI or MCP, schedule them with Temporal, chain them into pipelines, and share them with the community.
+MIT-licensed. Published to npm at `@some-useful-agents/*`. Designed to feel like `cron + shell scripts` except each "script" can also be a Claude Code prompt and the whole thing is observable, durable, and composable.
 
-## Quick start — from npm, no clone
+## Quick start (no clone needed)
 
 ```bash
 npm install -g @some-useful-agents/cli
 mkdir my-agents && cd my-agents
-sua init           # scaffolds agents/local/hello.yaml
+sua init           # creates sua.config.json and agents/local/hello.yaml
 sua tutorial       # 5-stage walkthrough ending with a scheduled dad joke
 ```
 
-If you prefer running without global install, use `npx @some-useful-agents/cli <command>` anywhere.
+Prefer `npx`? `npx @some-useful-agents/cli <command>` works without installing globally.
 
-The tutorial ends with you having built the `dad-joke` agent, fetched a real joke from
-icanhazdadjoke.com, and optionally scheduled it to fire daily at 9am. Stages can be
-enriched on-demand with a Claude or Codex deep-dive — type `explain` at any prompt.
+The tutorial walks you through what sua is, builds a real agent that fetches a dad joke from icanhazdadjoke.com, and optionally schedules it daily at 9am. At any stage you can type `explain` to get a Claude or Codex deep-dive on that concept.
 
-## Cloning from source (for contributors)
+## Commands at a glance
+
+**Agents**
 
 ```bash
-git clone https://github.com/gregmeyer/some-useful-agents.git
-cd some-useful-agents
-npm install
-npm run build
+sua agent list                # runnable agents (examples + local)
+sua agent list --catalog      # browse the community catalog
+sua agent run <name>          # run an agent once
+sua agent status [runId]      # recent runs, or one specific run
+sua agent logs <runId>        # stdout/stderr of a past run
+sua agent cancel <runId>      # kill a running agent
 ```
+
+**Scheduling**
+
+```bash
+sua schedule list             # agents with a schedule field + next fire time
+sua schedule validate <name>  # validate the cron expression
+sua schedule start            # foreground cron daemon
+```
+
+**Secrets** (encrypted at rest, scoped per-agent)
+
+```bash
+sua secrets set <NAME>        # prompts for value, stores encrypted
+sua secrets get <NAME>
+sua secrets list
+sua secrets delete <NAME>
+sua secrets check <agent>     # which secrets an agent needs + whether set
+```
+
+**Services**
+
+```bash
+sua mcp start                 # HTTP/SSE MCP server (port 3003)
+sua worker start              # Temporal worker (requires docker compose up)
+```
+
+**Utilities**
+
+```bash
+sua init                      # scaffold a new sua directory
+sua doctor                    # check Node, Docker, Claude CLI, scheduler, etc.
+sua tutorial                  # guided walkthrough
+```
+
+## Agent YAML
+
+A full-fat example showing most of the available fields:
+
+```yaml
+name: daily-summary
+description: Summarize today's git activity with Claude
+type: claude-code
+prompt: |
+  Summarize the recent commits. Keep it under 5 bullets.
+  Commits:
+  {{outputs.fetch-commits.result}}
+model: claude-sonnet-4-20250514
+dependsOn: [fetch-commits]        # chain: fetch-commits runs first
+schedule: "0 18 * * *"            # daily at 6pm
+timeout: 120
+secrets:                          # resolved from the secrets store
+  - GITHUB_TOKEN
+envAllowlist:                     # extra process.env to inherit
+  - HTTP_PROXY
+author: your-github-handle
+version: "1.0.0"
+tags: [git, summary, daily]
+```
+
+Required fields: `name`, `type` (`shell` or `claude-code`). Shell agents need `command`; claude-code agents need `prompt`. Everything else is optional.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full schema and security review checklist.
 
 ## Running on Temporal
 
+Use Temporal instead of the local child-process provider when you want durable, observable execution.
+
 ```bash
-# 1. Start Temporal server (Docker)
-docker compose up -d
-
-# 2. Start the worker (on your host, so it has shell + Claude CLI access)
-sua worker start
-
-# 3. In another terminal, submit a run
-sua agent run hello-shell --provider temporal
-
-# 4. See the workflow in the Temporal UI
-open http://localhost:8233
+docker compose up -d                                # Temporal dev server
+sua worker start                                     # worker runs on your host
+sua agent run hello --provider temporal              # or set SUA_PROVIDER=temporal
+open http://localhost:8233                           # Temporal Web UI
 ```
 
-The worker runs on the host (not in Docker) because agents need access to your shell
-and `claude` CLI. Temporal itself is the only service running in Docker.
-
-## What is this?
-
-**some-useful-agents** lets you:
-
-- **Author** agents as simple YAML files (shell commands or Claude Code prompts)
-- **Run** them via a CLI (`sua`) or MCP server
-- **Schedule** them with Temporal (or n8n, coming soon)
-- **Chain** them into pipelines where one agent's output feeds the next
-- **Share** them with the community via GitHub
+The worker runs on the host (not in Docker) because agents need your shell and your Claude CLI install. Temporal itself is the only thing running in Docker.
 
 ## Architecture
 
 ```
 HOST MACHINE
-+-------------------------------------------------------------+
++---------------------------------------------------------------+
 |                                                               |
-|  CLI (sua)    MCP Server (HTTP/SSE)    Temporal Worker        |
-|      |              |                       |                 |
-|      +--------------+-----------------------+                 |
-|                     v                                         |
-|              packages/core                                    |
-|   AgentLoader -> Provider Interface -> RunStore (SQLite)      |
-|        |              |                    |                   |
-|   agents/*.yaml  LocalProvider        data/runs.db            |
-|                  TemporalProvider                              |
+|  sua (CLI)    MCP server (HTTP)    Temporal worker            |
+|      \             |                     /                    |
+|       \            v                    /                     |
+|        ----> packages/core <-----------                       |
+|              AgentLoader                                      |
+|              Provider (Local | Temporal)                      |
+|              RunStore (node:sqlite, WAL)                      |
+|              Scheduler (node-cron)                            |
+|              SecretsStore (AES-256-GCM file)                  |
 |                                                               |
-|  Dashboard (Express:3000)    Agent Execution                  |
-|  REST API + static HTML      +- shell: Docker sandbox         |
-|                               +- claude: host (trusted)       |
-+---------------------------+-----------------------------------+
-                            | localhost:7233 (gRPC)
-                 +----------v----------+
-                 |      DOCKER          |
-                 |  Temporal Server     |
-                 |  (SQLite, :8233)     |
-                 +---------------------+
+|  Agent execution                                              |
+|   - shell agents: child_process.spawn (on host)               |
+|   - claude-code agents: spawn('claude', ['--print', prompt])  |
++-------------------------------+-------------------------------+
+                                | localhost:7233 (gRPC)
+                       +--------v--------+
+                       |    DOCKER       |
+                       |  Temporal       |
+                       |  (SQLite, :8233)|
+                       +-----------------+
 ```
 
-## Agent definition format
-
-```yaml
-name: daily-summary
-description: Summarize today's git activity
-type: shell
-command: "git log --since='1 day ago' --oneline"
-timeout: 30
-author: your-github-handle
-version: "1.0.0"
-tags: [git, summary]
-```
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full schema.
+All infrastructure except Temporal runs on the host. See [ADR-0004](docs/adr/0004-temporal-worker-on-host.md) for why.
 
 ## Packages
 
-| Package | Description |
-|---------|-------------|
-| `@some-useful-agents/core` | Types, schemas, agent loader, run store |
-| `@some-useful-agents/cli` | CLI tool (`sua`) |
-| `@some-useful-agents/mcp-server` | MCP server (HTTP/SSE) |
-| `@some-useful-agents/temporal-provider` | Temporal workflow provider |
-| `@some-useful-agents/dashboard` | Web dashboard |
+| Package | Install | Purpose |
+|---------|---------|---------|
+| `@some-useful-agents/cli` | `npm i -g @some-useful-agents/cli` | the `sua` binary |
+| `@some-useful-agents/core` | `npm i @some-useful-agents/core` | types, schemas, run store, scheduler — build on top |
+| `@some-useful-agents/mcp-server` | auto via CLI | MCP server (HTTP/SSE) |
+| `@some-useful-agents/temporal-provider` | auto via CLI | Temporal workflows + worker |
+| `@some-useful-agents/dashboard` | not yet | (roadmap: Phase 3 web UI) |
+
+All packages are published via OIDC with provenance attestations — verify with `npm view @some-useful-agents/cli attestations`.
+
+## Security notes
+
+- **Env filtering by trust level** — community agents receive a minimal env (`PATH`, `HOME`, `LANG`, `TERM`, `TMPDIR` + allowlist). Dangerous vars like `AWS_SECRET_ACCESS_KEY` do not leak. See [ADR-0006](docs/adr/0006-env-filtering-by-trust-level.md).
+- **Encrypted secrets store** — machine-bound AES-256-GCM at `data/secrets.enc`, permissions `0600`. Obfuscation-grade, not vault-grade; OS keychain is on the roadmap. See [ADR-0007](docs/adr/0007-encrypted-file-secrets-store.md).
+- **Known-weak** — the shell-agent Docker sandbox is documented in [ADR-0005](docs/adr/0005-shell-sandbox-claude-on-host.md) but not yet implemented; the MCP server has no auth; template substitutions in chains aren't shell-escaped. See ROADMAP "Security audit" item.
 
 ## Where is this going?
 
-See [ROADMAP.md](ROADMAP.md) for direction, and [docs/adr/](docs/adr/) for the
-rationale behind past architecture decisions.
+- [ROADMAP.md](ROADMAP.md) — direction at three horizons (now / next / maybe) and what we've rejected
+- [docs/adr/](docs/adr/) — 13 architecture decision records explaining the "why" behind big calls
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md). TL;DR: fork, branch, add a `changeset` describing your change (`npx changeset`), open a PR against `main`. Agent contributions go in `agents/community/` and need a security review checklist.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,12 +23,26 @@ on direction.
 - **Agent registry** — `sua agent install <github-url>` fetches a YAML from a
   remote repo, validates with zod, drops it into `agents/local/`. Turns the
   community catalog into one-command installs.
+- **Daemon mode / unattended operation** — `sua schedule start` runs foreground
+  today. First-class backgrounding: either a bundled `sua daemon start|stop|status`
+  wrapper over pm2, or generators for `launchd` (macOS) and `systemd` (Linux)
+  unit files. Needed so scheduled agents actually fire when the terminal is closed.
 - **OS keychain for secrets (Phase S3)** — optional `keytar`-backed store for
   stronger at-rest encryption than the current machine-bound file cipher.
 - **Temporal scheduling** — use Temporal's Schedules API for agents running via
   the Temporal provider (so scheduling works without a local scheduler daemon).
 - **n8n provider** — second workflow provider alongside Temporal, for visual
   pipeline users.
+- **Tutorial resume** — save tutorial progress so re-running `sua tutorial` picks
+  up at the last completed stage rather than restarting the prose from stage 1.
+- **Parallel agents / swarms** — the chain-executor runs sequentially even for
+  independent DAG nodes. First-class fan-out/fan-in (e.g., `parallel: [A, B, C]`
+  YAML field) plus Temporal worker scaling. Separately consider whether
+  inter-agent messaging during execution is in scope or left to chaining.
+- **Security audit** — formal threat model + fixes for known weak spots:
+  shell sandbox actually implemented (currently aspirational), MCP server
+  authentication, escaping `{{outputs}}` template substitutions in shell
+  contexts, schedule frequency caps, stderr-leak mitigation.
 
 ## Maybe (6–12 months)
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+// MUST be the first import so the warning filter is attached before any
+// transitive import of node:sqlite fires the ExperimentalWarning.
+import './suppress-warnings.js';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';

--- a/packages/cli/src/suppress-warnings.ts
+++ b/packages/cli/src/suppress-warnings.ts
@@ -1,0 +1,30 @@
+/**
+ * Filter known-noise Node warnings so the CLI output stays clean.
+ *
+ * This MUST be imported as the first line of index.ts. ESM evaluates imports
+ * in the source order of the importing module; registering the listener here
+ * before any other import ensures it's attached before `node:sqlite` (loaded
+ * transitively via @some-useful-agents/core) fires its experimental warning.
+ *
+ * Node 22.x emits ExperimentalWarning for the built-in sqlite module. In
+ * Node 24+ sqlite is stable and this filter becomes a no-op. Keep until the
+ * project raises its minimum Node version.
+ *
+ * Other warnings pass through untouched so real issues still surface.
+ */
+
+const shouldSuppress = (warning: Error): boolean => {
+  return warning.name === 'ExperimentalWarning' && /SQLite/.test(warning.message);
+};
+
+// Replace Node's default warning listener (which always prints) with a
+// filtered one. We remove ALL existing listeners first so the default
+// doesn't also run alongside ours.
+process.removeAllListeners('warning');
+process.on('warning', (warning) => {
+  if (shouldSuppress(warning)) return;
+  process.stderr.write(`(node:${process.pid}) ${warning.name}: ${warning.message}\n`);
+  if (warning.stack) {
+    process.stderr.write(`${warning.stack}\n`);
+  }
+});


### PR DESCRIPTION
## Summary
Three small improvements all visible to end users:

### 1. Suppress the `node:sqlite` ExperimentalWarning
Every `sua` invocation was printing:
```
(node:XXXX) ExperimentalWarning: SQLite is an experimental feature and might change at any time
```
The CLI now filters that specific warning (and only that one) via a warning listener registered before any transitive `node:sqlite` import. Other warnings still print normally. When the project eventually moves to Node 24+, where sqlite is stable, this becomes a no-op.

### 2. Rewrite README
Old README was written around v0.1 and missed `sua tutorial`, `sua schedule`, `sua secrets`, and the full command surface. New README:
- Commands at a glance table covering every CLI entrypoint
- Agent YAML example shows chaining + scheduling + secrets + envAllowlist
- Security notes section with ADR links and honest callouts of known-weak spots (shell sandbox not actually implemented, MCP has no auth, `{{outputs}}` not shell-escaped)
- Links to ROADMAP and docs/adr

### 3. Expand ROADMAP
Added to the Next horizon:
- **Daemon mode** (pm2/launchd/systemd integration for unattended scheduling)
- **Tutorial resume** (save tutorial progress across invocations)
- **Parallel agents / swarms** (first-class fan-out/fan-in in YAML)
- **Security audit** (formal threat model + fixes for known weak spots)

## Context
Arose from two user questions: "how do I suppress the SQLite error" and "is the daemon/process-manager story in our roadmap?" — answered both in code/docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)