### PR TITLE
fix(cli): wire community agents into the v0.6.0 shell gate (v0.6.1)

### DIFF
--- a/.changeset/community-agents-runnable.md
+++ b/.changeset/community-agents-runnable.md
@@ -1,0 +1,31 @@
+---
+"@some-useful-agents/cli": patch
+"@some-useful-agents/core": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+**Fix: community agents are now runnable from the CLI so the v0.6.0 shell gate is actually reachable.** Before this patch, `sua agent run <name>` and `sua schedule start` only loaded `agents/examples/` + `agents/local/` — community agents were visible via `sua agent list --catalog` but "not found" at run time. The shell gate in `executeAgent` was effectively dead code for the primary CLI flow (it still fired for Temporal activities and `executeChain`, both tested).
+
+Now the runtime commands load from `dirs.all` (runnable + catalog) and the shell gate enforces per-agent opt-in via `--allow-untrusted-shell <name>` exactly as the v0.6.0 docs promised.
+
+### Behavior changes
+
+- `sua agent run <community-agent>` is now accepted at lookup time and refuses at execute time with the expected `UntrustedCommunityShellError` message. Opt in with `--allow-untrusted-shell <name>`.
+- `sua schedule start` will now fire community agents that have a `schedule:` field; the gate still refuses unaudited community shell.
+- `sua mcp start` exposes community agents that have `mcp: true` in their YAML (still filtered by the opt-in flag — no behavior change for agents without it).
+- `sua doctor --security` now counts community shell agents whether or not they've been copied into `agents/local/`.
+- `sua secrets check <name>` now works on community agents.
+
+### Unchanged by design
+
+- `sua agent list` still defaults to `runnable` vs `--catalog` so users can tell their own agents apart from third-party catalog entries.
+- `sua agent audit <name>` already loaded both; unchanged.
+
+### Docs
+
+- `docs/SECURITY.md` and `README` version labels updated from the aspirational `v0.5.1` (what the plan predicted) to `v0.6.0` (what actually shipped). Future passphrase-KEK work renumbered to `v0.7.0`.
+- Version history in SECURITY.md gets a new `v0.6.1` entry documenting the gate wiring fix.
+
+No API changes. No migration needed.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MIT-licensed. Published to npm at `@some-useful-agents/*`. Designed to feel like
 > agents marked `mcp: true` are callable from MCP clients. Community shell agents
 > refuse to run without explicit opt-in (`sua agent audit` + `--allow-untrusted-shell`);
 > community output flowing into a claude-code prompt is wrapped in UNTRUSTED
-> delimiters. Secrets are *obfuscated, not encrypted* until v0.6.0 lands
+> delimiters. Secrets are *obfuscated, not encrypted* until v0.7.0 lands
 > passphrase-based key derivation. Run `sua doctor --security` to verify your
 > install. Full model: [docs/SECURITY.md](docs/SECURITY.md).
 
@@ -164,10 +164,10 @@ See [docs/SECURITY.md](docs/SECURITY.md) for the full threat model. One-liners:
 - **MCP bearer token + loopback bind** — v0.4.0 closed a critical gap. `sua init` writes a 32-byte token to `~/.sua/mcp-token` (chmod 0600); the server binds `127.0.0.1`, requires `Authorization: Bearer <token>`, and rejects non-loopback Host/Origin headers.
 - **MCP agents opt in** — only agents with `mcp: true` in their YAML are exposed via MCP's `list-agents` and `run-agent` tools (v0.5.0). The rest are invisible to MCP clients.
 - **Chain trust propagation** — community agent output flowing into a downstream local agent is wrapped in UNTRUSTED delimiters (claude-code) or blocked outright (shell), unless the shell downstream is explicitly allow-listed (v0.5.0).
-- **Community shell agent gate** — shell agents sourced from `agents/community/` refuse to run without `--allow-untrusted-shell <name>` on the CLI. Use `sua agent audit <name>` to print the resolved YAML before opting in (v0.5.1).
-- **Run-store hygiene** — `data/runs.db` is chmod 0o600 at create. Rows older than `runRetentionDays` (default 30) are swept on startup. Opt-in `redactSecrets: true` on an agent scrubs known-prefix secrets (AWS, GitHub PAT, OpenAI / Anthropic, Slack) from its stdout/stderr before they land in the DB (v0.5.1).
+- **Community shell agent gate** — shell agents sourced from `agents/community/` refuse to run without `--allow-untrusted-shell <name>` on the CLI. Use `sua agent audit <name>` to print the resolved YAML before opting in (v0.6.0, wired end-to-end in v0.6.1).
+- **Run-store hygiene** — `data/runs.db` is chmod 0o600 at create. Rows older than `runRetentionDays` (default 30) are swept on startup. Opt-in `redactSecrets: true` on an agent scrubs known-prefix secrets (AWS, GitHub PAT, OpenAI / Anthropic, Slack) from its stdout/stderr before they land in the DB (v0.6.0).
 - **Cron frequency cap** — schedules fire no more than once per minute by default. 6-field sub-minute expressions require `allowHighFrequency: true` and emit a loud warning on every fire (v0.4.0).
-- **Secrets store** — machine-bound AES-256-GCM at `data/secrets.enc`, permissions `0600`. Obfuscation-grade, not vault-grade; passphrase-based key derivation is on the v0.6.0 roadmap. See [ADR-0007](docs/adr/0007-encrypted-file-secrets-store.md).
+- **Secrets store** — machine-bound AES-256-GCM at `data/secrets.enc`, permissions `0600`. Obfuscation-grade, not vault-grade; passphrase-based key derivation is on the v0.7.0 roadmap. See [ADR-0007](docs/adr/0007-encrypted-file-secrets-store.md).
 - **Self-check** — run `sua doctor --security` for a one-shot audit of file perms, MCP token presence, and community shell posture.
 - **Known-weak (still)** — the shell-agent Docker sandbox documented in [ADR-0005](docs/adr/0005-shell-sandbox-claude-on-host.md) remains aspirational; once you opt in past the community-shell gate, the agent runs with your full ambient authority. Don't install community agents you haven't audited.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -44,13 +44,13 @@ The bearer token's only job is to gate *any process that can hit localhost* from
 
 Only agents with `mcp: true` in their YAML are exposed via the MCP `list-agents` and `run-agent` tools. Agents without the flag respond as "not found" — not "forbidden" — so a compromised MCP client cannot enumerate the user's full catalog. Use `sua agent list` from the CLI to see everything.
 
-### Shell agent gate (v0.5.1)
+### Shell agent gate (v0.6.0)
 
 Shell-type agents sourced from `community/` refuse to run unless the caller has explicitly opted in. The CLI surfaces this as `--allow-untrusted-shell <name>` on `sua agent run` and `sua schedule start` (repeatable, per-agent, not global). Library consumers pass `LocalProvider({ allowUntrustedShell: Set<string> })` or the equivalent on `TemporalProvider`. The executor throws `UntrustedCommunityShellError` before `spawn` is called, and the provider records a failed run in the store so the refusal shows up in history.
 
 This is a forcing function, not a sandbox. Once you opt in, the shell runs with your full ambient authority. The point is to make you read the `command:` field first. Use `sua agent audit <name>` to print the resolved YAML before opting in.
 
-### Run-store hygiene (v0.5.1)
+### Run-store hygiene (v0.6.0)
 
 - `data/runs.db` is chmod 0o600 at create time. Agent stdout can contain secrets that were echoed by an agent; the DB is unencrypted plaintext, so POSIX perms are the only at-rest protection.
 - Retention sweep: the store deletes rows older than `runRetentionDays` (default 30) on startup. Configure via `sua.config.json`. Long-running agent history is an ambient leak surface — we cap it unless you opt out.
@@ -93,9 +93,9 @@ See [ADR-0006](adr/0006-env-filtering-by-trust-level.md).
 Being explicit so you can evaluate whether sua is the right tool for your threat model:
 
 - **Shell agent sandboxing.** Once you opt in past the community-shell gate, the agent runs as the invoking user with full ambient authority: filesystem, network, processes. A malicious shell agent can `rm -rf $HOME`, exfiltrate `~/.ssh`, read browser cookies, or run any other command the user could run. The env filter reduces secret-leak blast radius but does not create a sandbox. Treat every `--allow-untrusted-shell` invocation like running the shell script yourself — because you effectively are. Real sandboxing (`nsjail` on Linux, `sandbox-exec` on macOS) is on the long-term roadmap.
-- **Secrets-store encryption.** The AES-256-GCM cipher in `data/secrets.enc` uses a key derived from `scrypt(hostname + username)`. If the file ever leaves the machine — iCloud sync, Time Machine to a network share, accidental commit — an attacker who can guess the hostname and username (trivial for a targeted attacker) can decrypt the whole store. Today's encryption is **obfuscation, not a real defense**. The file's POSIX `0600` permission is the actual at-rest protection. Passphrase-based key derivation lands in v0.6.0; until then, treat the encrypted store as plaintext for threat-modeling purposes.
+- **Secrets-store encryption.** The AES-256-GCM cipher in `data/secrets.enc` uses a key derived from `scrypt(hostname + username)`. If the file ever leaves the machine — iCloud sync, Time Machine to a network share, accidental commit — an attacker who can guess the hostname and username (trivial for a targeted attacker) can decrypt the whole store. Today's encryption is **obfuscation, not a real defense**. The file's POSIX `0600` permission is the actual at-rest protection. Passphrase-based key derivation lands in v0.7.0; until then, treat the encrypted store as plaintext for threat-modeling purposes.
 - **Prompt injection from claude-code upstream agents.** We only wrap values from `community` agents. If you write a `local` claude-code agent that can be manipulated by a user into producing prompt-injection payloads, and a second `local` agent reads its output, that output flows through unwrapped. Don't chain agents whose inputs you don't control.
-- **Run output secrets (by default).** Agent stdout lands verbatim in `data/runs.db` unless the agent opts into `redactSecrets: true` (v0.5.1). The default behavior is still "store what the agent printed." If an agent you author calls a third-party API that might return a token, set `redactSecrets: true` to catch the AWS / GitHub / LLM / Slack prefixes. Do not rely on the scrubber for unknown secret formats — it's narrow on purpose. As of v0.5.1, `runs.db` is chmod 0o600 at create and rows older than 30 days are swept on startup; neither of those replaces redaction for live secrets.
+- **Run output secrets (by default).** Agent stdout lands verbatim in `data/runs.db` unless the agent opts into `redactSecrets: true` (v0.6.0). The default behavior is still "store what the agent printed." If an agent you author calls a third-party API that might return a token, set `redactSecrets: true` to catch the AWS / GitHub / LLM / Slack prefixes. Do not rely on the scrubber for unknown secret formats — it's narrow on purpose. As of v0.6.0, `runs.db` is chmod 0o600 at create and rows older than 30 days are swept on startup; neither of those replaces redaction for live secrets.
 - **Temporal workflow history.** When running under the Temporal provider, agent inputs and outputs are persisted in Temporal's own history store. That is a second plaintext sink outside sua's control. Same advice: don't echo secrets.
 - **Remote MCP access.** MCP is localhost-only by design. If you need remote access, stand up a reverse proxy with its own auth in front of `--host 127.0.0.1` and understand that you are now maintaining that remote surface.
 - **Denial of service.** sua does not rate-limit anything. An attacker with the bearer token (i.e., a local user) can hammer `run-agent` until disk or CPU runs out. The local-first threat model considers this a non-goal.
@@ -124,5 +124,6 @@ We respond within a week. There is no bug bounty.
 
 - **v0.4.0** — MCP transport lockdown (loopback bind, bearer token, Host/Origin allowlists, session-to-token binding), cron frequency cap, CI action SHA-pinning, CODEOWNERS.
 - **v0.5.0** — Chain trust propagation (wrap community values, block community→shell), `mcp: true` agent opt-in, this document.
-- **v0.5.1** — Community shell agent gate (`UntrustedCommunityShellError` + `--allow-untrusted-shell`), run-store `chmod 0600`, 30-day retention sweep, opt-in known-prefix secret redaction, `sua agent audit`, `sua doctor --security`.
-- **v0.6.0 (planned)** — Passphrase-based KEK for the secrets store, replacing today's hostname-derived obfuscation.
+- **v0.6.0** — Community shell agent gate (`UntrustedCommunityShellError` + `--allow-untrusted-shell`), run-store `chmod 0600`, 30-day retention sweep, opt-in known-prefix secret redaction, `sua agent audit`, `sua doctor --security`.
+- **v0.6.1** — Community agents are runnable from `sua agent run` / `sua schedule start` directly; the shell gate enforces per-invocation opt-in. Previously the gate lived in the executor but was unreachable from the CLI because community agents weren't in the runnable load set.
+- **v0.7.0 (planned)** — Passphrase-based KEK for the secrets store, replacing today's hostname-derived obfuscation.

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -68,7 +68,7 @@ function buildSecurityChecks(config: ReturnType<typeof loadConfig>): Check[] {
     {
       name: 'Community shell agents',
       run: () => {
-        const { agents } = loadAgents({ directories: dirs.runnable });
+        const { agents } = loadAgents({ directories: dirs.all });
         const offenders = Array.from(agents.values()).filter(
           a => a.type === 'shell' && a.source === 'community',
         );
@@ -85,7 +85,7 @@ function buildSecurityChecks(config: ReturnType<typeof loadConfig>): Check[] {
     {
       name: 'Agents exposed via MCP',
       run: () => {
-        const { agents } = loadAgents({ directories: dirs.runnable });
+        const { agents } = loadAgents({ directories: dirs.all });
         const exposed = Array.from(agents.values()).filter(a => a.mcp === true);
         return {
           ok: true,
@@ -176,7 +176,7 @@ export const doctorCommand = new Command('doctor')
         name: 'Agents directory',
         run: () => {
           const dirs = getAgentDirs(config);
-          const { agents, warnings } = loadAgents({ directories: dirs.runnable });
+          const { agents, warnings } = loadAgents({ directories: dirs.all });
           if (agents.size === 0 && warnings.length > 0) {
             return { ok: false, message: `No agents found (${warnings.length} warning(s))` };
           }
@@ -227,7 +227,7 @@ export const doctorCommand = new Command('doctor')
         name: 'Scheduled agents',
         run: () => {
           const dirs = getAgentDirs(config);
-          const { agents } = loadAgents({ directories: dirs.runnable });
+          const { agents } = loadAgents({ directories: dirs.all });
           const scheduled = Array.from(agents.values()).filter(a => a.schedule);
           if (scheduled.length === 0) {
             return { ok: true, message: 'none' };
@@ -243,7 +243,7 @@ export const doctorCommand = new Command('doctor')
         name: 'Agent secrets',
         run: () => {
           const dirs = getAgentDirs(config);
-          const { agents } = loadAgents({ directories: dirs.runnable });
+          const { agents } = loadAgents({ directories: dirs.all });
           const store = new EncryptedFileStore(getSecretsPath(config));
 
           const declaredSecrets = new Set<string>();

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -34,7 +34,7 @@ mcpCommand
     console.log(chalk.bold('Starting MCP server...'));
     console.log(chalk.dim(`  Host:   ${host}`));
     console.log(chalk.dim(`  Port:   ${port}`));
-    console.log(chalk.dim(`  Agents: ${dirs.runnable.join(', ')}`));
+    console.log(chalk.dim(`  Agents: ${dirs.all.join(', ')}`));
     console.log(chalk.dim(`  DB:     ${dbPath}`));
     console.log(chalk.dim(`  Token:  ${tokenPath}`));
     console.log('');
@@ -67,7 +67,9 @@ mcpCommand
     await startMcpServer({
       port,
       host,
-      agentDirs: dirs.runnable,
+      // MCP sees runnable + catalog; the `mcp: true` filter in tools.ts
+      // decides which agents are actually callable from MCP clients.
+      agentDirs: dirs.all,
       dbPath,
       secretsPath: getSecretsPath(config),
       tokenPath,

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -23,7 +23,9 @@ export const runCommand = new Command('run')
   .action(async (name: string, options: { provider?: string; allowUntrustedShell: string[] }) => {
     const config = loadConfig();
     const dirs = getAgentDirs(config);
-    const { agents } = loadAgents({ directories: dirs.runnable });
+    // Include community catalog so community agents are runnable; the shell
+    // gate in `executeAgent` enforces per-agent opt-in via --allow-untrusted-shell.
+    const { agents } = loadAgents({ directories: dirs.all });
 
     const agent = agents.get(name);
     if (!agent) {

--- a/packages/cli/src/commands/schedule.ts
+++ b/packages/cli/src/commands/schedule.ts
@@ -14,7 +14,7 @@ scheduleCommand
   .action(() => {
     const config = loadConfig();
     const dirs = getAgentDirs(config);
-    const { agents } = loadAgents({ directories: dirs.runnable });
+    const { agents } = loadAgents({ directories: dirs.all });
 
     const scheduled = Array.from(agents.values()).filter(a => a.schedule);
     if (scheduled.length === 0) {
@@ -44,7 +44,7 @@ scheduleCommand
   .action((name: string) => {
     const config = loadConfig();
     const dirs = getAgentDirs(config);
-    const { agents } = loadAgents({ directories: dirs.runnable });
+    const { agents } = loadAgents({ directories: dirs.all });
     const agent = agents.get(name);
     if (!agent) {
       console.error(chalk.red(`Agent "${name}" not found.`));
@@ -79,7 +79,9 @@ scheduleCommand
   .action(async (options: { allowUntrustedShell: string[] }) => {
     const config = loadConfig();
     const dirs = getAgentDirs(config);
-    const { agents, warnings } = loadAgents({ directories: dirs.runnable });
+    // Load runnable + catalog so community agents can fire on schedule;
+    // the shell gate in executeAgent enforces per-agent opt-in.
+    const { agents, warnings } = loadAgents({ directories: dirs.all });
 
     for (const w of warnings) {
       console.error(chalk.yellow(`Warning: ${w.file}: ${w.message}`));

--- a/packages/cli/src/commands/secrets.ts
+++ b/packages/cli/src/commands/secrets.ts
@@ -132,7 +132,7 @@ secretsCommand
   .action(async (agentName: string) => {
     const config = loadConfig();
     const dirs = getAgentDirs(config);
-    const { agents } = loadAgents({ directories: dirs.runnable });
+    const { agents } = loadAgents({ directories: dirs.all });
 
     const agent = agents.get(agentName);
     if (!agent) {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -56,11 +56,21 @@ export function resolveProvider(config: SuaConfig, override?: string): 'local' |
   return choice;
 }
 
-export function getAgentDirs(config: SuaConfig): { runnable: string[]; catalog: string[] } {
+export function getAgentDirs(config: SuaConfig): {
+  /** Agents the user authored or ships with sua. No gate needed. */
+  runnable: string[];
+  /** Third-party community agents. Visible in `agent list --catalog`; runnable with the shell gate. */
+  catalog: string[];
+  /** Union of `runnable` + `catalog`. Use this for any command that executes an agent — the shell gate in `executeAgent` handles trust enforcement. */
+  all: string[];
+} {
   const base = resolve(config.agentsDir);
+  const runnable = [join(base, 'examples'), join(base, 'local')];
+  const catalog = [join(base, 'community')];
   return {
-    runnable: [join(base, 'examples'), join(base, 'local')],
-    catalog: [join(base, 'community')],
+    runnable,
+    catalog,
+    all: [...runnable, ...catalog],
   };
 }
 


### PR DESCRIPTION
## Summary

v0.6.0 shipped a community-shell-agent gate in `executeAgent` that throws `UntrustedCommunityShellError` without an explicit opt-in. The gate is correct and unit-tested. But the primary CLI surface — `sua agent run` — never reached it: the command loaded only `dirs.runnable` (examples + local), so a community agent came back as "not found" before the executor could refuse it.

**Manual repro on v0.6.0:**

```
sua init && mkdir -p agents/community
# drop a community yaml with type: shell
sua agent list --catalog     # ✓ the community agent shows up
sua agent run <name>         # ✗ "Agent not found"
sua agent run <name> --allow-untrusted-shell <name>   # ✗ still "not found"
```

So the v0.6.0 shell gate was effectively dead code for the primary CLI flow. It still fired for Temporal activities (`activities.test.ts`) and for chain execution (`chain-executor.test.ts`), both green in CI, but not for the most common path.

## The fix

One plumbing change in the CLI layer: `getAgentDirs(config)` now returns an `all` property that unions `runnable` + `catalog`, and every runtime command uses it. The shell gate in `executeAgent` handles trust enforcement. The discovery verb (`sua agent list`) keeps its runnable-vs-`--catalog` split so users can tell their own agents apart from the community catalog.

**After this PR:**

```
sua agent run <name>                                  # refuses with concrete --allow-untrusted-shell hint
sua agent run <name> --allow-untrusted-shell <name>   # runs
```

## Commands updated

| File | Callsites |
|---|---|
| `run.ts` | 1 — main lookup |
| `schedule.ts` | 3 — list, validate, start |
| `mcp.ts` | 2 — status print + server `agentDirs` (the `mcp: true` filter in `tools.ts` still gates MCP visibility) |
| `doctor.ts` | 5 — all agent-loading checks |
| `secrets.ts` | 1 — `secrets check <agent>` |
| `list.ts` | **unchanged** — split is intentional for discovery |
| `audit.ts` | **unchanged** — already loads both |

## Docs cleanup bundled in

While I was in the files: fix the stale `v0.5.1` labels in `docs/SECURITY.md` and README. The plan predicted 0.5.1; the changeset was tagged `minor`, so 0.5.0 → 0.6.0. Future passphrase-KEK work renumbered to `v0.7.0`. New `v0.6.1` entry in SECURITY.md's version history documents this wiring fix explicitly.

## Test plan

- [x] `npm test` — 162 tests still pass
- [x] Manual: `sua agent run <community-shell>` → refuses with the gate message
- [x] Manual: same with `--allow-untrusted-shell <name>` → runs
- [ ] After merge + publish (0.6.1): re-run the test plan in your prior message and confirm section 6 (community shell gate) passes end-to-end

## Not changed

- No new tests — the gate itself is already covered at three layers (executor, provider, Temporal activity). The fix is purely CLI plumbing. If we want belt-and-suspenders, I can add a smoke test that spawns the CLI and asserts the error; let me know.
- No API changes to `@some-useful-agents/core`.
- Patch bump (`0.6.1`) since the user-visible behavior is "the thing the docs said now works."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
