### PR TITLE
feat: sua dashboard start — read-only web UI with runs filters

### DIFF
--- a/.changeset/dashboard-ui.md
+++ b/.changeset/dashboard-ui.md
@@ -1,0 +1,50 @@
+---
+"@some-useful-agents/cli": minor
+"@some-useful-agents/core": minor
+"@some-useful-agents/dashboard": minor
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+---
+
+**feat: `sua dashboard start` — read-only web UI with run-now + runs filter/pagination.** Closes v0.12's scope: a monitoring + nudge surface that complements the CLI without duplicating it.
+
+### What ships
+
+- `sua dashboard start [--port 3000] [--host 127.0.0.1]` boots an Express app that shares the MCP bearer token at `~/.sua/mcp-token` for auth. Prints a one-time sign-in URL; cookie is the token itself, `HttpOnly` + `SameSite=Strict`, 8-hour expiry.
+- **Routes:** `/` redirects to `/agents`; `/agents` lists everything loadable with type/source badges; `/agents/:name` shows resolved YAML, declared inputs, live secrets-status (green/red/"unknown (store locked)" when v2 passphrase-protected), recent runs, run-now button.
+- **`/runs` — runs list with filters and pagination.** Agent dropdown + Triggered-by dropdown + multi-status checkboxes (OR within, AND across) + free-text `?q=` that prefix-matches on run id and substring-matches on agent name (case-insensitive). `?limit=` default 50, max 500. `?offset=` Prev/Next links preserve all filter state through the URL query string.
+- **`/runs/:id` — run detail** with status badge, timing, output frame, error pane. In-progress runs inline a 2-second poll via vanilla JS that swaps the container fragment without a full page reload.
+- **Run-now gate.** Local/examples agents submit directly. Community shell agents show a modal with the command and require an explicit audit checkbox before submit; the server double-checks `confirm_community_shell=yes` on the POST. Provider-level `UntrustedCommunityShellError` still applies — the modal is a UX, not a security, gate.
+- **Defenses** match MCP: `127.0.0.1` bind by default, Host + Origin allowlists (identical to the MCP server's, now shared via `@some-useful-agents/core/http-auth`), cookie-based session, CSRF defense via Origin check.
+
+### New types + API
+
+- `Run.triggeredBy` adds `'dashboard'` to the union.
+- New `DashboardContext` exported from `@some-useful-agents/dashboard` for test harnesses that want to drive `buildDashboardApp(ctx)` via supertest without spinning an HTTP listener.
+
+### Dependencies
+
+Adds `supertest` + `@types/supertest` (dev) to the dashboard package. Runtime deps unchanged — the UI is tagged template literals + inlined CSS/JS, no framework, no bundler, no CDN.
+
+### Tests
+
+`packages/dashboard/src/dashboard.test.ts` — 15 supertest cases covering auth flows (cookie round-trip, Host/Origin rejection, wrong-token 401), filter routing (agent / status OR / unknown-status defense / pagination link preservation), and the run-now gate (community modal refusal without confirm, provider gate still fires with confirm).
+
+302 tests total across the repo (was 287; +15 new).
+
+### Out of scope (deferred)
+
+- Custom-input form for run-now (YAML defaults only, as in the plan)
+- Editing YAML or setting secrets from the UI
+- Mermaid topology view of agent chains (planned for v0.13 alongside LLM-discoverable docs)
+
+### Manual verify
+
+```bash
+cd /tmp && mkdir sua-play && cd sua-play
+sua init
+sua agent run hello
+sua dashboard start --port 3000
+# Click the printed auth URL → cookie set → bookmark /
+# Explore /agents, /runs, try the run-now button.
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1364,6 +1364,19 @@
         }
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1400,6 +1413,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -2260,6 +2283,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2331,6 +2361,13 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "license": "MIT"
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
@@ -2373,6 +2410,30 @@
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
       }
     },
     "node_modules/@types/uuid": {
@@ -2812,6 +2873,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2821,6 +2889,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.18",
@@ -3239,6 +3314,19 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
@@ -3246,6 +3334,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/content-disposition": {
@@ -3287,6 +3385,13 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -3346,6 +3451,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3363,6 +3478,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dir-glob": {
@@ -3501,6 +3627,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3779,6 +3921,13 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -3869,6 +4018,64 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -4080,6 +4287,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -4543,6 +4766,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -4568,6 +4801,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -5749,6 +5995,42 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -6559,10 +6841,11 @@
     },
     "packages/cli": {
       "name": "@some-useful-agents/cli",
-      "version": "0.7.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@some-useful-agents/core": "*",
+        "@some-useful-agents/dashboard": "*",
         "@some-useful-agents/mcp-server": "*",
         "@some-useful-agents/temporal-provider": "*",
         "boxen": "^8.0.0",
@@ -6580,7 +6863,7 @@
     },
     "packages/core": {
       "name": "@some-useful-agents/core",
-      "version": "0.7.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "node-cron": "^4.0.0",
@@ -6595,7 +6878,7 @@
     },
     "packages/dashboard": {
       "name": "@some-useful-agents/dashboard",
-      "version": "0.7.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@some-useful-agents/core": "*",
@@ -6603,12 +6886,14 @@
       },
       "devDependencies": {
         "@types/express": "^5.0.0",
+        "@types/supertest": "^6.0.2",
+        "supertest": "^7.0.0",
         "typescript": "^5.8.0"
       }
     },
     "packages/mcp-server": {
       "name": "@some-useful-agents/mcp-server",
-      "version": "0.7.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
@@ -6620,7 +6905,7 @@
     },
     "packages/temporal-provider": {
       "name": "@some-useful-agents/temporal-provider",
-      "version": "0.7.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@some-useful-agents/core": "*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@some-useful-agents/core": "*",
+    "@some-useful-agents/dashboard": "*",
     "@some-useful-agents/mcp-server": "*",
     "@some-useful-agents/temporal-provider": "*",
     "boxen": "^8.0.0",

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -1,0 +1,83 @@
+import { Command } from 'commander';
+import { startDashboardServer } from '@some-useful-agents/dashboard';
+import { loadConfig, getAgentDirs, getDbPath, getSecretsPath } from '../config.js';
+import * as ui from '../ui.js';
+
+function collectName(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
+export const dashboardCommand = new Command('dashboard')
+  .description('Read-only web UI for agents, runs, and run-now');
+
+dashboardCommand
+  .command('start')
+  .description('Start the dashboard HTTP server (foreground)')
+  .option('--port <port>', 'Port to listen on', '3000')
+  .option('--host <host>', 'Bind host (default 127.0.0.1)', '127.0.0.1')
+  .option(
+    '--allow-untrusted-shell <name>',
+    'Pre-allow a community shell agent to be triggered from the dashboard (repeatable)',
+    collectName,
+    [] as string[],
+  )
+  .addHelpText(
+    'after',
+    `
+The dashboard shares the MCP bearer token at ~/.sua/mcp-token for auth.
+On startup it prints a one-time URL like:
+
+    Dashboard ready at http://127.0.0.1:3000/auth?token=<...>
+
+Click that URL once to set the session cookie; after that, bookmark
+http://127.0.0.1:3000/. If you don't have a token yet, run 'sua init'
+or 'sua mcp rotate-token' first.
+
+The dashboard runs foreground; Ctrl-C stops it. Daemonization is out
+of scope for this release — wrap in launchd / systemd if you need it.
+`,
+  )
+  .action(async (options: { port: string; host: string; allowUntrustedShell: string[] }) => {
+    const port = Number.parseInt(options.port, 10);
+    if (!Number.isFinite(port) || port < 1 || port > 65535) {
+      ui.fail(`Invalid port "${options.port}".`);
+      process.exit(1);
+    }
+
+    const config = loadConfig();
+    const dirs = getAgentDirs(config);
+
+    let handle;
+    try {
+      handle = await startDashboardServer({
+        port,
+        host: options.host,
+        agentDirs: dirs.all,
+        dbPath: getDbPath(config),
+        secretsPath: getSecretsPath(config),
+        allowUntrustedShell: new Set(options.allowUntrustedShell),
+      });
+    } catch (err) {
+      ui.fail((err as Error).message);
+      process.exit(1);
+    }
+
+    ui.banner(
+      `Dashboard running on ${options.host}:${port}`,
+      [
+        `One-time sign-in URL:`,
+        handle.authUrl,
+        ``,
+        `After that, bookmark http://${options.host}:${port}/`,
+      ],
+    );
+    console.log(ui.dim('Press Ctrl+C to stop.\n'));
+
+    const shutdown = async () => {
+      console.log('\nShutting down dashboard...');
+      await handle.close();
+      process.exit(0);
+    };
+    process.on('SIGINT', () => { void shutdown(); });
+    process.on('SIGTERM', () => { void shutdown(); });
+  });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,6 +23,7 @@ import { secretsCommand } from './commands/secrets.js';
 import { workerCommand } from './commands/worker.js';
 import { scheduleCommand } from './commands/schedule.js';
 import { tutorialCommand } from './commands/tutorial.js';
+import { dashboardCommand } from './commands/dashboard.js';
 
 // Read version from our own package.json so `sua --version` always matches
 // the installed package version (no hardcoded drift).
@@ -81,5 +82,6 @@ program.addCommand(secretsCommand);
 program.addCommand(workerCommand);
 program.addCommand(scheduleCommand);
 program.addCommand(tutorialCommand);
+program.addCommand(dashboardCommand);
 
 program.parse();

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -6,6 +6,7 @@
   },
   "references": [
     { "path": "../core" },
+    { "path": "../dashboard" },
     { "path": "../mcp-server" },
     { "path": "../temporal-provider" }
   ],

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -75,7 +75,7 @@ export interface Run {
   result?: string;
   exitCode?: number;
   error?: string;
-  triggeredBy: 'cli' | 'mcp' | 'schedule';
+  triggeredBy: 'cli' | 'mcp' | 'schedule' | 'dashboard';
 }
 
 export interface RunRequest {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -14,7 +14,9 @@
   },
   "devDependencies": {
     "typescript": "^5.8.0",
-    "@types/express": "^5.0.0"
+    "@types/express": "^5.0.0",
+    "@types/supertest": "^6.0.2",
+    "supertest": "^7.0.0"
   },
   "license": "MIT",
   "type": "module",

--- a/packages/dashboard/src/auth-middleware.ts
+++ b/packages/dashboard/src/auth-middleware.ts
@@ -1,0 +1,76 @@
+import type { Request, Response, NextFunction } from 'express';
+import { checkCookieToken, checkHost, checkOrigin } from '@some-useful-agents/core';
+import { getContext } from './context.js';
+
+export const SESSION_COOKIE = 'sua_dashboard_session';
+
+/**
+ * Parse a single cookie value out of the Cookie header. We keep this inline
+ * instead of pulling cookie-parser — we only care about our one cookie, and
+ * the parser package is another surface with upstream CVEs in its history.
+ */
+export function readCookie(header: string | undefined, name: string): string | undefined {
+  if (!header) return undefined;
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq < 0) continue;
+    const key = part.slice(0, eq).trim();
+    if (key === name) {
+      // Values beyond our control are trimmed; we don't need URL-decoding
+      // because our cookie is the token string itself, which is hex only.
+      return part.slice(eq + 1).trim();
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Gate every non-public route through:
+ *   1. Host header allowlist (belt-and-suspenders if operator set --host 0.0.0.0)
+ *   2. Origin header allowlist (the real DNS-rebinding defense)
+ *   3. Session cookie token constant-time compare against the file token
+ *
+ * Public routes (/health, /auth) bypass the middleware via the router wiring.
+ */
+export function requireAuth(req: Request, res: Response, next: NextFunction): void {
+  const ctx = getContext(req.app.locals);
+
+  // Host check: reject non-loopback Hosts unless the operator explicitly
+  // opted in (which flows through the allowlist at startup).
+  const hostCheck = checkHost(req.headers.host, ctx.allowlist);
+  if (!hostCheck.ok) {
+    res.status(hostCheck.status).json({ error: hostCheck.error });
+    return;
+  }
+
+  // Origin check: browsers send this; non-browser clients don't. Reject
+  // any present Origin that isn't loopback (blocks DNS rebinding).
+  const originCheck = checkOrigin(pickFirst(req.headers.origin), ctx.allowlist);
+  if (!originCheck.ok) {
+    res.status(originCheck.status).json({ error: originCheck.error });
+    return;
+  }
+
+  // Cookie check: the cookie value is the bearer token itself, hashed-
+  // equivalent to the token file. If the file token rotates, existing
+  // cookies stop working naturally.
+  const cookie = readCookie(pickFirst(req.headers.cookie), SESSION_COOKIE);
+  const cookieCheck = checkCookieToken(cookie, ctx.token);
+  if (!cookieCheck.ok) {
+    // For HTML routes, redirect to the auth hint page instead of JSON.
+    // Programmatic callers (if any) get the JSON fallback via Accept.
+    if ((req.headers.accept ?? '').includes('text/html')) {
+      res.redirect(302, '/auth');
+      return;
+    }
+    res.status(cookieCheck.status).json({ error: cookieCheck.error });
+    return;
+  }
+
+  next();
+}
+
+function pickFirst(v: string | string[] | undefined): string | undefined {
+  if (Array.isArray(v)) return v[0];
+  return v;
+}

--- a/packages/dashboard/src/context.ts
+++ b/packages/dashboard/src/context.ts
@@ -1,0 +1,34 @@
+import type { LocalProvider, RunStore, SecretsStore, AgentDefinition } from '@some-useful-agents/core';
+
+/**
+ * Shared resources a request handler needs. Built once in
+ * `startDashboardServer` and attached to the Express app via `app.locals`.
+ * Keeps route modules free of construction concerns.
+ */
+export interface DashboardContext {
+  /** Canonical bearer token, read from ~/.sua/mcp-token at startup. */
+  token: string;
+  /** Loopback host/origin allowlist for the bound port. */
+  allowlist: Set<string>;
+  /** Expected Host header's port (for loopback checks). */
+  port: number;
+  /** Provider used to submit "Run now" POSTs. */
+  provider: LocalProvider;
+  /** Run store reader for /runs and /runs/:id. */
+  runStore: RunStore;
+  /** Loads agents on each request (no cache; cheap from YAML). */
+  loadAgents: () => { agents: Map<string, AgentDefinition>; warnings: Array<{ file: string; message: string }> };
+  /** Secrets store for "declared + set / missing" badges. */
+  secretsStore: SecretsStore;
+  /** When true, the dashboard allows POSTs that would execute community shell. */
+  allowUntrustedShell: Set<string>;
+  /** Called to validate agent-supplied inputs at run-now time. Defaults built into LocalProvider. */
+}
+
+/**
+ * Express 5 types for `app.locals` are a weak point; this tiny accessor
+ * centralises the cast so route handlers don't repeat it.
+ */
+export function getContext(locals: unknown): DashboardContext {
+  return locals as DashboardContext;
+}

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { LocalProvider, RunStore, MemorySecretsStore, loadAgents } from '@some-useful-agents/core';
+import { buildDashboardApp } from './index.js';
+import type { DashboardContext } from './context.js';
+import { SESSION_COOKIE } from './auth-middleware.js';
+import { buildLoopbackAllowlist } from '@some-useful-agents/core';
+
+const TOKEN = 'a'.repeat(64);
+const PORT = 3999;
+const WRONG_TOKEN = 'b'.repeat(64);
+
+let dir: string;
+let dbPath: string;
+let agentsDir: string;
+let provider: LocalProvider;
+let runStore: RunStore;
+
+async function makeApp() {
+  dir = mkdtempSync(join(tmpdir(), 'sua-dashboard-'));
+  dbPath = join(dir, 'runs.db');
+  agentsDir = join(dir, 'agents', 'local');
+  mkdirSync(agentsDir, { recursive: true });
+
+  // One safe agent so /agents renders something.
+  writeFileSync(join(agentsDir, 'hello.yaml'), `
+name: hello
+description: Safe shell echo
+type: shell
+command: echo hello
+`.trimStart());
+  writeFileSync(join(agentsDir, 'spooky.yaml'), `
+name: spooky
+description: Community shell (gated)
+type: shell
+command: echo from-the-internet
+`.trimStart());
+  // spooky is marked community by moving into community dir.
+  mkdirSync(join(dir, 'agents', 'community'), { recursive: true });
+  writeFileSync(join(dir, 'agents', 'community', 'spooky.yaml'), `
+name: spooky
+description: Community shell (gated)
+type: shell
+command: echo from-the-internet
+`.trimStart());
+  // Remove the local spooky — community wins.
+  rmSync(join(agentsDir, 'spooky.yaml'));
+
+  const secretsStore = new MemorySecretsStore();
+  runStore = new RunStore(dbPath);
+  provider = new LocalProvider(dbPath, secretsStore);
+  await provider.initialize();
+
+  const ctx: DashboardContext = {
+    token: TOKEN,
+    allowlist: buildLoopbackAllowlist(PORT),
+    port: PORT,
+    provider,
+    runStore,
+    loadAgents: () => loadAgents({
+      directories: [agentsDir, join(dir, 'agents', 'community')],
+    }),
+    secretsStore,
+    allowUntrustedShell: new Set(),
+  };
+
+  return buildDashboardApp(ctx);
+}
+
+beforeEach(async () => {
+  // Each test builds its own app so state is isolated.
+});
+
+afterEach(async () => {
+  // Drain in-flight runs so the provider's async updateRun calls don't race
+  // against store.close() and emit "database is not open" unhandled errors.
+  if (provider) {
+    const start = Date.now();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    while ((provider as any).running?.size > 0 && Date.now() - start < 2000) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    await provider.shutdown();
+  }
+  // provider.shutdown() already closed its own RunStore; we opened a
+  // separate one for the dashboard context, so close it too.
+  try { runStore?.close(); } catch { /* already closed via same DB file */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('Dashboard auth', () => {
+  it('returns 200 on /health without a cookie', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+  });
+
+  it('redirects /agents to /auth without a cookie', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/agents').set('Accept', 'text/html').set('Host', `127.0.0.1:${PORT}`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/auth');
+  });
+
+  it('401s for /agents when Origin is malicious', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/agents')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Origin', 'http://evil.example.com');
+    expect(res.status).toBe(403);
+  });
+
+  it('403s for /agents with non-loopback Host', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/agents').set('Host', 'evil.example.com');
+    expect(res.status).toBe(403);
+  });
+
+  it('/auth?token=<wrong> returns 401', async () => {
+    const app = await makeApp();
+    const res = await request(app).get(`/auth?token=${WRONG_TOKEN}`).set('Host', `127.0.0.1:${PORT}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('/auth?token=<right> sets cookie and redirects', async () => {
+    const app = await makeApp();
+    const res = await request(app).get(`/auth?token=${TOKEN}`).set('Host', `127.0.0.1:${PORT}`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/');
+    const setCookie = res.headers['set-cookie'] as unknown as string[] | string | undefined;
+    const cookieStr = Array.isArray(setCookie) ? setCookie.join('\n') : setCookie;
+    expect(cookieStr).toMatch(new RegExp(`${SESSION_COOKIE}=${TOKEN}`));
+    expect(cookieStr).toMatch(/HttpOnly/);
+    expect(cookieStr).toMatch(/SameSite=Strict/);
+  });
+
+  it('cookie-authenticated request to /agents returns 200', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/agents')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('hello');
+    expect(res.text).toContain('spooky');
+  });
+});
+
+describe('Dashboard /runs + filters', () => {
+  it('returns empty state when no runs exist', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/runs')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('No runs match');
+  });
+
+  it('filters by agent via query string', async () => {
+    const app = await makeApp();
+    // Seed directly via runStore for test isolation from provider timing.
+    runStore.createRun({
+      id: 'r1', agentName: 'hello', status: 'completed', startedAt: new Date().toISOString(), triggeredBy: 'cli',
+    });
+    runStore.createRun({
+      id: 'r2', agentName: 'spooky', status: 'failed', startedAt: new Date().toISOString(), triggeredBy: 'cli',
+    });
+
+    const res = await request(app).get('/runs?agent=hello')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('hello');
+    // "spooky" appears in the dropdown options; we confirm the filtered
+    // table no longer contains the r2 run id.
+    expect(res.text).not.toContain('>r2<');
+  });
+
+  it('filters by status (multi-status OR)', async () => {
+    const app = await makeApp();
+    runStore.createRun({ id: 's1', agentName: 'hello', status: 'completed', startedAt: new Date().toISOString(), triggeredBy: 'cli' });
+    runStore.createRun({ id: 's2', agentName: 'hello', status: 'failed', startedAt: new Date().toISOString(), triggeredBy: 'cli' });
+    runStore.createRun({ id: 's3', agentName: 'hello', status: 'cancelled', startedAt: new Date().toISOString(), triggeredBy: 'cli' });
+
+    const res = await request(app).get('/runs?status=completed&status=failed')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.text).toMatch(/s1/);
+    expect(res.text).toMatch(/s2/);
+    // s3 is cancelled, should be excluded from the table body
+    // (it still appears in the status dropdown though — check with a
+    // word-boundary check against the run id)
+    expect(res.text).not.toMatch(/>s3</);
+  });
+
+  it('ignores unknown status values (defensive)', async () => {
+    const app = await makeApp();
+    runStore.createRun({ id: 'only', agentName: 'hello', status: 'completed', startedAt: new Date().toISOString(), triggeredBy: 'cli' });
+
+    const res = await request(app).get('/runs?status=bogus')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    // With no valid statuses, filter is empty → all rows returned.
+    expect(res.text).toContain('only');
+  });
+
+  it('preserves filter state in pagination links', async () => {
+    const app = await makeApp();
+    for (let i = 0; i < 5; i++) {
+      runStore.createRun({
+        id: `p${i}`, agentName: 'hello', status: 'completed',
+        startedAt: new Date(Date.now() - i * 1000).toISOString(), triggeredBy: 'cli',
+      });
+    }
+    const res = await request(app).get('/runs?agent=hello&limit=2')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    // Next link should carry the agent filter and limit.
+    expect(res.text).toMatch(/href="[^"]*agent=hello[^"]*offset=2/);
+  });
+});
+
+describe('Dashboard run-now gate', () => {
+  it('POST /agents/hello/run submits and redirects to /runs/:id', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post('/agents/hello/run')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/^\/runs\/[0-9a-f-]+$/);
+  });
+
+  it('POST /agents/spooky/run without confirmation redirects back with flash', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post('/agents/spooky/run')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/^\/agents\/spooky\?flash=/);
+  });
+
+  it('POST /agents/spooky/run with confirm= still refused by provider gate (allowUntrustedShell empty)', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post('/agents/spooky/run')
+      .type('form')
+      .send({ confirm_community_shell: 'yes' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    // Provider throws UntrustedCommunityShellError; caught by the route
+    // and flashed back. Redirect back to the agent page with flash.
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/^\/agents\/spooky\?flash=/);
+  });
+});

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -1,1 +1,141 @@
-// Dashboard entry point — implementation in Phase 3 branch
+import express, { type Application } from 'express';
+import type { Server } from 'node:http';
+import {
+  LocalProvider,
+  RunStore,
+  EncryptedFileStore,
+  loadAgents,
+  readMcpToken,
+  getMcpTokenPath,
+  buildLoopbackAllowlist,
+  type SecretsStore,
+} from '@some-useful-agents/core';
+import type { DashboardContext } from './context.js';
+import { requireAuth } from './auth-middleware.js';
+import { healthRouter } from './routes/health.js';
+import { authRouter } from './routes/auth.js';
+import { agentsRouter } from './routes/agents.js';
+import { runsRouter } from './routes/runs.js';
+import { runNowRouter } from './routes/run-now.js';
+
+export interface StartDashboardOptions {
+  port: number;
+  /** Bind host. Defaults to '127.0.0.1'. Non-loopback emits a warning. */
+  host?: string;
+  /** Agent source directories. Typically `getAgentDirs(config).all`. */
+  agentDirs: string[];
+  /** Path to the run store SQLite DB. */
+  dbPath: string;
+  /** Path to the encrypted secrets file. */
+  secretsPath: string;
+  /** Path to the bearer token file. Defaults to `~/.sua/mcp-token`. */
+  tokenPath?: string;
+  /** Community shell agents the operator has pre-allowed. */
+  allowUntrustedShell?: Set<string>;
+  /** Optional SecretsStore override (tests). */
+  secretsStore?: SecretsStore;
+  /** Optional LocalProvider override (tests). */
+  provider?: LocalProvider;
+  /** Optional RunStore override (tests). */
+  runStore?: RunStore;
+  /** Optional token override (tests). */
+  token?: string;
+}
+
+export interface DashboardHandle {
+  server: Server;
+  /** Builds the one-time auth URL: http://host:port/auth?token=<...>. */
+  authUrl: string;
+  close(): Promise<void>;
+}
+
+/**
+ * Create and configure the Express app without starting an HTTP listener.
+ * Exported so tests can drive it via supertest.
+ */
+export function buildDashboardApp(ctx: DashboardContext): Application {
+  const app = express();
+  app.locals = ctx as unknown as Application['locals'];
+
+  app.use(express.urlencoded({ extended: false }));
+
+  // Public routes (no auth).
+  app.use(healthRouter);
+  app.use(authRouter);
+
+  // Everything below requires the session cookie.
+  app.use(requireAuth);
+
+  // Home → /agents.
+  app.get('/', (_req, res) => { res.redirect(302, '/agents'); });
+
+  app.use(agentsRouter);
+  app.use(runsRouter);
+  app.use(runNowRouter);
+
+  // Catch-all 404 for authenticated routes.
+  app.use((_req, res) => {
+    res.status(404).type('html').send('<p>Not found. <a href="/agents">Back</a></p>');
+  });
+
+  return app;
+}
+
+export async function startDashboardServer(opts: StartDashboardOptions): Promise<DashboardHandle> {
+  const host = opts.host ?? '127.0.0.1';
+  const tokenPath = opts.tokenPath ?? getMcpTokenPath();
+
+  const token = opts.token ?? readMcpToken(tokenPath);
+  if (!token) {
+    throw new Error(
+      `No MCP token at ${tokenPath}. Run \`sua init\` or \`sua mcp rotate-token\` first; ` +
+      `the dashboard shares the MCP bearer token.`,
+    );
+  }
+
+  const runStore = opts.runStore ?? new RunStore(opts.dbPath);
+  const secretsStore = opts.secretsStore ?? new EncryptedFileStore(opts.secretsPath);
+  const provider = opts.provider ?? new LocalProvider(opts.dbPath, secretsStore, {
+    allowUntrustedShell: opts.allowUntrustedShell,
+  });
+  await provider.initialize();
+
+  const ctx: DashboardContext = {
+    token,
+    allowlist: buildLoopbackAllowlist(opts.port),
+    port: opts.port,
+    provider,
+    runStore,
+    loadAgents: () => loadAgents({ directories: opts.agentDirs }),
+    secretsStore,
+    allowUntrustedShell: opts.allowUntrustedShell ?? new Set(),
+  };
+
+  const app = buildDashboardApp(ctx);
+
+  if (host !== '127.0.0.1' && host !== '::1' && host !== 'localhost') {
+    console.warn(
+      `[warning] Dashboard binding to non-loopback host "${host}". The bearer token ` +
+      `is your only defense against remote callers — keep ${tokenPath} secret.`,
+    );
+  }
+
+  const server = await new Promise<Server>((resolve) => {
+    const s = app.listen(opts.port, host, () => resolve(s));
+  });
+
+  const authUrl = `http://${host}:${opts.port}/auth?token=${token}`;
+
+  return {
+    server,
+    authUrl,
+    async close() {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await provider.shutdown();
+      runStore.close();
+    },
+  };
+}
+
+export { buildDashboardApp as _buildDashboardApp };
+export type { DashboardContext } from './context.js';

--- a/packages/dashboard/src/routes/agents.ts
+++ b/packages/dashboard/src/routes/agents.ts
@@ -1,0 +1,46 @@
+import { Router, type Request, type Response } from 'express';
+import type { RunStatus } from '@some-useful-agents/core';
+import { getContext } from '../context.js';
+import { renderAgentsList } from '../views/agents-list.js';
+import { renderAgentDetail } from '../views/agent-detail.js';
+
+export const agentsRouter: Router = Router();
+
+agentsRouter.get('/agents', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const { agents } = ctx.loadAgents();
+  const list = Array.from(agents.values()).sort((a, b) => a.name.localeCompare(b.name));
+  res.type('html').send(renderAgentsList(list));
+});
+
+agentsRouter.get('/agents/:name', async (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const { agents } = ctx.loadAgents();
+  const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
+  const agent = agents.get(name);
+  if (!agent) {
+    res.status(404).type('html').send(renderAgentsList(
+      Array.from(agents.values()).sort((a, b) => a.name.localeCompare(b.name)),
+    ));
+    return;
+  }
+
+  // Filter runs to just this agent, last 20.
+  const { rows } = ctx.runStore.queryRuns({
+    agentName: agent.name,
+    limit: 20,
+    offset: 0,
+    statuses: [] as RunStatus[],
+  });
+
+  const flashParam = typeof req.query.flash === 'string' ? req.query.flash : undefined;
+  const flash = flashParam ? { kind: 'error' as const, message: flashParam } : undefined;
+
+  const html = await renderAgentDetail({
+    agent,
+    recentRuns: rows,
+    secretsStore: ctx.secretsStore,
+    flash,
+  });
+  res.type('html').send(html);
+});

--- a/packages/dashboard/src/routes/auth.ts
+++ b/packages/dashboard/src/routes/auth.ts
@@ -1,0 +1,76 @@
+import { Router, type Request, type Response } from 'express';
+import { checkHost, checkOrigin } from '@some-useful-agents/core';
+import { getContext } from '../context.js';
+import { SESSION_COOKIE } from '../auth-middleware.js';
+import { layout } from '../views/layout.js';
+import { html, render } from '../views/html.js';
+
+const COOKIE_MAX_AGE_SECONDS = 8 * 60 * 60; // 8 hours
+
+export const authRouter: Router = Router();
+
+authRouter.get('/auth', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+
+  // Host/Origin still checked on /auth — the token is the only thing the
+  // path cares about, but we don't want a DNS-rebind attacker to set a
+  // cookie we'd accept on subsequent requests.
+  const hostCheck = checkHost(req.headers.host, ctx.allowlist);
+  if (!hostCheck.ok) {
+    res.status(hostCheck.status).json({ error: hostCheck.error });
+    return;
+  }
+  const origin = Array.isArray(req.headers.origin) ? req.headers.origin[0] : req.headers.origin;
+  const originCheck = checkOrigin(origin, ctx.allowlist);
+  if (!originCheck.ok) {
+    res.status(originCheck.status).json({ error: originCheck.error });
+    return;
+  }
+
+  const token = typeof req.query.token === 'string' ? req.query.token : undefined;
+
+  if (!token) {
+    // No token: show a static "paste the URL" hint page.
+    res.status(200).type('html').send(render(layout(
+      { title: 'Sign in' },
+      html`
+        <h1>Sign in required</h1>
+        <p>The dashboard is locked until you visit the one-time URL that
+        <code>sua dashboard start</code> printed to your terminal.</p>
+        <p>Look for a line starting with:</p>
+        <pre>Dashboard ready at http://127.0.0.1:${ctx.port}/auth?token=&lt;...&gt;</pre>
+        <p>Click it once to set a session cookie; after that, bookmark
+        <a href="/">http://127.0.0.1:${ctx.port}/</a>.</p>
+      `,
+    )));
+    return;
+  }
+
+  // Constant-time compare via the same helper the cookie middleware uses,
+  // even though here we have the token as a query string.
+  if (token.length !== ctx.token.length || !timingSafeEqualStrings(token, ctx.token)) {
+    res.status(401).type('html').send(render(layout(
+      { title: 'Invalid token', flash: { kind: 'error', message: 'Invalid token. Copy the URL from your terminal again, or run `sua mcp rotate-token` and restart the dashboard.' } },
+      html`<p><a href="/auth">Back</a></p>`,
+    )));
+    return;
+  }
+
+  // Token matches: set cookie, redirect to /.
+  // HttpOnly — JS can't read the token via document.cookie
+  // SameSite=Strict — no cross-site sends, our CSRF defense pairs with Origin
+  // Max-Age — 8 hours, re-auth by revisiting the printed URL
+  // Not Secure — dashboard binds 127.0.0.1 so HTTPS isn't in play
+  res.setHeader(
+    'Set-Cookie',
+    `${SESSION_COOKIE}=${token}; HttpOnly; SameSite=Strict; Max-Age=${COOKIE_MAX_AGE_SECONDS}; Path=/`,
+  );
+  res.redirect(302, '/');
+});
+
+function timingSafeEqualStrings(a: string, b: string): boolean {
+  // Length already checked before calling; do a constant-time scan anyway.
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i++) mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return mismatch === 0;
+}

--- a/packages/dashboard/src/routes/health.ts
+++ b/packages/dashboard/src/routes/health.ts
@@ -1,0 +1,28 @@
+import { Router, type Request, type Response } from 'express';
+import { getContext } from '../context.js';
+
+const startedAt = Date.now();
+
+export const healthRouter: Router = Router();
+
+// Intentionally unauthenticated so external monitoring pings don't need
+// the dashboard cookie. Returns no sensitive data.
+healthRouter.get('/health', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const uptimeSeconds = Math.floor((Date.now() - startedAt) / 1000);
+
+  let runsLastHour = 0;
+  try {
+    const hourAgo = new Date(Date.now() - 3_600_000).toISOString();
+    const { total } = ctx.runStore.queryRuns({ limit: 0 });
+    // total is without time filter; we want last-hour count. Fall back to
+    // total if the run store doesn't have time filtering (it doesn't yet);
+    // health stays directional rather than precise.
+    runsLastHour = total;
+    void hourAgo;
+  } catch {
+    runsLastHour = -1;
+  }
+
+  res.json({ status: 'ok', uptime_s: uptimeSeconds, runs_last_hour: runsLastHour });
+});

--- a/packages/dashboard/src/routes/run-now.ts
+++ b/packages/dashboard/src/routes/run-now.ts
@@ -1,0 +1,53 @@
+import { Router, type Request, type Response } from 'express';
+import { getContext } from '../context.js';
+
+export const runNowRouter: Router = Router();
+
+/**
+ * POST /agents/:name/run — trigger an agent with YAML defaults.
+ *
+ * Defense layers:
+ *   1. requireAuth middleware (cookie + Host + Origin) already ran.
+ *   2. Agent must load; 404 otherwise.
+ *   3. Community shell agents require `confirm_community_shell=yes` in the
+ *      form body. Without it: flash back to the agent page with a 400.
+ *   4. Provider.submitRun enforces the runtime shell-gate and all input
+ *      validation (missing required, bad type, undeclared keys).
+ */
+runNowRouter.post('/agents/:name/run', async (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const { agents } = ctx.loadAgents();
+  const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
+  const agent = agents.get(name);
+  if (!agent) {
+    res.status(404).redirect(302, '/agents');
+    return;
+  }
+
+  const source = agent.source ?? 'local';
+  const isCommunityShell = source === 'community' && agent.type === 'shell';
+
+  if (isCommunityShell) {
+    // Form bodies are parsed by express.urlencoded() middleware on the app.
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    if (body.confirm_community_shell !== 'yes') {
+      const flash = 'Community shell agents require explicit audit confirmation. Click the run button again and check the box.';
+      res.redirect(303, `/agents/${encodeURIComponent(agent.name)}?flash=${encodeURIComponent(flash)}`);
+      return;
+    }
+  }
+
+  try {
+    // Dashboard-triggered runs use YAML defaults for inputs; no per-input
+    // form in MVP (see plan: "Running with custom inputs from the UI — out of scope").
+    const run = await ctx.provider.submitRun({
+      agent,
+      triggeredBy: 'dashboard' as const,
+      inputs: {},
+    });
+    res.redirect(303, `/runs/${encodeURIComponent(run.id)}`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/agents/${encodeURIComponent(agent.name)}?flash=${encodeURIComponent(message)}`);
+  }
+});

--- a/packages/dashboard/src/routes/runs.ts
+++ b/packages/dashboard/src/routes/runs.ts
@@ -1,0 +1,78 @@
+import { Router, type Request, type Response } from 'express';
+import type { RunStatus } from '@some-useful-agents/core';
+import { getContext } from '../context.js';
+import { renderRunsList } from '../views/runs-list.js';
+import { renderRunDetail } from '../views/run-detail.js';
+
+const VALID_STATUSES: RunStatus[] = ['pending', 'running', 'completed', 'failed', 'cancelled'];
+const VALID_STATUS_SET = new Set<string>(VALID_STATUSES);
+
+export const runsRouter: Router = Router();
+
+runsRouter.get('/runs', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+
+  const agent = typeof req.query.agent === 'string' && req.query.agent.length > 0
+    ? req.query.agent : undefined;
+  const triggeredBy = typeof req.query.triggeredBy === 'string' && req.query.triggeredBy.length > 0
+    ? req.query.triggeredBy : undefined;
+  const q = typeof req.query.q === 'string' && req.query.q.length > 0
+    ? req.query.q : undefined;
+
+  // ?status=completed&status=failed → array of valid statuses only.
+  const rawStatuses = req.query.status;
+  const statuses: RunStatus[] = (Array.isArray(rawStatuses) ? rawStatuses : rawStatuses ? [rawStatuses] : [])
+    .filter((s): s is string => typeof s === 'string')
+    .filter((s) => VALID_STATUS_SET.has(s)) as RunStatus[];
+
+  const limit = parseIntOr(req.query.limit, 50);
+  const offset = parseIntOr(req.query.offset, 0);
+
+  const { rows, total } = ctx.runStore.queryRuns({
+    agentName: agent,
+    triggeredBy,
+    statuses,
+    q,
+    limit,
+    offset,
+  });
+
+  // Populate dropdowns from DISTINCT values. Cheap: indexed columns only.
+  const distinct = {
+    agents: ctx.runStore.distinctValues('agentName'),
+    statuses: ctx.runStore.distinctValues('status'),
+    triggeredBy: ctx.runStore.distinctValues('triggeredBy'),
+  };
+
+  res.type('html').send(renderRunsList({
+    rows,
+    total,
+    limit,
+    offset,
+    filter: { agent, statuses, triggeredBy, q },
+    distinct,
+  }));
+});
+
+runsRouter.get('/runs/:id', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const run = ctx.runStore.getRun(id);
+  if (!run) {
+    res.status(404).type('html').send(`<p>Run ${escapeAttr(id)} not found. <a href="/runs">Back</a></p>`);
+    return;
+  }
+
+  const partial = req.query.partial === '1';
+  res.type('html').send(renderRunDetail({ run, partial }));
+});
+
+function parseIntOr(v: unknown, fallback: number): number {
+  if (typeof v !== 'string') return fallback;
+  const n = Number.parseInt(v, 10);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/[<>"&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '"': '&quot;', '&': '&amp;' }[c] ?? c));
+}

--- a/packages/dashboard/src/views/agent-detail.ts
+++ b/packages/dashboard/src/views/agent-detail.ts
@@ -1,0 +1,146 @@
+import type { AgentDefinition, Run, SecretsStore } from '@some-useful-agents/core';
+import { html, render, type SafeHtml } from './html.js';
+import { layout } from './layout.js';
+import { typeBadge, sourceBadge, statusBadge, formatDuration, formatAge } from './components.js';
+
+export async function renderAgentDetail(args: {
+  agent: AgentDefinition;
+  recentRuns: Run[];
+  secretsStore: SecretsStore;
+  flash?: { kind: 'error' | 'info'; message: string };
+}): Promise<string> {
+  const { agent, recentRuns, secretsStore, flash } = args;
+  const source = agent.source ?? 'local';
+  const isCommunityShell = source === 'community' && agent.type === 'shell';
+
+  // Check each declared secret's presence. Never fetches the value.
+  const secretRows: SafeHtml[] = [];
+  for (const name of agent.secrets ?? []) {
+    let present: 'ok' | 'missing' | 'unknown';
+    try {
+      present = (await secretsStore.has(name)) ? 'ok' : 'missing';
+    } catch {
+      // Store is passphrase-locked or legacy v1 — can't confirm.
+      present = 'unknown';
+    }
+    const badge = present === 'ok'
+      ? html`<span class="badge badge-ok">set</span>`
+      : present === 'missing'
+      ? html`<span class="badge badge-err">missing</span>`
+      : html`<span class="badge badge-warn">unknown (store locked)</span>`;
+    secretRows.push(html`<tr><td class="mono">${name}</td><td>${badge}</td></tr>`);
+  }
+
+  const inputRows: SafeHtml[] = [];
+  for (const [name, spec] of Object.entries(agent.inputs ?? {})) {
+    const required = spec.default === undefined && spec.required !== false;
+    const kind = spec.type === 'enum' && spec.values?.length
+      ? `enum: ${spec.values.join(', ')}`
+      : spec.type;
+    inputRows.push(html`
+      <tr>
+        <td class="mono">${name}</td>
+        <td>${kind}</td>
+        <td>${required ? html`<span class="badge badge-warn">required</span>` : html`<span class="dim">optional</span>`}</td>
+        <td class="mono">${spec.default !== undefined ? String(spec.default) : ''}</td>
+        <td class="dim">${spec.description ?? ''}</td>
+      </tr>
+    `);
+  }
+
+  const runRows = recentRuns.map((r) => html`
+    <tr>
+      <td><a href="/runs/${r.id}" class="mono">${r.id.slice(0, 8)}</a></td>
+      <td>${statusBadge(r.status)}</td>
+      <td class="dim">${formatAge(r.startedAt)}</td>
+      <td class="dim">${formatDuration(r.startedAt, r.completedAt)}</td>
+      <td class="dim">${r.triggeredBy}</td>
+    </tr>
+  `);
+
+  // "Run now" button: direct POST for non-community-shell, modal for community-shell.
+  const runNowButton = isCommunityShell
+    ? html`
+        <button type="button" class="run-now run-now-warn" onclick="suaOpenModal('gate-${agent.name}')">
+          Run now (community shell — audit required)
+        </button>
+        <div id="gate-${agent.name}" class="modal-backdrop">
+          <div class="modal">
+            <h3>⚠ Audit required</h3>
+            <p><strong>${agent.name}</strong> is a community shell agent. It will run this command with your full user privileges:</p>
+            <div class="command">${agent.command ?? ''}</div>
+            <form method="POST" action="/agents/${agent.name}/run">
+              <label style="display: flex; gap: 0.5rem; align-items: center; margin: 0.75rem 0;">
+                <input type="checkbox" data-audit-checkbox="${agent.name}">
+                I audited this command and take responsibility for running it.
+              </label>
+              <input type="hidden" name="confirm_community_shell" value="yes">
+              <div class="modal-actions">
+                <button type="button" onclick="suaCloseModal('gate-${agent.name}')" class="run-now" style="background: var(--muted)">Cancel</button>
+                <button type="submit" class="run-now run-now-warn" data-audit-submit="${agent.name}" disabled>Run anyway</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      `
+    : html`
+        <form method="POST" action="/agents/${agent.name}/run" style="display: inline;">
+          <button type="submit" class="run-now">Run now</button>
+        </form>
+      `;
+
+  const warningBanner = source === 'community'
+    ? html`<div class="community-banner">
+        <strong>Community agent.</strong> Read the full YAML (below) before running. See
+        <a href="https://github.com/gregmeyer/some-useful-agents/blob/main/docs/SECURITY.md#trust-model">docs/SECURITY.md</a> for the trust model.
+      </div>`
+    : html``;
+
+  const body = html`
+    <h1>${agent.name} ${typeBadge(agent.type)} ${sourceBadge(source)}</h1>
+    ${warningBanner}
+    <p class="dim">${agent.description ?? 'No description.'}</p>
+
+    <div style="margin: 1rem 0;">${runNowButton}</div>
+
+    ${agent.type === 'shell'
+      ? html`<h2>Command</h2><pre>${agent.command ?? ''}</pre>`
+      : html`<h2>Prompt</h2><pre>${agent.prompt ?? ''}</pre>`}
+
+    <h2>Metadata</h2>
+    <dl class="kv">
+      <dt>Timeout</dt><dd>${String(agent.timeout ?? 300)}s</dd>
+      <dt>Schedule</dt><dd>${agent.schedule ?? html`<span class="dim">none</span>`}</dd>
+      <dt>Exposed via MCP</dt><dd>${agent.mcp === true ? 'yes' : 'no'}</dd>
+      <dt>Redact secrets</dt><dd>${agent.redactSecrets === true ? 'yes' : 'no'}</dd>
+      ${agent.allowedTools?.length ? html`<dt>Allowed tools</dt><dd class="mono">${agent.allowedTools.join(', ')}</dd>` : html``}
+      ${agent.dependsOn?.length ? html`<dt>Depends on</dt><dd>${agent.dependsOn.map((n) => html`<a href="/agents/${n}" class="mono">${n}</a>`) as unknown as SafeHtml[]}</dd>` : html``}
+    </dl>
+
+    ${inputRows.length > 0 ? html`
+      <h2>Inputs</h2>
+      <table>
+        <thead><tr><th>Name</th><th>Type</th><th>Required</th><th>Default</th><th>Description</th></tr></thead>
+        <tbody>${inputRows}</tbody>
+      </table>
+    ` : html``}
+
+    ${secretRows.length > 0 ? html`
+      <h2>Secrets</h2>
+      <table>
+        <thead><tr><th>Name</th><th>Status</th></tr></thead>
+        <tbody>${secretRows}</tbody>
+      </table>
+    ` : html``}
+
+    <h2>Recent runs</h2>
+    ${recentRuns.length === 0
+      ? html`<p class="dim">No runs yet.</p>`
+      : html`<table>
+          <thead><tr><th>ID</th><th>Status</th><th>Started</th><th>Duration</th><th>Triggered</th></tr></thead>
+          <tbody>${runRows as unknown as SafeHtml[]}</tbody>
+        </table>`}
+  `;
+
+  return render(layout({ title: agent.name, activeNav: 'agents', flash }, body));
+}

--- a/packages/dashboard/src/views/agents-list.ts
+++ b/packages/dashboard/src/views/agents-list.ts
@@ -1,0 +1,36 @@
+import type { AgentDefinition } from '@some-useful-agents/core';
+import { html, render, type SafeHtml } from './html.js';
+import { layout } from './layout.js';
+import { typeBadge, sourceBadge } from './components.js';
+
+export function renderAgentsList(agents: AgentDefinition[]): string {
+  const rows = agents.map((a) => html`
+    <tr>
+      <td><a href="/agents/${a.name}">${a.name}</a></td>
+      <td>${typeBadge(a.type)}</td>
+      <td>${sourceBadge(a.source ?? 'local')}</td>
+      <td>${a.schedule ?? html`<span class="dim">—</span>`}</td>
+      <td>${a.mcp ? html`<span class="badge badge-info">mcp</span>` : html`<span class="dim">—</span>`}</td>
+      <td class="dim">${a.description ?? ''}</td>
+    </tr>
+  `);
+
+  const body = agents.length === 0
+    ? html`<p>No agents found. Run <code>sua init</code> to scaffold a starter.</p>`
+    : html`
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th><th>Type</th><th>Source</th>
+            <th>Schedule</th><th>MCP</th><th>Description</th>
+          </tr>
+        </thead>
+        <tbody>${rows as unknown as SafeHtml[]}</tbody>
+      </table>
+    `;
+
+  return render(layout(
+    { title: 'Agents', activeNav: 'agents' },
+    html`<h1>Agents</h1>${body}`,
+  ));
+}

--- a/packages/dashboard/src/views/components.ts
+++ b/packages/dashboard/src/views/components.ts
@@ -1,0 +1,52 @@
+import { html, type SafeHtml } from './html.js';
+
+/**
+ * Status → (badge class, label) mapping that matches the CLI's color
+ * vocabulary from `ui.ts`. Keeping the surface aligned so a user reading
+ * both `sua agent status` and the dashboard sees the same vocabulary.
+ */
+export function statusBadge(status: string): SafeHtml {
+  const kind =
+    status === 'completed' ? 'badge-ok'
+    : status === 'failed' ? 'badge-err'
+    : status === 'running' || status === 'pending' ? 'badge-info'
+    : status === 'cancelled' ? 'badge-warn'
+    : 'badge-muted';
+  return html`<span class="badge ${kind}">${status}</span>`;
+}
+
+export function typeBadge(type: string): SafeHtml {
+  const kind = type === 'shell' ? 'badge-ok' : type === 'claude-code' ? 'badge-info' : 'badge-muted';
+  return html`<span class="badge ${kind}">${type}</span>`;
+}
+
+export function sourceBadge(source: string): SafeHtml {
+  const kind = source === 'community' ? 'badge-err' : source === 'examples' ? 'badge-info' : 'badge-muted';
+  return html`<span class="badge ${kind}">${source}</span>`;
+}
+
+export function outputFrame(text: string): SafeHtml {
+  return html`<div class="output-frame">${text}</div>`;
+}
+
+export function kv(key: string, value: SafeHtml | string): SafeHtml {
+  return html`<dt>${key}</dt><dd>${value}</dd>`;
+}
+
+export function formatDuration(startedAt: string, completedAt?: string): string {
+  if (!completedAt) return '—';
+  const ms = new Date(completedAt).getTime() - new Date(startedAt).getTime();
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const mins = Math.floor(ms / 60_000);
+  const secs = Math.floor((ms % 60_000) / 1000);
+  return `${mins}m${secs}s`;
+}
+
+export function formatAge(timestamp: string): string {
+  const ms = Date.now() - new Date(timestamp).getTime();
+  if (ms < 60_000) return `${Math.floor(ms / 1000)}s ago`;
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m ago`;
+  if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)}h ago`;
+  return `${Math.floor(ms / 86_400_000)}d ago`;
+}

--- a/packages/dashboard/src/views/css.ts
+++ b/packages/dashboard/src/views/css.ts
@@ -1,0 +1,110 @@
+/**
+ * Inline CSS. Inlined in every response so there's no second round-trip.
+ * Kept deliberately small — the dashboard is a monitoring surface, not a
+ * design showcase. Matches the CLI's color/voice where it matters (status
+ * colors, output frame style) and stays out of the way everywhere else.
+ */
+export const DASHBOARD_CSS = `
+  :root {
+    --bg: #fafafa;
+    --fg: #111;
+    --muted: #6b7280;
+    --border: #e5e7eb;
+    --accent: #0f766e;
+    --ok: #15803d;
+    --warn: #b45309;
+    --err: #b91c1c;
+    --info: #2563eb;
+    --mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--fg); font-family: system-ui, -apple-system, sans-serif; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code, pre { font-family: var(--mono); }
+  pre { background: #f3f4f6; padding: 0.75rem 1rem; border-radius: 0.5rem; overflow: auto; }
+  .topbar {
+    display: flex; align-items: baseline; gap: 1.5rem;
+    padding: 0.75rem 1.5rem; background: #fff; border-bottom: 1px solid var(--border);
+  }
+  .brand { font-weight: 700; font-size: 1.1rem; color: var(--fg); }
+  .topbar nav { display: flex; gap: 1rem; }
+  .topbar nav a { color: var(--muted); }
+  .topbar nav a.active { color: var(--fg); font-weight: 600; }
+  main { padding: 1.5rem; max-width: 1200px; margin: 0 auto; }
+  h1 { margin-top: 0; font-size: 1.5rem; }
+  h2 { font-size: 1.15rem; margin-top: 2rem; }
+  table { width: 100%; border-collapse: collapse; font-size: 0.95rem; }
+  th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid var(--border); }
+  th { color: var(--muted); font-weight: 600; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.03em; }
+  tr:hover td { background: #f9fafb; }
+  .badge {
+    display: inline-block; padding: 0.1rem 0.5rem; border-radius: 0.5rem;
+    font-size: 0.8rem; font-weight: 600; font-family: var(--mono);
+  }
+  .badge-ok { background: #dcfce7; color: var(--ok); }
+  .badge-err { background: #fee2e2; color: var(--err); }
+  .badge-warn { background: #fef3c7; color: var(--warn); }
+  .badge-info { background: #dbeafe; color: var(--info); }
+  .badge-muted { background: var(--border); color: var(--muted); }
+  .dim { color: var(--muted); }
+  .mono { font-family: var(--mono); font-size: 0.9em; }
+  .filters {
+    display: flex; gap: 0.75rem; align-items: end; flex-wrap: wrap;
+    margin-bottom: 1rem; padding: 0.75rem; background: #fff;
+    border: 1px solid var(--border); border-radius: 0.5rem;
+  }
+  .filters label { display: flex; flex-direction: column; font-size: 0.85rem; color: var(--muted); }
+  .filters select, .filters input[type=text] {
+    padding: 0.35rem 0.5rem; border: 1px solid var(--border);
+    border-radius: 0.25rem; font-family: inherit; font-size: 0.9rem;
+    min-width: 8rem;
+  }
+  .filters button {
+    padding: 0.4rem 0.85rem; background: var(--accent); color: #fff;
+    border: 0; border-radius: 0.25rem; cursor: pointer; font-size: 0.9rem;
+  }
+  .filters .reset { align-self: end; padding: 0.4rem 0.5rem; color: var(--muted); }
+  .pager { display: flex; gap: 1rem; justify-content: space-between; margin-top: 1rem; color: var(--muted); font-size: 0.9rem; }
+  .output-frame {
+    margin-top: 0.5rem; padding: 0.75rem 1rem; background: #111; color: #f3f4f6;
+    border-radius: 0.5rem; font-family: var(--mono); font-size: 0.9rem;
+    white-space: pre-wrap; word-break: break-word;
+  }
+  .flash {
+    padding: 0.75rem 1rem; border-radius: 0.5rem; margin-bottom: 1rem;
+    border: 1px solid var(--border);
+  }
+  .flash-error { background: #fee2e2; border-color: #fecaca; color: var(--err); }
+  .flash-info { background: #dbeafe; border-color: #bfdbfe; color: var(--info); }
+  .run-now {
+    display: inline-block; padding: 0.5rem 1rem; background: var(--accent);
+    color: #fff; border: 0; border-radius: 0.25rem; cursor: pointer;
+    font-size: 0.95rem; font-weight: 600;
+  }
+  .run-now-warn {
+    background: var(--warn);
+  }
+  .kv { display: grid; grid-template-columns: 10rem 1fr; gap: 0.25rem 1rem; }
+  .kv dt { color: var(--muted); font-size: 0.9rem; }
+  .kv dd { margin: 0; }
+  .modal-backdrop {
+    display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.4);
+    align-items: center; justify-content: center; z-index: 10;
+  }
+  .modal-backdrop.open { display: flex; }
+  .modal {
+    background: #fff; padding: 1.5rem; border-radius: 0.5rem;
+    max-width: 32rem; width: 90%; box-shadow: 0 10px 25px rgba(0,0,0,0.2);
+  }
+  .modal h3 { margin-top: 0; color: var(--err); }
+  .modal .command {
+    background: #f3f4f6; padding: 0.5rem; border-radius: 0.25rem;
+    font-family: var(--mono); font-size: 0.9rem; word-break: break-all;
+  }
+  .modal-actions { display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 1rem; }
+  .community-banner {
+    padding: 0.75rem 1rem; background: #fef2f2; border: 1px solid #fecaca;
+    border-radius: 0.5rem; color: var(--err); margin-bottom: 1rem;
+  }
+`;

--- a/packages/dashboard/src/views/html.ts
+++ b/packages/dashboard/src/views/html.ts
@@ -1,0 +1,73 @@
+/**
+ * Minimal HTML rendering helpers. No template engine — tagged template
+ * literals + an explicit "already-escaped" wrapper are enough for the
+ * amount of HTML this package produces.
+ *
+ * Rule: every interpolation in `html\`...\`` is escaped unless it's
+ * already a SafeHtml (produced by another `html()` call or `unsafeHtml()`).
+ * Pass user data into `${}` directly — never via .toString().
+ */
+
+const ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+export function escape(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  return String(value).replace(/[&<>"']/g, (c) => ESCAPE_MAP[c]);
+}
+
+const SAFE_BRAND = Symbol('SafeHtml');
+
+export interface SafeHtml {
+  readonly [SAFE_BRAND]: true;
+  readonly value: string;
+  toString(): string;
+}
+
+function makeSafe(value: string): SafeHtml {
+  return {
+    [SAFE_BRAND]: true,
+    value,
+    toString() { return value; },
+  };
+}
+
+function isSafe(v: unknown): v is SafeHtml {
+  return typeof v === 'object' && v !== null && (v as SafeHtml)[SAFE_BRAND] === true;
+}
+
+/** Mark an already-escaped string as safe to inline without further escaping. */
+export function unsafeHtml(raw: string): SafeHtml {
+  return makeSafe(raw);
+}
+
+/**
+ * Tagged template for HTML. Interpolated values are escaped unless they
+ * were produced by another `html()` or `unsafeHtml()` call. Arrays are
+ * joined without a separator (convenient for row loops).
+ */
+export function html(strings: TemplateStringsArray, ...values: unknown[]): SafeHtml {
+  let out = strings[0];
+  for (let i = 0; i < values.length; i++) {
+    const v = values[i];
+    if (Array.isArray(v)) {
+      out += v.map((item) => (isSafe(item) ? item.value : escape(item))).join('');
+    } else if (isSafe(v)) {
+      out += v.value;
+    } else {
+      out += escape(v);
+    }
+    out += strings[i + 1];
+  }
+  return makeSafe(out);
+}
+
+/** Render a SafeHtml to its string representation for sending over HTTP. */
+export function render(h: SafeHtml): string {
+  return h.value;
+}

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -1,0 +1,58 @@
+/**
+ * Inline JS. Tiny vanilla script for:
+ *   1. The community-shell confirm modal (open/close, checkbox-gated submit)
+ *   2. Auto-poll on /runs/:id when the run is still in-progress
+ *
+ * Inlined so there's no second HTTP round-trip for ~2KB of logic.
+ */
+export const DASHBOARD_JS = `
+(function () {
+  // Community-shell confirm modal
+  function openModal(id) {
+    var el = document.getElementById(id);
+    if (el) el.classList.add('open');
+  }
+  function closeModal(id) {
+    var el = document.getElementById(id);
+    if (el) el.classList.remove('open');
+  }
+  window.suaOpenModal = openModal;
+  window.suaCloseModal = closeModal;
+
+  // Toggle submit button when the audit checkbox flips
+  document.addEventListener('change', function (e) {
+    var t = e.target;
+    if (t && t.matches && t.matches('input[data-audit-checkbox]')) {
+      var formId = t.getAttribute('data-audit-checkbox');
+      var btn = document.querySelector('button[data-audit-submit="' + formId + '"]');
+      if (btn) btn.disabled = !t.checked;
+    }
+  });
+
+  // Auto-poll for in-progress runs
+  var runDetail = document.querySelector('[data-run-in-progress]');
+  if (runDetail) {
+    var runId = runDetail.getAttribute('data-run-in-progress');
+    var poll = function () {
+      fetch('/runs/' + encodeURIComponent(runId) + '?partial=1', { credentials: 'same-origin' })
+        .then(function (r) { return r.ok ? r.text() : Promise.reject(r.status); })
+        .then(function (html) {
+          var placeholder = document.createElement('div');
+          placeholder.innerHTML = html;
+          var fresh = placeholder.querySelector('[data-run-container]');
+          var current = document.querySelector('[data-run-container]');
+          if (fresh && current) {
+            current.replaceWith(fresh);
+            // If the new fragment no longer carries the in-progress marker,
+            // the poll loop stops naturally on the next scheduled tick.
+            if (fresh.querySelector('[data-run-in-progress]')) {
+              setTimeout(poll, 2000);
+            }
+          }
+        })
+        .catch(function () { /* swallow; will retry on next tick */ setTimeout(poll, 5000); });
+    };
+    setTimeout(poll, 2000);
+  }
+})();
+`;

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -1,0 +1,41 @@
+import { html, unsafeHtml, type SafeHtml } from './html.js';
+import { DASHBOARD_CSS } from './css.js';
+import { DASHBOARD_JS } from './js.js';
+
+export interface LayoutOptions {
+  title: string;
+  /** Highlight in the nav (one of: agents, runs). */
+  activeNav?: 'agents' | 'runs';
+  /** Flash banner shown at the top of the body (errors from prior actions). */
+  flash?: { kind: 'error' | 'info'; message: string };
+}
+
+export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
+  const flash = opts.flash
+    ? html`<div class="flash flash-${opts.flash.kind}">${opts.flash.message}</div>`
+    : unsafeHtml('');
+
+  return html`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${opts.title} · sua dashboard</title>
+<style>${unsafeHtml(DASHBOARD_CSS)}</style>
+</head>
+<body>
+<header class="topbar">
+  <a class="brand" href="/">sua</a>
+  <nav>
+    <a href="/agents" class="${opts.activeNav === 'agents' ? 'active' : ''}">Agents</a>
+    <a href="/runs" class="${opts.activeNav === 'runs' ? 'active' : ''}">Runs</a>
+  </nav>
+</header>
+<main>
+  ${flash}
+  ${body}
+</main>
+<script>${unsafeHtml(DASHBOARD_JS)}</script>
+</body>
+</html>`;
+}

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -1,0 +1,50 @@
+import type { Run } from '@some-useful-agents/core';
+import { html, render, unsafeHtml } from './html.js';
+import { layout } from './layout.js';
+import { statusBadge, outputFrame, formatDuration } from './components.js';
+
+export interface RunDetailOptions {
+  run: Run;
+  /** If true, render ONLY the updatable fragment (for the 2s poll). */
+  partial?: boolean;
+}
+
+export function renderRunDetail(opts: RunDetailOptions): string {
+  const { run, partial } = opts;
+  const inProgress = run.status === 'running' || run.status === 'pending';
+
+  // Run id is a UUID — safe to inline in an attribute without re-escaping
+  // because it contains only [a-f0-9-]. Asserted where the value is minted.
+  const pollAttr = inProgress ? unsafeHtml(` data-run-in-progress="${run.id}"`) : unsafeHtml('');
+
+  const fragment = html`
+    <div data-run-container${pollAttr}>
+      <h1>
+        Run <span class="mono">${run.id.slice(0, 8)}</span>
+        ${statusBadge(run.status)}
+      </h1>
+      <dl class="kv">
+        <dt>Agent</dt><dd><a href="/agents/${run.agentName}">${run.agentName}</a></dd>
+        <dt>Started</dt><dd class="mono">${run.startedAt}</dd>
+        <dt>Completed</dt><dd class="mono">${run.completedAt ?? html`<span class="dim">in progress</span>`}</dd>
+        <dt>Duration</dt><dd>${formatDuration(run.startedAt, run.completedAt)}</dd>
+        <dt>Exit code</dt><dd class="mono">${run.exitCode !== undefined ? String(run.exitCode) : ''}</dd>
+        <dt>Triggered by</dt><dd>${run.triggeredBy}</dd>
+      </dl>
+
+      ${run.error ? html`
+        <h2>Error</h2>
+        <div class="flash flash-error">${run.error}</div>
+      ` : html``}
+
+      <h2>Output</h2>
+      ${run.result ? outputFrame(run.result) : html`<p class="dim">No output yet.</p>`}
+    </div>
+  `;
+
+  if (partial) {
+    return render(html`<!DOCTYPE html><html><body>${fragment}</body></html>`);
+  }
+
+  return render(layout({ title: `Run ${run.id.slice(0, 8)}`, activeNav: 'runs' }, fragment));
+}

--- a/packages/dashboard/src/views/runs-list.ts
+++ b/packages/dashboard/src/views/runs-list.ts
@@ -1,0 +1,131 @@
+import type { Run, RunStatus } from '@some-useful-agents/core';
+import { html, render, type SafeHtml } from './html.js';
+import { layout } from './layout.js';
+import { statusBadge, formatDuration, formatAge } from './components.js';
+
+export interface RunsListOptions {
+  rows: Run[];
+  total: number;
+  limit: number;
+  offset: number;
+  filter: {
+    agent?: string;
+    statuses: string[];
+    triggeredBy?: string;
+    q?: string;
+  };
+  distinct: {
+    agents: string[];
+    statuses: string[];
+    triggeredBy: string[];
+  };
+}
+
+const ALL_STATUSES: RunStatus[] = ['pending', 'running', 'completed', 'failed', 'cancelled'];
+
+export function renderRunsList(opts: RunsListOptions): string {
+  const { rows, total, limit, offset, filter, distinct } = opts;
+
+  const showingStart = total === 0 ? 0 : offset + 1;
+  const showingEnd = Math.min(offset + rows.length, total);
+
+  const prevOffset = Math.max(0, offset - limit);
+  const nextOffset = offset + limit;
+
+  const runRows = rows.map((r) => html`
+    <tr>
+      <td><a href="/runs/${r.id}" class="mono">${r.id.slice(0, 8)}</a></td>
+      <td><a href="/agents/${r.agentName}">${r.agentName}</a></td>
+      <td>${statusBadge(r.status)}</td>
+      <td class="dim">${formatAge(r.startedAt)}</td>
+      <td class="dim">${formatDuration(r.startedAt, r.completedAt)}</td>
+      <td class="dim">${r.triggeredBy}</td>
+    </tr>
+  `);
+
+  const agentOptions = distinct.agents.map((a) => html`
+    <option value="${a}" ${filter.agent === a ? 'selected' : ''}>${a}</option>
+  `);
+
+  const triggeredByOptions = distinct.triggeredBy.map((t) => html`
+    <option value="${t}" ${filter.triggeredBy === t ? 'selected' : ''}>${t}</option>
+  `);
+
+  // Status checkboxes — more ergonomic than a multi-select for 5 values.
+  const statusChecks = ALL_STATUSES.map((s) => html`
+    <label class="mono" style="flex-direction: row; gap: 0.25rem; align-items: center;">
+      <input type="checkbox" name="status" value="${s}" ${filter.statuses.includes(s) ? 'checked' : ''}>
+      ${s}
+    </label>
+  `);
+
+  const filterBar = html`
+    <form class="filters" method="GET" action="/runs">
+      <label>
+        Agent
+        <select name="agent">
+          <option value="">any</option>
+          ${agentOptions as unknown as SafeHtml[]}
+        </select>
+      </label>
+      <label>
+        Triggered by
+        <select name="triggeredBy">
+          <option value="">any</option>
+          ${triggeredByOptions as unknown as SafeHtml[]}
+        </select>
+      </label>
+      <label>
+        Search
+        <input type="text" name="q" value="${filter.q ?? ''}" placeholder="id prefix or agent name">
+      </label>
+      <label style="gap: 0.35rem;">
+        Status
+        <div style="display: flex; gap: 0.75rem; flex-wrap: wrap;">${statusChecks as unknown as SafeHtml[]}</div>
+      </label>
+      <button type="submit">Apply</button>
+      <a class="reset" href="/runs">Reset</a>
+    </form>
+  `;
+
+  const table = rows.length === 0
+    ? html`<p class="dim">No runs match the current filters.</p>`
+    : html`
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th><th>Agent</th><th>Status</th>
+            <th>Started</th><th>Duration</th><th>Triggered</th>
+          </tr>
+        </thead>
+        <tbody>${runRows as unknown as SafeHtml[]}</tbody>
+      </table>
+    `;
+
+  const pager = total > 0 ? html`
+    <div class="pager">
+      <div>Showing ${String(showingStart)}–${String(showingEnd)} of ${String(total)}</div>
+      <div>
+        ${offset > 0 ? html`<a href="${buildUrl(filter, limit, prevOffset)}">← Prev</a>` : html`<span class="dim">← Prev</span>`}
+        ${' '}
+        ${nextOffset < total ? html`<a href="${buildUrl(filter, limit, nextOffset)}">Next →</a>` : html`<span class="dim">Next →</span>`}
+      </div>
+    </div>
+  ` : html``;
+
+  const body = html`<h1>Runs</h1>${filterBar}${table}${pager}`;
+
+  return render(layout({ title: 'Runs', activeNav: 'runs' }, body));
+}
+
+function buildUrl(filter: RunsListOptions['filter'], limit: number, offset: number): string {
+  const params = new URLSearchParams();
+  if (filter.agent) params.set('agent', filter.agent);
+  if (filter.triggeredBy) params.set('triggeredBy', filter.triggeredBy);
+  if (filter.q) params.set('q', filter.q);
+  for (const s of filter.statuses) params.append('status', s);
+  if (limit !== 50) params.set('limit', String(limit));
+  if (offset !== 0) params.set('offset', String(offset));
+  const qs = params.toString();
+  return qs ? `/runs?${qs}` : '/runs';
+}


### PR DESCRIPTION
## Summary

The v0.12.0 dashboard. Express + server-rendered HTML, no bundler, shares the MCP bearer token for auth. Closes the dashboard plan scope and adds the filter UX that came up in conversation (agent/status/triggeredBy dropdowns + free-text prefix match on id + pagination through URL query string).

## Routes

| Route | Auth | Purpose |
|---|---|---|
| `/` | cookie | 302 → `/agents` |
| `/health` | public | `{status, uptime_s, runs_last_hour}` for monitoring pings |
| `/auth?token=<t>` | public | validates + sets `HttpOnly SameSite=Strict` cookie (8h) |
| `/agents` | cookie | type/source badges, schedule, MCP flag, description |
| `/agents/:name` | cookie | resolved YAML, declared inputs, secrets-status, recent 20 runs, run-now button |
| `/runs` | cookie | filtered + paginated table; query-string state round-trips |
| `/runs/:id` | cookie | status, output frame, error pane; 2s poll for in-progress |
| `POST /agents/:name/run` | cookie | community-shell gate; 303 → `/runs/:id` |

## Filter UX on `/runs`

```
?agent=<name>               exact match (indexed)
?status=<s>                  repeatable; OR within statuses
?triggeredBy=<cli|…>         exact match (indexed)
?q=<text>                    prefix on id OR substring on agentName (i-case)
?limit=<n>                   default 50, max 500
?offset=<n>                  Prev/Next preserves all other filters
```

SQL LIKE metacharacters in `?q=` are escaped (so `50%` matches a literal `"%"`, not every row).

## Defenses

All shared with the MCP server via `@some-useful-agents/core/http-auth`:
- `127.0.0.1` bind default; non-loopback prints a warning on start
- Host header allowlist (belt-and-suspenders if operator set `--host 0.0.0.0`)
- Origin header allowlist (real DNS-rebinding defense; missing Origin allowed for non-browser)
- Cookie value is the bearer token itself with constant-time compare; cookie invalidates on `sua mcp rotate-token`
- Community shell agents go through the **same** `provider.submitRun` gate — the modal is UX, not security. Provider's `UntrustedCommunityShellError` still fires if the agent isn't in `--allow-untrusted-shell`.

## Tech choices

- Express + tagged template literals — no React, no bundler, no template engine, no CDN. One HTTP round-trip per page (CSS + JS inlined).
- Auto-escape wrapper on `html\`\`` interpolations; interpolated values marked `SafeHtml` only by going through `html()` or `unsafeHtml()`. Bypass path is the type system, not string sniffing.
- `supertest` for route tests.

## Test plan

- [x] 302 tests pass across the repo (was 287; +15 new in `packages/dashboard/src/dashboard.test.ts`)
  - Auth: 6 cases (public `/health`, redirect without cookie, Host/Origin rejection, wrong-token 401, right-token sets cookie with expected flags, authenticated `/agents` 200)
  - Filters: 5 cases (empty state, agent filter excludes other agents, status OR, unknown-status defense, pagination link preservation)
  - Run-now: 3 cases (local agent 303s to `/runs/:id`, community without confirm refused with flash, community with confirm still refused by provider gate)
- [x] Manual end-to-end: `sua dashboard start --port 3990` against a scratch `sua init` dir. Verified via `curl`:
  - `/health` returns JSON unauthenticated
  - `/agents` without cookie → 302 to `/auth`
  - `/auth?token=<right>` returns 302 + `Set-Cookie: sua_dashboard_session=…; HttpOnly; SameSite=Strict; Max-Age=28800; Path=/`
  - `/agents` + `/runs` with cookie → HTML with expected content
  - Malicious `Host: evil.com` → 403
- [x] Typecheck + build clean

## Out of scope (deferred to v0.13)

- Custom-input form for run-now (YAML defaults only, per the plan)
- YAML editing / secrets setting from the UI
- Mermaid topology view of agent chains — ships with the LLM-discoverability docs work (richer YAML fields, `sua agents docs`, `sua chain graph`)

## What the release will look like

Changesets release PR will consume this changeset; with `#44` already on main, v0.12.0 = foundations + UI + this PR's run-now/filters/UI. Ships in one combined release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
