### PR TITLE
feat(cli): sua agent new — interactive agent scaffolder (v0.7.0)

### DIFF
--- a/.changeset/sua-agent-new.md
+++ b/.changeset/sua-agent-new.md
@@ -1,0 +1,55 @@
+---
+"@some-useful-agents/cli": minor
+"@some-useful-agents/core": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+**feat: `sua agent new` — interactive agent scaffolder.** Graduates users from "I ran an example" to "I authored an agent" without hand-writing YAML. Closes the *Interactive agent creator* roadmap item.
+
+### What it does
+
+`sua agent new` walks through a short prompt flow:
+
+1. **Type** — shell or claude-code (default shell)
+2. **Name** — validated against `[a-z0-9-]+` at prompt time
+3. **Description** — optional one-liner
+4. **Command** (shell) or **Prompt + Model** (claude-code)
+5. **Customize more?** — gate to the advanced fields
+   - Timeout (default 300s)
+   - Cron schedule (5-field; the v0.4.0 frequency cap still applies)
+   - Secrets (comma-separated uppercase names; invalid ones are ignored with a warning)
+   - `mcp: true` opt-in for Claude Desktop exposure
+   - `redactSecrets: true` for known-prefix scrubbing of output
+6. **Preview + confirm** — prints the resolved YAML, asks before writing
+7. **Write** — lands in `agents/local/<name>.yaml`, chmod-safe, overwrite-guarded
+
+Every emitted YAML is validated against `agentDefinitionSchema` *before* the file is written — if validation fails (shouldn't, given the prompt guards), the command exits 1 without side effects.
+
+### Why now
+
+The security PRs (v0.4.0 → v0.6.1) added fields to the schema that are easy to forget by hand: `mcp`, `allowHighFrequency`, `redactSecrets`. Having the creator land *after* those PRs means the prompt flow covers the full schema from day one, rather than being retrofitted.
+
+### Implementation notes
+
+- Pure `buildAgentYaml(answers)` function is exported for testing — given an answers object, it emits deterministic, validated YAML with a stable key order (identity → type → execution → scheduling → capabilities).
+- Interactive flow uses `node:readline/promises`, matching the pattern already in `sua tutorial`. No new prompt-library dependency.
+- The command is read-only until the user confirms at the very end, so Ctrl-C at any stage leaves the filesystem untouched.
+
+### Tests
+
+14 new tests in `packages/cli/src/commands/new.test.ts`:
+
+- YAML round-trips through `yaml.parse` to the expected object (shell + claude-code minimums).
+- Key order is semantic and stable.
+- Optional fields are omitted when not set; `mcp: false` / `redactSecrets: false` don't clutter the output.
+- Shell and claude-code fields don't leak into each other.
+- Every emitted YAML parses AND validates through `agentDefinitionSchema` (parameterized across several answer shapes).
+- Schedules emitted by the creator pass the v0.4.0 cron frequency cap.
+
+176 total tests pass.
+
+### Follow-up (not in this PR)
+
+The tutorial's "now make your own" stage-6 wrapper — the thing that invokes this verb from inside `sua tutorial` — stays on the roadmap. It's a guided wrapper around this verb, not a new capability; making `sua agent new` a first-class verb means it's reusable outside the tutorial too.

--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@ The tutorial walks you through what sua is, builds a real agent that fetches a d
 ```bash
 sua agent list                # runnable agents (examples + local)
 sua agent list --catalog      # browse the community catalog
+sua agent new                 # interactive scaffold → writes agents/local/<name>.yaml
 sua agent run <name>          # run an agent once
 sua agent status [runId]      # recent runs, or one specific run
 sua agent logs <runId>        # stdout/stderr of a past run
 sua agent cancel <runId>      # kill a running agent
+sua agent audit <name>        # print resolved YAML (use before --allow-untrusted-shell)
 ```
 
 **Scheduling**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 A living document of where `some-useful-agents` is heading. Light on detail, heavy
 on direction.
 
-## Now (v0.4.0 shipped, v0.5.0 in flight)
+## Now (v0.7.0 shipped)
 
 - **Onboarding walkthrough** — `sua tutorial` walks new users through 5 stages
   ending in a real, scheduled agent (dad-joke from icanhazdadjoke.com). Claude or
@@ -18,6 +18,21 @@ on direction.
   with bearer-token auth in `~/.sua/mcp-token`, Host/Origin allowlists to
   defeat DNS rebinding, and session-to-token binding so `sua mcp rotate-token`
   cannot be hijacked. Closes the largest item from the `/cso` audit.
+- **Chain trust + MCP agent scope (v0.5.0)** — community agent output flowing
+  into claude-code downstreams is wrapped in UNTRUSTED delimiters; community
+  shell downstream is refused unless explicitly allow-listed. MCP only exposes
+  agents that opt in via `mcp: true` in their YAML. Full threat model at
+  `docs/SECURITY.md`.
+- **Community shell gate + run-store hygiene (v0.6.0/v0.6.1)** — community
+  shell agents refuse to run without `--allow-untrusted-shell <name>`.
+  `data/runs.db` is chmod 0o600 with a 30-day retention sweep. Opt-in
+  `redactSecrets: true` scrubs known-prefix tokens (AWS, GitHub PAT, OpenAI,
+  Slack) from captured output. New `sua agent audit` and `sua doctor --security`
+  verbs for self-inspection.
+- **Interactive agent creator (v0.7.0)** — `sua agent new` walks through type,
+  name, description, command/prompt, and optional advanced fields
+  (timeout, schedule, secrets, `mcp:`, `redactSecrets`), validates via
+  `agentDefinitionSchema`, and writes to `agents/local/<name>.yaml`.
 
 ## Next (3–6 months)
 
@@ -41,15 +56,10 @@ on direction.
   pipeline users.
 - **Tutorial resume** — save tutorial progress so re-running `sua tutorial` picks
   up at the last completed stage rather than restarting the prose from stage 1.
-- **Interactive agent creator** — `sua agent new` walks through type
-  (shell vs claude-code), name, description, command/prompt, optional
-  schedule, optional secrets, MCP exposure (`mcp: true`), and writes a
-  validated YAML to `agents/local/`. Validates against
-  `agentDefinitionSchema` before writing so users can't end up with
-  broken YAML. Tutorial gets a stage 6 that wraps this verb as the
-  "now make your own" graduation step. Lands after the security PRs
-  so the new schema fields (`mcp`, `allowHighFrequency`, future trust
-  flags) are baked into the prompt flow from day one.
+- **Tutorial "make your own" stage** — `sua tutorial` currently ends after
+  scheduling the dad joke. Add a stage 6 that wraps `sua agent new` so users
+  graduate from "ran examples" to "authored one myself" without leaving the
+  walkthrough. The verb shipped in v0.7.0; this is the guided wrapper.
 - **Parallel agents / swarms** — the chain-executor runs sequentially even for
   independent DAG nodes. First-class fan-out/fan-in (e.g., `parallel: [A, B, C]`
   YAML field) plus Temporal worker scaling. Separately consider whether

--- a/packages/cli/src/commands/new.test.ts
+++ b/packages/cli/src/commands/new.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { parse as yamlParse } from 'yaml';
+import { agentDefinitionSchema } from '@some-useful-agents/core';
+import { buildAgentYaml, type AgentAnswers } from './new.js';
+
+function shell(overrides: Partial<AgentAnswers> = {}): AgentAnswers {
+  return {
+    name: 'my-agent',
+    type: 'shell',
+    command: 'echo hi',
+    ...overrides,
+  };
+}
+
+function claude(overrides: Partial<AgentAnswers> = {}): AgentAnswers {
+  return {
+    name: 'my-claude-agent',
+    type: 'claude-code',
+    prompt: 'Say hi.',
+    ...overrides,
+  };
+}
+
+describe('buildAgentYaml', () => {
+  it('emits a minimum-viable shell agent', () => {
+    const yaml = buildAgentYaml(shell());
+    const parsed = yamlParse(yaml);
+    expect(parsed).toEqual({ name: 'my-agent', type: 'shell', command: 'echo hi' });
+  });
+
+  it('emits a minimum-viable claude-code agent', () => {
+    const yaml = buildAgentYaml(claude());
+    const parsed = yamlParse(yaml);
+    expect(parsed).toEqual({ name: 'my-claude-agent', type: 'claude-code', prompt: 'Say hi.' });
+  });
+
+  it('orders keys: identity → type → execution → schedule → capabilities', () => {
+    const yaml = buildAgentYaml(
+      shell({
+        description: 'does a thing',
+        timeout: 60,
+        schedule: '0 9 * * *',
+        secrets: ['MY_KEY'],
+        mcp: true,
+        redactSecrets: true,
+      }),
+    );
+    const lines = yaml
+      .split('\n')
+      .filter(l => l && !l.startsWith(' ') && !l.startsWith('-'))
+      .map(l => l.split(':')[0]);
+    expect(lines).toEqual([
+      'name',
+      'description',
+      'type',
+      'command',
+      'timeout',
+      'schedule',
+      'secrets',
+      'mcp',
+      'redactSecrets',
+    ]);
+  });
+
+  it('skips optional fields when not set', () => {
+    const yaml = buildAgentYaml(shell({ description: undefined }));
+    expect(yaml).not.toContain('description');
+    expect(yaml).not.toContain('schedule');
+    expect(yaml).not.toContain('secrets');
+    expect(yaml).not.toContain('mcp:');
+    expect(yaml).not.toContain('redactSecrets');
+  });
+
+  it('drops mcp and redactSecrets when false', () => {
+    const yaml = buildAgentYaml(shell({ mcp: false, redactSecrets: false }));
+    expect(yaml).not.toContain('mcp:');
+    expect(yaml).not.toContain('redactSecrets');
+  });
+
+  it('includes model only for claude-code agents that specify one', () => {
+    const withModel = buildAgentYaml(claude({ model: 'claude-sonnet-4-20250514' }));
+    expect(withModel).toContain('model: claude-sonnet-4-20250514');
+    const withoutModel = buildAgentYaml(claude({ model: undefined }));
+    expect(withoutModel).not.toContain('model:');
+  });
+
+  it('does not leak shell fields into a claude-code agent', () => {
+    const yaml = buildAgentYaml(claude({ command: 'oops', prompt: 'do X' }));
+    const parsed = yamlParse(yaml);
+    expect(parsed.command).toBeUndefined();
+    expect(parsed.prompt).toBe('do X');
+  });
+
+  it('does not leak claude-code fields into a shell agent', () => {
+    const yaml = buildAgentYaml(shell({ prompt: 'oops', model: 'oops', command: 'echo hi' }));
+    const parsed = yamlParse(yaml);
+    expect(parsed.prompt).toBeUndefined();
+    expect(parsed.model).toBeUndefined();
+    expect(parsed.command).toBe('echo hi');
+  });
+
+  it('serializes secrets as a YAML list', () => {
+    const yaml = buildAgentYaml(shell({ secrets: ['A', 'B'] }));
+    // yaml package may emit either block or flow style; assert round-trip
+    const parsed = yamlParse(yaml);
+    expect(parsed.secrets).toEqual(['A', 'B']);
+  });
+});
+
+describe('buildAgentYaml → agentDefinitionSchema round-trip', () => {
+  // The creator's promise is "we won't write a YAML the loader would reject."
+  // Every emitted YAML must parse AND validate.
+
+  it.each<[string, AgentAnswers]>([
+    ['minimum shell', shell()],
+    ['minimum claude-code', claude()],
+    ['shell with everything', shell({
+      description: 'kitchen sink',
+      timeout: 45,
+      schedule: '*/30 * * * *',
+      secrets: ['TOKEN_A', 'TOKEN_B'],
+      mcp: true,
+      redactSecrets: true,
+    })],
+    ['claude-code with model + schedule', claude({
+      model: 'claude-sonnet-4-20250514',
+      timeout: 120,
+      schedule: '0 8 * * 1-5',
+      mcp: true,
+    })],
+  ])('%s parses and validates', (_label, answers) => {
+    const yaml = buildAgentYaml(answers);
+    const parsed = yamlParse(yaml);
+    const result = agentDefinitionSchema.safeParse({
+      ...parsed,
+      timeout: parsed.timeout ?? 300,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('emits a schedule that passes the v0.4.0 frequency cap', () => {
+    const yaml = buildAgentYaml(shell({ schedule: '* * * * *' }));
+    const parsed = yamlParse(yaml);
+    const result = agentDefinitionSchema.safeParse({ ...parsed, timeout: 300 });
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -1,0 +1,277 @@
+import { Command } from 'commander';
+import { createInterface, type Interface as Rl } from 'node:readline/promises';
+import { existsSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import chalk from 'chalk';
+import { stringify as yamlStringify } from 'yaml';
+import { agentDefinitionSchema } from '@some-useful-agents/core';
+import { loadConfig, getAgentDirs } from '../config.js';
+
+export interface AgentAnswers {
+  name: string;
+  description?: string;
+  type: 'shell' | 'claude-code';
+  command?: string;
+  prompt?: string;
+  model?: string;
+  timeout?: number;
+  schedule?: string;
+  secrets?: string[];
+  mcp?: boolean;
+  redactSecrets?: boolean;
+}
+
+/**
+ * Build a YAML document for an agent given a set of prompt answers.
+ *
+ * Pure function so it can be unit-tested without running the interactive
+ * flow. Key order is stable and semantic (identity first, execution next,
+ * scheduling third, capabilities last) so generated files read the same
+ * as hand-written ones.
+ */
+export function buildAgentYaml(answers: AgentAnswers): string {
+  const doc: Record<string, unknown> = { name: answers.name };
+  if (answers.description) doc.description = answers.description;
+  doc.type = answers.type;
+  if (answers.type === 'shell' && answers.command) {
+    doc.command = answers.command;
+  }
+  if (answers.type === 'claude-code' && answers.prompt) {
+    doc.prompt = answers.prompt;
+    if (answers.model) doc.model = answers.model;
+  }
+  if (typeof answers.timeout === 'number') doc.timeout = answers.timeout;
+  if (answers.schedule) doc.schedule = answers.schedule;
+  if (answers.secrets && answers.secrets.length > 0) doc.secrets = answers.secrets;
+  if (answers.mcp) doc.mcp = true;
+  if (answers.redactSecrets) doc.redactSecrets = true;
+  return yamlStringify(doc);
+}
+
+const NAME_RE = /^[a-z0-9-]+$/;
+const SECRET_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
+
+async function askNonEmpty(rl: Rl, prompt: string): Promise<string> {
+  while (true) {
+    const answer = (await rl.question(prompt)).trim();
+    if (answer) return answer;
+    console.log(chalk.red('  Required.'));
+  }
+}
+
+async function askYesNo(rl: Rl, prompt: string, defaultYes = false): Promise<boolean> {
+  const suffix = defaultYes ? ' [Y/n] ' : ' [y/N] ';
+  const raw = (await rl.question(prompt + suffix)).trim().toLowerCase();
+  if (!raw) return defaultYes;
+  return raw === 'y' || raw === 'yes';
+}
+
+export const newCommand = new Command('new')
+  .description('Interactively scaffold a new agent YAML under agents/local/')
+  .action(async () => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    try {
+      await runInteractive(rl);
+    } finally {
+      rl.close();
+    }
+  });
+
+async function runInteractive(rl: Rl): Promise<void> {
+  console.log('');
+  console.log(chalk.bold('sua agent new') + chalk.dim(' — scaffold a new local agent'));
+  console.log(chalk.dim('  Ctrl-C to abort. Nothing is written until you confirm at the end.'));
+  console.log('');
+
+  // 1. Type
+  const typeRaw = (await rl.question(
+    'Agent type:\n' +
+      '  [1] shell        — runs a bash command\n' +
+      '  [2] claude-code  — runs a Claude Code prompt (requires claude CLI)\n' +
+      chalk.dim('  Choice (1/2) [1]: '),
+  )).trim();
+  const type: AgentAnswers['type'] =
+    typeRaw === '2' || typeRaw.startsWith('c') ? 'claude-code' : 'shell';
+  console.log(chalk.dim(`  → ${type}`));
+  console.log('');
+
+  // 2. Name
+  let name = '';
+  while (!name) {
+    const raw = await askNonEmpty(rl, 'Agent name (lowercase, hyphens only, e.g. my-agent): ');
+    if (!NAME_RE.test(raw)) {
+      console.log(chalk.red('  Must match /^[a-z0-9-]+$/ — lowercase letters, digits, hyphens only.'));
+      continue;
+    }
+    name = raw;
+  }
+
+  // 3. Description
+  const descriptionRaw = (await rl.question(
+    'One-line description (optional, press Enter to skip): ',
+  )).trim();
+  const description = descriptionRaw || undefined;
+
+  // 4. Command or prompt
+  let command: string | undefined;
+  let prompt: string | undefined;
+  let model: string | undefined;
+  if (type === 'shell') {
+    command = await askNonEmpty(rl, 'Shell command to run: ');
+  } else {
+    prompt = await askNonEmpty(rl, 'Prompt (single line; edit the YAML afterwards for multi-line): ');
+    const modelRaw = (await rl.question(
+      'Model (optional, e.g. claude-sonnet-4-20250514 — press Enter for default): ',
+    )).trim();
+    model = modelRaw || undefined;
+  }
+
+  // 5. Advanced fields gate
+  const wantAdvanced = await askYesNo(
+    rl,
+    '\nCustomize more (timeout, schedule, secrets, MCP, redaction)?',
+    false,
+  );
+
+  let timeout: number | undefined;
+  let schedule: string | undefined;
+  let secrets: string[] | undefined;
+  let mcp = false;
+  let redactSecrets = false;
+
+  if (wantAdvanced) {
+    console.log('');
+
+    // Timeout
+    const timeoutRaw = (await rl.question(
+      'Timeout in seconds [300]: ',
+    )).trim();
+    if (timeoutRaw) {
+      const n = Number(timeoutRaw);
+      if (!Number.isFinite(n) || n <= 0) {
+        console.log(chalk.yellow(`  Ignoring invalid timeout "${timeoutRaw}"; leaving default.`));
+      } else {
+        timeout = Math.floor(n);
+      }
+    }
+
+    // Schedule
+    schedule = (await rl.question(
+      'Cron schedule (optional 5-field, e.g. "0 9 * * *", blank for manual-only): ',
+    )).trim() || undefined;
+
+    // Secrets
+    const secretsRaw = (await rl.question(
+      'Secrets this agent needs (comma-separated names like MY_API_KEY, blank for none): ',
+    )).trim();
+    if (secretsRaw) {
+      const names = secretsRaw.split(',').map(s => s.trim()).filter(Boolean);
+      const bad = names.filter(n => !SECRET_NAME_RE.test(n));
+      if (bad.length > 0) {
+        console.log(
+          chalk.yellow(
+            `  Ignoring invalid secret name(s): ${bad.join(', ')} (must be UPPERCASE_WITH_UNDERSCORES)`,
+          ),
+        );
+      }
+      const good = names.filter(n => SECRET_NAME_RE.test(n));
+      if (good.length > 0) secrets = good;
+    }
+
+    // MCP
+    mcp = await askYesNo(rl, 'Expose via MCP (callable from Claude Desktop etc.)?', false);
+
+    // Redact
+    redactSecrets = await askYesNo(
+      rl,
+      'Scrub known-prefix secrets (AWS, GitHub PAT, OpenAI, Slack) from captured output?',
+      false,
+    );
+  }
+
+  const answers: AgentAnswers = {
+    name,
+    description,
+    type,
+    command,
+    prompt,
+    model,
+    timeout,
+    schedule,
+    secrets,
+    mcp,
+    redactSecrets,
+  };
+
+  // Validate via the same schema the loader uses. Should never fail given
+  // the prompt guards, but better to catch here than at load time.
+  const parsed = agentDefinitionSchema.safeParse({
+    name: answers.name,
+    description: answers.description,
+    type: answers.type,
+    command: answers.command,
+    prompt: answers.prompt,
+    model: answers.model,
+    timeout: answers.timeout ?? 300,
+    schedule: answers.schedule,
+    secrets: answers.secrets,
+    mcp: answers.mcp ?? false,
+    redactSecrets: answers.redactSecrets ?? false,
+  });
+  if (!parsed.success) {
+    console.error('');
+    console.error(chalk.red('Validation failed. This is a bug — please report:'));
+    for (const issue of parsed.error.issues) {
+      console.error(chalk.red(`  ${issue.path.join('.')}: ${issue.message}`));
+    }
+    process.exit(1);
+  }
+
+  const yamlText = buildAgentYaml(answers);
+
+  console.log('');
+  console.log(chalk.bold('Preview:'));
+  console.log(chalk.dim('---'));
+  process.stdout.write(yamlText);
+  console.log(chalk.dim('---'));
+  console.log('');
+
+  // Destination
+  const config = loadConfig();
+  const dirs = getAgentDirs(config);
+  // First entry of runnable is examples; agents/local is second.
+  const localDir = dirs.runnable[1];
+  const destPath = join(localDir, `${name}.yaml`);
+
+  if (existsSync(destPath)) {
+    const overwrite = await askYesNo(
+      rl,
+      chalk.yellow(`${destPath} already exists. Overwrite?`),
+      false,
+    );
+    if (!overwrite) {
+      console.log(chalk.yellow('Aborted. No file written.'));
+      return;
+    }
+  } else {
+    const confirm = await askYesNo(rl, `Write to ${destPath}?`, true);
+    if (!confirm) {
+      console.log(chalk.yellow('Aborted. No file written.'));
+      return;
+    }
+  }
+
+  if (!existsSync(localDir)) mkdirSync(localDir, { recursive: true });
+  writeFileSync(destPath, yamlText, 'utf-8');
+  console.log(chalk.green(`✓ Created ${destPath}`));
+  console.log('');
+  console.log(chalk.bold('Next:'));
+  console.log(`  ${chalk.cyan(`sua agent run ${name}`)}        ${chalk.dim('run it once')}`);
+  if (schedule) {
+    console.log(`  ${chalk.cyan('sua schedule start')}       ${chalk.dim(`fire on cron "${schedule}"`)}`);
+  }
+  if (mcp) {
+    console.log(`  ${chalk.cyan('sua mcp start')}            ${chalk.dim('expose via MCP')}`);
+  }
+  console.log(`  ${chalk.cyan(`sua agent audit ${name}`)}     ${chalk.dim('inspect the generated YAML')}`);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,6 +13,7 @@ import { statusCommand } from './commands/status.js';
 import { logsCommand } from './commands/logs.js';
 import { cancelCommand } from './commands/cancel.js';
 import { auditCommand } from './commands/audit.js';
+import { newCommand } from './commands/new.js';
 import { initCommand } from './commands/init.js';
 import { doctorCommand } from './commands/doctor.js';
 import { mcpCommand } from './commands/mcp.js';
@@ -39,6 +40,7 @@ const agent = program
   .description('Manage and run agents');
 
 agent.addCommand(listCommand);
+agent.addCommand(newCommand);
 agent.addCommand(runCommand);
 agent.addCommand(statusCommand);
 agent.addCommand(logsCommand);


### PR DESCRIPTION
## Summary

`sua agent new` — interactive agent scaffolder. Graduates users from "I ran an example" to "I authored an agent" without hand-writing YAML. Closes the *Interactive agent creator* roadmap item.

## Prompt flow

```
type (shell | claude-code) → name → description → command / prompt+model
→ customize more? [y/N]
  ↳ timeout, schedule, secrets, mcp, redactSecrets
→ preview → confirm → write to agents/local/<name>.yaml
```

Every emitted YAML is validated against `agentDefinitionSchema` **before** the file is written. If validation fails (shouldn't, given the prompt guards), the command exits 1 with zero side effects. Ctrl-C at any prompt stage also leaves the filesystem untouched.

## Why now

The security PRs (v0.4.0 → v0.6.1) added schema fields that are easy to forget by hand: `mcp`, `allowHighFrequency`, `redactSecrets`. Having the creator land *after* those means the prompt flow covers the full schema from day one.

## Design decisions

- **Pure `buildAgentYaml(answers)` exported for testing.** Given an answers object, emits deterministic YAML with stable key order: identity → type → execution → scheduling → capabilities.
- **No new prompt dep.** Interactive flow uses `node:readline/promises`, matching the existing `sua tutorial` pattern.
- **Schedules default to safe.** 5-field cron only at the prompt level; a 6-field expression would be caught by the schema cap before write.
- **Overwrite-guarded.** Existing target prompts for confirmation.
- **Secret names validated at input.** Invalid ones are dropped with a warning; valid ones go into the `secrets:` list.

## Tests

14 new in `packages/cli/src/commands/new.test.ts`:

- YAML round-trips through `yaml.parse` to the expected object (shell + claude-code minimums)
- Key order is semantic and stable
- Optional fields omitted when not set; `mcp: false` / `redactSecrets: false` don't clutter the output
- Shell and claude-code fields don't leak into each other
- Parameterized round-trip: every emitted YAML parses AND validates through `agentDefinitionSchema`
- Schedules emitted by the creator pass the v0.4.0 cron frequency cap

**176 total tests pass** (was 162; +14).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm test` — 176 pass
- [x] `sua agent new --help` registers in the `sua agent` subcommand list
- [ ] After merge + publish: `sua agent new` runs interactively on a TTY and produces a runnable agent

## Docs

- **README** "Commands at a glance" gains `sua agent new` and (while I was there) `sua agent audit` which had been missing since v0.6.0.
- **ROADMAP** moves *Interactive agent creator* from "Next" to "Now" (shipped). Replaces it in "Next" with a narrower *Tutorial stage 6 wraps `sua agent new`* item. Also promotes the v0.5.0 and v0.6.0/v0.6.1 security milestones to the "Now" shipped list so the roadmap reflects reality.

## Follow-up (deliberately NOT in this PR)

The tutorial's "now make your own" stage 6 that wraps this verb from inside `sua tutorial`. Keeping them separate so the verb is reusable outside the tutorial — a user who finished the walkthrough last week shouldn't have to re-run it to make their 4th agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
