### PR TITLE
feat: agent v2 types + YAML round-trip (PR 1/5 for agents-as-DAGs)

### DIFF
--- a/.changeset/agents-v2-types.md
+++ b/.changeset/agents-v2-types.md
@@ -1,0 +1,38 @@
+---
+"@some-useful-agents/core": minor
+---
+
+**feat: Agent v2 types + YAML schema + round-trip (PR 1 of 5 for agents-as-DAGs).**
+
+Foundation work for the v0.13.0 "agent is a DAG of nodes" architecture. No runtime behavior change yet; nothing else in the repo consumes these types. Each subsequent PR in the series adds a layer:
+
+- **This PR (v2 types + YAML):** `Agent`, `AgentNode`, `AgentVersion`, `NodeExecutionRecord` types; Zod schema for YAML v2; `parseAgent()` + `exportAgent()` round-trip
+- **PR 2 (agent-store + run-store):** DB schema for `agents`, `agent_versions`, `node_executions`; CRUD
+- **PR 3 (DAG executor):** topological walk, per-node record writes, trust-source propagation (lifted from `chain-executor`), `{{upstream.<nodeId>.result}}` template substitution
+- **PR 4 (migration + CLI):** auto-merge v1 YAML chains into DAG-agents; `sua workflow` verbs
+- **PR 5 (dashboard viz):** Cytoscape-rendered DAG on `/agents/:id`, per-node execution table on `/runs/:id`
+
+### What's in this PR
+
+- `Agent` / `AgentNode` / `AgentStatus` / `NodeOutput` / `NodeExecutionRecord` / `AgentVersion` types
+- Zod schema with:
+  - Unique node ids, valid `dependsOn` references, cycle detection
+  - Template validation: `{{inputs.X}}` must be declared; `{{upstream.Y.result}}` must be a declared upstream node
+  - Shell-command template rejection (same env-var convention as v1)
+  - Sensitive-env input name shadowing rejection (reuses v1's `SENSITIVE_ENV_NAMES`)
+  - Cron cap (reuses v1's `validateScheduleInterval`)
+- `parseAgent(yaml): Agent` with a typed `AgentYamlParseError` carrying validation issues
+- `exportAgent(agent): string` with stable key order for git-diff-friendly output
+- `exportAgents(agents): Map<filename, yaml>` for dumping a whole workspace
+
+36 new tests (24 schema + 12 YAML round-trip). 302 → 338 repo-wide.
+
+### Why YAML stays a first-class concern
+
+Per the v0.13 plan: DB is editable runtime state; YAML is the lossless serialization format for git, portability, and review. `parse(export(a)) ≈ a` for every valid `Agent` is a test invariant. Stable key order + omit-undefined-fields keeps diffs predictable.
+
+### Template vocabulary recap
+
+- `{{inputs.X}}` — agent-level caller-supplied input (caller passes `--input X=value`)
+- `{{upstream.<nodeId>.result}}` — upstream node's stdout within this agent (claude-code only; shell nodes read `$UPSTREAM_<NODEID>_RESULT` env vars)
+- `{{outputs.X.result}}` (v1 cross-agent) — removed. Migration in PR 4 rewrites these as `{{upstream.X.result}}` within merged agents.

--- a/packages/core/src/agent-v2-schema.test.ts
+++ b/packages/core/src/agent-v2-schema.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from 'vitest';
+import { agentV2Schema, extractUpstreamReferences } from './agent-v2-schema.js';
+
+function validSingleNode(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'hello',
+    name: 'Hello',
+    description: 'A greeter',
+    nodes: [{ id: 'main', type: 'shell', command: 'echo hi' }],
+    ...overrides,
+  };
+}
+
+describe('agentV2Schema — happy paths', () => {
+  it('accepts a minimal single-node shell agent', () => {
+    const r = agentV2Schema.safeParse(validSingleNode());
+    expect(r.success).toBe(true);
+  });
+
+  it('applies sensible defaults', () => {
+    const r = agentV2Schema.safeParse(validSingleNode());
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.status).toBe('draft');
+      expect(r.data.source).toBe('local');
+      expect(r.data.mcp).toBe(false);
+      expect(r.data.version).toBe(1);
+    }
+  });
+
+  it('accepts a three-node DAG with declared dependencies', () => {
+    const r = agentV2Schema.safeParse({
+      id: 'news-digest',
+      name: 'News Digest',
+      nodes: [
+        { id: 'fetch', type: 'shell', command: 'curl -s https://example.com' },
+        { id: 'summarize', type: 'claude-code', prompt: 'Summarize: {{upstream.fetch.result}}', dependsOn: ['fetch'] },
+        { id: 'post', type: 'shell', command: 'echo done', dependsOn: ['summarize'] },
+      ],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts declared inputs and per-node references', () => {
+    const r = agentV2Schema.safeParse({
+      id: 'weather-verse',
+      name: 'Weather verse',
+      inputs: { ZIP: { type: 'number', required: true } },
+      nodes: [
+        {
+          id: 'compose',
+          type: 'claude-code',
+          prompt: 'Weather for zip {{inputs.ZIP}}',
+        },
+      ],
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('agentV2Schema — rejections', () => {
+  it('rejects agent id with uppercase', () => {
+    const r = agentV2Schema.safeParse(validSingleNode({ id: 'HelloAgent' }));
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects empty nodes array', () => {
+    const r = agentV2Schema.safeParse({ id: 'x', name: 'X', nodes: [] });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects shell node without command', () => {
+    const r = agentV2Schema.safeParse({
+      id: 'x', name: 'X',
+      nodes: [{ id: 'main', type: 'shell' }],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects claude-code node without prompt', () => {
+    const r = agentV2Schema.safeParse({
+      id: 'x', name: 'X',
+      nodes: [{ id: 'main', type: 'claude-code' }],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects duplicate node ids', () => {
+    const r = agentV2Schema.safeParse({
+      id: 'x', name: 'X',
+      nodes: [
+        { id: 'a', type: 'shell', command: 'echo 1' },
+        { id: 'a', type: 'shell', command: 'echo 2' },
+      ],
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => /Duplicate node id/i.test(i.message))).toBe(true);
+    }
+  });
+
+  it('rejects dependsOn on a non-existent node', () => {
+    const r = agentV2Schema.safeParse({
+      id: 'x', name: 'X',
+      nodes: [{ id: 'a', type: 'shell', command: 'echo 1', dependsOn: ['phantom'] }],
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => /dependsOn "phantom"/.test(i.message))).toBe(true);
+    }
+  });
+
+  it('rejects self-dependency', () => {
+    const r = agentV2Schema.safeParse({
+      id: 'x', name: 'X',
+      nodes: [{ id: 'a', type: 'shell', command: 'echo 1', dependsOn: ['a'] }],
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => /cannot depend on itself/i.test(i.message))).toBe(true);
+    }
+  });
+
+  it('rejects a 2-node cycle', () => {
+    const r = agentV2Schema.safeParse({
+      id: 'x', name: 'X',
+      nodes: [
+        { id: 'a', type: 'shell', command: 'echo 1', dependsOn: ['b'] },
+        { id: 'b', type: 'shell', command: 'echo 2', dependsOn: ['a'] },
+      ],
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => /Cycle detected/i.test(i.message))).toBe(true);
+    }
+  });
+
+  it('rejects a 3-node cycle', () => {
+    const r = agentV2Schema.safeParse({
+      id: 'x', name: 'X',
+      nodes: [
+        { id: 'a', type: 'shell', command: 'echo 1', dependsOn: ['c'] },
+        { id: 'b', type: 'shell', command: 'echo 2', dependsOn: ['a'] },
+        { id: 'c', type: 'shell', command: 'echo 3', dependsOn: ['b'] },
+      ],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects {{inputs.X}} reference to an undeclared input', () => {
+    const r = agentV2Schema.safeParse({
+      id: 'x', name: 'X',
+      nodes: [{ id: 'a', type: 'claude-code', prompt: 'Hello {{inputs.MISSING}}' }],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects {{upstream.Y.result}} reference to a non-existent node', () => {
+    const r = agentV2Schema.safeParse({
+      id: 'x', name: 'X',
+      nodes: [{ id: 'a', type: 'claude-code', prompt: '{{upstream.ghost.result}}' }],
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => /not a node in this agent/i.test(i.message))).toBe(true);
+    }
+  });
+
+  it('rejects {{upstream.Y.result}} when Y is not in the node\'s dependsOn', () => {
+    const r = agentV2Schema.safeParse({
+      id: 'x', name: 'X',
+      nodes: [
+        { id: 'a', type: 'shell', command: 'echo hello' },
+        { id: 'b', type: 'claude-code', prompt: '{{upstream.a.result}}' }, // no dependsOn
+      ],
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => /does not declare "a" in its dependsOn/i.test(i.message))).toBe(true);
+    }
+  });
+
+  it('rejects {{inputs.X}} inside a shell command (env-var convention)', () => {
+    const r = agentV2Schema.safeParse({
+      id: 'x', name: 'X',
+      inputs: { ZIP: { type: 'number' } },
+      nodes: [{ id: 'a', type: 'shell', command: 'echo {{inputs.ZIP}}' }],
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => /shell nodes access inputs via environment variables/i.test(i.message))).toBe(true);
+    }
+  });
+
+  it('rejects {{upstream.X.result}} inside a shell command (env-var convention)', () => {
+    const r = agentV2Schema.safeParse({
+      id: 'x', name: 'X',
+      nodes: [
+        { id: 'a', type: 'shell', command: 'echo hi' },
+        { id: 'b', type: 'shell', command: 'echo {{upstream.a.result}}', dependsOn: ['a'] },
+      ],
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => /\$UPSTREAM_A_RESULT/i.test(i.message))).toBe(true);
+    }
+  });
+
+  it('rejects reserved input names (SENSITIVE_ENV_NAMES)', () => {
+    const r = agentV2Schema.safeParse({
+      id: 'x', name: 'X',
+      inputs: { PATH: { type: 'string' } },
+      nodes: [{ id: 'a', type: 'shell', command: 'echo hi' }],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects sub-minute schedule without allowHighFrequency', () => {
+    const r = agentV2Schema.safeParse(validSingleNode({ schedule: '*/30 * * * * *' }));
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('extractUpstreamReferences', () => {
+  it('extracts a single reference', () => {
+    expect([...extractUpstreamReferences('{{upstream.fetch.result}}')]).toEqual(['fetch']);
+  });
+
+  it('extracts multiple distinct references', () => {
+    const refs = extractUpstreamReferences('X={{upstream.a.result}} Y={{upstream.b.result}}');
+    expect([...refs].sort()).toEqual(['a', 'b']);
+  });
+
+  it('dedupes repeated references', () => {
+    const refs = extractUpstreamReferences('{{upstream.a.result}} / {{upstream.a.result}}');
+    expect([...refs]).toEqual(['a']);
+  });
+
+  it('ignores malformed references', () => {
+    expect([...extractUpstreamReferences('{{upstream.a}}')]).toEqual([]);
+    expect([...extractUpstreamReferences('{{upstream.a.other}}')]).toEqual([]);
+  });
+});

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -1,0 +1,272 @@
+/**
+ * Zod schema for YAML v2 agents. Validates the shape a user wrote or an
+ * importer produced before it ever reaches the DB. Catches:
+ *   - bad ids (agent or node)
+ *   - node-type / command-or-prompt mismatches
+ *   - dependsOn references that don't exist in this agent's node list
+ *   - cycles in the DAG
+ *   - template refs ({{inputs.X}}, {{upstream.X.result}}) to undeclared targets
+ *   - shell-command templating (same rule as v1: shell uses env vars)
+ *   - cron cap (reuses v1 cron validator)
+ *   - sensitive-env-var input-name shadowing (reuses v1 check)
+ *
+ * Kept structurally close to `schema.ts` so anyone familiar with the v1
+ * schema can read this without a context switch.
+ */
+
+import { z } from 'zod';
+import { validateScheduleInterval, CronInvalidError, CronTooFrequentError } from './cron-validator.js';
+import { extractInputReferences, SENSITIVE_ENV_NAMES } from './input-resolver.js';
+import { inputSpecSchema } from './schema.js';
+
+const AGENT_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+const NODE_ID_RE = /^[a-z0-9][a-z0-9_-]*$/;
+const SECRET_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
+const INPUT_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
+
+/**
+ * Match `{{upstream.<nodeId>.result}}` anywhere in a string. Captures the
+ * node id so we can cross-check against the declared node set.
+ */
+const UPSTREAM_REF_RE = /\{\{upstream\.([a-z0-9][a-z0-9_-]*)\.result\}\}/g;
+
+export function extractUpstreamReferences(text: string): Set<string> {
+  const out = new Set<string>();
+  for (const m of text.matchAll(UPSTREAM_REF_RE)) {
+    out.add(m[1]);
+  }
+  return out;
+}
+
+export const agentNodeSchema = z.object({
+  id: z.string().regex(NODE_ID_RE, 'Node ids must be lowercase with hyphens/underscores only'),
+  type: z.enum(['shell', 'claude-code']),
+
+  command: z.string().optional(),
+  prompt: z.string().optional(),
+  model: z.string().optional(),
+  maxTurns: z.number().int().positive().optional(),
+  allowedTools: z.array(z.string()).optional(),
+
+  timeout: z.number().positive().optional(),
+  env: z.record(z.string()).optional(),
+  envAllowlist: z.array(z.string()).optional(),
+  secrets: z.array(z.string().regex(SECRET_NAME_RE, 'Secret names must be UPPERCASE_WITH_UNDERSCORES')).optional(),
+  redactSecrets: z.boolean().optional(),
+  workingDirectory: z.string().optional(),
+
+  dependsOn: z.array(z.string()).optional(),
+  position: z.object({ x: z.number(), y: z.number() }).optional(),
+}).refine(
+  (data) => {
+    if (data.type === 'shell') return !!data.command;
+    if (data.type === 'claude-code') return !!data.prompt;
+    return false;
+  },
+  { message: 'Shell nodes require "command", claude-code nodes require "prompt"' },
+);
+
+export const agentV2Schema = z.object({
+  id: z.string().regex(AGENT_ID_RE, 'Agent id must be lowercase with hyphens only'),
+  name: z.string().min(1),
+  description: z.string().optional(),
+  status: z.enum(['active', 'paused', 'archived', 'draft']).default('draft'),
+  schedule: z.string().optional(),
+  allowHighFrequency: z.boolean().optional(),
+  source: z.enum(['examples', 'local', 'community']).default('local'),
+  mcp: z.boolean().default(false),
+  version: z.number().int().positive().default(1),
+
+  inputs: z.record(
+    z.string().regex(INPUT_NAME_RE, 'Input names must be UPPERCASE_WITH_UNDERSCORES'),
+    inputSpecSchema,
+  ).optional(),
+
+  nodes: z.array(agentNodeSchema).min(1, 'An agent must have at least one node'),
+
+  author: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+}).superRefine((data, ctx) => {
+  // Unique node ids
+  const seen = new Map<string, number>();
+  for (let i = 0; i < data.nodes.length; i++) {
+    const id = data.nodes[i].id;
+    if (seen.has(id)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['nodes', i, 'id'],
+        message: `Duplicate node id "${id}" (first seen at index ${seen.get(id)}).`,
+      });
+    }
+    seen.set(id, i);
+  }
+
+  const nodeIds = new Set(data.nodes.map((n) => n.id));
+
+  // dependsOn targets exist in this agent's node list
+  for (let i = 0; i < data.nodes.length; i++) {
+    const node = data.nodes[i];
+    for (const dep of node.dependsOn ?? []) {
+      if (!nodeIds.has(dep)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['nodes', i, 'dependsOn'],
+          message: `Node "${node.id}" dependsOn "${dep}", which is not a node in this agent.`,
+        });
+      }
+      if (dep === node.id) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['nodes', i, 'dependsOn'],
+          message: `Node "${node.id}" cannot depend on itself.`,
+        });
+      }
+    }
+  }
+
+  // Cycle detection (depth-first with colour states). Only run if dependsOn
+  // references have resolved cleanly; otherwise the error above already
+  // surfaces the structural problem.
+  const colour = new Map<string, 'white' | 'grey' | 'black'>();
+  for (const node of data.nodes) colour.set(node.id, 'white');
+  const adj = new Map<string, string[]>();
+  for (const node of data.nodes) adj.set(node.id, node.dependsOn ?? []);
+
+  function visit(nodeId: string, stack: string[]): string[] | undefined {
+    const c = colour.get(nodeId);
+    if (c === 'grey') return [...stack, nodeId];
+    if (c === 'black') return undefined;
+    colour.set(nodeId, 'grey');
+    for (const dep of adj.get(nodeId) ?? []) {
+      const cycle = visit(dep, [...stack, nodeId]);
+      if (cycle) return cycle;
+    }
+    colour.set(nodeId, 'black');
+    return undefined;
+  }
+
+  for (const node of data.nodes) {
+    if (colour.get(node.id) === 'white') {
+      const cycle = visit(node.id, []);
+      if (cycle) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['nodes'],
+          message: `Cycle detected in DAG: ${cycle.join(' → ')}.`,
+        });
+        break; // one cycle report is enough
+      }
+    }
+  }
+
+  // Cron cap (same rule as v1)
+  if (data.schedule) {
+    try {
+      validateScheduleInterval(data.schedule, { allowHighFrequency: data.allowHighFrequency });
+    } catch (err) {
+      if (err instanceof CronInvalidError || err instanceof CronTooFrequentError) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['schedule'], message: err.message });
+      } else throw err;
+    }
+  }
+
+  // Sensitive-env input-name shadowing
+  if (data.inputs) {
+    for (const name of Object.keys(data.inputs)) {
+      if (SENSITIVE_ENV_NAMES.has(name)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['inputs', name],
+          message:
+            `Input name "${name}" is reserved. It would override a sensitive ` +
+            `process environment variable. Pick a different name.`,
+        });
+      }
+    }
+  }
+
+  // Per-node template checks:
+  //   - {{inputs.X}} refs must map to a declared agent-level input
+  //   - {{upstream.Y.result}} refs must be declared in this node's dependsOn
+  //   - shell `command:` can't use either template style (env-var convention)
+  const declaredInputs = new Set(Object.keys(data.inputs ?? {}));
+  for (let i = 0; i < data.nodes.length; i++) {
+    const node = data.nodes[i];
+    const deps = new Set(node.dependsOn ?? []);
+
+    const checkText = (text: string | undefined, pathSuffix: (string | number)[]) => {
+      if (!text) return;
+      const basePath = ['nodes', i, ...pathSuffix] as (string | number)[];
+      const inputRefs = extractInputReferences(text);
+      for (const ref of inputRefs) {
+        if (!declaredInputs.has(ref)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: basePath,
+            message: `Template references {{inputs.${ref}}} but "${ref}" is not declared in this agent's inputs block.`,
+          });
+        }
+      }
+      const upstreamRefs = extractUpstreamReferences(text);
+      for (const ref of upstreamRefs) {
+        if (!nodeIds.has(ref)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: basePath,
+            message: `Template references {{upstream.${ref}.result}} but "${ref}" is not a node in this agent.`,
+          });
+        } else if (!deps.has(ref)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: basePath,
+            message:
+              `Template references {{upstream.${ref}.result}} but "${node.id}" does not declare ` +
+              `"${ref}" in its dependsOn list. Add "${ref}" to dependsOn so the executor knows the order.`,
+          });
+        }
+      }
+    };
+
+    if (node.type === 'shell' && node.command) {
+      // Shell nodes use env-var convention for both inputs and upstream
+      // outputs. Templates in the command string would force us to shell-
+      // escape substituted values, which is fraught.
+      const inputRefs = extractInputReferences(node.command);
+      if (inputRefs.size > 0) {
+        const first = [...inputRefs][0];
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['nodes', i, 'command'],
+          message:
+            `Shell nodes access inputs via environment variables, not templates. ` +
+            `Replace {{inputs.${first}}} with $${first} in the command.`,
+        });
+      }
+      const upstreamRefs = extractUpstreamReferences(node.command);
+      if (upstreamRefs.size > 0) {
+        const first = [...upstreamRefs][0];
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['nodes', i, 'command'],
+          message:
+            `Shell nodes access upstream outputs via environment variables, not templates. ` +
+            `Replace {{upstream.${first}.result}} with $UPSTREAM_${first.toUpperCase().replace(/-/g, '_')}_RESULT in the command.`,
+        });
+      }
+    }
+
+    if (node.type === 'claude-code') {
+      checkText(node.prompt, ['prompt']);
+    }
+
+    // env values (both shell and claude-code) may reference inputs + upstream
+    if (node.env) {
+      for (const [k, v] of Object.entries(node.env)) {
+        checkText(v, ['env', k]);
+      }
+    }
+  }
+});
+
+export type AgentV2Input = z.input<typeof agentV2Schema>;
+export type AgentV2Parsed = z.output<typeof agentV2Schema>;

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -20,6 +20,33 @@ export type AgentStatus = 'active' | 'paused' | 'archived' | 'draft';
 export type NodeType = 'shell' | 'claude-code';
 export type NodeExecutionStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled' | 'skipped';
 
+/**
+ * Why a node ended in its final state. Lets users filter run logs by failure
+ * mode ("show me every timeout this week") and lets the dashboard / CLI
+ * render debugging-useful messages without parsing free-text errors.
+ *
+ * - `setup`: failure before the node started running (e.g. resolving
+ *   secrets against a locked store, missing required input)
+ * - `input_resolution`: template substitution failed (e.g. an upstream's
+ *   output was empty when this node needed it)
+ * - `spawn_failure`: the process couldn't be launched (missing binary,
+ *   permission denied)
+ * - `exit_nonzero`: node ran to completion but the process returned
+ *   a non-zero exit code
+ * - `timeout`: node exceeded its timeout
+ * - `cancelled`: explicitly cancelled (provider shutdown, user abort)
+ * - `upstream_failed`: this node never ran because an upstream failed;
+ *   error text names the failing upstream for coherent top-to-bottom logs
+ */
+export type NodeErrorCategory =
+  | 'setup'
+  | 'input_resolution'
+  | 'spawn_failure'
+  | 'exit_nonzero'
+  | 'timeout'
+  | 'cancelled'
+  | 'upstream_failed';
+
 // Re-export so consumers of v2 types can import from one place without
 // reaching back into the v1 loader module.
 export type { AgentSource };
@@ -144,6 +171,12 @@ export interface NodeExecutionRecord {
   result?: string;
   exitCode?: number;
   error?: string;
+  /**
+   * Structured failure mode. Present when `status` is `failed`, `cancelled`,
+   * or `skipped`. Absent (undefined) for `completed` nodes. See
+   * `NodeErrorCategory` for the enum and semantics.
+   */
+  errorCategory?: NodeErrorCategory;
   /** Inputs that were resolved and injected into the node at exec time. */
   inputsJson?: string;
   /** Snapshot of upstream node results that fed into this node. */

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -1,0 +1,163 @@
+/**
+ * Agent-v2 types. An agent is now a **versioned DAG of nodes**, not a single
+ * executable YAML. These types are the in-memory shape after parsing YAML v2
+ * or reading from the `agents` + `agent_versions` DB tables.
+ *
+ * See ~/.claude/plans/eager-splashing-toast.md for the full design and the
+ * migration story from v1 (one YAML = one node) to v2 (one agent = DAG).
+ *
+ * Template vocabulary a node's command/prompt may use:
+ *   - `{{inputs.X}}` for agent-level caller-supplied input X
+ *   - `{{upstream.<nodeId>.result}}` for upstream node's stdout (claude-code
+ *     only — shell nodes receive the same value as `$UPSTREAM_<NODEID>_RESULT`
+ *     via env injection, matching how shell agents already consume inputs).
+ */
+
+import type { AgentInputSpec } from './types.js';
+import type { AgentSource } from './agent-loader.js';
+
+export type AgentStatus = 'active' | 'paused' | 'archived' | 'draft';
+export type NodeType = 'shell' | 'claude-code';
+export type NodeExecutionStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled' | 'skipped';
+
+// Re-export so consumers of v2 types can import from one place without
+// reaching back into the v1 loader module.
+export type { AgentSource };
+
+/**
+ * A single executable step within an agent's DAG. Corresponds 1:1 with what
+ * a v1 `AgentDefinition` described, minus the cross-file chaining fields
+ * (`dependsOn`/`input`/`source`) which now live at the agent or edge level.
+ */
+export interface AgentNode {
+  id: string;
+  type: NodeType;
+
+  // Shell
+  command?: string;
+
+  // Claude-code
+  prompt?: string;
+  model?: string;
+  maxTurns?: number;
+  allowedTools?: string[];
+
+  // Common per-node
+  timeout?: number;
+  env?: Record<string, string>;
+  envAllowlist?: string[];
+  /** Secret names (UPPERCASE_WITH_UNDERSCORES) this node needs injected. */
+  secrets?: string[];
+  /** Scrub known-prefix secrets from captured stdout/stderr before storage. */
+  redactSecrets?: boolean;
+  workingDirectory?: string;
+
+  /**
+   * Upstream node ids within the SAME agent. Analogous to v1's `dependsOn:`
+   * but scoped to the enclosing agent rather than cross-file. The executor
+   * topologically sorts on this field and rejects cycles.
+   */
+  dependsOn?: string[];
+
+  /**
+   * Optional layout hint for the v0.14 drag/drop editor. Ignored by the
+   * executor. Stored in the DAG JSON so layouts survive export/import.
+   */
+  position?: { x: number; y: number };
+}
+
+/**
+ * A versioned DAG. `nodes[]` is the source of truth; the edge set is derived
+ * from each node's `dependsOn`. Keeping the DAG representation in a single
+ * list (not `nodes[]` + `edges[]`) mirrors existing v1 YAML conventions and
+ * avoids edge/node sync bugs.
+ */
+export interface Agent {
+  id: string;
+  name: string;
+  description?: string;
+  status: AgentStatus;
+  schedule?: string;
+  allowHighFrequency?: boolean;
+  source: AgentSource;
+  mcp?: boolean;
+  /**
+   * The agent_versions row number. On parse from YAML this is the author's
+   * hint; on read from DB it's the `current_version` pointer's target.
+   */
+  version: number;
+
+  /** Agent-level runtime inputs. Nodes reference these as `{{inputs.X}}`. */
+  inputs?: Record<string, AgentInputSpec>;
+
+  nodes: AgentNode[];
+
+  // Metadata
+  author?: string;
+  tags?: string[];
+}
+
+/**
+ * Immutable snapshot stored in the `agent_versions` table. `dag_json` is the
+ * JSON-serialised shape of the `Agent` (minus the DB-managed status/schedule/
+ * mcp fields, which live on the parent row). `commit_message` is optional
+ * freetext the author supplies at save time.
+ */
+export interface AgentVersion {
+  agentId: string;
+  version: number;
+  dag: AgentVersionDag;
+  createdAt: string;
+  createdBy: 'cli' | 'dashboard' | 'import';
+  commitMessage?: string;
+}
+
+/**
+ * Shape actually serialised into `agent_versions.dag_json`. Excludes the
+ * per-row fields the parent `agents` table owns (status/schedule/mcp/
+ * current_version) so they can be edited without creating a new version.
+ */
+export interface AgentVersionDag {
+  id: string;
+  name: string;
+  description?: string;
+  source: AgentSource;
+  inputs?: Record<string, AgentInputSpec>;
+  nodes: AgentNode[];
+  author?: string;
+  tags?: string[];
+}
+
+/**
+ * Per-node record for one DAG run. Stored in `node_executions`. Surfaces
+ * the resolved inputs and upstream snapshot at exec time so replay can
+ * reconstruct what a node saw even if the upstream output was later
+ * overwritten by a newer run.
+ */
+export interface NodeExecutionRecord {
+  runId: string;
+  nodeId: string;
+  workflowVersion: number;
+  status: NodeExecutionStatus;
+  startedAt: string;
+  completedAt?: string;
+  result?: string;
+  exitCode?: number;
+  error?: string;
+  /** Inputs that were resolved and injected into the node at exec time. */
+  inputsJson?: string;
+  /** Snapshot of upstream node results that fed into this node. */
+  upstreamInputsJson?: string;
+}
+
+/**
+ * Runtime handle produced by the executor for one node execution. Short-lived;
+ * not persisted. Useful for trust-source propagation in the DAG executor
+ * (see `chain-executor.ts:76-155` for the v1 equivalent we're lifting).
+ */
+export interface NodeOutput {
+  result: string;
+  exitCode: number;
+  /** Agent source at the time of execution; propagates for trust wrapping. */
+  source: AgentSource;
+}

--- a/packages/core/src/agent-yaml.test.ts
+++ b/packages/core/src/agent-yaml.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from 'vitest';
+import { parseAgent, exportAgent, AgentYamlParseError } from './agent-yaml.js';
+import type { Agent } from './agent-v2-types.js';
+
+const MINIMAL_YAML = `
+id: hello
+name: Hello
+description: A greeter
+nodes:
+  - id: main
+    type: shell
+    command: echo hi
+`;
+
+const THREE_NODE_YAML = `
+id: news-digest
+name: News Digest
+description: Daily AI news digest
+status: active
+schedule: "0 9 * * *"
+source: local
+mcp: false
+version: 2
+inputs:
+  TOPIC:
+    type: string
+    default: ai
+nodes:
+  - id: fetch
+    type: shell
+    command: curl -s https://news.example.com
+  - id: summarize
+    type: claude-code
+    prompt: |
+      Summarize these headlines: {{upstream.fetch.result}}
+    allowedTools:
+      - WebFetch
+    dependsOn:
+      - fetch
+  - id: post
+    type: shell
+    command: echo published
+    secrets:
+      - SLACK_WEBHOOK
+    dependsOn:
+      - summarize
+`;
+
+describe('parseAgent', () => {
+  it('parses a minimal single-node agent', () => {
+    const a = parseAgent(MINIMAL_YAML);
+    expect(a.id).toBe('hello');
+    expect(a.nodes).toHaveLength(1);
+    expect(a.nodes[0].command).toBe('echo hi');
+    // Defaults applied:
+    expect(a.status).toBe('draft');
+    expect(a.source).toBe('local');
+    expect(a.version).toBe(1);
+  });
+
+  it('parses a three-node DAG with inputs and dependencies', () => {
+    const a = parseAgent(THREE_NODE_YAML);
+    expect(a.nodes).toHaveLength(3);
+    expect(a.nodes[1].dependsOn).toEqual(['fetch']);
+    expect(a.nodes[2].secrets).toEqual(['SLACK_WEBHOOK']);
+    expect(a.inputs?.TOPIC?.default).toBe('ai');
+  });
+
+  it('throws AgentYamlParseError on empty input', () => {
+    expect(() => parseAgent('')).toThrow(AgentYamlParseError);
+    expect(() => parseAgent('   \n  \n')).toThrow(AgentYamlParseError);
+  });
+
+  it('throws AgentYamlParseError on invalid YAML', () => {
+    expect(() => parseAgent('id: [[[')).toThrow(AgentYamlParseError);
+  });
+
+  it('throws AgentYamlParseError with all issues on schema failure', () => {
+    try {
+      parseAgent(`
+id: BadId
+name: X
+nodes:
+  - id: phantom-ref
+    type: shell
+    command: echo hi
+    dependsOn: [ghost]
+`);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AgentYamlParseError);
+      const issues = (err as AgentYamlParseError).issues as Array<{ message: string }>;
+      expect(issues).toBeDefined();
+      expect(issues.some((i) => /lowercase/i.test(i.message))).toBe(true);
+      expect(issues.some((i) => /dependsOn "ghost"/.test(i.message))).toBe(true);
+    }
+  });
+});
+
+describe('exportAgent + round-trip', () => {
+  it('round-trips a three-node agent losslessly', () => {
+    const a1 = parseAgent(THREE_NODE_YAML);
+    const yaml = exportAgent(a1);
+    const a2 = parseAgent(yaml);
+    // Deep equality is the bar; serialization is allowed to reshape whitespace.
+    expect(a2).toEqual(a1);
+  });
+
+  it('round-trips a minimal agent losslessly', () => {
+    const a1 = parseAgent(MINIMAL_YAML);
+    const a2 = parseAgent(exportAgent(a1));
+    expect(a2).toEqual(a1);
+  });
+
+  it('emits fields in stable order (id, name, description, ... nodes, ...)', () => {
+    const a = parseAgent(THREE_NODE_YAML);
+    const yaml = exportAgent(a);
+
+    // Find the line indices of the agent-level top-level keys. They should
+    // appear in the order declared by AGENT_KEY_ORDER.
+    const lines = yaml.split('\n');
+    const order = ['id:', 'name:', 'description:', 'status:', 'schedule:', 'source:', 'mcp:', 'version:', 'inputs:', 'nodes:'];
+    let lastIndex = -1;
+    for (const key of order) {
+      const idx = lines.findIndex((l) => l.startsWith(key));
+      if (idx === -1) continue; // optional field
+      expect(idx).toBeGreaterThan(lastIndex);
+      lastIndex = idx;
+    }
+  });
+
+  it('emits node fields in stable order (id, type, command|prompt, ... dependsOn)', () => {
+    const a: Agent = {
+      id: 'x',
+      name: 'X',
+      status: 'active',
+      source: 'local',
+      mcp: false,
+      version: 1,
+      nodes: [
+        {
+          id: 'n1',
+          type: 'shell',
+          command: 'echo hi',
+          timeout: 30,
+          secrets: ['MY_KEY'],
+          dependsOn: [],
+        },
+      ],
+    };
+    const yaml = exportAgent(a);
+    // id must appear before type, type before command, command before secrets, etc.
+    const idPos = yaml.indexOf('- id: n1');
+    const typePos = yaml.indexOf('type: shell');
+    const cmdPos = yaml.indexOf('command: echo hi');
+    const secretsPos = yaml.indexOf('secrets:');
+    expect(idPos).toBeLessThan(typePos);
+    expect(typePos).toBeLessThan(cmdPos);
+    expect(cmdPos).toBeLessThan(secretsPos);
+  });
+
+  it('omits undefined fields from the output', () => {
+    const a = parseAgent(MINIMAL_YAML);
+    const yaml = exportAgent(a);
+    // Minimal agent has no schedule, no inputs, no tags — none should appear.
+    expect(yaml).not.toMatch(/^schedule:/m);
+    expect(yaml).not.toMatch(/^inputs:/m);
+    expect(yaml).not.toMatch(/^tags:/m);
+  });
+
+  it('preserves node-level position hint for the v0.14 editor', () => {
+    const yaml = `
+id: laid-out
+name: Laid out
+nodes:
+  - id: a
+    type: shell
+    command: echo 1
+    position:
+      x: 120
+      y: 60
+  - id: b
+    type: shell
+    command: echo 2
+    dependsOn: [a]
+    position:
+      x: 300
+      y: 60
+`;
+    const a1 = parseAgent(yaml);
+    expect(a1.nodes[0].position).toEqual({ x: 120, y: 60 });
+    const a2 = parseAgent(exportAgent(a1));
+    expect(a2.nodes[0].position).toEqual({ x: 120, y: 60 });
+    expect(a2.nodes[1].position).toEqual({ x: 300, y: 60 });
+  });
+
+  it('handles multi-line prompts with block scalars cleanly', () => {
+    const yaml = `
+id: multi
+name: Multi
+nodes:
+  - id: c
+    type: claude-code
+    prompt: |
+      Line one
+      Line two
+      Line three
+`;
+    const a1 = parseAgent(yaml);
+    expect(a1.nodes[0].prompt).toBe('Line one\nLine two\nLine three\n');
+    const a2 = parseAgent(exportAgent(a1));
+    expect(a2.nodes[0].prompt).toBe('Line one\nLine two\nLine three\n');
+  });
+});

--- a/packages/core/src/agent-yaml.ts
+++ b/packages/core/src/agent-yaml.ts
@@ -1,0 +1,153 @@
+/**
+ * Agent v2 YAML import/export. The DB is the runtime source of truth;
+ * YAML is the lossless serialisation format used for git commits, sharing,
+ * and "before I hit save, let me diff this" workflows.
+ *
+ * parse → validate → in-memory Agent object.
+ * export → stable key order → YAML string that parse can round-trip.
+ *
+ * Round-trip fidelity is a test invariant: `parse(export(a)) ≈ a` for any
+ * valid Agent. "Approximately equal" ignores insignificant whitespace the
+ * YAML serialiser may reshape.
+ */
+
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+import type { Agent, AgentNode, AgentStatus, AgentSource } from './agent-v2-types.js';
+import { agentV2Schema, type AgentV2Parsed } from './agent-v2-schema.js';
+
+export class AgentYamlParseError extends Error {
+  constructor(message: string, public readonly issues?: unknown[]) {
+    super(message);
+    this.name = 'AgentYamlParseError';
+  }
+}
+
+/**
+ * Parse a YAML v2 agent document. Validates via the Zod schema and returns
+ * a ready-to-insert-into-DB Agent object. Throws `AgentYamlParseError` on
+ * validation failure with issue details for the CLI to surface.
+ */
+export function parseAgent(yamlText: string): Agent {
+  if (!yamlText.trim()) {
+    throw new AgentYamlParseError('Empty agent YAML document.');
+  }
+
+  let raw: unknown;
+  try {
+    raw = parseYaml(yamlText);
+  } catch (err) {
+    throw new AgentYamlParseError(`Invalid YAML: ${(err as Error).message}`);
+  }
+
+  const result = agentV2Schema.safeParse(raw);
+  if (!result.success) {
+    const summary = result.error.issues
+      .map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`)
+      .join('; ');
+    throw new AgentYamlParseError(`Agent schema validation failed: ${summary}`, result.error.issues);
+  }
+
+  return parsedToAgent(result.data);
+}
+
+function parsedToAgent(p: AgentV2Parsed): Agent {
+  const nodes: AgentNode[] = p.nodes.map((n) => ({
+    id: n.id,
+    type: n.type,
+    ...(n.command !== undefined && { command: n.command }),
+    ...(n.prompt !== undefined && { prompt: n.prompt }),
+    ...(n.model !== undefined && { model: n.model }),
+    ...(n.maxTurns !== undefined && { maxTurns: n.maxTurns }),
+    ...(n.allowedTools && { allowedTools: n.allowedTools }),
+    ...(n.timeout !== undefined && { timeout: n.timeout }),
+    ...(n.env && { env: n.env }),
+    ...(n.envAllowlist && { envAllowlist: n.envAllowlist }),
+    ...(n.secrets && { secrets: n.secrets }),
+    ...(n.redactSecrets !== undefined && { redactSecrets: n.redactSecrets }),
+    ...(n.workingDirectory !== undefined && { workingDirectory: n.workingDirectory }),
+    ...(n.dependsOn && { dependsOn: n.dependsOn }),
+    ...(n.position && { position: n.position }),
+  }));
+
+  return {
+    id: p.id,
+    name: p.name,
+    ...(p.description !== undefined && { description: p.description }),
+    status: p.status as AgentStatus,
+    ...(p.schedule !== undefined && { schedule: p.schedule }),
+    ...(p.allowHighFrequency !== undefined && { allowHighFrequency: p.allowHighFrequency }),
+    source: p.source as AgentSource,
+    mcp: p.mcp,
+    version: p.version,
+    ...(p.inputs && { inputs: p.inputs }),
+    nodes,
+    ...(p.author !== undefined && { author: p.author }),
+    ...(p.tags && { tags: p.tags }),
+  };
+}
+
+/**
+ * Field emission order for `exportAgent`. Stable. Keeps git diffs predictable
+ * and matches the order used by `sua agent new` in v0.7. Fields that are
+ * undefined on a given agent are simply omitted.
+ */
+const AGENT_KEY_ORDER = [
+  'id', 'name', 'description',
+  'status', 'schedule', 'allowHighFrequency',
+  'source', 'mcp', 'version',
+  'inputs',
+  'nodes',
+  'author', 'tags',
+] as const;
+
+const NODE_KEY_ORDER = [
+  'id', 'type',
+  'command', 'prompt', 'model', 'maxTurns', 'allowedTools',
+  'timeout', 'env', 'envAllowlist', 'secrets', 'redactSecrets', 'workingDirectory',
+  'dependsOn',
+  'position',
+] as const;
+
+/**
+ * Serialise an Agent to YAML with stable key order. Skips any field that is
+ * `undefined` (vs leaving it as `~` / null). Round-trips cleanly through
+ * `parseAgent`.
+ */
+export function exportAgent(agent: Agent): string {
+  const ordered: Record<string, unknown> = {};
+  for (const key of AGENT_KEY_ORDER) {
+    if (key === 'nodes') {
+      ordered.nodes = agent.nodes.map((n) => orderedNode(n));
+    } else {
+      const v = (agent as unknown as Record<string, unknown>)[key];
+      if (v !== undefined) ordered[key] = v;
+    }
+  }
+  return stringifyYaml(ordered, {
+    // Block-style output for multi-line command / prompt fields; keeps
+    // YAML readable when a prompt spans several lines.
+    lineWidth: 0,
+    minContentWidth: 0,
+  });
+}
+
+function orderedNode(node: AgentNode): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of NODE_KEY_ORDER) {
+    const v = (node as unknown as Record<string, unknown>)[key];
+    if (v !== undefined) out[key] = v;
+  }
+  return out;
+}
+
+/**
+ * Export many agents as a directory-tree-ready map of `filename → YAML text`.
+ * Used by `sua workflow export` to dump an entire workspace to disk.
+ */
+export function exportAgents(agents: Agent[]): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const a of agents) {
+    out.set(`${a.id}.yaml`, exportAgent(a));
+  }
+  return out;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,3 +16,12 @@ export * from './mcp-token.js';
 export * from './secret-redactor.js';
 export * from './input-resolver.js';
 export * from './http-auth.js';
+export * from './agent-v2-types.js';
+export {
+  agentV2Schema,
+  agentNodeSchema,
+  extractUpstreamReferences,
+  type AgentV2Input,
+  type AgentV2Parsed,
+} from './agent-v2-schema.js';
+export { parseAgent, exportAgent, exportAgents, AgentYamlParseError } from './agent-yaml.js';


### PR DESCRIPTION
## Summary

**PR 1 of 5** for the agents-as-DAGs work (plan: `~/.claude/plans/eager-splashing-toast.md`). Foundation: types + YAML round-trip. No runtime behavior change; nothing else in the repo consumes these yet.

Each PR in the series is standalone-reviewable:

| PR | Scope |
|---|---|
| **1 (this)** | v2 types, Zod schema, YAML parse/export |
| 2 | `agents` + `agent_versions` + `node_executions` tables + CRUD |
| 3 | DAG executor (replaces chain-executor); per-node record writes; trust propagation |
| 4 | Migration of v1 YAML chains → merged DAG-agents; `sua workflow` verbs |
| 5 | Dashboard DAG visualization (Cytoscape, read-only in v0.13) |

## What's in this PR

- **Types** — `Agent`, `AgentNode`, `AgentStatus`, `AgentVersion`, `NodeExecutionRecord`, `NodeOutput`. See [agent-v2-types.ts](packages/core/src/agent-v2-types.ts).
- **Zod schema** — [agent-v2-schema.ts](packages/core/src/agent-v2-schema.ts). Validates:
  - Unique node ids; valid `dependsOn` refs; **cycle detection** via 3-color DFS
  - `{{inputs.X}}` must reference a declared agent input
  - `{{upstream.<nodeId>.result}}` must reference a declared upstream node (node must exist AND be in this node's `dependsOn`)
  - Shell `command:` rejects both template styles — pushes authors into the `$VAR` / `$UPSTREAM_<NODEID>_RESULT` env-var convention (same rule as v1 for consistency)
  - Reserved input-name shadowing (reuses v1's `SENSITIVE_ENV_NAMES`)
  - Cron cap (reuses v1's `validateScheduleInterval`)
- **YAML round-trip** — [agent-yaml.ts](packages/core/src/agent-yaml.ts). `parseAgent(yaml): Agent` + `exportAgent(agent): string` with stable key order and `parse(export(a)) ≈ a` as a test invariant.

## Template vocabulary

- `{{inputs.X}}` — agent-level caller input
- `{{upstream.<nodeId>.result}}` — upstream node's stdout (within this agent)
- `{{outputs.X.result}}` (v1 cross-agent) — **removed**. Migration in PR 4 rewrites these as `{{upstream.X.result}}` within merged agents.

## Test plan

- [x] 338 tests pass (was 302; +36 new)
  - `agent-v2-schema.test.ts` — 24 cases covering every validation rule plus 4 helper tests for `extractUpstreamReferences`
  - `agent-yaml.test.ts` — 12 cases: minimal parse, three-node DAG parse, error surfaces, round-trip fidelity (minimal + full), stable field order (agent-level + node-level), undefined-field omission, position hint preservation, multi-line block-scalar preservation
- [x] `npm run build` clean

## Why YAML stays first-class

Per the v0.13 plan: DB will be editable runtime state; YAML is the lossless serialization format for git commits, sharing, and pre-save diffs. Stable key order + omit-undefined-fields keeps diffs predictable; round-trip fidelity is a test invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
