### PR TITLE
feat: RunStore.queryRuns + shared HTTP auth module (dashboard foundations)

### DIFF
--- a/.changeset/dashboard-foundations.md
+++ b/.changeset/dashboard-foundations.md
@@ -1,0 +1,35 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/mcp-server": patch
+---
+
+**feat: RunStore.queryRuns + shared HTTP auth module.** Foundation for the v0.12.0 dashboard — no user-facing behavior changes yet, but two pieces are now ready for the dashboard to build on:
+
+### `RunStore.queryRuns({ filter })`
+
+Richer run-query API with filter composition, offset pagination, and a total-count return. Supersedes `listRuns` for the dashboard's `/runs` page (and any caller that needs paged output without a second COUNT query):
+
+```ts
+const { rows, total } = store.queryRuns({
+  agentName: 'hello',
+  statuses: ['completed', 'failed'],     // OR within statuses
+  triggeredBy: 'schedule',
+  q: 'abc',                              // prefix on id OR substring on agentName (case-insensitive)
+  limit: 50,
+  offset: 0,
+});
+```
+
+- All filter fields compose with `AND`; `statuses[]` OR's within itself
+- `q` escapes SQL `LIKE` metacharacters so `50%` matches `"50%-win"` literally instead of every row
+- `limit` is clamped to `MAX_RUNS_LIMIT = 500`; `DEFAULT_RUNS_LIMIT = 50`
+- Two new indexes (`idx_runs_triggeredBy`, `idx_runs_startedAt` — DESC for the newest-first default) keep filter + order costs cheap
+- `distinctValues(column)` helper enumerates seen agents / statuses / triggeredBy values for dropdown population; the column name is allowlist-checked so there's no SQL-injection surface from the string
+
+Existing `listRuns` is untouched — MCP server, CLI `status`/`logs`/`cancel` keep working. Migration to `queryRuns` is opt-in per caller.
+
+### Shared HTTP loopback auth (`@some-useful-agents/core/http-auth`)
+
+The `checkAuthorization`, `checkHost`, `checkOrigin`, and `buildLoopbackAllowlist` helpers that lived in `packages/mcp-server/src/auth.ts` are now in core. Same implementations, same tests (via the existing mcp-server suite). The mcp-server's `auth.ts` is now a thin re-export so existing internal imports keep working unchanged. New `checkCookieToken` sibling for cookie-based auth (the dashboard's case).
+
+Why: the dashboard needs the same three checks. Having it import from `@some-useful-agents/mcp-server` would couple a human-facing HTML surface to a programmatic-API package for a concern that belongs at the shared layer.

--- a/packages/core/src/http-auth.ts
+++ b/packages/core/src/http-auth.ts
@@ -1,0 +1,128 @@
+import { timingSafeEqual } from 'node:crypto';
+
+/**
+ * Shared HTTP loopback defenses used by both the MCP server and the web
+ * dashboard. Extracted from `packages/mcp-server/src/auth.ts` so the
+ * dashboard doesn't have to import from a sibling package to get the same
+ * three checks (bearer / Host / Origin) the MCP server already uses.
+ *
+ * Three concrete attacks this module mitigates:
+ *
+ *  1. LAN attacker reaching the bound port directly. Mitigated by binding
+ *     to 127.0.0.1 in the http server itself; this module assumes the bind
+ *     happened. The Host check is belt-and-suspenders for the case where
+ *     the operator opted into a non-loopback bind via --host.
+ *
+ *  2. DNS rebinding from a browser. The browser sends a real Origin header
+ *     when issuing CORS requests; we reject any present Origin that isn't
+ *     loopback. (Non-browser clients send no Origin and pass through.)
+ *
+ *  3. Unauthorized local processes. A bearer token in a 0o600 file under
+ *     ~/.sua/ separates "any process on this machine" from "a process the
+ *     user has shared the token with."
+ */
+
+export type AuthCheckResult =
+  | { ok: true }
+  | { ok: false; status: number; error: string };
+
+function safeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  const ba = Buffer.from(a, 'utf-8');
+  const bb = Buffer.from(b, 'utf-8');
+  if (ba.length !== bb.length) return false;
+  return timingSafeEqual(ba, bb);
+}
+
+/** Verify the Authorization header carries a matching bearer token. */
+export function checkAuthorization(
+  header: string | undefined,
+  expectedToken: string,
+): AuthCheckResult {
+  if (!header) {
+    return { ok: false, status: 401, error: 'Missing Authorization header' };
+  }
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  if (!match) {
+    return { ok: false, status: 401, error: 'Authorization must be "Bearer <token>"' };
+  }
+  if (!safeEqual(match[1], expectedToken)) {
+    return { ok: false, status: 401, error: 'Invalid bearer token' };
+  }
+  return { ok: true };
+}
+
+/** Constant-time compare for a cookie value against the expected token. */
+export function checkCookieToken(
+  cookieValue: string | undefined,
+  expectedToken: string,
+): AuthCheckResult {
+  if (!cookieValue) {
+    return { ok: false, status: 401, error: 'Missing session cookie' };
+  }
+  if (!safeEqual(cookieValue, expectedToken)) {
+    return { ok: false, status: 401, error: 'Invalid session cookie' };
+  }
+  return { ok: true };
+}
+
+/**
+ * Build the allowlist of hostnames we accept on the Host and Origin headers
+ * for a given listen port. Only loopback names; remote names are never OK.
+ */
+export function buildLoopbackAllowlist(port: number): Set<string> {
+  return new Set([
+    `localhost:${port}`,
+    `127.0.0.1:${port}`,
+    `[::1]:${port}`,
+    'localhost',
+    '127.0.0.1',
+    '[::1]',
+  ]);
+}
+
+/** Reject Host header values that aren't loopback. */
+export function checkHost(
+  host: string | undefined,
+  allowlist: Set<string>,
+): AuthCheckResult {
+  if (!host) {
+    return { ok: false, status: 400, error: 'Missing Host header' };
+  }
+  if (!allowlist.has(host.toLowerCase())) {
+    return {
+      ok: false,
+      status: 403,
+      error: `Host header "${host}" is not allowed. Only loopback hosts are accepted.`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * Reject Origin headers that look like they came from a remote browser. A
+ * missing Origin is allowed (non-browser clients don't send one); a present
+ * Origin must point at a loopback host on our port.
+ */
+export function checkOrigin(
+  origin: string | undefined,
+  allowlist: Set<string>,
+): AuthCheckResult {
+  if (!origin) return { ok: true };
+  let url: URL;
+  try {
+    url = new URL(origin);
+  } catch {
+    return { ok: false, status: 403, error: `Malformed Origin header "${origin}"` };
+  }
+  const hostWithPort = url.host.toLowerCase();
+  const hostOnly = url.hostname.toLowerCase();
+  if (!allowlist.has(hostWithPort) && !allowlist.has(hostOnly)) {
+    return {
+      ok: false,
+      status: 403,
+      error: `Origin "${origin}" is not allowed. Only loopback origins are accepted.`,
+    };
+  }
+  return { ok: true };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,3 +15,4 @@ export * from './fs-utils.js';
 export * from './mcp-token.js';
 export * from './secret-redactor.js';
 export * from './input-resolver.js';
+export * from './http-auth.js';

--- a/packages/core/src/run-store.test.ts
+++ b/packages/core/src/run-store.test.ts
@@ -134,3 +134,129 @@ describe('RunStore', () => {
     store = new RunStore(TEST_DB);  // for afterEach cleanup
   });
 });
+
+describe('RunStore.queryRuns', () => {
+  beforeEach(() => {
+    // Seed a fixture set that covers the filter dimensions the dashboard
+    // ships. Mixing agents, statuses, and triggered-by values.
+    const t = Date.now();
+    const secondsAgo = (n: number) => new Date(t - n * 1000).toISOString();
+    const seed: Array<Partial<Run>> = [
+      { id: 'abc-111', agentName: 'hello',   status: 'completed', triggeredBy: 'cli',      startedAt: secondsAgo(10) },
+      { id: 'abc-222', agentName: 'hello',   status: 'failed',    triggeredBy: 'schedule', startedAt: secondsAgo(20) },
+      { id: 'def-333', agentName: 'greet',   status: 'completed', triggeredBy: 'cli',      startedAt: secondsAgo(30) },
+      { id: 'def-444', agentName: 'greet',   status: 'failed',    triggeredBy: 'mcp',      startedAt: secondsAgo(40) },
+      { id: 'ghi-555', agentName: 'weather', status: 'running',   triggeredBy: 'schedule', startedAt: secondsAgo(50) },
+      { id: 'ghi-666', agentName: 'weather', status: 'cancelled', triggeredBy: 'cli',      startedAt: secondsAgo(60) },
+    ];
+    for (const s of seed) store.createRun(makeRun(s));
+  });
+
+  it('returns all rows when no filters, newest first', () => {
+    const { rows, total } = store.queryRuns();
+    expect(total).toBe(6);
+    expect(rows).toHaveLength(6);
+    expect(rows[0].id).toBe('abc-111');
+    expect(rows[5].id).toBe('ghi-666');
+  });
+
+  it('filters by agentName', () => {
+    const { rows, total } = store.queryRuns({ agentName: 'greet' });
+    expect(total).toBe(2);
+    expect(rows.map((r) => r.id).sort()).toEqual(['def-333', 'def-444']);
+  });
+
+  it('filters by single status', () => {
+    const { rows, total } = store.queryRuns({ statuses: ['failed'] });
+    expect(total).toBe(2);
+    expect(rows.every((r) => r.status === 'failed')).toBe(true);
+  });
+
+  it('ORs multiple statuses', () => {
+    const { rows, total } = store.queryRuns({ statuses: ['completed', 'failed'] });
+    expect(total).toBe(4);
+    expect(rows.every((r) => r.status === 'completed' || r.status === 'failed')).toBe(true);
+  });
+
+  it('filters by triggeredBy', () => {
+    const { rows, total } = store.queryRuns({ triggeredBy: 'schedule' });
+    expect(total).toBe(2);
+    expect(rows.every((r) => r.triggeredBy === 'schedule')).toBe(true);
+  });
+
+  it('composes filters with AND', () => {
+    const { rows, total } = store.queryRuns({
+      agentName: 'hello',
+      statuses: ['failed'],
+      triggeredBy: 'schedule',
+    });
+    expect(total).toBe(1);
+    expect(rows[0].id).toBe('abc-222');
+  });
+
+  it('q matches run-id prefix', () => {
+    const { rows, total } = store.queryRuns({ q: 'abc' });
+    expect(total).toBe(2);
+    expect(rows.map((r) => r.id).sort()).toEqual(['abc-111', 'abc-222']);
+  });
+
+  it('q matches agentName substring case-insensitively', () => {
+    const { rows, total } = store.queryRuns({ q: 'EATHE' });
+    expect(total).toBe(2);
+    expect(rows.every((r) => r.agentName === 'weather')).toBe(true);
+  });
+
+  it('q escapes SQL LIKE metacharacters', () => {
+    // Seed a row whose id includes a literal %. Searching for "%" should
+    // not match every row — it should only match this one.
+    store.createRun(makeRun({ id: '50%-win', agentName: 'edge' }));
+    const { rows, total } = store.queryRuns({ q: '50%' });
+    expect(total).toBe(1);
+    expect(rows[0].id).toBe('50%-win');
+  });
+
+  it('clamps limit to MAX_RUNS_LIMIT', () => {
+    const { rows } = store.queryRuns({ limit: 10_000 });
+    expect(rows.length).toBeLessThanOrEqual(500);
+  });
+
+  it('honors offset for pagination', () => {
+    const page1 = store.queryRuns({ limit: 2, offset: 0 });
+    const page2 = store.queryRuns({ limit: 2, offset: 2 });
+    expect(page1.rows[0].id).toBe('abc-111');
+    expect(page2.rows[0].id).toBe('def-333');
+    expect(page1.total).toBe(page2.total); // total is filter-relative, not page-relative
+  });
+
+  it('returns empty rows but correct total when offset exceeds size', () => {
+    const { rows, total } = store.queryRuns({ offset: 1000 });
+    expect(rows).toHaveLength(0);
+    expect(total).toBe(6);
+  });
+
+  it('limit=0 returns zero rows but correct total', () => {
+    const { rows, total } = store.queryRuns({ limit: 0 });
+    expect(rows).toHaveLength(0);
+    expect(total).toBe(6);
+  });
+});
+
+describe('RunStore.distinctValues', () => {
+  beforeEach(() => {
+    store.createRun(makeRun({ id: 'a', agentName: 'hello',   status: 'completed', triggeredBy: 'cli' }));
+    store.createRun(makeRun({ id: 'b', agentName: 'greet',   status: 'failed',    triggeredBy: 'schedule' }));
+    store.createRun(makeRun({ id: 'c', agentName: 'hello',   status: 'failed',    triggeredBy: 'cli' }));
+  });
+
+  it('returns distinct agent names', () => {
+    expect(store.distinctValues('agentName')).toEqual(['greet', 'hello']);
+  });
+
+  it('returns distinct statuses', () => {
+    expect(store.distinctValues('status')).toEqual(['completed', 'failed']);
+  });
+
+  it('returns distinct triggeredBy values', () => {
+    expect(store.distinctValues('triggeredBy')).toEqual(['cli', 'schedule']);
+  });
+});

--- a/packages/core/src/run-store.ts
+++ b/packages/core/src/run-store.ts
@@ -18,6 +18,16 @@ export interface RunStoreOptions {
 /** Default retention window for run rows. */
 export const DEFAULT_RETENTION_DAYS = 30;
 
+/** Default + cap for queryRuns pagination. */
+export const DEFAULT_RUNS_LIMIT = 50;
+export const MAX_RUNS_LIMIT = 500;
+
+function clampLimit(limit: number | undefined): number {
+  if (limit === undefined || !Number.isFinite(limit)) return DEFAULT_RUNS_LIMIT;
+  if (limit < 0) return 0;
+  return Math.min(Math.floor(limit), MAX_RUNS_LIMIT);
+}
+
 export class RunStore {
   private db: DatabaseSync;
 
@@ -50,6 +60,10 @@ export class RunStore {
     this.db.exec(`
       CREATE INDEX IF NOT EXISTS idx_runs_agent ON runs(agentName);
       CREATE INDEX IF NOT EXISTS idx_runs_status ON runs(status);
+      CREATE INDEX IF NOT EXISTS idx_runs_triggeredBy ON runs(triggeredBy);
+      -- DESC ordering is the dashboard's runs-list default; without this
+      -- the ORDER BY scans the whole table.
+      CREATE INDEX IF NOT EXISTS idx_runs_startedAt ON runs(startedAt DESC);
     `);
 
     this.sweepExpired(options.retentionDays ?? DEFAULT_RETENTION_DAYS);
@@ -130,6 +144,75 @@ export class RunStore {
     const stmt = this.db.prepare(sql);
     const rows = stmt.all(...values) as Record<string, unknown>[];
     return rows.map(row => this.rowToRun(row));
+  }
+
+  /**
+   * Richer query for the dashboard. Supports filter composition (AND across
+   * fields, OR within `statuses`), pagination, and returns a total count
+   * alongside the rows so callers can render "Showing N–M of T" without a
+   * second query from the caller.
+   */
+  queryRuns(filter: {
+    agentName?: string;
+    statuses?: RunStatus[];
+    triggeredBy?: string;
+    q?: string;
+    limit?: number;
+    offset?: number;
+  } = {}): { rows: Run[]; total: number } {
+    const clauses: string[] = [];
+    const values: SqlValue[] = [];
+
+    if (filter.agentName) {
+      clauses.push('agentName = ?');
+      values.push(filter.agentName);
+    }
+    if (filter.triggeredBy) {
+      clauses.push('triggeredBy = ?');
+      values.push(filter.triggeredBy);
+    }
+    if (filter.statuses && filter.statuses.length > 0) {
+      const placeholders = filter.statuses.map(() => '?').join(', ');
+      clauses.push(`status IN (${placeholders})`);
+      values.push(...filter.statuses);
+    }
+    if (filter.q && filter.q.length > 0) {
+      // Prefix match on run id OR substring match on agent name.
+      // Escape SQL LIKE metacharacters in the user-supplied value so "%foo"
+      // doesn't match the literal "%" character by accident.
+      const escaped = filter.q.replace(/([\\%_])/g, '\\$1');
+      clauses.push(`(id LIKE ? ESCAPE '\\' OR LOWER(agentName) LIKE ? ESCAPE '\\')`);
+      values.push(`${escaped}%`, `%${escaped.toLowerCase()}%`);
+    }
+
+    const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
+
+    const limit = clampLimit(filter.limit);
+    const offset = Math.max(0, filter.offset ?? 0);
+
+    const rowStmt = this.db.prepare(
+      `SELECT * FROM runs ${where} ORDER BY startedAt DESC LIMIT ? OFFSET ?`,
+    );
+    const rows = rowStmt.all(...values, limit, offset) as Record<string, unknown>[];
+
+    const countStmt = this.db.prepare(`SELECT COUNT(*) as c FROM runs ${where}`);
+    const countRow = countStmt.get(...values) as { c: number | bigint };
+    const total = Number(countRow.c);
+
+    return { rows: rows.map((r) => this.rowToRun(r)), total };
+  }
+
+  /**
+   * Distinct values for a given indexed column. Used to populate the
+   * dashboard's filter dropdowns without hardcoding the enum. Column name
+   * is restricted to an allowlist to avoid any SQL injection surface.
+   */
+  distinctValues(column: 'agentName' | 'status' | 'triggeredBy'): string[] {
+    const stmt = this.db.prepare(
+      `SELECT DISTINCT ${column} AS v FROM runs WHERE ${column} IS NOT NULL ORDER BY v`,
+    );
+    const rows = stmt.all() as Array<{ v: string }>;
+    return rows.map((r) => r.v);
   }
 
   close(): void {

--- a/packages/mcp-server/src/auth.ts
+++ b/packages/mcp-server/src/auth.ts
@@ -1,114 +1,15 @@
-import { timingSafeEqual } from 'node:crypto';
-
 /**
- * The MCP server is intended for localhost-only access. These layers defend
- * against three concrete attacks:
- *
- *  1. LAN attacker reaching the bound port directly. Mitigated by binding
- *     to 127.0.0.1 in the http server itself; this module assumes the bind
- *     happened. The Host check is belt-and-suspenders for the case where
- *     the operator opted into a non-loopback bind via --host.
- *
- *  2. DNS rebinding from a browser. The browser sends a real Origin header
- *     when issuing CORS requests; we reject any present Origin that isn't
- *     loopback. (Non-browser clients send no Origin and pass through.)
- *
- *  3. Unauthorized local processes. A bearer token in a 0o600 file under
- *     ~/.sua/ separates "any process on this machine" from "a process the
- *     user has shared the token with."
+ * Re-exports of the shared HTTP auth helpers that used to live here. The
+ * canonical implementations moved to `@some-useful-agents/core/http-auth`
+ * in v0.12.0 so both the MCP server and the dashboard can share them.
+ * Keeping the names stable here so existing `./auth.js` imports inside
+ * this package don't need to change.
  */
-
-export type AuthCheckResult =
-  | { ok: true }
-  | { ok: false; status: number; error: string };
-
-/** Constant-time string compare. Both arguments must be the same length. */
-function safeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  const ba = Buffer.from(a, 'utf-8');
-  const bb = Buffer.from(b, 'utf-8');
-  if (ba.length !== bb.length) return false;
-  return timingSafeEqual(ba, bb);
-}
-
-/** Verify the Authorization header carries a matching bearer token. */
-export function checkAuthorization(
-  header: string | undefined,
-  expectedToken: string,
-): AuthCheckResult {
-  if (!header) {
-    return { ok: false, status: 401, error: 'Missing Authorization header' };
-  }
-  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
-  if (!match) {
-    return { ok: false, status: 401, error: 'Authorization must be "Bearer <token>"' };
-  }
-  if (!safeEqual(match[1], expectedToken)) {
-    return { ok: false, status: 401, error: 'Invalid bearer token' };
-  }
-  return { ok: true };
-}
-
-/**
- * Build the allowlist of hostnames we accept on the Host and Origin headers
- * for a given listen port. Only loopback names; remote names are never OK.
- */
-export function buildLoopbackAllowlist(port: number): Set<string> {
-  return new Set([
-    `localhost:${port}`,
-    `127.0.0.1:${port}`,
-    `[::1]:${port}`,
-    // Some clients may strip the default port; we never run on 80/443
-    // but accept bare loopback names defensively.
-    'localhost',
-    '127.0.0.1',
-    '[::1]',
-  ]);
-}
-
-/** Reject Host header values that aren't loopback. */
-export function checkHost(
-  host: string | undefined,
-  allowlist: Set<string>,
-): AuthCheckResult {
-  if (!host) {
-    return { ok: false, status: 400, error: 'Missing Host header' };
-  }
-  if (!allowlist.has(host.toLowerCase())) {
-    return {
-      ok: false,
-      status: 403,
-      error: `Host header "${host}" is not allowed. MCP only accepts loopback hosts.`,
-    };
-  }
-  return { ok: true };
-}
-
-/**
- * Reject Origin headers that look like they came from a remote browser. A
- * missing Origin is allowed (non-browser clients don't send one); a present
- * Origin must point at a loopback host on our port.
- */
-export function checkOrigin(
-  origin: string | undefined,
-  allowlist: Set<string>,
-): AuthCheckResult {
-  if (!origin) return { ok: true };
-  let url: URL;
-  try {
-    url = new URL(origin);
-  } catch {
-    return { ok: false, status: 403, error: `Malformed Origin header "${origin}"` };
-  }
-  // url.host includes the port (or is empty for default ports). Compare both.
-  const hostWithPort = url.host.toLowerCase();
-  const hostOnly = url.hostname.toLowerCase();
-  if (!allowlist.has(hostWithPort) && !allowlist.has(hostOnly)) {
-    return {
-      ok: false,
-      status: 403,
-      error: `Origin "${origin}" is not allowed. MCP only accepts loopback origins.`,
-    };
-  }
-  return { ok: true };
-}
+export {
+  checkAuthorization,
+  checkCookieToken,
+  buildLoopbackAllowlist,
+  checkHost,
+  checkOrigin,
+  type AuthCheckResult,
+} from '@some-useful-agents/core';


### PR DESCRIPTION
## Summary

Foundation work for the v0.12.0 dashboard. No user-facing surface yet — the dashboard UI lands in a follow-up PR so the actual web app is a focused diff of just the Express app + views. This PR is the load-bearing plumbing.

### `RunStore.queryRuns({ filter })`

Richer run-query API for paged, filtered reads from the run store:

```ts
const { rows, total } = store.queryRuns({
  agentName: 'hello',
  statuses: ['completed', 'failed'],     // OR within statuses
  triggeredBy: 'schedule',
  q: 'abc',                              // prefix on id OR substring on agentName
  limit: 50,
  offset: 0,
});
```

- AND across fields, OR within `statuses[]`
- `q` escapes SQL `LIKE` metacharacters (so `50%` matches a literal `"%"`, not every row)
- `limit` clamped to `MAX_RUNS_LIMIT=500`
- Two new indexes (`idx_runs_triggeredBy`, `idx_runs_startedAt` DESC) — speeds up the dashboard's newest-first default AND the CLI's `sua agent status` path incidentally
- `distinctValues(column)` helper for dropdown population; column name is allowlist-checked so there's no string-interpolation / SQL-injection surface
- Existing `listRuns` untouched — MCP server, `sua agent status`/`logs`/`cancel` keep working

### Shared HTTP loopback auth (`@some-useful-agents/core/http-auth`)

Moved `checkAuthorization`, `checkHost`, `checkOrigin`, `buildLoopbackAllowlist` out of `packages/mcp-server/src/auth.ts` into core. Same implementations — the mcp-server's `auth.ts` is now a thin re-export so its internal imports don't need to change. Added `checkCookieToken` as a sibling for the dashboard's cookie-based auth model.

Why not leave it in mcp-server? The dashboard would then couple to mcp-server for a shared loopback-auth concern that belongs at a lower layer. Core is the right home.

## Test plan

- [x] 287 tests pass (was 271; +16: 13 for `queryRuns`, 3 for `distinctValues`)
- [x] Full existing mcp-server auth suite still green against the re-exported names
- [x] Build clean (`npm run build`)
- [x] Manual: `sua agent status`, `sua agent logs`, `sua agent cancel` all still work against the unchanged `listRuns` — no behavioral drift from the refactor

## What ships next

Follow-up PR on `feat/dashboard` (branches off this one, or off main after this merges): the Express app + views + `sua dashboard start` command. This PR's `queryRuns` is the one the runs-list page consumes; `checkCookieToken` is what the auth middleware checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
