### PR TITLE
ci: auto-run CI on changeset-release/main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,16 @@
 name: CI
 
 on:
+  # Run on direct pushes to main and on any pull_request targeting main.
+  #
+  # We also run on pushes to `changeset-release/main` so the Release PR
+  # that changesets/action opens gets CI status checks automatically.
+  # PRs opened by `github-actions[bot]` don't trigger `pull_request`
+  # workflows (GitHub prevents action-from-action loops), but the bot's
+  # *push* to the release branch is a normal push event and surfaces
+  # the checks on the PR without requiring a close+reopen dance.
   push:
-    branches: [main]
+    branches: [main, changeset-release/main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary

One-line CI trigger change so each changesets release PR gets status checks automatically. No more close+reopen dance.

## Problem

GitHub suppresses `pull_request` workflows on PRs opened by `github-actions[bot]` — an anti-loop guard. Every release PR (#22, #27, #29, soon #31) required manually closing and reopening the PR to get checks to appear.

## Fix

Add `changeset-release/main` to the `push.branches` list in `.github/workflows/ci.yml`. The bot's *push* to the release branch is a normal push event and not suppressed; GitHub attaches the workflow runs to the commit SHA, which surfaces as status checks on any PR pointing at that SHA.

```yaml
on:
  push:
    branches: [main, changeset-release/main]   # ← added
  pull_request:
    branches: [main]
```

## Why this vs alternatives

- **PAT**: works but adds a long-lived secret to rotate, scopes it to one user.
- **GitHub App**: best practice for large orgs but overkill here.
- **Push trigger (this PR)**: zero new secrets, zero ongoing maintenance. Only changesets writes to `changeset-release/main` so no spurious triggers.

## Test plan

- [x] YAML parses (tsc / lint unaffected; GitHub validates on push)
- [ ] Next release PR after this merges gets checks automatically — the live test is the open release PR #31. Merge this first, then check #31 shows status checks without manual intervention.

Repo-level only. No package code, no changeset, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)