### PR TITLE
fix: only open secrets store for agents that declare secrets

### DIFF
--- a/.changeset/lazy-secrets-fetch.md
+++ b/.changeset/lazy-secrets-fetch.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/dashboard": patch
+---
+
+**fix: don't open the secrets store for agents that declare no secrets.**
+
+v0.10.0 regression: `LocalProvider.submitRun` and `runAgentActivity` both called `secretsStore.getAll()` unconditionally for every run, which meant any agent — even one with no `secrets:` field — needed the store to be unlockable. On a v2 passphrase-protected store that turned every run into "set SUA_SECRETS_PASSPHRASE or nothing works", which was never the intent.
+
+Now the store is only opened when the agent actually declares secrets. Regression test in `local-provider.test.ts` uses a store that throws on any read and asserts the provider never touches it for an agent with no `secrets:` field.

--- a/packages/core/src/local-provider.test.ts
+++ b/packages/core/src/local-provider.test.ts
@@ -3,7 +3,22 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { LocalProvider, UntrustedCommunityShellError, MemorySecretsStore } from './index.js';
-import type { AgentDefinition } from './index.js';
+import type { AgentDefinition, SecretsStore } from './index.js';
+
+/**
+ * SecretsStore that explodes on any read. Lets tests assert that the
+ * provider never touches the store for agents that don't declare any
+ * `secrets:` — the regression introduced when v2 passphrase-protection
+ * landed in v0.10.0.
+ */
+class ExplodingSecretsStore implements SecretsStore {
+  async get(): Promise<string | undefined> { throw new Error('store opened unexpectedly'); }
+  async set(): Promise<void> { throw new Error('store opened unexpectedly'); }
+  async delete(): Promise<void> { throw new Error('store opened unexpectedly'); }
+  async list(): Promise<string[]> { throw new Error('store opened unexpectedly'); }
+  async has(): Promise<boolean> { throw new Error('store opened unexpectedly'); }
+  async getAll(): Promise<Record<string, string>> { throw new Error('store opened unexpectedly'); }
+}
 
 let dir: string;
 let dbPath: string;
@@ -213,6 +228,44 @@ describe('LocalProvider typed inputs', () => {
       delete process.env.ZIP;
       await provider.shutdown();
     }
+  });
+});
+
+describe('LocalProvider lazy secrets fetch (v0.10.x fix)', () => {
+  it('never opens the secrets store for agents with no declared secrets', async () => {
+    const provider = new LocalProvider(dbPath, new ExplodingSecretsStore());
+    await provider.initialize();
+
+    // Agent declares no `secrets:` — the store should never be read.
+    const run = await provider.submitRun({
+      agent: shellAgent({ name: 'no-secrets', command: 'echo ok' }),
+      triggeredBy: 'cli',
+    });
+    const final = await waitFor(provider, run.id);
+
+    expect(final!.status).toBe('completed');
+    expect(final!.result).toContain('ok');
+    await provider.shutdown();
+  });
+
+  it('still opens the store and reports missing secrets for agents that declare them', async () => {
+    const provider = new LocalProvider(dbPath, new MemorySecretsStore());
+    await provider.initialize();
+
+    const run = await provider.submitRun({
+      agent: shellAgent({
+        name: 'needs-secret',
+        command: 'echo $API_KEY',
+        secrets: ['API_KEY'],
+      }),
+      triggeredBy: 'cli',
+    });
+    const final = await waitFor(provider, run.id);
+
+    expect(final!.status).toBe('failed');
+    expect(final!.error).toContain('Missing secrets');
+    expect(final!.error).toContain('API_KEY');
+    await provider.shutdown();
   });
 });
 

--- a/packages/core/src/local-provider.ts
+++ b/packages/core/src/local-provider.ts
@@ -89,7 +89,14 @@ export class LocalProvider implements Provider {
     }
 
     const trustLevel = getTrustLevel(request.agent);
-    const secrets = this.secretsStore ? await this.secretsStore.getAll() : undefined;
+    // Only open the secrets store when the agent actually declares secrets.
+    // Agents with no `secrets:` field never read from the store, and forcing
+    // them to unlock a v2 passphrase-protected store is a v0.10 regression:
+    // it coupled every run to the store's lock state even when no secret
+    // was ever going to be injected.
+    const needsSecrets = (request.agent.secrets?.length ?? 0) > 0;
+    const secrets =
+      needsSecrets && this.secretsStore ? await this.secretsStore.getAll() : undefined;
     const { env, missingSecrets, warnings } = buildAgentEnv({
       agent: request.agent,
       trustLevel,

--- a/packages/temporal-provider/src/activities.ts
+++ b/packages/temporal-provider/src/activities.ts
@@ -41,8 +41,13 @@ export interface RunAgentActivityResult {
  * Workflows call this activity; workflows themselves are deterministic and can't spawn processes.
  */
 export async function runAgentActivity(input: RunAgentActivityInput): Promise<RunAgentActivityResult> {
-  const secretsStore = new EncryptedFileStore(input.secretsPath);
-  const secrets = await secretsStore.getAll();
+  // Only open the secrets store when the agent actually declares secrets.
+  // Parallels the local-provider fix: a v2 passphrase-protected store
+  // should not gate agents that never ask for a secret.
+  const needsSecrets = (input.agent.secrets?.length ?? 0) > 0;
+  const secrets = needsSecrets
+    ? await new EncryptedFileStore(input.secretsPath).getAll()
+    : undefined;
   const trustLevel = getTrustLevel(input.agent);
 
   const { env, missingSecrets, warnings } = buildAgentEnv({


### PR DESCRIPTION
## Summary

v0.10.0 regression. `LocalProvider.submitRun` and `runAgentActivity` unconditionally call `secretsStore.getAll()` for every run. Pre-v0.10 that was harmless — the v1 hostname-derived key always succeeded — but with v2 passphrase-protection live, every run now inherits the store's lock state. Agents that never reference a secret still failed with `Secrets store is passphrase-protected...` unless `SUA_SECRETS_PASSPHRASE` was set.

Gate the `getAll()` call on `agent.secrets?.length > 0`. No-secrets agents skip the store entirely. Agents that do declare secrets keep the existing missing-secrets / wrong-passphrase surfaces.

## Repro (before this fix)

```bash
cd /tmp && mkdir sua-bug && cd sua-bug
sua init
SUA_SECRETS_PASSPHRASE=pp sua secrets set UNUSED   # type any value
cat > agents/local/greet.yaml <<YAMLEOF
name: greet
type: shell
command: echo hi
YAMLEOF
sua agent run greet
# Before: fails with "Secrets store is passphrase-protected..."
# After:  runs cleanly; greet never referenced a secret.
```

## Test plan

- [x] `npx vitest run` — 271 tests pass (was 269; +2 regression tests in `local-provider.test.ts`)
  - `never opens the secrets store for agents with no declared secrets` — uses `ExplodingSecretsStore` that throws on any read; run completes successfully
  - `still opens the store and reports missing secrets for agents that declare them` — verifies the "missing secret" error path still fires
- [x] Manual: reproduced the original failure against a passphrase-protected `/tmp/sua-tty/data/secrets.enc`, confirmed the `greet` agent runs cleanly without `SUA_SECRETS_PASSPHRASE` after this patch

## Patch bumps

- `@some-useful-agents/core` — patch (fix in `local-provider.ts`)
- `@some-useful-agents/temporal-provider` — patch (same fix in `runAgentActivity`)
- `cli` / `mcp-server` / `dashboard` — patch via the `fixed` group in `.changeset/config.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
