### PR TITLE
feat: typed runtime inputs for agents (v0.9.0)

### DIFF
--- a/.changeset/typed-inputs.md
+++ b/.changeset/typed-inputs.md
@@ -1,0 +1,89 @@
+---
+"@some-useful-agents/cli": minor
+"@some-useful-agents/core": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+**feat: typed runtime inputs for agents.** Callers can now supply named, typed values at invocation time and agents substitute them into prompts or read them as environment variables. Closes the "I want my agent to take a parameter" story.
+
+### Declare once, use everywhere
+
+```yaml
+name: weather-verse
+type: claude-code
+prompt: "Weather for zip {{inputs.ZIP}} as a {{inputs.STYLE}}."
+inputs:
+  ZIP:
+    type: number
+    required: true
+  STYLE:
+    type: enum
+    values: [haiku, verse, limerick]
+    default: haiku
+```
+
+```bash
+sua agent run weather-verse --input ZIP=94110
+sua agent run weather-verse --input ZIP=10001 --input STYLE=limerick
+```
+
+### Two execution models, one declaration
+
+- **claude-code agents** — `{{inputs.X}}` in the prompt (and in `env:` values) is substituted before spawn. Claude reads the resolved text; no injection class because prompts aren't executed.
+- **shell agents** — declared inputs become env vars. Authors write `"$ZIP"` in their commands; bash handles quoting. `{{inputs.X}}` inside a shell `command:` is rejected at load time with a clear error pointing to the `$X` form.
+
+### Types
+
+| `type` | Accepts | Notes |
+|---|---|---|
+| `string` | any string | default if unspecified |
+| `number` | `Number(x)` must be finite; empty string rejected | renders as decimal string |
+| `boolean` | `true/false/1/0/yes/no` (case-insensitive) | renders as `"true"` / `"false"` |
+| `enum` | values listed in the spec's `values` array | must declare `values` |
+
+Type is for *validation at the boundary*, not downstream coercion. Every resolved input renders as a string — `{{inputs.VERBOSE}}` with `VERBOSE=true` substitutes the literal text `"true"`.
+
+### Precedence (highest wins)
+
+1. `sua agent run --input K=V` (per-invocation)
+2. `sua schedule start --input K=V` (daemon-wide override, applies to every fired run; agents that don't declare the input ignore it)
+3. YAML `default:` (per-agent)
+4. Else fail loudly (`MissingInputError`, `InvalidInputTypeError`, `UndeclaredInputError`)
+
+### Load-time checks
+
+- `inputs:` names must be `UPPERCASE_WITH_UNDERSCORES` (env-var convention)
+- `type: enum` must declare a non-empty `values:` array
+- Every `{{inputs.X}}` in prompt or `env:` values must appear in the `inputs:` block (typos caught before execution)
+- Shell `command:` cannot contain `{{inputs.X}}` — use `$X` instead
+
+### Run-time checks
+
+Ordered: undeclared provided key → invalid type → missing required. All fail before spawn, recorded as a failed run in history.
+
+### New exports from `@some-useful-agents/core`
+
+- `AgentInputSpec` type
+- `inputSpecSchema` — zod schema
+- `resolveInputs(specs, provided, options?)` — returns resolved string map or throws
+- `validateAndRender(name, spec, raw)` — single-value validator
+- `extractInputReferences(text)` — returns set of `{{inputs.X}}` names
+- `substituteInputs(text, resolved)` — applies the map to a string
+- `MissingInputError`, `InvalidInputTypeError`, `UndeclaredInputError`
+- `RunRequest` — formalized `submitRun` request shape with optional `inputs`
+
+### API changes (library consumers)
+
+- `Provider.submitRun(request: RunRequest)` — request type now has `inputs?: Record<string, string>`.
+- `ExecutionOptions.inputs?: Record<string, string>` on `executeAgent`.
+- `ChainOptions.inputs?: Record<string, string>` on `executeChain` — flows to every agent in the chain.
+- `LocalSchedulerOptions.inputs?: Record<string, string>` — daemon-wide overrides applied to every fired run.
+- Temporal activities/workflows carry `inputs` in their payload so workers on other hosts inherit the caller's input values.
+
+### Docs
+
+- README commands table and full-fat YAML example updated to show `inputs:` and `--input`.
+- ROADMAP lists v0.9.0 under "Now".
+- `sua agent audit` prints declared inputs with types, defaults, required flags, and descriptions.

--- a/README.md
+++ b/README.md
@@ -31,14 +31,15 @@ The tutorial walks you through what sua is, builds a real agent that fetches a d
 **Agents**
 
 ```bash
-sua agent list                # runnable agents (examples + local)
-sua agent list --catalog      # browse the community catalog
-sua agent new                 # interactive scaffold → writes agents/local/<name>.yaml
-sua agent run <name>          # run an agent once
-sua agent status [runId]      # recent runs, or one specific run
-sua agent logs <runId>        # stdout/stderr of a past run
-sua agent cancel <runId>      # kill a running agent
-sua agent audit <name>        # print resolved YAML (use before --allow-untrusted-shell)
+sua agent list                          # runnable agents (examples + local)
+sua agent list --catalog                # browse the community catalog
+sua agent new                           # interactive scaffold → agents/local/<name>.yaml
+sua agent run <name>                    # run an agent once
+sua agent run <name> --input K=V        # supply a declared input (repeatable)
+sua agent status [runId]                # recent runs, or one specific run
+sua agent logs <runId>                  # stdout/stderr of a past run
+sua agent cancel <runId>                # kill a running agent
+sua agent audit <name>                  # print resolved YAML (use before --allow-untrusted-shell)
 ```
 
 **Scheduling**
@@ -83,10 +84,18 @@ name: daily-summary
 description: Summarize today's git activity with Claude
 type: claude-code
 prompt: |
-  Summarize the recent commits. Keep it under 5 bullets.
+  Summarize the recent commits for {{inputs.REPO}}. Keep it under
+  {{inputs.MAX_BULLETS}} bullets.
   Commits:
   {{outputs.fetch-commits.result}}
 model: claude-sonnet-4-20250514
+inputs:                           # typed runtime parameters
+  REPO:
+    type: string
+    default: gregmeyer/some-useful-agents
+  MAX_BULLETS:
+    type: number
+    default: 5
 dependsOn: [fetch-commits]        # chain: fetch-commits runs first
 schedule: "0 18 * * *"            # daily at 6pm
 timeout: 120
@@ -98,6 +107,11 @@ author: your-github-handle
 version: "1.0.0"
 tags: [git, summary, daily]
 ```
+
+Claude-code agents use `{{inputs.X}}` templates; shell agents access
+declared inputs as `$X` environment variables (bash handles its own
+quoting). Supply values at runtime with `sua agent run <name> --input K=V`
+or bake defaults into the YAML.
 
 Required fields: `name`, `type` (`shell` or `claude-code`). Shell agents need `command`; claude-code agents need `prompt`. Everything else is optional.
 

--- a/README.md
+++ b/README.md
@@ -86,36 +86,95 @@ type: claude-code
 prompt: |
   Summarize the recent commits for {{inputs.REPO}}. Keep it under
   {{inputs.MAX_BULLETS}} bullets.
-  Commits:
-  {{outputs.fetch-commits.result}}
 model: claude-sonnet-4-20250514
-inputs:                           # typed runtime parameters
+inputs:                                  # typed runtime parameters
   REPO:
     type: string
     default: gregmeyer/some-useful-agents
   MAX_BULLETS:
     type: number
     default: 5
-dependsOn: [fetch-commits]        # chain: fetch-commits runs first
-schedule: "0 18 * * *"            # daily at 6pm
+dependsOn: [fetch-commits]               # chain: fetch-commits runs first
+input: "{{outputs.fetch-commits.result}}"  # upstream output flows in here
+schedule: "0 18 * * *"                   # daily at 6pm
 timeout: 120
-secrets:                          # resolved from the secrets store
+secrets:                                 # resolved from the secrets store
   - GITHUB_TOKEN
-envAllowlist:                     # extra process.env to inherit
+envAllowlist:                            # extra process.env to inherit
   - HTTP_PROXY
 author: your-github-handle
 version: "1.0.0"
 tags: [git, summary, daily]
 ```
 
-Claude-code agents use `{{inputs.X}}` templates; shell agents access
-declared inputs as `$X` environment variables (bash handles its own
-quoting). Supply values at runtime with `sua agent run <name> --input K=V`
-or bake defaults into the YAML.
-
 Required fields: `name`, `type` (`shell` or `claude-code`). Shell agents need `command`; claude-code agents need `prompt`. Everything else is optional.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full schema and security review checklist.
+
+### Templates: `{{inputs.X}}` and `{{outputs.X.result}}`
+
+Two template namespaces live in agent YAML. They look similar but do different things.
+
+#### `{{inputs.X}}` — caller-supplied values
+
+Declare typed parameters in the agent YAML and supply values at runtime with `--input K=V`:
+
+```yaml
+name: weather
+type: claude-code
+prompt: "Describe weather for zip {{inputs.ZIP}} as a {{inputs.STYLE}}."
+inputs:
+  ZIP:
+    type: number
+    required: true
+  STYLE:
+    type: enum
+    values: [haiku, verse, limerick]
+    default: haiku
+```
+
+```bash
+sua agent run weather --input ZIP=94110 --input STYLE=verse
+```
+
+Validated against the declared type (`string`, `number`, `boolean`, `enum`). Precedence: `--input` flag → `default:` in YAML → else fail. Works in `prompt:` and any `env:` value.
+
+**Shell agents read inputs as env vars**, not templates — bash's `$VAR` is the native idiom, and sua rejects `{{inputs.X}}` inside a shell `command:` at load time:
+
+```yaml
+type: shell
+command: 'curl -s "https://api.example.com/weather/$ZIP"'
+inputs:
+  ZIP: { type: number, required: true }
+```
+
+Supply via `sua agent run` (per invocation), `sua schedule start --input K=V` (daemon-wide override for every scheduled fire), or bake defaults into the YAML.
+
+#### `{{outputs.X.result}}` — chain handoff
+
+Pipe one agent's output into the next. Lives in the `input:` field of a dependent agent:
+
+```yaml
+name: fetch
+type: shell
+command: "curl -s https://icanhazdadjoke.com/ -H 'Accept: text/plain'"
+
+# ---
+
+name: summarize-joke
+type: claude-code
+prompt: "Summarize this joke in one sentence of formal English."
+dependsOn: [fetch]
+input: "{{outputs.fetch.result}}"    # appended to the prompt at run time
+```
+
+```bash
+sua agent run summarize-joke    # fetch runs first; its output flows into summarize-joke
+```
+
+You can reference `{{outputs.X.exitCode}}` the same way. For claude-code downstreams, the resolved value is appended to the prompt. For shell downstreams, it arrives as `$SUA_CHAIN_INPUT`. When the upstream is sourced from `agents/community/`, values are wrapped in `BEGIN/END UNTRUSTED INPUT` delimiters — see [docs/SECURITY.md](docs/SECURITY.md).
+
+`{{outputs.X.*}}` only resolves inside the `input:` field. Inside a `prompt:` or `command:` the literal text is sent through unchanged.
 
 ## Running on Temporal
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 A living document of where `some-useful-agents` is heading. Light on detail, heavy
 on direction.
 
-## Now (v0.7.0 shipped)
+## Now (v0.9.0 shipped)
 
 - **Onboarding walkthrough** — `sua tutorial` walks new users through 5 stages
   ending in a real, scheduled agent (dad-joke from icanhazdadjoke.com). Claude or
@@ -33,6 +33,19 @@ on direction.
   name, description, command/prompt, and optional advanced fields
   (timeout, schedule, secrets, `mcp:`, `redactSecrets`), validates via
   `agentDefinitionSchema`, and writes to `agents/local/<name>.yaml`.
+- **CLI visual polish (v0.8.0)** — shared `ui.ts` helpers unify every
+  command's output. One voice, one look: ✅ / ❌ / ⚠️ / 💡 / 🚀 symbols,
+  boxen-bordered banners for daemon startups, unified output frame for
+  `sua agent run`, Examples block in `sua --help`.
+- **Typed runtime inputs (v0.9.0)** — agents declare `inputs:` with types
+  (string, number, boolean, enum), defaults, and required flags. Callers
+  supply values via `sua agent run <name> --input KEY=value` (repeatable);
+  scheduler daemons via `sua schedule start --input KEY=value` (global
+  override). claude-code prompts read `{{inputs.X}}` templates; shell
+  agents read `$X` env vars (idiomatic bash, no template-injection surface).
+  Schema rejects templates in shell commands and undeclared references at
+  load time; resolver rejects missing-required, bad-type, and undeclared
+  provided values at run time.
 
 ## Next (3–6 months)
 

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -76,6 +76,28 @@ export const auditCommand = new Command('audit')
       console.log('  ' + agent.input);
     }
 
+    if (agent.inputs && Object.keys(agent.inputs).length > 0) {
+      console.log('');
+      console.log(chalk.bold('inputs:'));
+      for (const [name, spec] of Object.entries(agent.inputs)) {
+        const parts: string[] = [chalk.cyan(name), ui.dim(`(${spec.type})`)];
+        if (spec.type === 'enum' && spec.values?.length) {
+          parts.push(ui.dim(`one of: ${spec.values.join(', ')}`));
+        }
+        if (spec.default !== undefined) {
+          parts.push(ui.dim(`default=${JSON.stringify(spec.default)}`));
+        } else if (spec.required !== false) {
+          parts.push(chalk.yellow('required'));
+        } else {
+          parts.push(ui.dim('optional'));
+        }
+        console.log('  ' + parts.join('  '));
+        if (spec.description) {
+          console.log('    ' + ui.dim(spec.description));
+        }
+      }
+    }
+
     if (sourceLabel === 'community') {
       console.log('');
       ui.warn(

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -75,6 +75,23 @@ Inputs:
       process.exit(1);
     }
 
+    // Strict pre-validation for the targeted-invocation case: any `--input`
+    // key the user typed must match something this specific agent declares.
+    // Catches typos (`--input ZIPP=...`) as a fatal before we submit. The
+    // provider itself tolerates extras (required for chain/scheduler fan-out);
+    // strict checking lives here at the per-agent CLI boundary.
+    const declaredInputs = new Set(Object.keys(agent.inputs ?? {}));
+    for (const key of Object.keys(options.input)) {
+      if (!declaredInputs.has(key)) {
+        ui.fail(
+          `Input "${key}" is not declared by agent "${name}". ` +
+            `Declared: ${declaredInputs.size > 0 ? [...declaredInputs].join(', ') : '(none)'}.`,
+        );
+        console.error(ui.dim(`Run "sua agent audit ${name}" to see the agent's inputs block.`));
+        process.exit(1);
+      }
+    }
+
     const provider = await createProvider(config, {
       providerOverride: options.provider,
       allowUntrustedShell: new Set(options.allowUntrustedShell),

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -37,6 +37,26 @@ export const runCommand = new Command('run')
     {} as Record<string, string>,
   )
   .option('--verbose', 'Show detailed output')
+  .addHelpText(
+    'after',
+    `
+Inputs:
+  Agents can declare typed parameters in their YAML; supply values with
+  --input. Example:
+
+    # In agents/local/weather.yaml
+    inputs:
+      ZIP:   { type: number, required: true }
+      STYLE: { type: enum, values: [haiku, verse], default: haiku }
+
+    # Then:
+    $ sua agent run weather --input ZIP=94110
+    $ sua agent run weather --input ZIP=10001 --input STYLE=verse
+
+  claude-code prompts can reference {{inputs.X}}; shell commands read
+  them as $X environment variables. See README "Templates" section.
+`,
+  )
   .action(async (name: string, options: {
     provider?: string;
     allowUntrustedShell: string[];

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -10,6 +10,16 @@ function collectName(value: string, previous: string[]): string[] {
   return [...previous, value];
 }
 
+function collectInput(value: string, previous: Record<string, string>): Record<string, string> {
+  const eq = value.indexOf('=');
+  if (eq <= 0) {
+    throw new Error(`--input expects KEY=value (got: "${value}")`);
+  }
+  const key = value.slice(0, eq);
+  const val = value.slice(eq + 1);
+  return { ...previous, [key]: val };
+}
+
 export const runCommand = new Command('run')
   .description('Run an agent')
   .argument('<name>', 'Agent name')
@@ -20,8 +30,18 @@ export const runCommand = new Command('run')
     collectName,
     [] as string[],
   )
+  .option(
+    '--input <KEY=value>',
+    'Supply a value for a declared input (repeatable). KEY must be UPPERCASE_WITH_UNDERSCORES.',
+    collectInput,
+    {} as Record<string, string>,
+  )
   .option('--verbose', 'Show detailed output')
-  .action(async (name: string, options: { provider?: string; allowUntrustedShell: string[] }) => {
+  .action(async (name: string, options: {
+    provider?: string;
+    allowUntrustedShell: string[];
+    input: Record<string, string>;
+  }) => {
     const config = loadConfig();
     const dirs = getAgentDirs(config);
     // Include community catalog so community agents are runnable; the shell
@@ -44,7 +64,11 @@ export const runCommand = new Command('run')
     try {
       let run;
       try {
-        run = await provider.submitRun({ agent, triggeredBy: 'cli' });
+        run = await provider.submitRun({
+          agent,
+          triggeredBy: 'cli',
+          inputs: options.input,
+        });
       } catch (err) {
         spinner.fail(err instanceof Error ? err.message : String(err));
         process.exitCode = 1;

--- a/packages/cli/src/commands/schedule.ts
+++ b/packages/cli/src/commands/schedule.ts
@@ -68,6 +68,14 @@ function collectName(value: string, previous: string[]): string[] {
   return [...previous, value];
 }
 
+function collectInput(value: string, previous: Record<string, string>): Record<string, string> {
+  const eq = value.indexOf('=');
+  if (eq <= 0) {
+    throw new Error(`--input expects KEY=value (got: "${value}")`);
+  }
+  return { ...previous, [value.slice(0, eq)]: value.slice(eq + 1) };
+}
+
 scheduleCommand
   .command('start')
   .description('Start the scheduler daemon (foreground)')
@@ -77,7 +85,13 @@ scheduleCommand
     collectName,
     [] as string[],
   )
-  .action(async (options: { allowUntrustedShell: string[] }) => {
+  .option(
+    '--input <KEY=value>',
+    'Daemon-wide input override applied to every fired run (repeatable). Agents that don\'t declare the input ignore it.',
+    collectInput,
+    {} as Record<string, string>,
+  )
+  .action(async (options: { allowUntrustedShell: string[]; input: Record<string, string> }) => {
     const config = loadConfig();
     const dirs = getAgentDirs(config);
     // Load runnable + catalog so community agents can fire on schedule;
@@ -95,6 +109,7 @@ scheduleCommand
     const scheduler = new LocalScheduler({
       provider,
       agents,
+      inputs: options.input,
       onFire: (agent, runId) => {
         const ts = new Date().toISOString();
         console.log(`${ui.dim(ts)} ${chalk.green('fired')} ${ui.agent(agent.name)} ${ui.dim(`run=${runId.slice(0, 8)}`)}`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -39,13 +39,18 @@ program
     'after',
     `
 Examples:
-  $ sua init                        Create sua.config.json in the current dir
-  $ sua agent new                   Scaffold a new agent interactively
-  $ sua agent run my-agent          Run an agent once
-  $ sua agent list                  See everything runnable
-  $ sua schedule start              Fire scheduled agents on cron
-  $ sua mcp start                   Start the MCP server on 127.0.0.1:3003
-  $ sua doctor --security           Audit security posture
+  $ sua init                                     Create sua.config.json in the current dir
+  $ sua agent new                                Scaffold a new agent interactively
+  $ sua agent run my-agent                       Run an agent once
+  $ sua agent run weather --input ZIP=94110      Supply a declared input
+  $ sua agent list                               See everything runnable
+  $ sua schedule start                           Fire scheduled agents on cron
+  $ sua mcp start                                Start the MCP server on 127.0.0.1:3003
+  $ sua doctor --security                        Audit security posture
+
+Template syntax in agent YAML:
+  {{inputs.X}}               caller-supplied values (see \`sua agent run --help\`)
+  {{outputs.X.result}}       upstream chain output (inside the \`input:\` field only)
 
 Security model: docs/SECURITY.md
 Full docs:      https://github.com/gregmeyer/some-useful-agents

--- a/packages/core/src/agent-executor.ts
+++ b/packages/core/src/agent-executor.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import type { AgentDefinition } from './types.js';
-import { substituteInputs } from './input-resolver.js';
+import { substituteInputs, SENSITIVE_ENV_NAMES } from './input-resolver.js';
 
 export interface ExecutionResult {
   result: string;
@@ -86,9 +86,22 @@ function mergeInputsIntoEnv(
     if (v === undefined) continue;
     out[k] = inputs ? substituteInputs(v, inputs) : v;
   }
-  // Declared inputs override (highest-priority source).
+  // Declared inputs override (highest-priority source). Belt-and-suspenders
+  // deny-list: even if something in the schema layer regresses and a
+  // sensitive env var name slips through, refuse to write it here. Sensitive
+  // names (LD_PRELOAD, PATH, NODE_OPTIONS, etc.) are defined in
+  // input-resolver.ts. The schema should reject these at load time, so
+  // hitting this branch means something upstream is broken.
   if (inputs) {
     for (const [k, v] of Object.entries(inputs)) {
+      if (SENSITIVE_ENV_NAMES.has(k)) {
+        console.warn(
+          `[security] refusing to inject sensitive env var "${k}" from declared ` +
+            `input. This should have been rejected at schema load time; please file ` +
+            `a bug at https://github.com/gregmeyer/some-useful-agents/issues`,
+        );
+        continue;
+      }
       out[k] = v;
     }
   }

--- a/packages/core/src/agent-executor.ts
+++ b/packages/core/src/agent-executor.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import type { AgentDefinition } from './types.js';
+import { substituteInputs } from './input-resolver.js';
 
 export interface ExecutionResult {
   result: string;
@@ -20,6 +21,23 @@ export interface ExecutionOptions {
    * Per-agent, not global, so one stray invocation cannot trust everything.
    */
   allowUntrustedShell?: ReadonlySet<string>;
+  /**
+   * Resolved input values for this run (already validated against the
+   * agent's declared `inputs:` specs — use `resolveInputs` from
+   * `input-resolver.ts` upstream to produce this map).
+   *
+   * For shell agents: entries are merged into the process env, overriding
+   * both inherited env and YAML `env:` values — authors reference them as
+   * `$VAR` or `"$VAR"`.
+   *
+   * For claude-code agents: `{{inputs.X}}` tokens in `prompt` are
+   * substituted. Entries are ALSO merged into the env for consistency with
+   * shell agents, so a tool Claude invokes can read them.
+   *
+   * In both types, `{{inputs.X}}` tokens in `env:` values are substituted
+   * before spawn.
+   */
+  inputs?: Record<string, string>;
 }
 
 /**
@@ -48,7 +66,33 @@ export function executeAgent(
   if (agent.type === 'shell') {
     return executeShellAgent(agent, env, options);
   }
-  return executeClaudeCodeAgent(agent, env);
+  return executeClaudeCodeAgent(agent, env, options);
+}
+
+/**
+ * Apply `{{inputs.X}}` substitution to an env map's values, then layer
+ * the resolved inputs on top so declared inputs win over both ambient env
+ * and YAML `env:` values. Pure helper used by both executor paths.
+ *
+ * Tolerates `undefined` values in the source map (process.env's shape) and
+ * drops them from the output — Node's spawn expects string values only.
+ */
+function mergeInputsIntoEnv(
+  baseEnv: Record<string, string | undefined>,
+  inputs: Record<string, string> | undefined,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(baseEnv)) {
+    if (v === undefined) continue;
+    out[k] = inputs ? substituteInputs(v, inputs) : v;
+  }
+  // Declared inputs override (highest-priority source).
+  if (inputs) {
+    for (const [k, v] of Object.entries(inputs)) {
+      out[k] = v;
+    }
+  }
+  return out;
 }
 
 function executeShellAgent(
@@ -72,7 +116,8 @@ function executeShellAgent(
   let timer: ReturnType<typeof setTimeout> | undefined;
 
   const promise = new Promise<ExecutionResult>((resolve) => {
-    const env = prebuiltEnv ?? { ...process.env, ...(agent.env ?? {}) };
+    const baseEnv = prebuiltEnv ?? { ...process.env, ...(agent.env ?? {}) };
+    const env = mergeInputsIntoEnv(baseEnv, options.inputs);
 
     child = spawn('bash', ['-c', agent.command!], {
       cwd: agent.workingDirectory ?? process.cwd(),
@@ -118,7 +163,11 @@ function executeShellAgent(
   };
 }
 
-function executeClaudeCodeAgent(agent: AgentDefinition, prebuiltEnv?: Record<string, string>): ExecutionHandle {
+function executeClaudeCodeAgent(
+  agent: AgentDefinition,
+  prebuiltEnv?: Record<string, string>,
+  options: ExecutionOptions = {},
+): ExecutionHandle {
   if (!agent.prompt) {
     throw new Error(`Claude-code agent "${agent.name}" has no prompt`);
   }
@@ -128,12 +177,20 @@ function executeClaudeCodeAgent(agent: AgentDefinition, prebuiltEnv?: Record<str
   let timer: ReturnType<typeof setTimeout> | undefined;
 
   const promise = new Promise<ExecutionResult>((resolve) => {
-    const args = ['--print', agent.prompt!];
+    // Resolve `{{inputs.X}}` tokens in the prompt before handing to Claude.
+    // The schema loader already verified every reference is declared, so
+    // substitution is safe — missing inputs would have failed at load time.
+    const resolvedPrompt = options.inputs
+      ? substituteInputs(agent.prompt!, options.inputs)
+      : agent.prompt!;
+
+    const args = ['--print', resolvedPrompt];
     if (agent.model) { args.push('--model', agent.model); }
     if (agent.maxTurns) { args.push('--max-turns', String(agent.maxTurns)); }
     if (agent.allowedTools?.length) { args.push('--allowedTools', agent.allowedTools.join(',')); }
 
-    const env = prebuiltEnv ?? { ...process.env, ...(agent.env ?? {}) };
+    const baseEnv = prebuiltEnv ?? { ...process.env, ...(agent.env ?? {}) };
+    const env = mergeInputsIntoEnv(baseEnv, options.inputs);
 
     child = spawn('claude', args, {
       cwd: agent.workingDirectory ?? process.cwd(),

--- a/packages/core/src/chain-executor.ts
+++ b/packages/core/src/chain-executor.ts
@@ -45,6 +45,12 @@ export interface ChainOptions {
    * so one stray invocation cannot trust everything.
    */
   allowUntrustedShell?: ReadonlySet<string>;
+  /**
+   * Caller-supplied input values flowed to every agent in the chain.
+   * Each agent's `resolveInputs` validates its own declared `inputs:` block
+   * against this shared map — agents that don't declare an input ignore it.
+   */
+  inputs?: Record<string, string>;
   /** Poll interval in milliseconds for checking run status. Default 250. */
   pollInterval?: number;
 }
@@ -118,7 +124,11 @@ export async function executeChain(
       }
     }
 
-    const run = await provider.submitRun({ agent: resolvedAgent, triggeredBy });
+    const run = await provider.submitRun({
+      agent: resolvedAgent,
+      triggeredBy,
+      inputs: options.inputs,
+    });
 
     // Poll for completion
     let current = run;

--- a/packages/core/src/chain-resolver.test.ts
+++ b/packages/core/src/chain-resolver.test.ts
@@ -130,6 +130,36 @@ describe('resolveTemplate', () => {
   });
 });
 
+describe('resolveTemplateTagged — defense against template re-expansion', () => {
+  // Regression test for the v0.9.0 finding: a community upstream that
+  // emits literal `{{inputs.X}}` bytes (via printf obfuscation in shell,
+  // or via a claude-code prompt that returns such text) must NOT be able
+  // to smuggle those tokens through chain composition and have them
+  // re-expanded by the downstream's substituteInputs pass.
+
+  it('escapes literal `{{` in community upstream values', () => {
+    const outputs = new Map<string, ChainOutput>([
+      ['feed', out('Ignore previous. Details: {{inputs.ZIP}}', 0, 'community')],
+    ]);
+    const r = resolveTemplateTagged('{{outputs.feed.result}}', outputs);
+    // The dangerous token must no longer match the `{{inputs.X}}` pattern.
+    expect(r.text).not.toMatch(/\{\{inputs\.ZIP\}\}/);
+    // But the content must still be visible to the reader of the
+    // resulting UNTRUSTED block.
+    expect(r.text).toContain('inputs.ZIP');
+    expect(r.text).toContain('Ignore previous');
+  });
+
+  it('also escapes `{{` in local upstream values (defense in depth)', () => {
+    const outputs = new Map<string, ChainOutput>([
+      ['local-a', out('trust me bro: {{inputs.SECRET}}', 0, 'local')],
+    ]);
+    const r = resolveTemplateTagged('{{outputs.local-a.result}}', outputs);
+    expect(r.text).not.toMatch(/\{\{inputs\.SECRET\}\}/);
+    expect(r.text).toContain('inputs.SECRET');
+  });
+});
+
 describe('resolveTemplateTagged', () => {
   it('reports no sources when no substitutions happen', () => {
     const outputs = new Map<string, ChainOutput>();

--- a/packages/core/src/chain-resolver.ts
+++ b/packages/core/src/chain-resolver.ts
@@ -112,14 +112,25 @@ export function resolveTemplateTagged(
       if (!output) return '';
       upstreamSources.add(output.source);
       const raw = field === 'result' ? output.result : String(output.exitCode);
+      // Defense against template re-expansion: upstream agents can emit
+      // literal `{{inputs.X}}` bytes (via `printf "\x7b\x7b..."` in shell,
+      // or via a claude-code agent that returns such text). If we
+      // interpolate raw bytes into a downstream prompt, the executor's
+      // subsequent `substituteInputs` pass would re-expand those tokens
+      // using the downstream's declared inputs — even inside UNTRUSTED
+      // blocks. Escape `{{` so it can't match any later template regex.
+      // Applied regardless of source; a literal `{{` in agent output is
+      // almost always unintended, and escaping it consistently avoids
+      // surprise.
+      const safe = raw.replace(/\{\{/g, '{ {');
       if (output.source === 'community') {
         return (
           `\n${UNTRUSTED_BEGIN} FROM ${agentName} (source=community) ---\n` +
-          `${raw}\n` +
+          `${safe}\n` +
           `${UNTRUSTED_END}\n`
         );
       }
-      return raw;
+      return safe;
     },
   );
   return { text, upstreamSources };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,3 +14,4 @@ export * from './llm-invoker.js';
 export * from './fs-utils.js';
 export * from './mcp-token.js';
 export * from './secret-redactor.js';
+export * from './input-resolver.js';

--- a/packages/core/src/input-resolver.test.ts
+++ b/packages/core/src/input-resolver.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveInputs,
+  validateAndRender,
+  extractInputReferences,
+  substituteInputs,
+  MissingInputError,
+  InvalidInputTypeError,
+  UndeclaredInputError,
+  type InputSpec,
+} from './input-resolver.js';
+
+describe('validateAndRender', () => {
+  it('passes strings through unchanged', () => {
+    expect(validateAndRender('X', { type: 'string' }, 'hello')).toBe('hello');
+    expect(validateAndRender('X', { type: 'string' }, '')).toBe('');
+  });
+
+  it('validates numbers and renders as decimal string', () => {
+    expect(validateAndRender('X', { type: 'number' }, '42')).toBe('42');
+    expect(validateAndRender('X', { type: 'number' }, '3.14')).toBe('3.14');
+    expect(validateAndRender('X', { type: 'number' }, '-0')).toBe('0');
+  });
+
+  it('rejects non-numeric values for number type', () => {
+    expect(() => validateAndRender('X', { type: 'number' }, 'abc')).toThrow(
+      InvalidInputTypeError,
+    );
+    expect(() => validateAndRender('X', { type: 'number' }, '')).toThrow(
+      InvalidInputTypeError,
+    );
+  });
+
+  it('accepts true/false/1/0/yes/no for boolean', () => {
+    for (const truthy of ['true', 'True', 'TRUE', '1', 'yes', 'Y']) {
+      expect(validateAndRender('X', { type: 'boolean' }, truthy)).toBe('true');
+    }
+    for (const falsy of ['false', 'False', '0', 'no', 'N']) {
+      expect(validateAndRender('X', { type: 'boolean' }, falsy)).toBe('false');
+    }
+  });
+
+  it('rejects ambiguous boolean values', () => {
+    expect(() => validateAndRender('X', { type: 'boolean' }, 'maybe')).toThrow(
+      InvalidInputTypeError,
+    );
+  });
+
+  it('accepts declared enum values', () => {
+    const spec: InputSpec = { type: 'enum', values: ['haiku', 'verse', 'prose'] };
+    expect(validateAndRender('X', spec, 'haiku')).toBe('haiku');
+    expect(validateAndRender('X', spec, 'verse')).toBe('verse');
+  });
+
+  it('rejects undeclared enum values', () => {
+    const spec: InputSpec = { type: 'enum', values: ['haiku', 'verse'] };
+    expect(() => validateAndRender('X', spec, 'limerick')).toThrow(InvalidInputTypeError);
+  });
+
+  it('rejects enum without values array', () => {
+    const spec = { type: 'enum' } as InputSpec;
+    expect(() => validateAndRender('X', spec, 'anything')).toThrow(InvalidInputTypeError);
+  });
+});
+
+describe('resolveInputs', () => {
+  it('returns empty map when no specs are declared', () => {
+    expect(resolveInputs(undefined, {})).toEqual({});
+  });
+
+  it('applies YAML defaults when caller omits a value', () => {
+    const specs: Record<string, InputSpec> = {
+      ZIP: { type: 'number', default: 94110 },
+      STYLE: { type: 'enum', values: ['haiku'], default: 'haiku' },
+    };
+    expect(resolveInputs(specs, {})).toEqual({ ZIP: '94110', STYLE: 'haiku' });
+  });
+
+  it('caller-supplied values override defaults', () => {
+    const specs: Record<string, InputSpec> = {
+      ZIP: { type: 'number', default: 94110 },
+    };
+    expect(resolveInputs(specs, { ZIP: '10001' })).toEqual({ ZIP: '10001' });
+  });
+
+  it('throws MissingInputError when required and no default', () => {
+    const specs: Record<string, InputSpec> = { ZIP: { type: 'number', required: true } };
+    expect(() => resolveInputs(specs, {})).toThrow(MissingInputError);
+  });
+
+  it('implicit required: no required flag, no default → still required', () => {
+    const specs: Record<string, InputSpec> = { ZIP: { type: 'number' } };
+    expect(() => resolveInputs(specs, {})).toThrow(MissingInputError);
+  });
+
+  it('respects explicit required:false (input skipped when omitted)', () => {
+    const specs: Record<string, InputSpec> = { ZIP: { type: 'number', required: false } };
+    expect(resolveInputs(specs, {})).toEqual({});
+  });
+
+  it('throws InvalidInputTypeError for bad values', () => {
+    const specs: Record<string, InputSpec> = { ZIP: { type: 'number' } };
+    expect(() => resolveInputs(specs, { ZIP: 'abc' })).toThrow(InvalidInputTypeError);
+  });
+
+  it('rejects undeclared provided keys by default', () => {
+    const specs: Record<string, InputSpec> = { ZIP: { type: 'number', default: 0 } };
+    expect(() => resolveInputs(specs, { EXTRA: 'value' })).toThrow(UndeclaredInputError);
+  });
+
+  it('tolerates undeclared provided keys with rejectUndeclared:false', () => {
+    const specs: Record<string, InputSpec> = { ZIP: { type: 'number', default: 0 } };
+    const result = resolveInputs(
+      specs,
+      { EXTRA: 'value', ZIP: '10' },
+      { rejectUndeclared: false },
+    );
+    expect(result).toEqual({ ZIP: '10' });
+  });
+
+  it('validates defaults themselves (catches YAML author typos)', () => {
+    const specs: Record<string, InputSpec> = {
+      STYLE: { type: 'enum', values: ['haiku'], default: 'limerick' },
+    };
+    expect(() => resolveInputs(specs, {})).toThrow(InvalidInputTypeError);
+  });
+
+  it('includes agent name in missing-input error message', () => {
+    const specs: Record<string, InputSpec> = { ZIP: { type: 'number', required: true } };
+    try {
+      resolveInputs(specs, {}, { agentName: 'weather-verse' });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MissingInputError);
+      expect((err as Error).message).toContain('weather-verse');
+    }
+  });
+});
+
+describe('extractInputReferences', () => {
+  it('finds {{inputs.X}} references in a string', () => {
+    const text = 'Weather for {{inputs.ZIP}} in {{inputs.STYLE}} please.';
+    expect([...extractInputReferences(text)].sort()).toEqual(['STYLE', 'ZIP']);
+  });
+
+  it('returns empty set when no references', () => {
+    expect(extractInputReferences('no templates').size).toBe(0);
+    expect(extractInputReferences('').size).toBe(0);
+  });
+
+  it('deduplicates repeated references', () => {
+    const text = '{{inputs.X}} and {{inputs.X}} again';
+    expect([...extractInputReferences(text)]).toEqual(['X']);
+  });
+
+  it('ignores malformed-looking references', () => {
+    expect(extractInputReferences('{{inputs.lowercase}}').size).toBe(0);
+    expect(extractInputReferences('{{input.SINGULAR}}').size).toBe(0);
+  });
+});
+
+describe('substituteInputs', () => {
+  it('replaces tokens with provided values', () => {
+    expect(substituteInputs('zip={{inputs.ZIP}}', { ZIP: '94110' })).toBe('zip=94110');
+  });
+
+  it('handles multiple tokens in one string', () => {
+    const text = '{{inputs.A}} and {{inputs.B}}';
+    expect(substituteInputs(text, { A: 'foo', B: 'bar' })).toBe('foo and bar');
+  });
+
+  it('missing key renders as empty string', () => {
+    expect(substituteInputs('{{inputs.MISSING}}', {})).toBe('');
+  });
+
+  it('passes non-template text through unchanged', () => {
+    expect(substituteInputs('plain text', {})).toBe('plain text');
+  });
+});

--- a/packages/core/src/input-resolver.test.ts
+++ b/packages/core/src/input-resolver.test.ts
@@ -4,6 +4,7 @@ import {
   validateAndRender,
   extractInputReferences,
   substituteInputs,
+  SENSITIVE_ENV_NAMES,
   MissingInputError,
   InvalidInputTypeError,
   UndeclaredInputError,
@@ -134,6 +135,39 @@ describe('resolveInputs', () => {
       expect(err).toBeInstanceOf(MissingInputError);
       expect((err as Error).message).toContain('weather-verse');
     }
+  });
+});
+
+describe('SENSITIVE_ENV_NAMES', () => {
+  it('includes dynamic-loader injection vectors', () => {
+    expect(SENSITIVE_ENV_NAMES.has('LD_PRELOAD')).toBe(true);
+    expect(SENSITIVE_ENV_NAMES.has('LD_LIBRARY_PATH')).toBe(true);
+    expect(SENSITIVE_ENV_NAMES.has('DYLD_INSERT_LIBRARIES')).toBe(true);
+    expect(SENSITIVE_ENV_NAMES.has('DYLD_LIBRARY_PATH')).toBe(true);
+  });
+
+  it('includes interpreter-startup injection vectors', () => {
+    expect(SENSITIVE_ENV_NAMES.has('NODE_OPTIONS')).toBe(true);
+    expect(SENSITIVE_ENV_NAMES.has('NODE_PATH')).toBe(true);
+    expect(SENSITIVE_ENV_NAMES.has('PYTHONPATH')).toBe(true);
+    expect(SENSITIVE_ENV_NAMES.has('PYTHONSTARTUP')).toBe(true);
+    expect(SENSITIVE_ENV_NAMES.has('RUBYOPT')).toBe(true);
+    expect(SENSITIVE_ENV_NAMES.has('PERL5OPT')).toBe(true);
+  });
+
+  it('includes shell hijack vectors', () => {
+    expect(SENSITIVE_ENV_NAMES.has('PATH')).toBe(true);
+    expect(SENSITIVE_ENV_NAMES.has('SHELL')).toBe(true);
+    expect(SENSITIVE_ENV_NAMES.has('BASH_ENV')).toBe(true);
+    expect(SENSITIVE_ENV_NAMES.has('PROMPT_COMMAND')).toBe(true);
+    expect(SENSITIVE_ENV_NAMES.has('IFS')).toBe(true);
+  });
+
+  it('does not accidentally include benign names', () => {
+    expect(SENSITIVE_ENV_NAMES.has('ZIP')).toBe(false);
+    expect(SENSITIVE_ENV_NAMES.has('STYLE')).toBe(false);
+    expect(SENSITIVE_ENV_NAMES.has('MY_API_TOKEN')).toBe(false);
+    expect(SENSITIVE_ENV_NAMES.has('FOO')).toBe(false);
   });
 });
 

--- a/packages/core/src/input-resolver.ts
+++ b/packages/core/src/input-resolver.ts
@@ -22,6 +22,38 @@
  * input with value `true` renders as the literal string `"true"`.
  */
 
+/**
+ * Env-var names that must NEVER be declared as agent inputs. Injecting any
+ * of these into a child process lets an author or caller hijack the
+ * subprocess's program loader, interpreter, shell, or identity.
+ *
+ * Because declared inputs are layered on top of the env-builder's trust
+ * filter (see `mergeInputsIntoEnv`), allowing these names would let a
+ * community YAML bypass MINIMAL_ALLOWLIST — a direct RCE path, especially
+ * for claude-code agents which don't have the community-shell gate. Block
+ * at schema load time and add a belt-and-suspenders runtime filter in the
+ * executor.
+ *
+ * Additions welcome if/when new sensitive interpreter vars appear.
+ */
+export const SENSITIVE_ENV_NAMES: ReadonlySet<string> = new Set([
+  // Dynamic loader injection — inject shared libs at runtime
+  'LD_PRELOAD', 'LD_LIBRARY_PATH', 'LD_AUDIT', 'LD_BIND_NOW',
+  'DYLD_INSERT_LIBRARIES', 'DYLD_LIBRARY_PATH', 'DYLD_FORCE_FLAT_NAMESPACE',
+  'DYLD_FRAMEWORK_PATH', 'DYLD_FALLBACK_LIBRARY_PATH',
+  // Interpreter injection — load code at interpreter startup
+  'NODE_OPTIONS', 'NODE_PATH',
+  'PYTHONPATH', 'PYTHONSTARTUP', 'PYTHONINSPECT',
+  'RUBYLIB', 'RUBYOPT',
+  'PERL5LIB', 'PERL5OPT',
+  // Shell hijack — bash/zsh/sh startup hooks or path resolution
+  'PATH', 'SHELL', 'BASH_ENV', 'ENV', 'CDPATH',
+  'PROMPT_COMMAND', 'SHELLOPTS',
+  'IFS',
+  // Identity confusion
+  'HOME', 'USER', 'LOGNAME',
+]);
+
 /** Discriminated shape of a single input's declaration in YAML. */
 export interface InputSpec {
   type: 'string' | 'number' | 'boolean' | 'enum';
@@ -71,6 +103,18 @@ export class UndeclaredInputError extends Error {
         `Declared inputs: ${declared.length > 0 ? declared.join(', ') : '(none)'}.`,
     );
     this.name = 'UndeclaredInputError';
+  }
+}
+
+export class SensitiveInputNameError extends Error {
+  constructor(public readonly input: string) {
+    super(
+      `Input name "${input}" is reserved. It would override a sensitive process ` +
+        `environment variable (dynamic-loader, interpreter, shell, or identity ` +
+        `hijack vector). Pick a different name and reference its value ` +
+        `explicitly in your prompt/command — do not try to override "${input}".`,
+    );
+    this.name = 'SensitiveInputNameError';
   }
 }
 

--- a/packages/core/src/input-resolver.ts
+++ b/packages/core/src/input-resolver.ts
@@ -1,0 +1,233 @@
+/**
+ * Typed runtime inputs for agents.
+ *
+ * YAML declares what an agent expects:
+ *
+ *   inputs:
+ *     ZIP:
+ *       type: number
+ *       required: true
+ *     STYLE:
+ *       type: enum
+ *       values: [haiku, verse, prose]
+ *       default: haiku
+ *
+ * Callers (CLI `--input KEY=value`, scheduler defaults, chain propagation)
+ * supply values. This module merges them with per-agent defaults, validates
+ * each against the declared type, and returns a map of strings ready for
+ * template substitution or env injection.
+ *
+ * Strings are the render format regardless of declared type — the type is
+ * for *validation at the boundary*, not downstream coercion. A `boolean`
+ * input with value `true` renders as the literal string `"true"`.
+ */
+
+/** Discriminated shape of a single input's declaration in YAML. */
+export interface InputSpec {
+  type: 'string' | 'number' | 'boolean' | 'enum';
+  /** Closed set of allowed values. Required when `type === 'enum'`. */
+  values?: string[];
+  /** Default used when the caller supplies nothing. */
+  default?: string | number | boolean;
+  /** Required: no default + caller didn't supply → error. */
+  required?: boolean;
+  /** Shown by `sua agent audit`. */
+  description?: string;
+}
+
+// ── Errors ──────────────────────────────────────────────────────────────
+
+export class MissingInputError extends Error {
+  constructor(public readonly input: string, agentName?: string) {
+    const where = agentName ? ` for agent "${agentName}"` : '';
+    super(
+      `Missing required input: ${input}${where}. ` +
+        `Pass --input ${input}=<value> on the command line, ` +
+        `or add a \`default:\` to the agent's YAML.`,
+    );
+    this.name = 'MissingInputError';
+  }
+}
+
+export class InvalidInputTypeError extends Error {
+  constructor(
+    public readonly input: string,
+    public readonly expectedType: InputSpec['type'],
+    public readonly receivedValue: string,
+    public readonly detail?: string,
+  ) {
+    super(
+      `Invalid value for input "${input}": received ${JSON.stringify(receivedValue)}, ` +
+        `expected type ${expectedType}${detail ? ` (${detail})` : ''}.`,
+    );
+    this.name = 'InvalidInputTypeError';
+  }
+}
+
+export class UndeclaredInputError extends Error {
+  constructor(public readonly input: string, public readonly declared: string[]) {
+    super(
+      `Input "${input}" was provided but not declared in the agent's \`inputs:\` block. ` +
+        `Declared inputs: ${declared.length > 0 ? declared.join(', ') : '(none)'}.`,
+    );
+    this.name = 'UndeclaredInputError';
+  }
+}
+
+// ── Validation ──────────────────────────────────────────────────────────
+
+/**
+ * Coerce a provided string value to the declared type's rendered form.
+ * Throws `InvalidInputTypeError` on type mismatch.
+ *
+ * The return value is always a string (that's what templates substitute),
+ * but we round-trip through native types so we catch bad values at the
+ * boundary rather than shipping `"abc"` as the value of a `number` input.
+ */
+export function validateAndRender(name: string, spec: InputSpec, raw: string): string {
+  switch (spec.type) {
+    case 'string':
+      return raw;
+    case 'number': {
+      // Number('') and Number(' ') are both 0 in JS — never what the user
+      // meant. Reject empty/whitespace explicitly.
+      if (raw.trim() === '') {
+        throw new InvalidInputTypeError(name, 'number', raw, 'empty string is not a number');
+      }
+      const n = Number(raw);
+      if (!Number.isFinite(n)) {
+        throw new InvalidInputTypeError(name, 'number', raw);
+      }
+      return String(n);
+    }
+    case 'boolean': {
+      const lower = raw.toLowerCase();
+      if (['true', '1', 'yes', 'y'].includes(lower)) return 'true';
+      if (['false', '0', 'no', 'n'].includes(lower)) return 'false';
+      throw new InvalidInputTypeError(
+        name,
+        'boolean',
+        raw,
+        'expected true/false/1/0/yes/no',
+      );
+    }
+    case 'enum': {
+      if (!spec.values || spec.values.length === 0) {
+        throw new InvalidInputTypeError(name, 'enum', raw, 'no allowed values declared');
+      }
+      if (!spec.values.includes(raw)) {
+        throw new InvalidInputTypeError(
+          name,
+          'enum',
+          raw,
+          `must be one of ${spec.values.join(', ')}`,
+        );
+      }
+      return raw;
+    }
+  }
+}
+
+/**
+ * Stringify a declared default for template substitution. Defaults may be
+ * declared as native YAML types (true, 42, "foo"); we render all as strings.
+ */
+function renderDefault(value: string | number | boolean): string {
+  return String(value);
+}
+
+// ── Resolution ──────────────────────────────────────────────────────────
+
+export interface ResolveInputsOptions {
+  /** Agent name, included in error messages for clarity. Optional. */
+  agentName?: string;
+  /**
+   * When true, providing a value for an input not declared in `specs` is
+   * an error. When false, the extra value is silently ignored. Default
+   * true — declarations are the contract, extras are usually typos.
+   */
+  rejectUndeclared?: boolean;
+}
+
+/**
+ * Given per-agent input specs and a flat map of provided values, return
+ * the final resolved map ready for template substitution and env injection.
+ *
+ * Precedence (highest wins): `provided` → `spec.default` → else throw if required.
+ */
+export function resolveInputs(
+  specs: Record<string, InputSpec> | undefined,
+  provided: Record<string, string>,
+  options: ResolveInputsOptions = {},
+): Record<string, string> {
+  const resolved: Record<string, string> = {};
+  const declaredNames = Object.keys(specs ?? {});
+
+  // Undeclared provided values: error by default.
+  if (options.rejectUndeclared !== false) {
+    for (const name of Object.keys(provided)) {
+      if (!specs || !(name in specs)) {
+        throw new UndeclaredInputError(name, declaredNames);
+      }
+    }
+  }
+
+  if (!specs) return resolved;
+
+  for (const [name, spec] of Object.entries(specs)) {
+    const raw = provided[name];
+    if (raw !== undefined) {
+      resolved[name] = validateAndRender(name, spec, raw);
+      continue;
+    }
+    if (spec.default !== undefined) {
+      // Defaults are trusted (they come from the YAML author, not the caller)
+      // but we still validate them for self-consistency.
+      resolved[name] = validateAndRender(name, spec, renderDefault(spec.default));
+      continue;
+    }
+    // No provided value, no default:
+    // - If required, fail.
+    // - If the spec implicitly has no default AND no required flag, also fail
+    //   (a declared input with neither default nor value is meaningless).
+    if (spec.required !== false) {
+      throw new MissingInputError(name, options.agentName);
+    }
+    // If the caller explicitly set required: false and there's no default,
+    // the input is genuinely optional — skip it. Templates referencing an
+    // optional-and-missing input will render as empty string (handled at
+    // substitute time).
+  }
+
+  return resolved;
+}
+
+// ── Template substitution ───────────────────────────────────────────────
+
+/**
+ * Regex matching `{{inputs.NAME}}` where NAME is an uppercase
+ * alphanumeric-with-underscore identifier (same rules as env var names).
+ */
+const INPUT_TEMPLATE_RE = /\{\{inputs\.([A-Z_][A-Z0-9_]*)\}\}/g;
+
+/**
+ * Return the set of input names referenced by `{{inputs.X}}` in `text`.
+ * Used by the schema loader to validate that every reference has a
+ * declaration.
+ */
+export function extractInputReferences(text: string): Set<string> {
+  const names = new Set<string>();
+  for (const match of text.matchAll(INPUT_TEMPLATE_RE)) {
+    names.add(match[1]);
+  }
+  return names;
+}
+
+/**
+ * Substitute `{{inputs.X}}` tokens in `text` with values from the resolved
+ * map. Missing references render as empty strings — the schema loader is
+ * responsible for rejecting templates that reference undeclared inputs.
+ */
+export function substituteInputs(text: string, resolved: Record<string, string>): string {
+  return text.replace(INPUT_TEMPLATE_RE, (_, name) => resolved[name] ?? '');
+}

--- a/packages/core/src/local-provider.test.ts
+++ b/packages/core/src/local-provider.test.ts
@@ -91,6 +91,106 @@ describe('LocalProvider shell gate', () => {
   });
 });
 
+describe('LocalProvider typed inputs', () => {
+  it('substitutes {{inputs.X}} in claude-code prompts and merges into env', async () => {
+    const provider = new LocalProvider(dbPath, new MemorySecretsStore());
+    await provider.initialize();
+
+    // Using a shell agent instead of claude-code for end-to-end checking,
+    // since shell is easier to observe. The substitution path for claude-code
+    // prompts is unit-tested in input-resolver.test.ts; this test exercises
+    // the end-to-end env-merge for declared inputs in a real subprocess.
+    const run = await provider.submitRun({
+      agent: shellAgent({
+        name: 'weather',
+        command: 'echo "zip=$ZIP style=$STYLE"',
+        inputs: {
+          ZIP: { type: 'number', required: true },
+          STYLE: { type: 'enum', values: ['haiku', 'verse'], default: 'haiku' },
+        },
+      }),
+      triggeredBy: 'cli',
+      inputs: { ZIP: '94110' },
+    });
+    const final = await waitFor(provider, run.id);
+
+    expect(final!.status).toBe('completed');
+    expect(final!.result).toContain('zip=94110');
+    expect(final!.result).toContain('style=haiku');
+    await provider.shutdown();
+  });
+
+  it('records a failed run + rethrows on missing required input', async () => {
+    const provider = new LocalProvider(dbPath, new MemorySecretsStore());
+    await provider.initialize();
+
+    await expect(
+      provider.submitRun({
+        agent: shellAgent({
+          name: 'needs-zip',
+          command: 'echo "$ZIP"',
+          inputs: { ZIP: { type: 'number', required: true } },
+        }),
+        triggeredBy: 'cli',
+        inputs: {},
+      }),
+    ).rejects.toThrow(/Missing required input: ZIP/);
+
+    const runs = await provider.listRuns({ agentName: 'needs-zip' });
+    expect(runs.length).toBe(1);
+    expect(runs[0].status).toBe('failed');
+
+    await provider.shutdown();
+  });
+
+  it('rejects invalid types before the run starts', async () => {
+    const provider = new LocalProvider(dbPath, new MemorySecretsStore());
+    await provider.initialize();
+
+    await expect(
+      provider.submitRun({
+        agent: shellAgent({
+          name: 'typed-zip',
+          command: 'echo "$ZIP"',
+          inputs: { ZIP: { type: 'number', required: true } },
+        }),
+        triggeredBy: 'cli',
+        inputs: { ZIP: 'not-a-number' },
+      }),
+    ).rejects.toThrow(/Invalid value for input "ZIP"/);
+
+    await provider.shutdown();
+  });
+
+  it('declared input overrides an ambient env var of the same name', async () => {
+    const provider = new LocalProvider(dbPath, new MemorySecretsStore(), {
+      // Widen the env allowlist so the ambient ZIP reaches the shell at all,
+      // otherwise the filter would have dropped it already.
+    });
+    await provider.initialize();
+
+    // Set an ambient value that the agent's env-builder would pass through.
+    process.env.ZIP = '00000';
+    try {
+      const run = await provider.submitRun({
+        agent: shellAgent({
+          name: 'override',
+          command: 'echo "zip=$ZIP"',
+          envAllowlist: ['ZIP'],
+          inputs: { ZIP: { type: 'number', required: true } },
+        }),
+        triggeredBy: 'cli',
+        inputs: { ZIP: '94110' },
+      });
+      const final = await waitFor(provider, run.id);
+      expect(final!.result).toContain('zip=94110');
+    } finally {
+      delete process.env.ZIP;
+      await provider.shutdown();
+    }
+  });
+});
+
 describe('LocalProvider redactSecrets', () => {
   it('scrubs known-prefix secrets from result when redactSecrets is true', async () => {
     const provider = new LocalProvider(dbPath, new MemorySecretsStore());

--- a/packages/core/src/local-provider.test.ts
+++ b/packages/core/src/local-provider.test.ts
@@ -143,7 +143,32 @@ describe('LocalProvider typed inputs', () => {
     await provider.shutdown();
   });
 
-  it('rejects invalid types before the run starts', async () => {
+  it('tolerates caller-supplied inputs the agent did not declare (chain/scheduler fan-out)', async () => {
+    // The provider is called from per-agent CLI (strict, validates at CLI
+    // layer), chain execution (shared inputs for a fleet), and the
+    // scheduler daemon (daemon-wide overrides). (2) and (3) need the
+    // provider to tolerate extras — otherwise a single `--input ZIP=...`
+    // breaks every scheduled agent that doesn't declare ZIP.
+    const provider = new LocalProvider(dbPath, new MemorySecretsStore());
+    await provider.initialize();
+
+    const run = await provider.submitRun({
+      agent: shellAgent({
+        name: 'no-inputs-declared',
+        command: 'echo tolerated',
+        // no inputs field
+      }),
+      triggeredBy: 'schedule',
+      inputs: { ZIP: '94110', EXTRA: 'ignored' },
+    });
+    const final = await waitFor(provider, run.id);
+
+    expect(final!.status).toBe('completed');
+    expect(final!.result).toContain('tolerated');
+    await provider.shutdown();
+  });
+
+  it('still rejects invalid-type values for DECLARED inputs', async () => {
     const provider = new LocalProvider(dbPath, new MemorySecretsStore());
     await provider.initialize();
 

--- a/packages/core/src/local-provider.ts
+++ b/packages/core/src/local-provider.ts
@@ -62,12 +62,22 @@ export class LocalProvider implements Provider {
     this.store.createRun(run);
 
     // Resolve typed inputs (merge provided + YAML defaults, validate types).
-    // Failures here (missing required, invalid type, undeclared provided key)
-    // surface as a failed run in history AND rethrow so the caller sees it.
+    // Failures here (missing required, invalid type) surface as a failed run
+    // in history AND rethrow so the caller sees it.
+    //
+    // `rejectUndeclared: false` — the provider is called from three places:
+    // (1) per-agent `sua agent run` (one target), (2) chain execution
+    // (shared inputs across a fleet), (3) scheduler daemon (daemon-wide
+    // overrides across a mixed-declaration fleet). Only (1) can sensibly
+    // know what the targeted agent declares; (2) and (3) pass a shared
+    // map to every agent. Strict reject here would fail any agent in the
+    // fleet that happens not to declare a given key. The CLI layer
+    // pre-validates for case (1) before calling submitRun.
     let inputs: Record<string, string>;
     try {
       inputs = resolveInputs(request.agent.inputs, request.inputs ?? {}, {
         agentName: request.agent.name,
+        rejectUndeclared: false,
       });
     } catch (err) {
       this.store.updateRun(run.id, {

--- a/packages/core/src/local-provider.ts
+++ b/packages/core/src/local-provider.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from 'node:crypto';
-import type { Provider, AgentDefinition, Run, RunStatus } from './types.js';
+import type { Provider, RunRequest, Run, RunStatus } from './types.js';
 import { RunStore, type RunStoreOptions } from './run-store.js';
 import { executeAgent, type ExecutionHandle } from './agent-executor.js';
 import { buildAgentEnv, getTrustLevel } from './env-builder.js';
 import { redactKnownSecrets } from './secret-redactor.js';
+import { resolveInputs } from './input-resolver.js';
 import type { SecretsStore } from './secrets-store.js';
 
 export interface LocalProviderOptions {
@@ -49,7 +50,7 @@ export class LocalProvider implements Provider {
     this.store.close();
   }
 
-  async submitRun(request: { agent: AgentDefinition; triggeredBy: Run['triggeredBy'] }): Promise<Run> {
+  async submitRun(request: RunRequest): Promise<Run> {
     const run: Run = {
       id: randomUUID(),
       agentName: request.agent.name,
@@ -59,6 +60,23 @@ export class LocalProvider implements Provider {
     };
 
     this.store.createRun(run);
+
+    // Resolve typed inputs (merge provided + YAML defaults, validate types).
+    // Failures here (missing required, invalid type, undeclared provided key)
+    // surface as a failed run in history AND rethrow so the caller sees it.
+    let inputs: Record<string, string>;
+    try {
+      inputs = resolveInputs(request.agent.inputs, request.inputs ?? {}, {
+        agentName: request.agent.name,
+      });
+    } catch (err) {
+      this.store.updateRun(run.id, {
+        status: 'failed',
+        completedAt: new Date().toISOString(),
+        error: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
+    }
 
     const trustLevel = getTrustLevel(request.agent);
     const secrets = this.secretsStore ? await this.secretsStore.getAll() : undefined;
@@ -83,7 +101,10 @@ export class LocalProvider implements Provider {
 
     let handle: ExecutionHandle;
     try {
-      handle = executeAgent(request.agent, env, { allowUntrustedShell: this.allowUntrustedShell });
+      handle = executeAgent(request.agent, env, {
+        allowUntrustedShell: this.allowUntrustedShell,
+        inputs,
+      });
     } catch (err) {
       // Executor can throw synchronously for gate violations (e.g.
       // UntrustedCommunityShellError). Record the failure so the run

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -12,6 +12,12 @@ export interface LocalSchedulerOptions {
   agents: Map<string, AgentDefinition>;
   onFire?: (agent: AgentDefinition, runId: string) => void;
   onError?: (agent: AgentDefinition, error: Error) => void;
+  /**
+   * Daemon-wide input overrides supplied via `sua schedule start --input K=V`.
+   * Applied to every run the scheduler fires; individual agents that don't
+   * declare a given input simply ignore it (via `resolveInputs`).
+   */
+  inputs?: Record<string, string>;
 }
 
 export class LocalScheduler {
@@ -20,12 +26,14 @@ export class LocalScheduler {
   private readonly agents: Map<string, AgentDefinition>;
   private readonly onFire?: (agent: AgentDefinition, runId: string) => void;
   private readonly onError?: (agent: AgentDefinition, error: Error) => void;
+  private readonly inputs: Record<string, string>;
 
   constructor(options: LocalSchedulerOptions) {
     this.provider = options.provider;
     this.agents = options.agents;
     this.onFire = options.onFire;
     this.onError = options.onError;
+    this.inputs = options.inputs ?? {};
   }
 
   /**
@@ -60,7 +68,11 @@ export class LocalScheduler {
           );
         }
         try {
-          const run = await this.provider.submitRun({ agent, triggeredBy: 'schedule' });
+          const run = await this.provider.submitRun({
+            agent,
+            triggeredBy: 'schedule',
+            inputs: this.inputs,
+          });
           this.onFire?.(agent, run.id);
         } catch (err) {
           this.onError?.(agent, err instanceof Error ? err : new Error(String(err)));

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -142,6 +142,34 @@ describe('agentDefinitionSchema', () => {
       expect(result.success).toBe(false);
     });
 
+    it.each([
+      'LD_PRELOAD',
+      'LD_LIBRARY_PATH',
+      'DYLD_INSERT_LIBRARIES',
+      'NODE_OPTIONS',
+      'PYTHONPATH',
+      'PATH',
+      'SHELL',
+      'BASH_ENV',
+      'PROMPT_COMMAND',
+      'IFS',
+      'HOME',
+    ])('rejects declared input with sensitive env name %s', (name) => {
+      const result = agentDefinitionSchema.safeParse({
+        name: 'hostile',
+        type: 'claude-code',
+        prompt: 'hello',
+        inputs: { [name]: { type: 'string', default: '/tmp/evil' } },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find(
+          i => i.path[0] === 'inputs' && i.path[1] === name,
+        );
+        expect(issue?.message).toMatch(/reserved|sensitive/i);
+      }
+    });
+
     it('rejects enum inputs without a values array', () => {
       const result = agentDefinitionSchema.safeParse({
         name: 'bad',

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -118,6 +118,94 @@ describe('agentDefinitionSchema', () => {
     expect(result.mcp).toBe(true);
   });
 
+  describe('inputs', () => {
+    it('accepts a full inputs declaration', () => {
+      const result = agentDefinitionSchema.safeParse({
+        name: 'weather',
+        type: 'claude-code',
+        prompt: 'Weather for zip {{inputs.ZIP}} in {{inputs.STYLE}} form.',
+        inputs: {
+          ZIP: { type: 'number', required: true },
+          STYLE: { type: 'enum', values: ['haiku', 'verse'], default: 'haiku' },
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects input names that are not UPPERCASE_WITH_UNDERSCORES', () => {
+      const result = agentDefinitionSchema.safeParse({
+        name: 'bad',
+        type: 'claude-code',
+        prompt: 'hi',
+        inputs: { lowercase: { type: 'string' } },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects enum inputs without a values array', () => {
+      const result = agentDefinitionSchema.safeParse({
+        name: 'bad',
+        type: 'claude-code',
+        prompt: 'hi',
+        inputs: { STYLE: { type: 'enum' } },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects {{inputs.X}} inside shell command', () => {
+      const result = agentDefinitionSchema.safeParse({
+        name: 'bad-shell',
+        type: 'shell',
+        command: 'curl {{inputs.URL}}',
+        inputs: { URL: { type: 'string', required: true } },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find(i => i.path[0] === 'command');
+        expect(issue?.message).toMatch(/environment variables, not templates/);
+        expect(issue?.message).toMatch(/\$URL/);
+      }
+    });
+
+    it('accepts $VAR in shell command (the idiomatic path)', () => {
+      const result = agentDefinitionSchema.safeParse({
+        name: 'weather-shell',
+        type: 'shell',
+        command: 'curl "https://example.com/weather/$ZIP"',
+        inputs: { ZIP: { type: 'number', required: true } },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects undeclared {{inputs.X}} in prompt', () => {
+      const result = agentDefinitionSchema.safeParse({
+        name: 'bad-prompt',
+        type: 'claude-code',
+        prompt: 'Hello {{inputs.NAME}}',
+        inputs: { OTHER: { type: 'string', default: 'x' } },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find(i => i.path[0] === 'prompt');
+        expect(issue?.message).toMatch(/NAME.*not declared/);
+      }
+    });
+
+    it('rejects undeclared {{inputs.X}} in env values', () => {
+      const result = agentDefinitionSchema.safeParse({
+        name: 'bad-env',
+        type: 'shell',
+        command: 'echo ok',
+        env: { TARGET: 'https://api.example.com/{{inputs.SLUG}}' },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find(i => i.path.join('.') === 'env.TARGET');
+        expect(issue?.message).toMatch(/SLUG.*not declared/);
+      }
+    });
+  });
+
   it('rejects 6-field cron schedules without allowHighFrequency', () => {
     const result = agentDefinitionSchema.safeParse({
       name: 'fast',

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,5 +1,21 @@
 import { z } from 'zod';
 import { validateScheduleInterval, CronInvalidError, CronTooFrequentError } from './cron-validator.js';
+import { extractInputReferences } from './input-resolver.js';
+
+/**
+ * Per-input declaration. See docs/SECURITY.md and input-resolver.ts for the
+ * full type/default/required semantics.
+ */
+export const inputSpecSchema = z.object({
+  type: z.enum(['string', 'number', 'boolean', 'enum']),
+  values: z.array(z.string()).optional(),
+  default: z.union([z.string(), z.number(), z.boolean()]).optional(),
+  required: z.boolean().optional(),
+  description: z.string().optional(),
+}).refine(
+  (data) => data.type !== 'enum' || (data.values && data.values.length > 0),
+  { message: 'Enum inputs must declare a non-empty "values" array.', path: ['values'] },
+);
 
 export const agentDefinitionSchema = z.object({
   name: z.string().min(1).regex(/^[a-z0-9-]+$/, 'Must be lowercase with hyphens only'),
@@ -50,6 +66,17 @@ export const agentDefinitionSchema = z.object({
   secrets: z.array(z.string().regex(/^[A-Z_][A-Z0-9_]*$/, 'Must be a valid env var name (e.g. MY_API_KEY)')).optional(),
   envAllowlist: z.array(z.string()).optional(),
 
+  /**
+   * Runtime inputs declared by this agent. Callers supply values via
+   * `--input KEY=value`; YAML defaults fill in the rest. Input names must
+   * match env-var conventions (uppercase with underscores). See
+   * `input-resolver.ts` for full semantics.
+   */
+  inputs: z.record(
+    z.string().regex(/^[A-Z_][A-Z0-9_]*$/, 'Input names must be UPPERCASE_WITH_UNDERSCORES'),
+    inputSpecSchema,
+  ).optional(),
+
   // Metadata
   author: z.string().optional(),
   version: z.string().optional(),
@@ -62,19 +89,65 @@ export const agentDefinitionSchema = z.object({
   },
   { message: 'Shell agents require "command", claude-code agents require "prompt"' }
 ).superRefine((data, ctx) => {
-  if (!data.schedule) return;
-  try {
-    validateScheduleInterval(data.schedule, { allowHighFrequency: data.allowHighFrequency });
-  } catch (err) {
-    if (err instanceof CronInvalidError || err instanceof CronTooFrequentError) {
+  if (data.schedule) {
+    try {
+      validateScheduleInterval(data.schedule, { allowHighFrequency: data.allowHighFrequency });
+    } catch (err) {
+      if (err instanceof CronInvalidError || err instanceof CronTooFrequentError) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['schedule'],
+          message: err.message,
+        });
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  // Inputs: reject `{{inputs.*}}` in shell commands. Shell agents access
+  // inputs via `$VAR` env vars; templating inside a command string would
+  // force us to shell-escape substituted values, which is fraught. This
+  // rule pushes authors into the idiomatic shell path.
+  if (data.type === 'shell' && data.command) {
+    const refs = extractInputReferences(data.command);
+    if (refs.size > 0) {
+      const first = [...refs][0];
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: ['schedule'],
-        message: err.message,
+        path: ['command'],
+        message:
+          `Shell agents access inputs via environment variables, not templates. ` +
+          `Replace {{inputs.${first}}} with $${first} in the command ` +
+          `(declared inputs are injected into the process env automatically).`,
       });
-      return;
     }
-    throw err;
+  }
+
+  // Every `{{inputs.X}}` reference in prompt or env values must appear in
+  // the agent's `inputs:` declaration. Catches typos at load time rather
+  // than silent empty-string substitution at run time.
+  const declared = new Set(Object.keys(data.inputs ?? {}));
+  const checkRefs = (text: string | undefined, path: (string | number)[]): void => {
+    if (!text) return;
+    const refs = extractInputReferences(text);
+    for (const name of refs) {
+      if (!declared.has(name)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path,
+          message:
+            `Template references {{inputs.${name}}} but "${name}" is not declared ` +
+            `in this agent's \`inputs:\` block.`,
+        });
+      }
+    }
+  };
+  checkRefs(data.prompt, ['prompt']);
+  if (data.env) {
+    for (const [k, v] of Object.entries(data.env)) {
+      checkRefs(v, ['env', k]);
+    }
   }
 });
 

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { validateScheduleInterval, CronInvalidError, CronTooFrequentError } from './cron-validator.js';
-import { extractInputReferences } from './input-resolver.js';
+import { extractInputReferences, SENSITIVE_ENV_NAMES } from './input-resolver.js';
 
 /**
  * Per-input declaration. See docs/SECURITY.md and input-resolver.ts for the
@@ -121,6 +121,26 @@ export const agentDefinitionSchema = z.object({
           `Replace {{inputs.${first}}} with $${first} in the command ` +
           `(declared inputs are injected into the process env automatically).`,
       });
+    }
+  }
+
+  // Reject declared input names that would override sensitive process env
+  // vars (LD_PRELOAD, PATH, NODE_OPTIONS, etc.). Declared inputs are
+  // layered on top of the env-builder's trust filter, so allowing any of
+  // these names turns the inputs system into a trust-filter bypass for
+  // community agents. See input-resolver.ts SENSITIVE_ENV_NAMES.
+  if (data.inputs) {
+    for (const name of Object.keys(data.inputs)) {
+      if (SENSITIVE_ENV_NAMES.has(name)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['inputs', name],
+          message:
+            `Input name "${name}" is reserved. It would override a sensitive ` +
+            `process environment variable (dynamic-loader, interpreter, shell, ` +
+            `or identity hijack vector). Pick a different name.`,
+        });
+      }
     }
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,3 +1,11 @@
+export interface AgentInputSpec {
+  type: 'string' | 'number' | 'boolean' | 'enum';
+  values?: string[];
+  default?: string | number | boolean;
+  required?: boolean;
+  description?: string;
+}
+
 export interface AgentDefinition {
   name: string;
   description?: string;
@@ -27,6 +35,12 @@ export interface AgentDefinition {
    * before they land in the run store.
    */
   redactSecrets?: boolean;
+  /**
+   * Typed runtime input declarations. Callers supply values via
+   * `--input KEY=value`; YAML defaults fill in the rest. See
+   * input-resolver.ts for full semantics.
+   */
+  inputs?: Record<string, AgentInputSpec>;
   workingDirectory?: string;
 
   // Chaining (Phase 2a)
@@ -58,11 +72,22 @@ export interface Run {
   triggeredBy: 'cli' | 'mcp' | 'schedule';
 }
 
+export interface RunRequest {
+  agent: AgentDefinition;
+  triggeredBy: Run['triggeredBy'];
+  /**
+   * Runtime input values supplied by the caller. Keys must match the
+   * agent's declared `inputs:` block; undeclared keys are rejected by
+   * `resolveInputs`. Missing values with no default also fail fast.
+   */
+  inputs?: Record<string, string>;
+}
+
 export interface Provider {
   name: string;
   initialize(): Promise<void>;
   shutdown(): Promise<void>;
-  submitRun(request: { agent: AgentDefinition; triggeredBy: Run['triggeredBy'] }): Promise<Run>;
+  submitRun(request: RunRequest): Promise<Run>;
   getRun(runId: string): Promise<Run | null>;
   listRuns(filter?: { agentName?: string; status?: RunStatus; limit?: number }): Promise<Run[]>;
   cancelRun(runId: string): Promise<void>;

--- a/packages/temporal-provider/src/activities.ts
+++ b/packages/temporal-provider/src/activities.ts
@@ -61,10 +61,15 @@ export async function runAgentActivity(input: RunAgentActivityInput): Promise<Ru
   }
 
   // Resolve declared inputs (defaults, type validation, required checks).
+  // `rejectUndeclared: false` here matches LocalProvider — the activity can
+  // be invoked from chain / scheduler paths that share a single inputs map
+  // across a fleet, so extras must be tolerated. The CLI layer does strict
+  // pre-validation for the targeted-invocation case.
   let inputs: Record<string, string>;
   try {
     inputs = resolveInputs(input.agent.inputs, input.inputs ?? {}, {
       agentName: input.agent.name,
+      rejectUndeclared: false,
     });
   } catch (err) {
     return {

--- a/packages/temporal-provider/src/activities.ts
+++ b/packages/temporal-provider/src/activities.ts
@@ -5,6 +5,7 @@ import {
   executeAgent,
   EncryptedFileStore,
   redactKnownSecrets,
+  resolveInputs,
 } from '@some-useful-agents/core';
 
 export interface RunAgentActivityInput {
@@ -18,6 +19,13 @@ export interface RunAgentActivityInput {
    * than applying its own.
    */
   allowUntrustedShell?: string[];
+  /**
+   * Caller-supplied input values keyed by name. Resolved against the agent's
+   * declared `inputs:` (defaults applied, types validated) inside the
+   * activity so a misconfigured submit fails the activity with a clear
+   * error rather than surfacing halfway through execution.
+   */
+  inputs?: Record<string, string>;
 }
 
 export interface RunAgentActivityResult {
@@ -52,10 +60,25 @@ export async function runAgentActivity(input: RunAgentActivityInput): Promise<Ru
     };
   }
 
+  // Resolve declared inputs (defaults, type validation, required checks).
+  let inputs: Record<string, string>;
+  try {
+    inputs = resolveInputs(input.agent.inputs, input.inputs ?? {}, {
+      agentName: input.agent.name,
+    });
+  } catch (err) {
+    return {
+      result: '',
+      exitCode: 1,
+      error: err instanceof Error ? err.message : String(err),
+      warnings,
+    };
+  }
+
   const allowUntrustedShell = new Set(input.allowUntrustedShell ?? []);
   let handle;
   try {
-    handle = executeAgent(input.agent, env, { allowUntrustedShell });
+    handle = executeAgent(input.agent, env, { allowUntrustedShell, inputs });
   } catch (err) {
     return {
       result: '',

--- a/packages/temporal-provider/src/provider.ts
+++ b/packages/temporal-provider/src/provider.ts
@@ -1,6 +1,6 @@
 import { Connection, Client, WorkflowNotFoundError } from '@temporalio/client';
 import { randomUUID } from 'node:crypto';
-import type { Provider, AgentDefinition, Run, RunStatus } from '@some-useful-agents/core';
+import type { Provider, RunRequest, Run, RunStatus } from '@some-useful-agents/core';
 import { RunStore } from '@some-useful-agents/core';
 import { DEFAULT_TASK_QUEUE } from './worker.js';
 import type { RunAgentWorkflowInput, RunAgentWorkflowResult } from './workflows.js';
@@ -51,7 +51,7 @@ export class TemporalProvider implements Provider {
     this.store.close();
   }
 
-  async submitRun(request: { agent: AgentDefinition; triggeredBy: Run['triggeredBy'] }): Promise<Run> {
+  async submitRun(request: RunRequest): Promise<Run> {
     const run: Run = {
       id: randomUUID(),
       agentName: request.agent.name,
@@ -65,6 +65,7 @@ export class TemporalProvider implements Provider {
       agent: request.agent,
       secretsPath: this.options.secretsPath,
       allowUntrustedShell: [...this.allowUntrustedShell],
+      inputs: request.inputs,
     };
 
     // Fire-and-forget start; poll for status later via workflow handle

--- a/packages/temporal-provider/src/workflows.ts
+++ b/packages/temporal-provider/src/workflows.ts
@@ -18,6 +18,11 @@ export interface RunAgentWorkflowInput {
    * serializable by Temporal's data converter.
    */
   allowUntrustedShell?: string[];
+  /**
+   * Caller-supplied input values. Validated inside the activity against
+   * the agent's `inputs:` declarations.
+   */
+  inputs?: Record<string, string>;
 }
 
 export interface RunAgentWorkflowResult {
@@ -37,5 +42,6 @@ export async function runAgentWorkflow(input: RunAgentWorkflowInput): Promise<Ru
     agent: input.agent,
     secretsPath: input.secretsPath,
     allowUntrustedShell: input.allowUntrustedShell,
+    inputs: input.inputs,
   });
 }


### PR DESCRIPTION
## Summary

Typed runtime inputs for agents. Declare parameters in YAML with types, defaults, and required flags; supply values at invocation via `--input KEY=value`. Closes the "I want my claude agent to take a zip code" story from `claude-hello.yaml`.

## The feature

**Declare once:**

```yaml
name: weather-verse
type: claude-code
prompt: "Weather for zip {{inputs.ZIP}} as a {{inputs.STYLE}}."
inputs:
  ZIP:
    type: number
    required: true
  STYLE:
    type: enum
    values: [haiku, verse, limerick]
    default: haiku
```

**Use everywhere:**

```bash
sua agent run weather-verse --input ZIP=94110
sua agent run weather-verse --input ZIP=10001 --input STYLE=limerick
sua schedule start --input ZIP=94110    # daemon-wide override
```

## Two execution models, one declaration

- **claude-code agents** — `{{inputs.X}}` in the prompt is substituted before spawn. No injection class because prompts aren't executed.
- **shell agents** — declared inputs become env vars. Authors write `"$ZIP"`; bash handles quoting. `{{inputs.X}}` inside a shell `command:` is **rejected at load time** with a clear error pointing to the `$X` form.

## Types

`string` · `number` · `boolean` · `enum`. Type is for validation at the boundary — every resolved input renders as a string in templates/env.

## Precedence (highest wins)

1. `sua agent run --input K=V`
2. `sua schedule start --input K=V` (daemon-wide; agents that don't declare ignore)
3. YAML `default:`
4. Else fail (`MissingInputError` / `InvalidInputTypeError` / `UndeclaredInputError`)

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm test` — **234 tests pass** (was 196; +38 new across input-resolver, schema, local-provider)
- [x] Manual verification:
  - `sua agent audit claude-hello` prints the new `inputs:` block with types + defaults
  - `sua agent run claude-hello` → `❌ Missing required input: ZIP ... pass --input ZIP=<value>`
  - `sua agent run claude-hello --input ZIP=abc` → `❌ Invalid value for input "ZIP" ... expected type number`
  - `sua agent run claude-hello --input ZIP=94110` → runs (when claude CLI available)
  - Shell agent: `command: 'echo "$ZIP"'` with `inputs: { ZIP: { type: number, required: true } }` works with `--input ZIP=94110`
- [ ] After merge + publish: repo `claude-hello.yaml` has been updated to use the new mechanism

## API changes

See the changeset for full list. Summary:

- `Provider.submitRun(request: RunRequest)` — request type formalized; `inputs?: Record<string, string>` added.
- `ExecutionOptions.inputs` on `executeAgent`.
- `ChainOptions.inputs` on `executeChain` — flows to every agent in the chain.
- `LocalSchedulerOptions.inputs` — daemon-wide overrides.
- Temporal carries `inputs` in the workflow payload so remote workers inherit them.
- New exports from `@some-useful-agents/core`: `AgentInputSpec`, `inputSpecSchema`, `resolveInputs`, `validateAndRender`, `extractInputReferences`, `substituteInputs`, `MissingInputError`, `InvalidInputTypeError`, `UndeclaredInputError`, `RunRequest`.

All additive. No breaking changes for existing agents — agents without an `inputs:` block behave identically.

## Design decisions worth calling out

1. **Typed but rendered as string.** Validation at CLI boundary, no implicit coercion downstream. Keeps the mental model simple.
2. **Shell: env vars, not templates.** Delegates quoting to bash (well-understood escape rules) rather than adding a template-injection surface.
3. **Fail loudly.** Missing/invalid/undeclared → fail before spawn, recorded as a failed run in history.
4. **Inputs declared in YAML.** Not free-form — the declaration is the contract; unexpected provided keys are a `UndeclaredInputError` (override with `rejectUndeclared: false` if you really want loose mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
