### PR TITLE
feat(cli): visual polish pass — one voice, one look (v0.8.0)

### DIFF
--- a/.changeset/cli-polish.md
+++ b/.changeset/cli-polish.md
@@ -1,0 +1,53 @@
+---
+"@some-useful-agents/cli": minor
+"@some-useful-agents/core": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+**feat(cli): visual polish pass across every command.** One voice, one look. No behavior changes, no API changes.
+
+### What shipped
+
+- **New `packages/cli/src/ui.ts`** — shared helpers (`ui.ok`, `ui.fail`, `ui.warn`, `ui.info`, `ui.step`, `ui.section`, `ui.banner`, `ui.outputFrame`, `ui.kv`, inline helpers `ui.agent`/`ui.cmd`/`ui.dim`/`ui.id`). Every command now routes its status lines through these helpers instead of reaching for `chalk.green/red/yellow` directly.
+- **Unified emoji symbol set** — ✅ success, ❌ failure, ⚠️ warning, 💡 info, 🚀 next-step. Tutorial's 🎭 dad-joke flourish preserved. Output looks the same whether you run `sua init`, `sua doctor --security`, or `sua agent new`.
+- **Boxed daemon banners** — `sua mcp start`, `sua schedule start`, and `sua worker start` now print a `boxen` banner with the config details instead of loose dim-text lines. Adds one new dep (`boxen@^8`, ~8KB, no surprises).
+- **Custom top-level `sua --help`** — now includes an Examples block and pointers to `docs/SECURITY.md` + the repo. `showHelpAfterError(true)` so unknown commands print help automatically.
+- **Unified output frame** — `sua agent run` and `sua agent logs` both wrap captured stdout in `╭── output ──╮ / ╰────────────╯` (was duplicated ad-hoc dim dashes in both files).
+- **`sua agent audit` key/value rows** go through `ui.kv()` instead of a command-local `row()` helper.
+- **`STATUS_COLORS` centralized** — moved from `commands/status.ts` to `ui.ts` so `status`, `schedule`, and future surfaces agree on what color a `running` / `pending` / `failed` run is.
+
+### Files touched
+
+**New:**
+- `packages/cli/src/ui.ts`
+- `packages/cli/src/ui.test.ts` — 20 tests, pure stdout capture, covers every helper.
+
+**Modified (every command):**
+- `packages/cli/package.json` — add `boxen` dep
+- `packages/cli/src/index.ts` — Examples block + `showHelpAfterError`
+- All 13 command files: `init.ts`, `list.ts`, `status.ts`, `run.ts`, `cancel.ts`, `logs.ts`, `mcp.ts`, `schedule.ts`, `worker.ts`, `secrets.ts`, `doctor.ts`, `audit.ts`, `new.ts`, `tutorial.ts`
+
+### Tests
+
+196 total (was 176; +20 new in `ui.test.ts`). Zero existing tests changed — the polish doesn't alter any assertable behavior. Lint + build clean.
+
+### User-visible diffs
+
+- Every success line is now `✅  Created foo.yaml` instead of green-only `Created foo.yaml`.
+- Every error line is `❌  Agent "foo" not found.` instead of `Error: Agent ...` / bare red.
+- Every warning is `⚠️  ...` instead of `Warning: ...`.
+- `sua mcp start` / `sua schedule start` / `sua worker start` print a cyan-bordered banner with host/port/paths.
+- `sua --help` ends with an Examples block.
+- Run output is framed in a unicode box.
+
+If you were grepping command output in scripts (you shouldn't be), those strings changed. No machine-readable output was altered (JSON / tables / exit codes are all identical).
+
+### Non-goals
+
+Deferred — not in this PR:
+- Switching `readline/promises` → `@inquirer/prompts` for `sua agent new` / `sua tutorial` (UX shift, separate design pass).
+- Timing info on `sua agent run` (`"completed in 2.3s"`).
+- Progress bars for long chains.
+- Themeable colors via config.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "some-useful-agents",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "some-useful-agents",
-      "version": "0.1.0",
+      "version": "0.0.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -2749,6 +2749,15 @@
         "ajv": "^8.8.2"
       }
     },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -2862,6 +2871,80 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/boxen": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+      "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^8.0.0",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^7.2.0",
+        "type-fest": "^4.21.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/boxen/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -2962,6 +3045,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001787",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
@@ -3035,6 +3130,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-cursor": {
@@ -5874,6 +5981,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -6287,6 +6406,44 @@
         "node": ">=8"
       }
     },
+    "node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -6402,12 +6559,13 @@
     },
     "packages/cli": {
       "name": "@some-useful-agents/cli",
-      "version": "0.2.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@some-useful-agents/core": "*",
         "@some-useful-agents/mcp-server": "*",
         "@some-useful-agents/temporal-provider": "*",
+        "boxen": "^8.0.0",
         "chalk": "^5.4.0",
         "cli-table3": "^0.6.5",
         "commander": "^13.1.0",
@@ -6422,7 +6580,7 @@
     },
     "packages/core": {
       "name": "@some-useful-agents/core",
-      "version": "0.2.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "node-cron": "^4.0.0",
@@ -6437,7 +6595,7 @@
     },
     "packages/dashboard": {
       "name": "@some-useful-agents/dashboard",
-      "version": "0.2.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@some-useful-agents/core": "*",
@@ -6450,7 +6608,7 @@
     },
     "packages/mcp-server": {
       "name": "@some-useful-agents/mcp-server",
-      "version": "0.2.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
@@ -6462,7 +6620,7 @@
     },
     "packages/temporal-provider": {
       "name": "@some-useful-agents/temporal-provider",
-      "version": "0.2.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@some-useful-agents/core": "*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,6 +15,7 @@
     "@some-useful-agents/core": "*",
     "@some-useful-agents/mcp-server": "*",
     "@some-useful-agents/temporal-provider": "*",
+    "boxen": "^8.0.0",
     "commander": "^13.1.0",
     "chalk": "^5.4.0",
     "ora": "^8.2.0",

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import { loadAgents } from '@some-useful-agents/core';
 import { loadConfig, getAgentDirs } from '../config.js';
+import * as ui from '../ui.js';
 
 /**
  * Read-only inspection of an agent. Prints the full resolved YAML including
@@ -18,8 +19,8 @@ export const auditCommand = new Command('audit')
 
     const agent = agents.get(name);
     if (!agent) {
-      console.error(chalk.red(`Agent "${name}" not found.`));
-      console.error(chalk.dim('Run "sua agent list" or "sua agent list --catalog" to see options.'));
+      ui.fail(`Agent "${name}" not found.`);
+      console.error(ui.dim('Run "sua agent list" or "sua agent list --catalog" to see options.'));
       process.exit(1);
     }
 
@@ -30,9 +31,9 @@ export const auditCommand = new Command('audit')
     console.log('');
 
     // Top-line fields
-    row('description', agent.description ?? chalk.dim('(none)'));
-    row('type', agent.type);
-    row('timeout', String(agent.timeout ?? 300));
+    ui.kv('description', agent.description ?? ui.dim('(none)'));
+    ui.kv('type', agent.type);
+    ui.kv('timeout', String(agent.timeout ?? 300));
 
     if (agent.type === 'shell') {
       console.log('');
@@ -43,23 +44,23 @@ export const auditCommand = new Command('audit')
       console.log('');
       console.log(chalk.bold('prompt:'));
       console.log('  ' + (agent.prompt ?? ''));
-      if (agent.model) row('model', agent.model);
-      if (agent.maxTurns) row('maxTurns', String(agent.maxTurns));
-      if (agent.allowedTools?.length) row('allowedTools', agent.allowedTools.join(', '));
+      if (agent.model) ui.kv('model', agent.model);
+      if (agent.maxTurns) ui.kv('maxTurns', String(agent.maxTurns));
+      if (agent.allowedTools?.length) ui.kv('allowedTools', agent.allowedTools.join(', '));
     }
 
     console.log('');
-    row('schedule', agent.schedule ?? chalk.dim('(none)'));
-    if (agent.allowHighFrequency) row('allowHighFrequency', chalk.yellow('true'));
-    row('mcp', agent.mcp === true ? chalk.green('true (exposed)') : 'false');
-    row('redactSecrets', agent.redactSecrets === true ? 'true' : 'false');
-    if (agent.workingDirectory) row('workingDirectory', agent.workingDirectory);
+    ui.kv('schedule', agent.schedule ?? ui.dim('(none)'));
+    if (agent.allowHighFrequency) ui.kv('allowHighFrequency', chalk.yellow('true'));
+    ui.kv('mcp', agent.mcp === true ? chalk.green('true (exposed)') : 'false');
+    ui.kv('redactSecrets', agent.redactSecrets === true ? 'true' : 'false');
+    if (agent.workingDirectory) ui.kv('workingDirectory', agent.workingDirectory);
 
     if (agent.secrets?.length) {
-      row('secrets', agent.secrets.join(', '));
+      ui.kv('secrets', agent.secrets.join(', '));
     }
     if (agent.envAllowlist?.length) {
-      row('envAllowlist', agent.envAllowlist.join(', '));
+      ui.kv('envAllowlist', agent.envAllowlist.join(', '));
     }
     if (agent.env && Object.keys(agent.env).length > 0) {
       console.log('');
@@ -68,7 +69,7 @@ export const auditCommand = new Command('audit')
         console.log(`  ${chalk.cyan(k)}=${v}`);
       }
     }
-    if (agent.dependsOn?.length) row('dependsOn', agent.dependsOn.join(', '));
+    if (agent.dependsOn?.length) ui.kv('dependsOn', agent.dependsOn.join(', '));
     if (agent.input) {
       console.log('');
       console.log(chalk.bold('input:'));
@@ -77,25 +78,11 @@ export const auditCommand = new Command('audit')
 
     if (sourceLabel === 'community') {
       console.log('');
-      console.log(
-        chalk.yellow(
-          `⚠ This is a community agent. Shell agents from community sources are refused by default; `,
-        ),
-      );
-      console.log(
-        chalk.yellow(
-          `  opt in with --allow-untrusted-shell ${agent.name} on "sua agent run" / "sua schedule start" `,
-        ),
-      );
-      console.log(
-        chalk.yellow(
+      ui.warn(
+        `This is a community agent. Shell agents from community sources are refused by default;\n` +
+          `  opt in with --allow-untrusted-shell ${agent.name} on "sua agent run" / "sua schedule start"\n` +
           `  only after reading the command above and confirming it is safe to execute as your user.`,
-        ),
       );
     }
     console.log('');
   });
-
-function row(label: string, value: string): void {
-  console.log(`  ${chalk.dim(label.padEnd(18))} ${value}`);
-}

--- a/packages/cli/src/commands/cancel.ts
+++ b/packages/cli/src/commands/cancel.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
-import chalk from 'chalk';
 import { LocalProvider, EncryptedFileStore } from '@some-useful-agents/core';
 import { loadConfig, getDbPath, getSecretsPath } from '../config.js';
+import * as ui from '../ui.js';
 
 export const cancelCommand = new Command('cancel')
   .description('Cancel a running agent')
@@ -15,16 +15,16 @@ export const cancelCommand = new Command('cancel')
     try {
       const run = await provider.getRun(runId);
       if (!run) {
-        console.error(chalk.red(`Run "${runId}" not found.`));
+        ui.fail(`Run "${runId}" not found.`);
         process.exit(1);
       }
       if (run.status !== 'running' && run.status !== 'pending') {
-        console.log(chalk.yellow(`Run is already ${run.status}.`));
+        ui.warn(`Run is already ${run.status}.`);
         return;
       }
 
       await provider.cancelRun(runId);
-      console.log(chalk.green(`Cancelled run ${chalk.dim(runId.slice(0, 8))}.`));
+      ui.ok(`Cancelled run ${ui.id(runId.slice(0, 8))}.`);
     } finally {
       await provider.shutdown();
     }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -12,6 +12,7 @@ import {
   getMcpTokenPath,
   readMcpToken,
 } from '@some-useful-agents/core';
+import * as ui from '../ui.js';
 
 interface Check {
   name: string;
@@ -107,20 +108,20 @@ export const doctorCommand = new Command('doctor')
 
     if (options.security) {
       const checks = buildSecurityChecks(config);
-      console.log(chalk.bold('\nsome-useful-agents doctor — security\n'));
+      ui.section('some-useful-agents doctor — security');
       let allOk = true;
       for (const check of checks) {
         const result = check.run();
-        const icon = result.ok ? chalk.green('✓') : chalk.red('✗');
-        const msg = result.ok ? chalk.dim(result.message) : chalk.red(result.message);
-        console.log(`  ${icon} ${check.name}  ${msg}`);
+        const icon = result.ok ? ui.SYMBOLS.ok : ui.SYMBOLS.fail;
+        const msg = result.ok ? ui.dim(result.message) : chalk.red(result.message);
+        console.log(`  ${icon}  ${check.name}  ${msg}`);
         if (!result.ok) allOk = false;
       }
       console.log('');
       if (allOk) {
-        console.log(chalk.green('Security posture looks good.'));
+        ui.ok('Security posture looks good.');
       } else {
-        console.log(chalk.yellow('Security findings above. See docs/SECURITY.md.'));
+        ui.warn('Security findings above. See docs/SECURITY.md.');
         process.exit(1);
       }
       return;
@@ -263,22 +264,22 @@ export const doctorCommand = new Command('doctor')
       },
     ];
 
-    console.log(chalk.bold('\nsome-useful-agents doctor\n'));
+    ui.section('some-useful-agents doctor');
 
     let allOk = true;
     for (const check of checks) {
       const result = check.run();
-      const icon = result.ok ? chalk.green('✓') : chalk.red('✗');
-      const msg = result.ok ? chalk.dim(result.message) : chalk.red(result.message);
-      console.log(`  ${icon} ${check.name} ${msg}`);
+      const icon = result.ok ? ui.SYMBOLS.ok : ui.SYMBOLS.fail;
+      const msg = result.ok ? ui.dim(result.message) : chalk.red(result.message);
+      console.log(`  ${icon}  ${check.name}  ${msg}`);
       if (!result.ok) allOk = false;
     }
 
     console.log('');
     if (allOk) {
-      console.log(chalk.green('All checks passed.'));
+      ui.ok('All checks passed.');
     } else {
-      console.log(chalk.yellow('Some checks failed. See above.'));
+      ui.warn('Some checks failed. See above.');
       process.exit(1);
     }
   });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,9 +1,9 @@
 import { Command } from 'commander';
 import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
-import chalk from 'chalk';
 import { ensureMcpToken, getMcpTokenPath } from '@some-useful-agents/core';
 import { HELLO_AGENT_YAML } from '../scaffolds.js';
+import * as ui from '../ui.js';
 
 export const initCommand = new Command('init')
   .description('Initialize some-useful-agents in the current directory')
@@ -11,7 +11,7 @@ export const initCommand = new Command('init')
     const configPath = join(process.cwd(), 'sua.config.json');
 
     if (existsSync(configPath)) {
-      console.log(chalk.yellow('sua.config.json already exists. Skipping.'));
+      ui.warn('sua.config.json already exists. Skipping.');
       // Still ensure the per-user MCP token exists, since init can be re-run.
       ensureMcpToken();
       return;
@@ -25,38 +25,37 @@ export const initCommand = new Command('init')
     };
 
     writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
-    console.log(chalk.green('Created sua.config.json'));
+    ui.ok('Created sua.config.json');
 
     // Ensure directories exist
     const agentsLocal = join(config.agentsDir, 'local');
     if (!existsSync(agentsLocal)) {
       mkdirSync(agentsLocal, { recursive: true });
-      console.log(chalk.green(`Created ${agentsLocal}/`));
+      ui.ok(`Created ${agentsLocal}/`);
     }
 
     if (!existsSync(config.dataDir)) {
       mkdirSync(config.dataDir, { recursive: true });
-      console.log(chalk.green(`Created ${config.dataDir}/`));
+      ui.ok(`Created ${config.dataDir}/`);
     }
 
     // Scaffold the hello agent so `sua agent list` isn't empty
     const helloPath = join(agentsLocal, 'hello.yaml');
     if (!existsSync(helloPath)) {
       writeFileSync(helloPath, HELLO_AGENT_YAML);
-      console.log(chalk.green(`Created ${helloPath}`));
+      ui.ok(`Created ${helloPath}`);
     }
 
     // Generate the per-user MCP bearer token. Idempotent.
     const tokenPath = getMcpTokenPath();
     const { created } = ensureMcpToken(tokenPath);
     if (created) {
-      console.log(chalk.green(`Created ${tokenPath} (mode 0600) — MCP bearer token`));
+      ui.ok(`Created ${tokenPath} (mode 0600) — MCP bearer token`);
     }
 
-    console.log('');
-    console.log(chalk.bold('Next steps:'));
-    console.log(`  ${chalk.cyan('sua tutorial')}           ${chalk.dim('- guided walkthrough (recommended)')}`);
-    console.log(`  ${chalk.cyan('sua agent run hello')}    ${chalk.dim('- run your first agent')}`);
-    console.log(`  ${chalk.cyan('sua doctor')}             ${chalk.dim('- check prerequisites')}`);
-    console.log(`  ${chalk.cyan('sua mcp start')}          ${chalk.dim('- start the local MCP server (localhost:3003)')}`);
+    ui.section('Next steps');
+    ui.step('sua tutorial', 'guided walkthrough (recommended)');
+    ui.step('sua agent run hello', 'run your first agent');
+    ui.step('sua doctor', 'check prerequisites');
+    ui.step('sua mcp start', 'start the local MCP server on 127.0.0.1:3003');
   });

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import Table from 'cli-table3';
 import { loadAgents } from '@some-useful-agents/core';
 import { loadConfig, getAgentDirs } from '../config.js';
+import * as ui from '../ui.js';
 
 export const listCommand = new Command('list')
   .description('List available agents')
@@ -17,11 +18,15 @@ export const listCommand = new Command('list')
     const { agents, warnings } = loadAgents({ directories });
 
     for (const w of warnings) {
-      console.error(chalk.yellow(`Warning: ${w.file}: ${w.message}`));
+      ui.warn(`${w.file}: ${w.message}`);
     }
 
     if (agents.size === 0) {
-      console.log(chalk.dim(`No agents found. ${options.catalog ? '' : 'Run "sua init" to get started.'}`));
+      ui.info(
+        options.catalog
+          ? 'No catalog agents found.'
+          : 'No agents found. Run "sua init" to get started.',
+      );
       return;
     }
 
@@ -31,13 +36,13 @@ export const listCommand = new Command('list')
 
     for (const [, agent] of agents) {
       table.push([
-        chalk.cyan(agent.name),
+        ui.agent(agent.name),
         agent.type === 'shell' ? chalk.green('shell') : chalk.magenta('claude-code'),
-        agent.description ?? chalk.dim('(no description)'),
+        agent.description ?? ui.dim('(no description)'),
       ]);
     }
 
-    console.log(`\n${chalk.bold(label)}\n`);
+    ui.section(label);
     console.log(table.toString());
-    console.log(chalk.dim(`\n${agents.size} agent(s)`));
+    console.log(ui.dim(`\n${agents.size} agent(s)`));
   });

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
-import chalk from 'chalk';
 import { LocalProvider, EncryptedFileStore } from '@some-useful-agents/core';
 import { loadConfig, getDbPath, getSecretsPath } from '../config.js';
+import * as ui from '../ui.js';
 
 export const logsCommand = new Command('logs')
   .description('Show logs for a run')
@@ -15,9 +15,9 @@ export const logsCommand = new Command('logs')
     try {
       const logs = await provider.getRunLogs(runId);
       if (!logs || logs === '(no output)') {
-        console.log(chalk.dim('No output for this run.'));
+        ui.info('No output for this run.');
       } else {
-        console.log(logs);
+        ui.outputFrame(logs);
       }
     } finally {
       await provider.shutdown();

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -7,6 +7,7 @@ import {
   rotateMcpToken,
 } from '@some-useful-agents/core';
 import { loadConfig, getAgentDirs, getDbPath, getSecretsPath } from '../config.js';
+import * as ui from '../ui.js';
 
 export const mcpCommand = new Command('mcp')
   .description('MCP server management');
@@ -31,26 +32,23 @@ mcpCommand
     // Dynamic import to avoid loading MCP deps when not needed
     const { startMcpServer } = await import('@some-useful-agents/mcp-server');
 
-    console.log(chalk.bold('Starting MCP server...'));
-    console.log(chalk.dim(`  Host:   ${host}`));
-    console.log(chalk.dim(`  Port:   ${port}`));
-    console.log(chalk.dim(`  Agents: ${dirs.all.join(', ')}`));
-    console.log(chalk.dim(`  DB:     ${dbPath}`));
-    console.log(chalk.dim(`  Token:  ${tokenPath}`));
-    console.log('');
+    ui.banner('Starting MCP server', [
+      `Host:   ${host}`,
+      `Port:   ${port}`,
+      `Agents: ${dirs.all.join(', ')}`,
+      `DB:     ${dbPath}`,
+      `Token:  ${tokenPath}`,
+    ]);
 
     if (host !== '127.0.0.1' && host !== '::1' && host !== 'localhost') {
-      console.warn(
-        chalk.yellow(
-          `⚠ MCP is binding to ${host}. The bearer token is your only defense ` +
-            `against remote callers. Keep ${tokenPath} secret.`,
-        ),
+      ui.warn(
+        `MCP is binding to ${host}. The bearer token is your only defense ` +
+          `against remote callers. Keep ${tokenPath} secret.`,
       );
       console.log('');
     }
 
-    console.log(chalk.bold('Add this to your MCP client config (Claude Desktop, etc.):'));
-    console.log('');
+    ui.section('Add this to your MCP client config (Claude Desktop, etc.)');
     const snippet = {
       mcpServers: {
         'some-useful-agents': {
@@ -84,16 +82,13 @@ mcpCommand
     const existing = readMcpToken(tokenPath);
     const action = existing ? 'Rotated' : 'Created';
     const newToken = rotateMcpToken(tokenPath);
-    console.log(chalk.green(`${action} bearer token at ${tokenPath} (mode 0600).`));
-    console.log('');
-    console.log(chalk.bold('New bearer token:'));
+    ui.ok(`${action} bearer token at ${tokenPath} (mode 0600).`);
+    ui.section('New bearer token');
     console.log(chalk.cyan(newToken));
     console.log('');
-    console.log(
-      chalk.yellow(
-        '⚠ Update your MCP client configs (Claude Desktop, etc.) with the new token. ' +
-          'Restart any running `sua mcp start` to pick it up.',
-      ),
+    ui.warn(
+      'Update your MCP client configs (Claude Desktop, etc.) with the new token. ' +
+        'Restart any running `sua mcp start` to pick it up.',
     );
   });
 
@@ -104,7 +99,7 @@ mcpCommand
     const tokenPath = getMcpTokenPath();
     const existing = readMcpToken(tokenPath);
     if (!existing) {
-      console.error(chalk.red(`No MCP token at ${tokenPath}. Run \`sua init\` or \`sua mcp rotate-token\`.`));
+      ui.fail(`No MCP token at ${tokenPath}. Run \`sua init\` or \`sua mcp rotate-token\`.`);
       process.exit(1);
     }
     console.log(existing);

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -6,6 +6,7 @@ import chalk from 'chalk';
 import { stringify as yamlStringify } from 'yaml';
 import { agentDefinitionSchema } from '@some-useful-agents/core';
 import { loadConfig, getAgentDirs } from '../config.js';
+import * as ui from '../ui.js';
 
 export interface AgentAnswers {
   name: string;
@@ -78,9 +79,8 @@ export const newCommand = new Command('new')
   });
 
 async function runInteractive(rl: Rl): Promise<void> {
-  console.log('');
-  console.log(chalk.bold('sua agent new') + chalk.dim(' — scaffold a new local agent'));
-  console.log(chalk.dim('  Ctrl-C to abort. Nothing is written until you confirm at the end.'));
+  ui.section('sua agent new — scaffold a new local agent');
+  console.log(ui.dim('  Ctrl-C to abort. Nothing is written until you confirm at the end.'));
   console.log('');
 
   // 1. Type
@@ -149,7 +149,7 @@ async function runInteractive(rl: Rl): Promise<void> {
     if (timeoutRaw) {
       const n = Number(timeoutRaw);
       if (!Number.isFinite(n) || n <= 0) {
-        console.log(chalk.yellow(`  Ignoring invalid timeout "${timeoutRaw}"; leaving default.`));
+        ui.warn(`Ignoring invalid timeout "${timeoutRaw}"; leaving default.`);
       } else {
         timeout = Math.floor(n);
       }
@@ -168,10 +168,8 @@ async function runInteractive(rl: Rl): Promise<void> {
       const names = secretsRaw.split(',').map(s => s.trim()).filter(Boolean);
       const bad = names.filter(n => !SECRET_NAME_RE.test(n));
       if (bad.length > 0) {
-        console.log(
-          chalk.yellow(
-            `  Ignoring invalid secret name(s): ${bad.join(', ')} (must be UPPERCASE_WITH_UNDERSCORES)`,
-          ),
+        ui.warn(
+          `Ignoring invalid secret name(s): ${bad.join(', ')} (must be UPPERCASE_WITH_UNDERSCORES)`,
         );
       }
       const good = names.filter(n => SECRET_NAME_RE.test(n));
@@ -220,7 +218,7 @@ async function runInteractive(rl: Rl): Promise<void> {
   });
   if (!parsed.success) {
     console.error('');
-    console.error(chalk.red('Validation failed. This is a bug — please report:'));
+    ui.fail('Validation failed. This is a bug — please report:');
     for (const issue of parsed.error.issues) {
       console.error(chalk.red(`  ${issue.path.join('.')}: ${issue.message}`));
     }
@@ -229,11 +227,10 @@ async function runInteractive(rl: Rl): Promise<void> {
 
   const yamlText = buildAgentYaml(answers);
 
-  console.log('');
-  console.log(chalk.bold('Preview:'));
-  console.log(chalk.dim('---'));
+  ui.section('Preview');
+  console.log(ui.dim('---'));
   process.stdout.write(yamlText);
-  console.log(chalk.dim('---'));
+  console.log(ui.dim('---'));
   console.log('');
 
   // Destination
@@ -250,28 +247,27 @@ async function runInteractive(rl: Rl): Promise<void> {
       false,
     );
     if (!overwrite) {
-      console.log(chalk.yellow('Aborted. No file written.'));
+      ui.warn('Aborted. No file written.');
       return;
     }
   } else {
     const confirm = await askYesNo(rl, `Write to ${destPath}?`, true);
     if (!confirm) {
-      console.log(chalk.yellow('Aborted. No file written.'));
+      ui.warn('Aborted. No file written.');
       return;
     }
   }
 
   if (!existsSync(localDir)) mkdirSync(localDir, { recursive: true });
   writeFileSync(destPath, yamlText, 'utf-8');
-  console.log(chalk.green(`✓ Created ${destPath}`));
-  console.log('');
-  console.log(chalk.bold('Next:'));
-  console.log(`  ${chalk.cyan(`sua agent run ${name}`)}        ${chalk.dim('run it once')}`);
+  ui.ok(`Created ${destPath}`);
+  ui.section('Next');
+  ui.step(`sua agent run ${name}`, 'run it once');
   if (schedule) {
-    console.log(`  ${chalk.cyan('sua schedule start')}       ${chalk.dim(`fire on cron "${schedule}"`)}`);
+    ui.step('sua schedule start', `fire on cron "${schedule}"`);
   }
   if (mcp) {
-    console.log(`  ${chalk.cyan('sua mcp start')}            ${chalk.dim('expose via MCP')}`);
+    ui.step('sua mcp start', 'expose via MCP');
   }
-  console.log(`  ${chalk.cyan(`sua agent audit ${name}`)}     ${chalk.dim('inspect the generated YAML')}`);
+  ui.step(`sua agent audit ${name}`, 'inspect the generated YAML');
 }

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -4,6 +4,7 @@ import ora from 'ora';
 import { loadAgents } from '@some-useful-agents/core';
 import { loadConfig, getAgentDirs } from '../config.js';
 import { createProvider } from '../provider-factory.js';
+import * as ui from '../ui.js';
 
 function collectName(value: string, previous: string[]): string[] {
   return [...previous, value];
@@ -29,8 +30,8 @@ export const runCommand = new Command('run')
 
     const agent = agents.get(name);
     if (!agent) {
-      console.error(chalk.red(`Agent "${name}" not found.`));
-      console.error(chalk.dim('Run "sua agent list" to see available agents.'));
+      ui.fail(`Agent "${name}" not found.`);
+      console.error(ui.dim('Run "sua agent list" to see available agents.'));
       process.exit(1);
     }
 
@@ -38,7 +39,7 @@ export const runCommand = new Command('run')
       providerOverride: options.provider,
       allowUntrustedShell: new Set(options.allowUntrustedShell),
     });
-    const spinner = ora(`Running ${chalk.cyan(name)} via ${chalk.dim(provider.name)}...`).start();
+    const spinner = ora(`Running ${ui.agent(name)} via ${ui.dim(provider.name)}...`).start();
 
     try {
       let run;
@@ -49,7 +50,7 @@ export const runCommand = new Command('run')
         process.exitCode = 1;
         return;
       }
-      spinner.text = `Running ${chalk.cyan(name)} (${chalk.dim(run.id.slice(0, 8))})...`;
+      spinner.text = `Running ${ui.agent(name)} (${ui.id(run.id.slice(0, 8))})...`;
 
       // Poll for completion
       let current = run;
@@ -63,7 +64,7 @@ export const runCommand = new Command('run')
         // Warn if workflow stays pending > 5s (likely no worker running for temporal)
         if (!pendingWarned && provider.name === 'temporal' && current.status === 'pending' && Date.now() - startedAt > 5000) {
           spinner.warn(
-            `Run still pending after 5s. Is the worker running? Start it with: ${chalk.cyan('sua worker start')}`
+            `Run still pending after 5s. Is the worker running? Start it with: ${ui.cmd('sua worker start')}`
           );
           pendingWarned = true;
           spinner.start();
@@ -71,20 +72,19 @@ export const runCommand = new Command('run')
       }
 
       if (current.status === 'completed') {
-        spinner.succeed(`${chalk.cyan(name)} completed`);
+        spinner.succeed(`${ui.agent(name)} completed`);
         if (current.result) {
-          console.log(chalk.dim('\n--- output ---'));
-          console.log(current.result.trimEnd());
-          console.log(chalk.dim('--- end ---'));
+          console.log('');
+          ui.outputFrame(current.result);
         }
       } else {
-        spinner.fail(`${chalk.cyan(name)} ${current.status}`);
+        spinner.fail(`${ui.agent(name)} ${current.status}`);
         if (current.error) {
           console.error(chalk.red(current.error));
         }
       }
 
-      console.log(chalk.dim(`\nRun ID: ${current.id}`));
+      console.log(ui.dim(`\nRun ID: ${current.id}`));
     } finally {
       await provider.shutdown();
     }

--- a/packages/cli/src/commands/schedule.ts
+++ b/packages/cli/src/commands/schedule.ts
@@ -4,6 +4,7 @@ import Table from 'cli-table3';
 import { loadAgents, LocalScheduler } from '@some-useful-agents/core';
 import { loadConfig, getAgentDirs } from '../config.js';
 import { createProvider } from '../provider-factory.js';
+import * as ui from '../ui.js';
 
 export const scheduleCommand = new Command('schedule')
   .description('Manage scheduled agent runs');
@@ -18,7 +19,7 @@ scheduleCommand
 
     const scheduled = Array.from(agents.values()).filter(a => a.schedule);
     if (scheduled.length === 0) {
-      console.log(chalk.dim('No agents have a schedule. Add `schedule: "<cron>"` to an agent YAML.'));
+      ui.info('No agents have a schedule. Add `schedule: "<cron>"` to an agent YAML.');
       return;
     }
 
@@ -28,12 +29,12 @@ scheduleCommand
     for (const agent of scheduled) {
       const valid = LocalScheduler.isValid(agent.schedule!);
       table.push([
-        chalk.cyan(agent.name),
+        ui.agent(agent.name),
         agent.schedule!,
         valid ? chalk.green('yes') : chalk.red('no'),
       ]);
     }
-    console.log('\n' + chalk.bold('Scheduled Agents') + '\n');
+    ui.section('Scheduled Agents');
     console.log(table.toString());
   });
 
@@ -47,18 +48,18 @@ scheduleCommand
     const { agents } = loadAgents({ directories: dirs.all });
     const agent = agents.get(name);
     if (!agent) {
-      console.error(chalk.red(`Agent "${name}" not found.`));
+      ui.fail(`Agent "${name}" not found.`);
       process.exit(1);
     }
     if (!agent.schedule) {
-      console.log(chalk.yellow(`Agent "${name}" has no schedule field.`));
+      ui.warn(`Agent "${name}" has no schedule field.`);
       return;
     }
     const valid = LocalScheduler.isValid(agent.schedule);
     if (valid) {
-      console.log(chalk.green(`"${agent.schedule}" is a valid cron expression.`));
+      ui.ok(`"${agent.schedule}" is a valid cron expression.`);
     } else {
-      console.error(chalk.red(`"${agent.schedule}" is not a valid cron expression.`));
+      ui.fail(`"${agent.schedule}" is not a valid cron expression.`);
       process.exit(1);
     }
   });
@@ -84,7 +85,7 @@ scheduleCommand
     const { agents, warnings } = loadAgents({ directories: dirs.all });
 
     for (const w of warnings) {
-      console.error(chalk.yellow(`Warning: ${w.file}: ${w.message}`));
+      ui.warn(`${w.file}: ${w.message}`);
     }
 
     const provider = await createProvider(config, {
@@ -96,10 +97,10 @@ scheduleCommand
       agents,
       onFire: (agent, runId) => {
         const ts = new Date().toISOString();
-        console.log(`${chalk.dim(ts)} ${chalk.green('fired')} ${chalk.cyan(agent.name)} run=${runId.slice(0, 8)}`);
+        console.log(`${ui.dim(ts)} ${chalk.green('fired')} ${ui.agent(agent.name)} ${ui.dim(`run=${runId.slice(0, 8)}`)}`);
       },
       onError: (agent, err) => {
-        console.error(chalk.red(`Error firing ${agent.name}: ${err.message}`));
+        ui.fail(`Error firing ${agent.name}: ${err.message}`);
       },
     });
 
@@ -107,22 +108,22 @@ scheduleCommand
     try {
       entries = scheduler.start();
     } catch (err) {
-      console.error(chalk.red((err as Error).message));
+      ui.fail((err as Error).message);
       await provider.shutdown();
       process.exit(1);
     }
 
     if (entries.length === 0) {
-      console.log(chalk.yellow('No agents have a schedule. Add `schedule: "<cron>"` to an agent YAML and restart.'));
+      ui.warn('No agents have a schedule. Add `schedule: "<cron>"` to an agent YAML and restart.');
       await provider.shutdown();
       return;
     }
 
-    console.log(chalk.bold(`\nScheduler running with ${entries.length} agent(s):`));
-    for (const { agent, schedule } of entries) {
-      console.log(`  ${chalk.cyan(agent.name)}  ${chalk.dim(schedule)}`);
-    }
-    console.log(chalk.dim('\nPress Ctrl+C to stop.\n'));
+    const bannerLines = entries.map(
+      ({ agent, schedule }) => `${agent.name.padEnd(24)} ${schedule}`,
+    );
+    ui.banner(`Scheduler running (${entries.length} agent${entries.length === 1 ? '' : 's'})`, bannerLines);
+    console.log(ui.dim('Press Ctrl+C to stop.\n'));
 
     const shutdown = async () => {
       console.log('\nShutting down scheduler...');

--- a/packages/cli/src/commands/secrets.ts
+++ b/packages/cli/src/commands/secrets.ts
@@ -4,6 +4,7 @@ import Table from 'cli-table3';
 import { createInterface } from 'node:readline';
 import { EncryptedFileStore, loadAgents } from '@some-useful-agents/core';
 import { loadConfig, getSecretsPath, getAgentDirs } from '../config.js';
+import * as ui from '../ui.js';
 
 function getStore() {
   const config = loadConfig();
@@ -62,19 +63,19 @@ secretsCommand
   .argument('<name>', 'Secret name (e.g. MY_API_KEY)')
   .action(async (name: string) => {
     if (!/^[A-Z_][A-Z0-9_]*$/.test(name)) {
-      console.error(chalk.red(`Invalid secret name "${name}". Must be uppercase with underscores (e.g. MY_API_KEY).`));
+      ui.fail(`Invalid secret name "${name}". Must be uppercase with underscores (e.g. MY_API_KEY).`);
       process.exit(1);
     }
 
     const value = await promptSecret(name);
     if (!value) {
-      console.error(chalk.red('No value provided.'));
+      ui.fail('No value provided.');
       process.exit(1);
     }
 
     const store = getStore();
     await store.set(name, value);
-    console.log(chalk.green(`Set secret ${chalk.cyan(name)}`));
+    ui.ok(`Set secret ${ui.agent(name)}`);
   });
 
 secretsCommand
@@ -85,7 +86,7 @@ secretsCommand
     const store = getStore();
     const value = await store.get(name);
     if (value === undefined) {
-      console.error(chalk.red(`Secret "${name}" not set.`));
+      ui.fail(`Secret "${name}" not set.`);
       process.exit(1);
     }
     console.log(value);
@@ -99,16 +100,16 @@ secretsCommand
     const names = await store.list();
 
     if (names.length === 0) {
-      console.log(chalk.dim('No secrets set. Run `sua secrets set <NAME>` to add one.'));
+      ui.info('No secrets set. Run `sua secrets set <NAME>` to add one.');
       return;
     }
 
     const table = new Table({ head: [chalk.bold('Name')] });
     for (const name of names) {
-      table.push([chalk.cyan(name)]);
+      table.push([ui.agent(name)]);
     }
     console.log(table.toString());
-    console.log(chalk.dim(`\n${names.length} secret(s)`));
+    console.log(ui.dim(`\n${names.length} secret(s)`));
   });
 
 secretsCommand
@@ -118,11 +119,11 @@ secretsCommand
   .action(async (name: string) => {
     const store = getStore();
     if (!(await store.has(name))) {
-      console.error(chalk.yellow(`Secret "${name}" not found.`));
+      ui.warn(`Secret "${name}" not found.`);
       process.exit(1);
     }
     await store.delete(name);
-    console.log(chalk.green(`Deleted secret ${chalk.cyan(name)}`));
+    ui.ok(`Deleted secret ${ui.agent(name)}`);
   });
 
 secretsCommand
@@ -136,13 +137,13 @@ secretsCommand
 
     const agent = agents.get(agentName);
     if (!agent) {
-      console.error(chalk.red(`Agent "${agentName}" not found.`));
+      ui.fail(`Agent "${agentName}" not found.`);
       process.exit(1);
     }
 
     const declared = agent.secrets ?? [];
     if (declared.length === 0) {
-      console.log(chalk.dim(`Agent "${agentName}" declares no secrets.`));
+      ui.info(`Agent "${agentName}" declares no secrets.`);
       return;
     }
 
@@ -152,7 +153,7 @@ secretsCommand
     for (const name of declared) {
       const has = await store.has(name);
       table.push([
-        chalk.cyan(name),
+        ui.agent(name),
         has ? chalk.green('set') : chalk.red('missing'),
       ]);
     }

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -3,14 +3,7 @@ import chalk from 'chalk';
 import Table from 'cli-table3';
 import { LocalProvider, EncryptedFileStore } from '@some-useful-agents/core';
 import { loadConfig, getDbPath, getSecretsPath } from '../config.js';
-
-const STATUS_COLORS: Record<string, (s: string) => string> = {
-  completed: chalk.green,
-  running: chalk.blue,
-  pending: chalk.yellow,
-  failed: chalk.red,
-  cancelled: chalk.gray,
-};
+import * as ui from '../ui.js';
 
 export const statusCommand = new Command('status')
   .description('Show run status')
@@ -26,24 +19,23 @@ export const statusCommand = new Command('status')
       if (runId) {
         const run = await provider.getRun(runId);
         if (!run) {
-          console.error(chalk.red(`Run "${runId}" not found.`));
+          ui.fail(`Run "${runId}" not found.`);
           process.exit(1);
         }
 
-        const colorFn = STATUS_COLORS[run.status] ?? chalk.white;
-        console.log(`\n${chalk.bold('Run')} ${chalk.dim(run.id)}`);
-        console.log(`  Agent:     ${chalk.cyan(run.agentName)}`);
-        console.log(`  Status:    ${colorFn(run.status)}`);
-        console.log(`  Started:   ${run.startedAt}`);
-        if (run.completedAt) console.log(`  Completed: ${run.completedAt}`);
-        if (run.exitCode !== undefined) console.log(`  Exit code: ${run.exitCode}`);
-        if (run.error) console.log(`  Error:     ${chalk.red(run.error)}`);
+        console.log(`\n${chalk.bold('Run')} ${ui.id(run.id)}`);
+        ui.kv('Agent', ui.agent(run.agentName), 10);
+        ui.kv('Status', ui.colorStatus(run.status), 10);
+        ui.kv('Started', run.startedAt, 10);
+        if (run.completedAt) ui.kv('Completed', run.completedAt, 10);
+        if (run.exitCode !== undefined) ui.kv('Exit code', String(run.exitCode), 10);
+        if (run.error) ui.kv('Error', chalk.red(run.error), 10);
       } else {
         const limit = parseInt(options?.limit ?? '10', 10);
         const runs = await provider.listRuns({ limit });
 
         if (runs.length === 0) {
-          console.log(chalk.dim('No runs yet.'));
+          ui.info('No runs yet.');
           return;
         }
 
@@ -52,16 +44,15 @@ export const statusCommand = new Command('status')
         });
 
         for (const run of runs) {
-          const colorFn = STATUS_COLORS[run.status] ?? chalk.white;
           table.push([
-            chalk.dim(run.id.slice(0, 8)),
-            chalk.cyan(run.agentName),
-            colorFn(run.status),
+            ui.id(run.id.slice(0, 8)),
+            ui.agent(run.agentName),
+            ui.colorStatus(run.status),
             run.startedAt,
           ]);
         }
 
-        console.log(`\n${chalk.bold('Recent Runs')}\n`);
+        ui.section('Recent Runs');
         console.log(table.toString());
       }
     } finally {

--- a/packages/cli/src/commands/tutorial.ts
+++ b/packages/cli/src/commands/tutorial.ts
@@ -13,6 +13,7 @@ import {
 import { loadConfig, getAgentDirs } from '../config.js';
 import { createProvider } from '../provider-factory.js';
 import { DAD_JOKE_AGENT_YAML, DAILY_9AM_SCHEDULE, HELLO_AGENT_YAML } from '../scaffolds.js';
+import * as ui from '../ui.js';
 
 const STAGES = [
   'What is sua?',
@@ -110,7 +111,7 @@ async function doExplain(ctx: Ctx, topic: string): Promise<void> {
   const result = await invokeLlm({ prompt, provider: ctx.llm, timeoutMs: 60_000 });
   spinner.stop();
   if (result.exitCode !== 0) {
-    console.log(chalk.red(`[${ctx.llm} error] ${result.error ?? 'unknown'}`));
+    ui.fail(`[${ctx.llm} error] ${result.error ?? 'unknown'}`);
     return;
   }
   console.log('\n' + chalk.dim('─── ' + ctx.llm + ' says ───'));
@@ -183,7 +184,7 @@ async function stage3(ctx: Ctx): Promise<void> {
   const { agents } = loadAgents({ directories: getAgentDirs(ctx.config).runnable });
   const agent = agents.get('hello');
   if (!agent) {
-    console.log(chalk.yellow('The hello agent is missing. Did you run `sua init`?'));
+    ui.warn('The hello agent is missing. Did you run `sua init`?');
     return;
   }
 
@@ -200,13 +201,13 @@ async function stage3(ctx: Ctx): Promise<void> {
     spinner.stop();
 
     if (current.status === 'completed') {
-      console.log(chalk.green('✓ completed'));
-      console.log(chalk.dim('  output: ') + (current.result ?? '').trim());
-      console.log(chalk.dim('  run ID: ') + current.id);
-      console.log(chalk.dim('  recorded in: ' + join(ctx.config.dataDir, 'runs.db')));
+      ui.ok('completed');
+      console.log(ui.dim('  output: ') + (current.result ?? '').trim());
+      console.log(ui.dim('  run ID: ') + current.id);
+      console.log(ui.dim('  recorded in: ' + join(ctx.config.dataDir, 'runs.db')));
     } else {
-      console.log(chalk.red('agent did not complete: ' + current.status));
-      if (current.error) console.log(chalk.red(current.error));
+      ui.fail('agent did not complete: ' + current.status);
+      if (current.error) console.error(chalk.red(current.error));
     }
   } finally {
     await provider.shutdown();
@@ -224,17 +225,17 @@ async function stage4(ctx: Ctx): Promise<void> {
 
   const path = join(ctx.agentsLocalDir, 'dad-joke.yaml');
   if (existsSync(path)) {
-    console.log(chalk.dim('(already exists at ' + path + ', skipping write)'));
+    console.log(ui.dim('(already exists at ' + path + ', skipping write)'));
   } else {
     writeFileSync(path, DAD_JOKE_AGENT_YAML);
-    console.log(chalk.green('Wrote ' + path));
+    ui.ok('Wrote ' + path);
   }
 
   console.log('\nRunning it now...');
   const { agents } = loadAgents({ directories: getAgentDirs(ctx.config).runnable });
   const agent = agents.get('dad-joke');
   if (!agent) {
-    console.log(chalk.yellow('dad-joke agent did not load. Check ' + path));
+    ui.warn('dad-joke agent did not load. Check ' + path);
     return;
   }
 
@@ -255,8 +256,8 @@ async function stage4(ctx: Ctx): Promise<void> {
       console.log(chalk.bold.yellow('🎭 ' + (current.result ?? '').trim()));
       console.log('');
     } else {
-      console.log(chalk.red('failed: ' + (current.error ?? current.status)));
-      console.log(chalk.dim('Network issue? Check `sua doctor` and try `sua agent run dad-joke` manually.'));
+      ui.fail('failed: ' + (current.error ?? current.status));
+      console.log(ui.dim('Network issue? Check `sua doctor` and try `sua agent run dad-joke` manually.'));
     }
   } finally {
     await provider.shutdown();
@@ -279,7 +280,7 @@ async function stage5(ctx: Ctx): Promise<void> {
 
   const path = join(ctx.agentsLocalDir, 'dad-joke.yaml');
   if (!existsSync(path)) {
-    console.log(chalk.yellow('dad-joke.yaml missing. Re-run stage 4.'));
+    ui.warn('dad-joke.yaml missing. Re-run stage 4.');
     return;
   }
 
@@ -287,35 +288,32 @@ async function stage5(ctx: Ctx): Promise<void> {
   const contents = readFileSync(path, 'utf-8');
   if (!contents.includes('schedule:')) {
     writeFileSync(path, contents.trimEnd() + '\n' + DAILY_9AM_SCHEDULE);
-    console.log(chalk.green('Added schedule field to ' + path));
+    ui.ok('Added schedule field to ' + path);
   } else {
-    console.log(chalk.dim('Schedule already present in ' + path));
+    console.log(ui.dim('Schedule already present in ' + path));
   }
 
+  ui.section('Next: start the scheduler to fire it on cron');
+  ui.step('sua schedule start', 'foreground; Ctrl+C to stop');
+  ui.step('sua schedule list', 'see all scheduled agents');
   console.log('');
-  console.log(chalk.bold('Next:') + ' start the scheduler to fire it on cron:');
-  console.log('  ' + chalk.cyan('sua schedule start') + '   ' + chalk.dim('(foreground; Ctrl+C to stop)'));
-  console.log('  ' + chalk.cyan('sua schedule list') + '    ' + chalk.dim('(see all scheduled agents)'));
-  console.log('');
-  console.log(chalk.dim('For the daemon to run unattended, use a process manager (pm2, launchd).'));
+  console.log(ui.dim('For the daemon to run unattended, use a process manager (pm2, launchd).'));
 
   await pause(ctx, 'How the cron scheduler works: node-cron loads agents with schedule fields, runs each on its own timer, records each fire in the run store with triggeredBy=schedule. What schedules look like (standard 5-field cron).');
 }
 
 function printOutro(): void {
-  console.log('');
-  console.log(chalk.bold.green('Tutorial complete.'));
-  console.log('');
+  ui.section(chalk.green('Tutorial complete.'));
   console.log('You now have:');
-  console.log('  • a working ' + chalk.cyan('hello') + ' agent');
-  console.log('  • a ' + chalk.cyan('dad-joke') + ' agent that fetches from an external API');
+  console.log('  • a working ' + ui.agent('hello') + ' agent');
+  console.log('  • a ' + ui.agent('dad-joke') + ' agent that fetches from an external API');
   console.log('  • a schedule set for daily 9am fires');
-  console.log('');
-  console.log('Try:');
-  console.log('  ' + chalk.cyan('sua agent list') + '              ' + chalk.dim('see what you have'));
-  console.log('  ' + chalk.cyan('sua agent status') + '            ' + chalk.dim('see your run history'));
-  console.log('  ' + chalk.cyan('sua agent run dad-joke') + '      ' + chalk.dim('get another joke now'));
-  console.log('  ' + chalk.cyan('sua schedule start') + '          ' + chalk.dim('start the scheduler'));
+  ui.section('Try');
+  ui.step('sua agent list', 'see what you have');
+  ui.step('sua agent status', 'see your run history');
+  ui.step('sua agent run dad-joke', 'get another joke now');
+  ui.step('sua schedule start', 'start the scheduler');
+  ui.step('sua agent new', 'scaffold your own agent');
   console.log('');
 }
 

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
-import chalk from 'chalk';
 import { loadConfig } from '../config.js';
+import * as ui from '../ui.js';
 
 export const workerCommand = new Command('worker')
   .description('Temporal worker management');
@@ -19,16 +19,16 @@ workerCommand
 
     const { startWorker } = await import('@some-useful-agents/temporal-provider');
 
-    console.log(chalk.bold('Starting Temporal worker...'));
-    console.log(chalk.dim(`  Address:    ${address}`));
-    console.log(chalk.dim(`  Namespace:  ${namespace}`));
-    console.log(chalk.dim(`  Task queue: ${taskQueue}`));
-    console.log('');
+    ui.banner('Starting Temporal worker', [
+      `Address:    ${address}`,
+      `Namespace:  ${namespace}`,
+      `Task queue: ${taskQueue}`,
+    ]);
 
     try {
       const worker = await startWorker({ address, namespace, taskQueue });
-      console.log(chalk.green('Worker connected. Listening for agent runs...'));
-      console.log(chalk.dim('Press Ctrl+C to stop.\n'));
+      ui.ok('Worker connected. Listening for agent runs...');
+      console.log(ui.dim('Press Ctrl+C to stop.\n'));
 
       process.on('SIGINT', () => {
         console.log('\nShutting down worker...');
@@ -38,9 +38,9 @@ workerCommand
       await worker.run();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      console.error(chalk.red(`Worker failed: ${msg}`));
+      ui.fail(`Worker failed: ${msg}`);
       if (msg.includes('ECONNREFUSED') || msg.includes('connection refused')) {
-        console.error(chalk.dim(`\nIs Temporal running? Start it with: ${chalk.cyan('docker compose up -d')}`));
+        console.error(ui.dim(`\nIs Temporal running? Start it with: ${ui.cmd('docker compose up -d')}`));
       }
       process.exit(1);
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,7 +33,24 @@ const program = new Command();
 program
   .name('sua')
   .description('some-useful-agents — a local-first agent playground')
-  .version(pkg.version);
+  .version(pkg.version)
+  .showHelpAfterError(true)
+  .addHelpText(
+    'after',
+    `
+Examples:
+  $ sua init                        Create sua.config.json in the current dir
+  $ sua agent new                   Scaffold a new agent interactively
+  $ sua agent run my-agent          Run an agent once
+  $ sua agent list                  See everything runnable
+  $ sua schedule start              Fire scheduled agents on cron
+  $ sua mcp start                   Start the MCP server on 127.0.0.1:3003
+  $ sua doctor --security           Audit security posture
+
+Security model: docs/SECURITY.md
+Full docs:      https://github.com/gregmeyer/some-useful-agents
+`,
+  );
 
 const agent = program
   .command('agent')

--- a/packages/cli/src/ui.test.ts
+++ b/packages/cli/src/ui.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  SYMBOLS,
+  STATUS_COLORS,
+  colorStatus,
+  ok,
+  fail,
+  warn,
+  info,
+  step,
+  section,
+  banner,
+  outputFrame,
+  kv,
+  agent,
+  cmd,
+  dim,
+  id,
+} from './ui.js';
+
+let stdoutSpy: ReturnType<typeof vi.spyOn>;
+let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  stdoutSpy.mockRestore();
+  stderrSpy.mockRestore();
+});
+
+function lastStdout(): string {
+  const calls = stdoutSpy.mock.calls;
+  return calls.length > 0 ? String(calls[calls.length - 1][0]) : '';
+}
+
+function lastStderr(): string {
+  const calls = stderrSpy.mock.calls;
+  return calls.length > 0 ? String(calls[calls.length - 1][0]) : '';
+}
+
+describe('SYMBOLS', () => {
+  it('exposes the five symbols used across the CLI', () => {
+    expect(SYMBOLS.ok).toBe('✅');
+    expect(SYMBOLS.fail).toBe('❌');
+    expect(SYMBOLS.warn.trim()).toBe('⚠️');
+    expect(SYMBOLS.info).toBe('💡');
+    expect(SYMBOLS.step).toBe('🚀');
+  });
+});
+
+describe('STATUS_COLORS + colorStatus', () => {
+  it('covers every RunStatus value', () => {
+    expect(STATUS_COLORS.completed).toBeTypeOf('function');
+    expect(STATUS_COLORS.running).toBeTypeOf('function');
+    expect(STATUS_COLORS.pending).toBeTypeOf('function');
+    expect(STATUS_COLORS.failed).toBeTypeOf('function');
+    expect(STATUS_COLORS.cancelled).toBeTypeOf('function');
+  });
+
+  it('colorStatus returns a wrapped string for known statuses', () => {
+    const out = colorStatus('completed');
+    // The wrapped string contains the literal status text somewhere.
+    expect(out).toMatch(/completed/);
+  });
+});
+
+describe('line-level helpers', () => {
+  it('ok writes to stdout with the ✅ symbol and the message', () => {
+    ok('file created');
+    const line = lastStdout();
+    expect(line).toContain(SYMBOLS.ok);
+    expect(line).toContain('file created');
+  });
+
+  it('fail writes to stderr with the ❌ symbol', () => {
+    fail('boom');
+    const line = lastStderr();
+    expect(line).toContain(SYMBOLS.fail);
+    expect(line).toContain('boom');
+    // and nothing was printed on stdout
+    expect(stdoutSpy).not.toHaveBeenCalled();
+  });
+
+  it('warn writes to stderr with ⚠️', () => {
+    warn('take note');
+    const line = lastStderr();
+    expect(line).toContain('⚠️');
+    expect(line).toContain('take note');
+  });
+
+  it('info writes to stdout with 💡', () => {
+    info('psst');
+    const line = lastStdout();
+    expect(line).toContain(SYMBOLS.info);
+    expect(line).toContain('psst');
+  });
+
+  it('step prints a padded command + optional description', () => {
+    step('sua agent run hello', 'run it once');
+    const line = lastStdout();
+    expect(line).toContain(SYMBOLS.step);
+    expect(line).toContain('sua agent run hello');
+    expect(line).toContain('run it once');
+  });
+
+  it('step works with no description', () => {
+    step('sua doctor');
+    const line = lastStdout();
+    expect(line).toContain('sua doctor');
+    expect(line).toContain(SYMBOLS.step);
+  });
+});
+
+describe('structural helpers', () => {
+  it('section prints a title with blank lines around', () => {
+    section('Next steps');
+    // three log calls: blank, title, blank
+    const calls = stdoutSpy.mock.calls.map(c => String(c[0] ?? ''));
+    expect(calls.length).toBeGreaterThanOrEqual(3);
+    expect(calls.some(l => l.includes('Next steps'))).toBe(true);
+  });
+
+  it('banner prints a boxed multi-line region containing the title', () => {
+    banner('MCP server', ['Host: 127.0.0.1', 'Port: 3003']);
+    const line = lastStdout();
+    expect(line).toContain('MCP server');
+    expect(line).toContain('Host: 127.0.0.1');
+    expect(line).toContain('Port: 3003');
+    // boxen uses round border characters
+    expect(line).toMatch(/[╭╮╰╯─│]/);
+  });
+
+  it('banner works with just a title and no body', () => {
+    banner('Scheduler');
+    const line = lastStdout();
+    expect(line).toContain('Scheduler');
+  });
+
+  it('outputFrame wraps body lines with frame characters', () => {
+    outputFrame('hello\nworld');
+    const calls = stdoutSpy.mock.calls.map(c => String(c[0] ?? ''));
+    const joined = calls.join('\n');
+    expect(joined).toContain('output');
+    expect(joined).toContain('hello');
+    expect(joined).toContain('world');
+    expect(joined).toMatch(/[╭╰│]/);
+  });
+
+  it('outputFrame prints "(no output)" for empty input', () => {
+    outputFrame('');
+    const line = lastStdout();
+    expect(line).toContain('(no output)');
+  });
+
+  it('outputFrame prints "(no output)" for whitespace-only input', () => {
+    outputFrame('   \n\n  ');
+    const line = lastStdout();
+    expect(line).toContain('(no output)');
+  });
+
+  it('kv prints label padded to column and value', () => {
+    kv('description', 'my agent');
+    const line = lastStdout();
+    expect(line).toContain('description');
+    expect(line).toContain('my agent');
+  });
+});
+
+describe('inline helpers', () => {
+  it('agent wraps a name (non-empty output)', () => {
+    const out = agent('my-agent');
+    expect(out).toContain('my-agent');
+  });
+
+  it('cmd wraps a command (non-empty output)', () => {
+    const out = cmd('sua tutorial');
+    expect(out).toContain('sua tutorial');
+  });
+
+  it('dim wraps text', () => {
+    const out = dim('quiet');
+    expect(out).toContain('quiet');
+  });
+
+  it('id wraps a short reference', () => {
+    const out = id('abc12345');
+    expect(out).toContain('abc12345');
+  });
+});

--- a/packages/cli/src/ui.ts
+++ b/packages/cli/src/ui.ts
@@ -1,0 +1,155 @@
+/**
+ * Shared visual helpers for all `sua` CLI commands. One voice, one look.
+ *
+ * Every command should route its success/error/warning/info through these
+ * helpers rather than reaching for `chalk.green` / `chalk.red` inline.
+ * This keeps the CLI consistent as it grows and makes future changes
+ * (theming, `--no-color`, `--quiet`) a one-file edit.
+ *
+ * Pure aside from writes to `process.stdout` / `process.stderr` via
+ * `console.log` / `console.error`.
+ */
+
+import chalk from 'chalk';
+import boxen from 'boxen';
+import type { RunStatus } from '@some-useful-agents/core';
+
+// ── Symbols ──────────────────────────────────────────────────────────────
+// Unicode-with-variation-selector emoji. Renders as pictograph on modern
+// terminals; widely supported. The one outlier we accept is old tmux
+// (<2.2) rendering ⚠️ with the wrong width.
+
+export const SYMBOLS = {
+  ok: '✅',
+  fail: '❌',
+  warn: '⚠️ ',
+  info: '💡',
+  step: '🚀',
+} as const;
+
+// ── Status coloring (shared across status, schedule, doctor) ─────────────
+// Moved here from commands/status.ts so every surface that displays a run
+// status picks the same color.
+
+export const STATUS_COLORS: Record<RunStatus, (s: string) => string> = {
+  completed: chalk.green,
+  running: chalk.blue,
+  pending: chalk.yellow,
+  failed: chalk.red,
+  cancelled: chalk.gray,
+};
+
+export function colorStatus(status: RunStatus): string {
+  const colorize = STATUS_COLORS[status] ?? chalk.white;
+  return colorize(status);
+}
+
+// ── Line-level helpers ───────────────────────────────────────────────────
+
+/** Success line. Goes to stdout. */
+export function ok(message: string): void {
+  console.log(`${SYMBOLS.ok}  ${chalk.green(message)}`);
+}
+
+/** Failure line. Goes to stderr so callers can redirect and get clean stdout. */
+export function fail(message: string): void {
+  console.error(`${SYMBOLS.fail}  ${chalk.red(message)}`);
+}
+
+/** Warning. Stderr. */
+export function warn(message: string): void {
+  console.error(`${SYMBOLS.warn} ${chalk.yellow(message)}`);
+}
+
+/** Informational note. Stdout. */
+export function info(message: string): void {
+  console.log(`${SYMBOLS.info}  ${chalk.cyan(message)}`);
+}
+
+/**
+ * A "next step" suggestion: one-liner command + dim description.
+ * Used in `sua init`, `sua agent new`, `sua tutorial` outros.
+ */
+export function step(command: string, description?: string): void {
+  const cmdPart = chalk.cyan(command.padEnd(30));
+  const descPart = description ? chalk.dim(description) : '';
+  console.log(`  ${SYMBOLS.step} ${cmdPart}${descPart}`);
+}
+
+// ── Structural helpers ───────────────────────────────────────────────────
+
+/** Section heading with blank lines above and below. Bold. */
+export function section(title: string): void {
+  console.log('');
+  console.log(chalk.bold(title));
+  console.log('');
+}
+
+/**
+ * Boxed banner for daemon startup (MCP server, scheduler, Temporal worker).
+ * Title is bold cyan; body lines are dim. Border is single-line cyan.
+ */
+export function banner(title: string, lines: string[] = []): void {
+  const body = [
+    chalk.bold.cyan(title),
+    ...(lines.length > 0 ? [''] : []),
+    ...lines.map(l => chalk.dim(l)),
+  ].join('\n');
+  console.log(
+    boxen(body, {
+      padding: { top: 0, bottom: 0, left: 2, right: 2 },
+      margin: { top: 1, bottom: 1, left: 0, right: 0 },
+      borderStyle: 'round',
+      borderColor: 'cyan',
+    }),
+  );
+}
+
+/**
+ * Wrap an agent's captured stdout (or logs) in a framed box so it's
+ * visually distinct from sua's own output. Used by `sua agent run` and
+ * `sua agent logs`.
+ */
+export function outputFrame(body: string): void {
+  if (!body || !body.trim()) {
+    console.log(chalk.dim('(no output)'));
+    return;
+  }
+  const trimmed = body.trimEnd();
+  console.log(chalk.dim('╭── output ──'));
+  for (const line of trimmed.split('\n')) {
+    console.log(chalk.dim('│ ') + line);
+  }
+  console.log(chalk.dim('╰────────────'));
+}
+
+/**
+ * Key/value row — two dim columns. Replaces the ad-hoc `padEnd(18)` we
+ * had in `sua agent audit`.
+ */
+export function kv(label: string, value: string, labelWidth = 18): void {
+  console.log(`  ${chalk.dim(label.padEnd(labelWidth))} ${value}`);
+}
+
+// ── Inline helpers (return a string, don't print) ────────────────────────
+// For use inside larger composed messages.
+
+/** Format an agent name consistently everywhere. Cyan + bold. */
+export function agent(name: string): string {
+  return chalk.cyan.bold(name);
+}
+
+/** Format an inline CLI command reference. Plain cyan. */
+export function cmd(command: string): string {
+  return chalk.cyan(command);
+}
+
+/** Format a dim / secondary value. Re-exported for consistency. */
+export function dim(text: string): string {
+  return chalk.dim(text);
+}
+
+/** Format an ID, hex digest, or similar short opaque reference. Dim. */
+export function id(value: string): string {
+  return chalk.dim(value);
+}


### PR DESCRIPTION
## Summary

One voice, one look across every command. Zero behavior changes, zero API changes — pure visual polish.

## What changed

### Foundation

- **New `packages/cli/src/ui.ts`** — shared helpers:
  - Line-level: `ok`, `fail`, `warn`, `info`, `step`
  - Structural: `section`, `banner`, `outputFrame`, `kv`
  - Inline: `agent`, `cmd`, `dim`, `id`
  - Shared: `STATUS_COLORS`, `colorStatus`, `SYMBOLS`
- **Emoji set** — ✅ ❌ ⚠️ 💡 🚀. Tutorial's 🎭 dad-joke flourish preserved.
- **New dep** — `boxen@^8` (~8KB).

### User-visible diffs

Before:

```
Created sua.config.json
Created agents/local/
Error: Agent "foo" not found.
Warning: Dangerous path...
```

After:

```
✅  Created sua.config.json
✅  Created agents/local/
❌  Agent "foo" not found.
⚠️  Dangerous path...
```

Daemon commands (`sua mcp start`, `sua schedule start`, `sua worker start`) now print a cyan-bordered banner with config details. `sua agent run` wraps stdout in `╭── output ──╮`. `sua --help` ends with an Examples block. `sua doctor` aligns ✅ / ❌ lines.

### Files touched

**New:** `packages/cli/src/ui.ts`, `packages/cli/src/ui.test.ts`.

**Modified:** `packages/cli/package.json` (boxen dep), `packages/cli/src/index.ts` (help), and every command file (`init`, `list`, `status`, `run`, `cancel`, `logs`, `mcp`, `schedule`, `worker`, `secrets`, `doctor`, `audit`, `new`, `tutorial`).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm test` — **196 tests pass** (was 176; +20 in `ui.test.ts`, zero existing tests touched)
- [x] Manual smoke in a clean `/tmp/sua-polish-test` dir:
  - `sua --help` → Examples block renders
  - `sua init` → ✅ lines, 🚀 next steps
  - `sua agent list` → table unchanged, `⚠️` on directory warnings
  - `sua doctor --security` → ✅/❌ aligned
  - `sua agent run hello` → `╭── output ──╮` frame
  - `sua agent audit <community>` → ⚠️ footer block
- [ ] After merge + publish: global-install upgrade and re-verify on a real terminal

## Non-goals (deliberately deferred)

- `readline/promises` → `@inquirer/prompts` swap (UX shift, separate design pass)
- Timing info on `sua agent run` ("completed in 2.3s")
- Progress bars for long chains
- Themeable colors via config

## Breaking changes

None technically — no API or exit code changed. **However:** if anyone was grepping stdout for `Error:` / `Warning:` prefixes, those strings are gone. Changelog notes this explicitly. Ship as `v0.8.0` (minor) because of the new dep and the visible string changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
