### PR TITLE
feat: AgentStore + RunStore extensions (PR 2/5 for agents-as-DAGs)

### DIFF
--- a/.changeset/agents-v2-store.md
+++ b/.changeset/agents-v2-store.md
@@ -1,0 +1,50 @@
+---
+"@some-useful-agents/core": minor
+---
+
+**feat: AgentStore + RunStore extensions (PR 2 of 5 for agents-as-DAGs).**
+
+DB schema + CRUD for the v0.13 agents-as-DAGs architecture. No runtime consumers yet — the executor (PR 3) and migration/CLI (PR 4) are the consumers.
+
+### `AgentStore`
+
+CRUD over two new tables in the same SQLite file as `runs.db`:
+
+- `agents` — mutable per-agent metadata (name, description, status, schedule, source, mcp exposure, `current_version` pointer, `provenance_json` for v0.15+ catalog tracking, timestamps).
+- `agent_versions` — immutable DAG snapshots (nodes + agent-level inputs + author/tags). FK to `agents` with ON DELETE CASCADE.
+
+```ts
+const agent = store.createAgent({ id, name, status, source, mcp, nodes, ... }, 'cli');
+// Every edit that changes the DAG = new version
+const v2 = store.createNewVersion(id, updatedDag, 'dashboard', 'added retry');
+// Metadata edits don't bump version
+store.updateAgentMeta(id, { status: 'archived' });
+// Rollback
+store.setCurrentVersion(id, 1);
+// List + filter
+store.listAgents({ status: 'active', source: 'community' });
+```
+
+`upsertAgent` handles the idempotent import case: creates on first call, updates metadata if only metadata changed, creates a new version only when the DAG shape actually differs. Used by the v1 → v2 migration (PR 4) to stay idempotent across re-runs.
+
+### `RunStore` extensions
+
+- `runs` table gets four new nullable columns via idempotent migration: `workflow_id`, `workflow_version`, `replayed_from_run_id`, `replayed_from_node_id`. Pre-v0.13 rows stay valid; migration uses `PRAGMA table_info` to skip if already applied.
+- New `node_executions` table keyed on `(runId, nodeId)` with FK cascade to `runs`. Persists per-node status, error, error category, results, resolved inputs, and the upstream output snapshot that fed the node (critical for replay-from-node).
+- New CRUD: `createNodeExecution`, `updateNodeExecution` (partial patch), `getNodeExecution`, `listNodeExecutions(runId)` (startedAt ASC — topological order), `queryNodeExecutionsByCategory(category)` (drives `sua workflow logs --category=timeout` in PR 4).
+- Partial index on `errorCategory` (where non-null) keeps category queries cheap.
+- `Run` type gains optional `workflowId`, `workflowVersion`, `replayedFromRunId`, `replayedFromNodeId` fields.
+
+### Shared-handle pattern
+
+Both stores expose a static `fromHandle(db: DatabaseSync)` factory. Used by the CLI main process and the DAG executor so both stores share one connection to `runs.db` (avoids two handles on the same file). Stores created via `fromHandle` do not close the DB on `.close()` — ownership stays with whoever opened the handle. Path-based constructors are unchanged; existing callers (`LocalProvider`, dashboard, CLI status/logs/cancel) need zero changes.
+
+### Tests
+
+29 new cases: 22 AgentStore + 7 RunStore extensions including the legacy-DB migration test. 338 → 367 repo-wide.
+
+### What's deliberately NOT here
+
+- DAG executor (PR 3) — consumes `AgentStore.getAgent()` + `RunStore.createNodeExecution()`
+- v1 YAML migration (PR 4) — uses `AgentStore.upsertAgent()` with `createdBy: 'import'`
+- Dashboard DAG viz (PR 5)

--- a/packages/core/src/agent-store.test.ts
+++ b/packages/core/src/agent-store.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { AgentStore } from './agent-store.js';
+import { RunStore } from './run-store.js';
+import type { Agent, AgentNode } from './agent-v2-types.js';
+
+let dir: string;
+let dbPath: string;
+let store: AgentStore;
+
+function seed(overrides: Partial<Agent> = {}): Omit<Agent, 'version'> {
+  const nodes: AgentNode[] = overrides.nodes ?? [
+    { id: 'main', type: 'shell', command: 'echo hi' },
+  ];
+  const { version: _ignoreVersion, ...rest } = {
+    id: 'hello',
+    name: 'Hello',
+    description: 'A greeter',
+    status: 'active' as const,
+    source: 'local' as const,
+    mcp: false,
+    nodes,
+    ...overrides,
+  };
+  return rest;
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'sua-agent-store-'));
+  dbPath = join(dir, 'runs.db');
+  store = new AgentStore(dbPath);
+});
+
+afterEach(() => {
+  store.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('AgentStore.createAgent + getAgent', () => {
+  it('round-trips a minimal agent at version 1', () => {
+    const created = store.createAgent(seed(), 'cli');
+    expect(created.version).toBe(1);
+
+    const got = store.getAgent('hello');
+    expect(got).not.toBeNull();
+    expect(got!.id).toBe('hello');
+    expect(got!.name).toBe('Hello');
+    expect(got!.status).toBe('active');
+    expect(got!.version).toBe(1);
+    expect(got!.nodes).toHaveLength(1);
+    expect(got!.nodes[0].command).toBe('echo hi');
+  });
+
+  it('persists description, schedule, mcp', () => {
+    store.createAgent(
+      seed({ description: 'Ada', schedule: '0 * * * *', mcp: true }),
+      'cli',
+    );
+    const got = store.getAgent('hello')!;
+    expect(got.description).toBe('Ada');
+    expect(got.schedule).toBe('0 * * * *');
+    expect(got.mcp).toBe(true);
+  });
+
+  it('returns null for unknown id', () => {
+    expect(store.getAgent('nope')).toBeNull();
+  });
+
+  it('refuses to create duplicate id', () => {
+    store.createAgent(seed(), 'cli');
+    expect(() => store.createAgent(seed(), 'cli')).toThrow();
+  });
+});
+
+describe('AgentStore.listAgents', () => {
+  beforeEach(() => {
+    store.createAgent(seed({ id: 'a', name: 'A', status: 'active', source: 'local' }), 'cli');
+    store.createAgent(seed({ id: 'b', name: 'B', status: 'paused', source: 'local' }), 'cli');
+    store.createAgent(seed({ id: 'c', name: 'C', status: 'active', source: 'community' }), 'cli');
+    store.createAgent(seed({ id: 'd', name: 'D', status: 'archived', source: 'local', mcp: true }), 'cli');
+  });
+
+  it('lists everything when no filter', () => {
+    expect(store.listAgents()).toHaveLength(4);
+  });
+
+  it('filters by status', () => {
+    const a = store.listAgents({ status: 'active' });
+    expect(a.map((x) => x.id).sort()).toEqual(['a', 'c']);
+  });
+
+  it('filters by source', () => {
+    const a = store.listAgents({ source: 'community' });
+    expect(a.map((x) => x.id)).toEqual(['c']);
+  });
+
+  it('filters by mcp=true', () => {
+    const a = store.listAgents({ mcp: true });
+    expect(a.map((x) => x.id)).toEqual(['d']);
+  });
+
+  it('sorts by name', () => {
+    const names = store.listAgents().map((x) => x.name);
+    expect(names).toEqual(['A', 'B', 'C', 'D']);
+  });
+});
+
+describe('AgentStore versioning', () => {
+  it('createNewVersion bumps the version counter', () => {
+    store.createAgent(seed(), 'cli');
+    const v2 = store.createNewVersion('hello', seed({
+      nodes: [
+        { id: 'main', type: 'shell', command: 'echo v2' },
+      ],
+    }), 'dashboard', 'add echo v2');
+    expect(v2.version).toBe(2);
+
+    const got = store.getAgent('hello')!;
+    expect(got.version).toBe(2);
+    expect(got.nodes[0].command).toBe('echo v2');
+  });
+
+  it('listVersions returns history newest-first', () => {
+    store.createAgent(seed(), 'cli');
+    store.createNewVersion('hello', seed({ nodes: [{ id: 'main', type: 'shell', command: 'echo 2' }] }), 'cli');
+    store.createNewVersion('hello', seed({ nodes: [{ id: 'main', type: 'shell', command: 'echo 3' }] }), 'cli');
+
+    const versions = store.listVersions('hello');
+    expect(versions.map((v) => v.version)).toEqual([3, 2, 1]);
+  });
+
+  it('getVersion returns the specific version regardless of current_version', () => {
+    store.createAgent(seed({ nodes: [{ id: 'main', type: 'shell', command: 'echo v1' }] }), 'cli');
+    store.createNewVersion('hello', seed({ nodes: [{ id: 'main', type: 'shell', command: 'echo v2' }] }), 'cli');
+
+    const v1 = store.getVersion('hello', 1);
+    expect(v1!.dag.nodes[0].command).toBe('echo v1');
+    const v2 = store.getVersion('hello', 2);
+    expect(v2!.dag.nodes[0].command).toBe('echo v2');
+  });
+
+  it('setCurrentVersion rolls back to an older version', () => {
+    store.createAgent(seed({ nodes: [{ id: 'main', type: 'shell', command: 'echo v1' }] }), 'cli');
+    store.createNewVersion('hello', seed({ nodes: [{ id: 'main', type: 'shell', command: 'echo v2' }] }), 'cli');
+
+    store.setCurrentVersion('hello', 1);
+    expect(store.getAgent('hello')!.nodes[0].command).toBe('echo v1');
+  });
+
+  it('setCurrentVersion throws on non-existent version', () => {
+    store.createAgent(seed(), 'cli');
+    expect(() => store.setCurrentVersion('hello', 99)).toThrow(/no version 99/);
+  });
+
+  it('persists commit_message and created_by', () => {
+    store.createAgent(seed(), 'import', 'migrated from v1');
+    store.createNewVersion('hello', seed(), 'dashboard', 'added retry');
+    const versions = store.listVersions('hello');
+    expect(versions[0].createdBy).toBe('dashboard');
+    expect(versions[0].commitMessage).toBe('added retry');
+    expect(versions[1].createdBy).toBe('import');
+    expect(versions[1].commitMessage).toBe('migrated from v1');
+  });
+});
+
+describe('AgentStore.upsertAgent', () => {
+  it('creates on first call, updates metadata without new version on identical DAG', () => {
+    const a1 = store.upsertAgent(seed(), 'import');
+    expect(a1.version).toBe(1);
+
+    // Same DAG but different description → metadata update, no new version
+    const a2 = store.upsertAgent(seed({ description: 'updated' }), 'import');
+    expect(a2.version).toBe(1);
+    expect(store.getAgent('hello')!.description).toBe('updated');
+    expect(store.listVersions('hello')).toHaveLength(1);
+  });
+
+  it('creates a new version when the DAG changes', () => {
+    store.upsertAgent(seed(), 'cli');
+    store.upsertAgent(
+      seed({ nodes: [{ id: 'main', type: 'shell', command: 'echo changed' }] }),
+      'cli',
+    );
+    expect(store.listVersions('hello')).toHaveLength(2);
+    expect(store.getAgent('hello')!.nodes[0].command).toBe('echo changed');
+  });
+});
+
+describe('AgentStore.updateAgentMeta', () => {
+  beforeEach(() => {
+    store.createAgent(seed(), 'cli');
+  });
+
+  it('updates status without bumping version', () => {
+    store.updateAgentMeta('hello', { status: 'archived' });
+    const got = store.getAgent('hello')!;
+    expect(got.status).toBe('archived');
+    expect(got.version).toBe(1);
+  });
+
+  it('updates schedule + mcp flag', () => {
+    store.updateAgentMeta('hello', { schedule: '*/15 * * * *', mcp: true });
+    const got = store.getAgent('hello')!;
+    expect(got.schedule).toBe('*/15 * * * *');
+    expect(got.mcp).toBe(true);
+  });
+
+  it('no-op when patch is empty', () => {
+    const before = store.getAgent('hello')!;
+    store.updateAgentMeta('hello', {});
+    const after = store.getAgent('hello')!;
+    expect(after.name).toBe(before.name);
+  });
+});
+
+describe('AgentStore.deleteAgent', () => {
+  it('removes agent + cascades versions', () => {
+    store.createAgent(seed(), 'cli');
+    store.createNewVersion('hello', seed({ nodes: [{ id: 'main', type: 'shell', command: 'echo 2' }] }), 'cli');
+    store.deleteAgent('hello');
+    expect(store.getAgent('hello')).toBeNull();
+    expect(store.listVersions('hello')).toHaveLength(0);
+  });
+});
+
+describe('AgentStore.fromHandle — shared connection with RunStore', () => {
+  it('two stores sharing one handle coexist', () => {
+    store.close(); // close the path-based default
+    const db = new DatabaseSync(dbPath);
+    const agentStore = AgentStore.fromHandle(db);
+    const runStore = RunStore.fromHandle(db);
+
+    agentStore.createAgent(seed({ id: 'x', name: 'X' }), 'cli');
+    runStore.createRun({
+      id: 'r1', agentName: 'x', status: 'completed',
+      startedAt: new Date().toISOString(), triggeredBy: 'cli',
+      workflowId: 'x', workflowVersion: 1,
+    });
+
+    expect(agentStore.getAgent('x')!.id).toBe('x');
+    expect(runStore.getRun('r1')!.workflowId).toBe('x');
+
+    // Neither store owns the connection; closing either should NOT close the DB.
+    agentStore.close();
+    runStore.close();
+    // Still usable:
+    const agentStore2 = AgentStore.fromHandle(db);
+    expect(agentStore2.getAgent('x')!.id).toBe('x');
+
+    // Manually close the handle.
+    db.close();
+    store = new AgentStore(dbPath); // reopen for afterEach.
+  });
+});

--- a/packages/core/src/agent-store.ts
+++ b/packages/core/src/agent-store.ts
@@ -1,0 +1,348 @@
+import { DatabaseSync } from 'node:sqlite';
+import { mkdirSync, existsSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { chmod600Safe } from './fs-utils.js';
+import type {
+  Agent,
+  AgentNode,
+  AgentSource,
+  AgentStatus,
+  AgentVersion,
+  AgentVersionDag,
+} from './agent-v2-types.js';
+
+type SqlValue = string | number | null | bigint | Uint8Array;
+
+/**
+ * DB-backed store for DAG agents + their immutable version history.
+ *
+ * - `agents` row holds mutable per-agent metadata (status, schedule, mcp
+ *   exposure, current_version pointer, provenance)
+ * - `agent_versions` rows hold the DAG snapshot (nodes, edges-via-dependsOn,
+ *   agent-level inputs). Immutable once written.
+ *
+ * Every save of a DAG creates a new version row and advances the
+ * `current_version` pointer (git-like). Editing metadata like status or
+ * schedule does NOT bump the version — those changes aren't part of the
+ * DAG shape.
+ *
+ * Connection model: by default opens its own DatabaseSync at `dbPath` (same
+ * file as RunStore by convention, usually `data/runs.db`). In tests / the
+ * CLI main process, use `AgentStore.fromHandle(db)` to share a
+ * DatabaseSync with RunStore — avoids two handles on the same file. The
+ * shared-handle variant does NOT close the connection on `close()`.
+ */
+export class AgentStore {
+  private db: DatabaseSync;
+  private readonly ownsConnection: boolean;
+
+  constructor(dbPath: string) {
+    const dir = dirname(dbPath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    this.db = new DatabaseSync(dbPath);
+    this.ownsConnection = true;
+    chmod600Safe(dbPath);
+    this.ensureSchema();
+  }
+
+  static fromHandle(db: DatabaseSync): AgentStore {
+    const store = Object.create(AgentStore.prototype) as AgentStore;
+    (store as unknown as { db: DatabaseSync }).db = db;
+    (store as unknown as { ownsConnection: boolean }).ownsConnection = false;
+    store.ensureSchema();
+    return store;
+  }
+
+  private ensureSchema(): void {
+    this.db.exec('PRAGMA journal_mode = WAL');
+    this.db.exec('PRAGMA foreign_keys = ON');
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS agents (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        description TEXT,
+        status TEXT NOT NULL CHECK (status IN ('active','paused','archived','draft')),
+        schedule TEXT,
+        source TEXT NOT NULL,
+        mcp INTEGER NOT NULL DEFAULT 0,
+        current_version INTEGER NOT NULL,
+        provenance_json TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `);
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS agent_versions (
+        agent_id TEXT NOT NULL,
+        version INTEGER NOT NULL,
+        dag_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        created_by TEXT NOT NULL CHECK (created_by IN ('cli','dashboard','import')),
+        commit_message TEXT,
+        PRIMARY KEY (agent_id, version),
+        FOREIGN KEY (agent_id) REFERENCES agents(id) ON DELETE CASCADE
+      )
+    `);
+    this.db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_agents_status ON agents(status);
+      CREATE INDEX IF NOT EXISTS idx_agents_schedule ON agents(schedule) WHERE schedule IS NOT NULL;
+      CREATE INDEX IF NOT EXISTS idx_agents_mcp ON agents(mcp) WHERE mcp = 1;
+    `);
+  }
+
+  /**
+   * Insert a new agent with its first version. Atomic — both rows or neither.
+   * Throws if `agent.id` already exists (use `upsertAgent` for import paths).
+   */
+  createAgent(
+    agent: Omit<Agent, 'version'>,
+    createdBy: 'cli' | 'dashboard' | 'import',
+    commitMessage?: string,
+  ): Agent {
+    const now = new Date().toISOString();
+    const dag: AgentVersionDag = this.extractDag(agent);
+
+    this.db.exec('BEGIN');
+    try {
+      this.db.prepare(`
+        INSERT INTO agents (id, name, description, status, schedule, source, mcp,
+                            current_version, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
+      `).run(
+        agent.id, agent.name, agent.description ?? null,
+        agent.status, agent.schedule ?? null, agent.source,
+        agent.mcp ? 1 : 0, now, now,
+      );
+      this.db.prepare(`
+        INSERT INTO agent_versions (agent_id, version, dag_json, created_at, created_by, commit_message)
+        VALUES (?, 1, ?, ?, ?, ?)
+      `).run(agent.id, JSON.stringify(dag), now, createdBy, commitMessage ?? null);
+      this.db.exec('COMMIT');
+    } catch (err) {
+      this.db.exec('ROLLBACK');
+      throw err;
+    }
+
+    return { ...agent, version: 1 };
+  }
+
+  /**
+   * Create or replace an agent. Used by the v1 → v2 migration (the importer
+   * reruns are idempotent) and `sua workflow import`. If the agent exists
+   * and the incoming DAG differs from the current version, creates a new
+   * version + advances current_version.
+   */
+  upsertAgent(
+    agent: Omit<Agent, 'version'>,
+    createdBy: 'cli' | 'dashboard' | 'import',
+    commitMessage?: string,
+  ): Agent {
+    const existing = this.getAgent(agent.id);
+    if (!existing) return this.createAgent(agent, createdBy, commitMessage);
+
+    // Same DAG? Just update metadata; skip the new version row.
+    const currentDagJson = this.getVersion(agent.id, existing.version)?.dag
+      ? JSON.stringify(this.getVersion(agent.id, existing.version)!.dag)
+      : '';
+    const newDag = this.extractDag(agent);
+    const newDagJson = JSON.stringify(newDag);
+    if (currentDagJson === newDagJson) {
+      this.updateAgentMeta(agent.id, {
+        name: agent.name,
+        description: agent.description,
+        status: agent.status,
+        schedule: agent.schedule,
+        mcp: agent.mcp,
+      });
+      return { ...agent, version: existing.version };
+    }
+
+    return this.createNewVersion(agent.id, agent, createdBy, commitMessage);
+  }
+
+  getAgent(id: string): Agent | null {
+    const row = this.db.prepare('SELECT * FROM agents WHERE id = ?').get(id) as Record<string, unknown> | undefined;
+    if (!row) return null;
+    const version = this.getVersion(id, row.current_version as number);
+    if (!version) return null;
+    return this.mergeRowWithVersion(row, version);
+  }
+
+  listAgents(filter?: { status?: AgentStatus; source?: AgentSource; mcp?: boolean }): Agent[] {
+    const clauses: string[] = [];
+    const values: SqlValue[] = [];
+    if (filter?.status) { clauses.push('status = ?'); values.push(filter.status); }
+    if (filter?.source) { clauses.push('source = ?'); values.push(filter.source); }
+    if (filter?.mcp !== undefined) { clauses.push('mcp = ?'); values.push(filter.mcp ? 1 : 0); }
+    const where = clauses.length > 0 ? 'WHERE ' + clauses.join(' AND ') : '';
+    const rows = this.db.prepare(`SELECT * FROM agents ${where} ORDER BY name`).all(...values) as Record<string, unknown>[];
+    const out: Agent[] = [];
+    for (const row of rows) {
+      const v = this.getVersion(row.id as string, row.current_version as number);
+      if (v) out.push(this.mergeRowWithVersion(row, v));
+    }
+    return out;
+  }
+
+  /**
+   * Update editable agent-level metadata. Does NOT bump the version — these
+   * fields aren't part of the DAG shape. Use `createNewVersion` to record a
+   * structural change.
+   */
+  updateAgentMeta(
+    id: string,
+    patch: Partial<Pick<Agent, 'name' | 'description' | 'status' | 'schedule' | 'mcp'>>,
+  ): void {
+    const fields: string[] = [];
+    const values: SqlValue[] = [];
+    if (patch.name !== undefined) { fields.push('name = ?'); values.push(patch.name); }
+    if (patch.description !== undefined) { fields.push('description = ?'); values.push(patch.description ?? null); }
+    if (patch.status !== undefined) { fields.push('status = ?'); values.push(patch.status); }
+    if (patch.schedule !== undefined) { fields.push('schedule = ?'); values.push(patch.schedule ?? null); }
+    if (patch.mcp !== undefined) { fields.push('mcp = ?'); values.push(patch.mcp ? 1 : 0); }
+    if (fields.length === 0) return;
+    fields.push('updated_at = ?');
+    values.push(new Date().toISOString());
+    values.push(id);
+    this.db.prepare(`UPDATE agents SET ${fields.join(', ')} WHERE id = ?`).run(...values);
+  }
+
+  /**
+   * Record a new DAG version for an existing agent and advance
+   * `current_version`. Atomic.
+   */
+  createNewVersion(
+    id: string,
+    agent: Omit<Agent, 'version'>,
+    createdBy: 'cli' | 'dashboard' | 'import',
+    commitMessage?: string,
+  ): Agent {
+    const existing = this.getAgent(id);
+    if (!existing) {
+      throw new Error(`Cannot create new version: agent "${id}" does not exist.`);
+    }
+    const now = new Date().toISOString();
+    const nextVersion = existing.version + 1;
+    const dag = this.extractDag(agent);
+
+    this.db.exec('BEGIN');
+    try {
+      this.db.prepare(`
+        INSERT INTO agent_versions (agent_id, version, dag_json, created_at, created_by, commit_message)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `).run(id, nextVersion, JSON.stringify(dag), now, createdBy, commitMessage ?? null);
+      this.updateAgentMeta(id, {
+        name: agent.name,
+        description: agent.description,
+        status: agent.status,
+        schedule: agent.schedule,
+        mcp: agent.mcp,
+      });
+      this.db.prepare(`UPDATE agents SET current_version = ?, updated_at = ? WHERE id = ?`).run(nextVersion, now, id);
+      this.db.exec('COMMIT');
+    } catch (err) {
+      this.db.exec('ROLLBACK');
+      throw err;
+    }
+
+    return { ...agent, version: nextVersion };
+  }
+
+  /** Rollback helper: move `current_version` to any existing version. */
+  setCurrentVersion(id: string, version: number): void {
+    const exists = this.db.prepare(
+      `SELECT 1 FROM agent_versions WHERE agent_id = ? AND version = ?`,
+    ).get(id, version);
+    if (!exists) {
+      throw new Error(`Agent "${id}" has no version ${version}.`);
+    }
+    this.db.prepare(
+      `UPDATE agents SET current_version = ?, updated_at = ? WHERE id = ?`,
+    ).run(version, new Date().toISOString(), id);
+  }
+
+  getVersion(agentId: string, version: number): AgentVersion | null {
+    const row = this.db.prepare(
+      `SELECT * FROM agent_versions WHERE agent_id = ? AND version = ?`,
+    ).get(agentId, version) as Record<string, unknown> | undefined;
+    if (!row) return null;
+    return this.rowToVersion(row);
+  }
+
+  listVersions(agentId: string): AgentVersion[] {
+    const rows = this.db.prepare(
+      `SELECT * FROM agent_versions WHERE agent_id = ? ORDER BY version DESC`,
+    ).all(agentId) as Record<string, unknown>[];
+    return rows.map((r) => this.rowToVersion(r));
+  }
+
+  /**
+   * Hard delete an agent + every version + cascade to node_executions via
+   * FK ON DELETE CASCADE on both agent_versions and node_executions-to-runs.
+   * Use sparingly — `updateAgentMeta({ status: 'archived' })` is the usual
+   * soft path.
+   */
+  deleteAgent(id: string): void {
+    this.db.prepare(`DELETE FROM agents WHERE id = ?`).run(id);
+  }
+
+  close(): void {
+    if (this.ownsConnection) {
+      this.db.close();
+    }
+  }
+
+  // -- helpers --
+
+  private extractDag(agent: Omit<Agent, 'version'>): AgentVersionDag {
+    // Only versioned parts of the shape. Agent-level metadata (name,
+    // description, status, schedule, mcp, source) lives on the `agents`
+    // row and can change without bumping the version.
+    const dag: AgentVersionDag = {
+      id: agent.id,
+      nodes: agent.nodes.map(cloneNode),
+    };
+    if (agent.inputs) dag.inputs = agent.inputs;
+    if (agent.author !== undefined) dag.author = agent.author;
+    if (agent.tags) dag.tags = agent.tags;
+    return dag;
+  }
+
+  private rowToVersion(row: Record<string, unknown>): AgentVersion {
+    return {
+      agentId: row.agent_id as string,
+      version: row.version as number,
+      dag: JSON.parse(row.dag_json as string) as AgentVersionDag,
+      createdAt: row.created_at as string,
+      createdBy: row.created_by as AgentVersion['createdBy'],
+      commitMessage: (row.commit_message as string | null) ?? undefined,
+    };
+  }
+
+  private mergeRowWithVersion(
+    row: Record<string, unknown>,
+    version: AgentVersion,
+  ): Agent {
+    const dag = version.dag;
+    return {
+      id: row.id as string,
+      name: row.name as string,
+      description: ((row.description as string | null) ?? undefined) as string | undefined,
+      status: row.status as AgentStatus,
+      schedule: ((row.schedule as string | null) ?? undefined) as string | undefined,
+      source: row.source as AgentSource,
+      mcp: (row.mcp as number) === 1,
+      version: row.current_version as number,
+      inputs: dag.inputs,
+      nodes: dag.nodes,
+      author: dag.author,
+      tags: dag.tags,
+    };
+  }
+}
+
+function cloneNode(n: AgentNode): AgentNode {
+  return JSON.parse(JSON.stringify(n)) as AgentNode;
+}

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -140,15 +140,16 @@ export interface AgentVersion {
 }
 
 /**
- * Shape actually serialised into `agent_versions.dag_json`. Excludes the
- * per-row fields the parent `agents` table owns (status/schedule/mcp/
- * current_version) so they can be edited without creating a new version.
+ * Shape actually serialised into `agent_versions.dag_json`. Strictly the
+ * versioned parts of the DAG: nodes (the topology + per-node config),
+ * agent-level inputs, and authorial metadata (author, tags). Excludes
+ * mutable per-agent metadata — `name`, `description`, `status`, `schedule`,
+ * `mcp`, `source` — which live on the parent `agents` row and can change
+ * without creating a new version. `id` is repeated here as a sanity-check
+ * for round-trips; the authoritative id is the parent row's PK.
  */
 export interface AgentVersionDag {
   id: string;
-  name: string;
-  description?: string;
-  source: AgentSource;
   inputs?: Record<string, AgentInputSpec>;
   nodes: AgentNode[];
   author?: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,3 +25,4 @@ export {
   type AgentV2Parsed,
 } from './agent-v2-schema.js';
 export { parseAgent, exportAgent, exportAgents, AgentYamlParseError } from './agent-yaml.js';
+export { AgentStore } from './agent-store.js';

--- a/packages/core/src/run-store.test.ts
+++ b/packages/core/src/run-store.test.ts
@@ -241,6 +241,153 @@ describe('RunStore.queryRuns', () => {
   });
 });
 
+describe('RunStore node_executions', () => {
+  function baseRun(id = 'r-x'): Parameters<RunStore['createRun']>[0] {
+    return {
+      id,
+      agentName: 'news-digest',
+      status: 'running',
+      startedAt: new Date().toISOString(),
+      triggeredBy: 'cli',
+      workflowId: 'news-digest',
+      workflowVersion: 1,
+    };
+  }
+
+  beforeEach(() => {
+    store.createRun(baseRun());
+  });
+
+  it('round-trips a single node execution', () => {
+    store.createNodeExecution({
+      runId: 'r-x', nodeId: 'fetch', workflowVersion: 1,
+      status: 'running', startedAt: new Date().toISOString(),
+    });
+    const got = store.getNodeExecution('r-x', 'fetch');
+    expect(got).not.toBeNull();
+    expect(got!.nodeId).toBe('fetch');
+    expect(got!.status).toBe('running');
+    expect(got!.errorCategory).toBeUndefined();
+  });
+
+  it('persists errorCategory on failed rows', () => {
+    store.createNodeExecution({
+      runId: 'r-x', nodeId: 'fetch', workflowVersion: 1,
+      status: 'failed', startedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(),
+      error: 'Timed out after 30s', errorCategory: 'timeout', exitCode: 124,
+    });
+    const got = store.getNodeExecution('r-x', 'fetch')!;
+    expect(got.errorCategory).toBe('timeout');
+    expect(got.error).toBe('Timed out after 30s');
+  });
+
+  it('updateNodeExecution applies a partial patch', () => {
+    store.createNodeExecution({
+      runId: 'r-x', nodeId: 'fetch', workflowVersion: 1,
+      status: 'running', startedAt: new Date().toISOString(),
+    });
+    store.updateNodeExecution('r-x', 'fetch', {
+      status: 'completed',
+      completedAt: new Date().toISOString(),
+      result: 'some stdout',
+      exitCode: 0,
+    });
+    const got = store.getNodeExecution('r-x', 'fetch')!;
+    expect(got.status).toBe('completed');
+    expect(got.result).toBe('some stdout');
+    expect(got.exitCode).toBe(0);
+  });
+
+  it('listNodeExecutions returns all rows for a run in startedAt order', () => {
+    const t0 = Date.now();
+    for (let i = 0; i < 3; i++) {
+      store.createNodeExecution({
+        runId: 'r-x', nodeId: `node-${i}`, workflowVersion: 1,
+        status: 'completed',
+        startedAt: new Date(t0 + i * 1000).toISOString(),
+      });
+    }
+    const list = store.listNodeExecutions('r-x');
+    expect(list.map((r) => r.nodeId)).toEqual(['node-0', 'node-1', 'node-2']);
+  });
+
+  it('queryNodeExecutionsByCategory finds rows of that category only', () => {
+    store.createRun(baseRun('r-y'));
+    store.createNodeExecution({
+      runId: 'r-x', nodeId: 'a', workflowVersion: 1,
+      status: 'failed', errorCategory: 'timeout',
+      startedAt: new Date().toISOString(),
+    });
+    store.createNodeExecution({
+      runId: 'r-x', nodeId: 'b', workflowVersion: 1,
+      status: 'failed', errorCategory: 'exit_nonzero',
+      startedAt: new Date().toISOString(),
+    });
+    store.createNodeExecution({
+      runId: 'r-y', nodeId: 'c', workflowVersion: 1,
+      status: 'failed', errorCategory: 'timeout',
+      startedAt: new Date().toISOString(),
+    });
+    const timeouts = store.queryNodeExecutionsByCategory('timeout');
+    expect(timeouts.map((r) => r.nodeId).sort()).toEqual(['a', 'c']);
+  });
+
+  it('cascades deletion via FK when a run is removed', () => {
+    store.createNodeExecution({
+      runId: 'r-x', nodeId: 'a', workflowVersion: 1,
+      status: 'completed', startedAt: new Date().toISOString(),
+    });
+    // Manually delete from runs to exercise the cascade.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (store as any).db.prepare('DELETE FROM runs WHERE id = ?').run('r-x');
+    expect(store.getNodeExecution('r-x', 'a')).toBeNull();
+  });
+});
+
+describe('RunStore migration — workflow_id / workflow_version columns', () => {
+  it('adds the columns to a legacy DB and keeps old rows queryable', async () => {
+    const { DatabaseSync } = await import('node:sqlite');
+    const { mkdirSync } = await import('node:fs');
+    const legacyDir = join(import.meta.dirname, '__legacy__');
+    rmSync(legacyDir, { recursive: true, force: true });
+    mkdirSync(legacyDir, { recursive: true });
+    const legacyPath = join(legacyDir, 'legacy.db');
+
+    // Step 1: build a legacy schema by hand.
+    const raw = new DatabaseSync(legacyPath);
+    raw.exec(`
+      CREATE TABLE runs (
+        id TEXT PRIMARY KEY, agentName TEXT NOT NULL, status TEXT NOT NULL,
+        startedAt TEXT NOT NULL, completedAt TEXT, result TEXT,
+        exitCode INTEGER, error TEXT, triggeredBy TEXT NOT NULL
+      )
+    `);
+    raw.prepare(`INSERT INTO runs (id, agentName, status, startedAt, triggeredBy) VALUES (?, ?, ?, ?, ?)`)
+      .run('old-row', 'legacy', 'completed', new Date().toISOString(), 'cli');
+    raw.close();
+
+    // Step 2: open with v2 RunStore — migration runs automatically.
+    const legacyStore = new RunStore(legacyPath);
+    const got = legacyStore.getRun('old-row');
+    expect(got).not.toBeNull();
+    expect(got!.workflowId).toBeUndefined();
+    expect(got!.workflowVersion).toBeUndefined();
+
+    // Step 3: new rows can use the new columns.
+    legacyStore.createRun({
+      id: 'new-row', agentName: 'news', status: 'completed',
+      startedAt: new Date().toISOString(), triggeredBy: 'cli',
+      workflowId: 'news', workflowVersion: 3,
+    });
+    expect(legacyStore.getRun('new-row')!.workflowId).toBe('news');
+    expect(legacyStore.getRun('new-row')!.workflowVersion).toBe(3);
+
+    legacyStore.close();
+    rmSync(legacyDir, { recursive: true, force: true });
+  });
+});
+
 describe('RunStore.distinctValues', () => {
   beforeEach(() => {
     store.createRun(makeRun({ id: 'a', agentName: 'hello',   status: 'completed', triggeredBy: 'cli' }));

--- a/packages/core/src/run-store.ts
+++ b/packages/core/src/run-store.ts
@@ -4,6 +4,11 @@ type SqlValue = string | number | null | bigint | Uint8Array;
 import { mkdirSync, existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import type { Run, RunStatus } from './types.js';
+import type {
+  NodeExecutionRecord,
+  NodeExecutionStatus,
+  NodeErrorCategory,
+} from './agent-v2-types.js';
 import { chmod600Safe } from './fs-utils.js';
 
 export interface RunStoreOptions {
@@ -28,8 +33,20 @@ function clampLimit(limit: number | undefined): number {
   return Math.min(Math.floor(limit), MAX_RUNS_LIMIT);
 }
 
+/**
+ * Set of `runs` column names (lowercased) — used for idempotent schema
+ * migrations. If a v1 DB is missing a v2-era column like `workflow_id`, we
+ * `ALTER TABLE` it in. `PRAGMA table_info` is the safe way to detect
+ * presence without re-running CREATE statements.
+ */
+function columnNames(db: DatabaseSync, table: string): Set<string> {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  return new Set(rows.map((r) => r.name.toLowerCase()));
+}
+
 export class RunStore {
   private db: DatabaseSync;
+  private readonly ownsConnection: boolean;
 
   constructor(dbPath: string, options: RunStoreOptions = {}) {
     const dir = dirname(dbPath);
@@ -38,11 +55,41 @@ export class RunStore {
     }
 
     this.db = new DatabaseSync(dbPath);
+    this.ownsConnection = true;
     // Lock the DB file down to user-only. Agent stdout can contain secrets
     // and the DB is unencrypted plaintext; the only at-rest protection is
     // POSIX perms. Safe on Windows / network mounts via chmod600Safe.
     chmod600Safe(dbPath);
 
+    this.ensureSchema();
+    this.sweepExpired(options.retentionDays ?? DEFAULT_RETENTION_DAYS);
+  }
+
+  /**
+   * Construct a RunStore sharing an existing DatabaseSync handle (e.g. with
+   * AgentStore against the same file). This variant does NOT close the
+   * connection on `close()` — whoever opened the handle owns shutdown.
+   * Skips retention sweep by default; pass `options.retentionDays` to opt in.
+   */
+  static fromHandle(db: DatabaseSync, options: RunStoreOptions = {}): RunStore {
+    const store = Object.create(RunStore.prototype) as RunStore;
+    // `db` and `ownsConnection` are `readonly` on the class but we're
+    // constructing via Object.create so direct assignment is fine.
+    (store as unknown as { db: DatabaseSync }).db = db;
+    (store as unknown as { ownsConnection: boolean }).ownsConnection = false;
+    store.ensureSchema();
+    if (options.retentionDays !== undefined) {
+      store.sweepExpired(options.retentionDays);
+    }
+    return store;
+  }
+
+  /**
+   * Create + migrate the `runs` and `node_executions` schemas. Idempotent;
+   * safe to call on an existing DB. Runs on construction and when
+   * attaching to a shared handle.
+   */
+  private ensureSchema(): void {
     this.db.exec('PRAGMA journal_mode = WAL');
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS runs (
@@ -57,6 +104,26 @@ export class RunStore {
         triggeredBy TEXT NOT NULL
       )
     `);
+
+    // v2 additions to `runs`: workflow_id + workflow_version. Nullable so
+    // pre-v0.13 rows stay valid. `PRAGMA table_info` avoids re-adding on
+    // every boot once the migration has run.
+    const runCols = columnNames(this.db, 'runs');
+    if (!runCols.has('workflow_id')) {
+      this.db.exec(`ALTER TABLE runs ADD COLUMN workflow_id TEXT`);
+    }
+    if (!runCols.has('workflow_version')) {
+      this.db.exec(`ALTER TABLE runs ADD COLUMN workflow_version INTEGER`);
+    }
+    if (!runCols.has('replayed_from_run_id')) {
+      // For v0.13's `sua workflow replay`: link a replay run back to the
+      // original so the UI can show a "replayed from X" breadcrumb.
+      this.db.exec(`ALTER TABLE runs ADD COLUMN replayed_from_run_id TEXT`);
+    }
+    if (!runCols.has('replayed_from_node_id')) {
+      this.db.exec(`ALTER TABLE runs ADD COLUMN replayed_from_node_id TEXT`);
+    }
+
     this.db.exec(`
       CREATE INDEX IF NOT EXISTS idx_runs_agent ON runs(agentName);
       CREATE INDEX IF NOT EXISTS idx_runs_status ON runs(status);
@@ -64,9 +131,36 @@ export class RunStore {
       -- DESC ordering is the dashboard's runs-list default; without this
       -- the ORDER BY scans the whole table.
       CREATE INDEX IF NOT EXISTS idx_runs_startedAt ON runs(startedAt DESC);
+      CREATE INDEX IF NOT EXISTS idx_runs_workflow ON runs(workflow_id) WHERE workflow_id IS NOT NULL;
     `);
 
-    this.sweepExpired(options.retentionDays ?? DEFAULT_RETENTION_DAYS);
+    // node_executions: per-node record within a DAG run. Keyed by
+    // (runId, nodeId). See agent-v2-types.ts NodeExecutionRecord.
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS node_executions (
+        runId TEXT NOT NULL,
+        nodeId TEXT NOT NULL,
+        workflowVersion INTEGER NOT NULL,
+        status TEXT NOT NULL,
+        errorCategory TEXT,
+        startedAt TEXT NOT NULL,
+        completedAt TEXT,
+        result TEXT,
+        exitCode INTEGER,
+        error TEXT,
+        inputsJson TEXT,
+        upstreamInputsJson TEXT,
+        PRIMARY KEY (runId, nodeId),
+        FOREIGN KEY (runId) REFERENCES runs(id) ON DELETE CASCADE
+      )
+    `);
+    this.db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_node_executions_run ON node_executions(runId);
+      -- Partial index: only populated rows. Lets 'sua workflow logs
+      -- --category=timeout' do an index seek rather than a table scan.
+      CREATE INDEX IF NOT EXISTS idx_node_executions_category
+        ON node_executions(errorCategory) WHERE errorCategory IS NOT NULL;
+    `);
   }
 
   /**
@@ -82,14 +176,19 @@ export class RunStore {
     return Number(result.changes ?? 0);
   }
 
-  createRun(run: Run): void {
+  createRun(run: Run & { workflowId?: string; workflowVersion?: number; replayedFromRunId?: string; replayedFromNodeId?: string }): void {
     const stmt = this.db.prepare(`
-      INSERT INTO runs (id, agentName, status, startedAt, completedAt, result, exitCode, error, triggeredBy)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO runs (id, agentName, status, startedAt, completedAt, result, exitCode, error, triggeredBy,
+                        workflow_id, workflow_version, replayed_from_run_id, replayed_from_node_id)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
-    stmt.run(run.id, run.agentName, run.status, run.startedAt,
+    stmt.run(
+      run.id, run.agentName, run.status, run.startedAt,
       run.completedAt ?? null, run.result ?? null, run.exitCode ?? null,
-      run.error ?? null, run.triggeredBy);
+      run.error ?? null, run.triggeredBy,
+      run.workflowId ?? null, run.workflowVersion ?? null,
+      run.replayedFromRunId ?? null, run.replayedFromNodeId ?? null,
+    );
   }
 
   getRun(id: string): Run | null {
@@ -215,8 +314,93 @@ export class RunStore {
     return rows.map((r) => r.v);
   }
 
+  // -- Node execution CRUD (v2 DAG runs) --
+
+  /** Insert a node_executions row. Duplicate (runId, nodeId) pairs throw. */
+  createNodeExecution(record: NodeExecutionRecord): void {
+    const stmt = this.db.prepare(`
+      INSERT INTO node_executions (
+        runId, nodeId, workflowVersion, status, errorCategory,
+        startedAt, completedAt, result, exitCode, error,
+        inputsJson, upstreamInputsJson
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    stmt.run(
+      record.runId, record.nodeId, record.workflowVersion, record.status,
+      record.errorCategory ?? null,
+      record.startedAt, record.completedAt ?? null,
+      record.result ?? null, record.exitCode ?? null, record.error ?? null,
+      record.inputsJson ?? null, record.upstreamInputsJson ?? null,
+    );
+  }
+
+  updateNodeExecution(
+    runId: string,
+    nodeId: string,
+    updates: Partial<Pick<NodeExecutionRecord,
+      'status' | 'errorCategory' | 'completedAt' | 'result' | 'exitCode' | 'error' | 'inputsJson' | 'upstreamInputsJson'
+    >>,
+  ): void {
+    const fields: string[] = [];
+    const values: SqlValue[] = [];
+    if (updates.status !== undefined) { fields.push('status = ?'); values.push(updates.status); }
+    if (updates.errorCategory !== undefined) { fields.push('errorCategory = ?'); values.push(updates.errorCategory); }
+    if (updates.completedAt !== undefined) { fields.push('completedAt = ?'); values.push(updates.completedAt); }
+    if (updates.result !== undefined) { fields.push('result = ?'); values.push(updates.result); }
+    if (updates.exitCode !== undefined) { fields.push('exitCode = ?'); values.push(updates.exitCode); }
+    if (updates.error !== undefined) { fields.push('error = ?'); values.push(updates.error); }
+    if (updates.inputsJson !== undefined) { fields.push('inputsJson = ?'); values.push(updates.inputsJson); }
+    if (updates.upstreamInputsJson !== undefined) { fields.push('upstreamInputsJson = ?'); values.push(updates.upstreamInputsJson); }
+    if (fields.length === 0) return;
+
+    values.push(runId, nodeId);
+    const stmt = this.db.prepare(
+      `UPDATE node_executions SET ${fields.join(', ')} WHERE runId = ? AND nodeId = ?`,
+    );
+    stmt.run(...values);
+  }
+
+  getNodeExecution(runId: string, nodeId: string): NodeExecutionRecord | null {
+    const stmt = this.db.prepare(
+      `SELECT * FROM node_executions WHERE runId = ? AND nodeId = ?`,
+    );
+    const row = stmt.get(runId, nodeId) as Record<string, unknown> | undefined;
+    if (!row) return null;
+    return this.rowToNodeExecution(row);
+  }
+
+  /**
+   * All node executions for a run, ordered by startedAt (i.e. topological
+   * execution order). Used by `sua workflow logs <runId>` and the
+   * dashboard's per-run node table.
+   */
+  listNodeExecutions(runId: string): NodeExecutionRecord[] {
+    const stmt = this.db.prepare(
+      `SELECT * FROM node_executions WHERE runId = ? ORDER BY startedAt ASC`,
+    );
+    const rows = stmt.all(runId) as Record<string, unknown>[];
+    return rows.map((r) => this.rowToNodeExecution(r));
+  }
+
+  /**
+   * Node executions that failed with a given category. Used by
+   * `sua workflow logs --category=timeout`.
+   */
+  queryNodeExecutionsByCategory(
+    category: NodeErrorCategory,
+    limit = 100,
+  ): NodeExecutionRecord[] {
+    const stmt = this.db.prepare(
+      `SELECT * FROM node_executions WHERE errorCategory = ? ORDER BY startedAt DESC LIMIT ?`,
+    );
+    const rows = stmt.all(category, limit) as Record<string, unknown>[];
+    return rows.map((r) => this.rowToNodeExecution(r));
+  }
+
   close(): void {
-    this.db.close();
+    if (this.ownsConnection) {
+      this.db.close();
+    }
   }
 
   private rowToRun(row: Record<string, unknown>): Run {
@@ -230,6 +414,27 @@ export class RunStore {
       exitCode: row.exitCode as number | undefined,
       error: row.error as string | undefined,
       triggeredBy: row.triggeredBy as Run['triggeredBy'],
+      workflowId: (row.workflow_id as string | null) ?? undefined,
+      workflowVersion: (row.workflow_version as number | null) ?? undefined,
+      replayedFromRunId: (row.replayed_from_run_id as string | null) ?? undefined,
+      replayedFromNodeId: (row.replayed_from_node_id as string | null) ?? undefined,
+    };
+  }
+
+  private rowToNodeExecution(row: Record<string, unknown>): NodeExecutionRecord {
+    return {
+      runId: row.runId as string,
+      nodeId: row.nodeId as string,
+      workflowVersion: row.workflowVersion as number,
+      status: row.status as NodeExecutionStatus,
+      errorCategory: (row.errorCategory as NodeErrorCategory | null) ?? undefined,
+      startedAt: row.startedAt as string,
+      completedAt: (row.completedAt as string | null) ?? undefined,
+      result: (row.result as string | null) ?? undefined,
+      exitCode: (row.exitCode as number | null) ?? undefined,
+      error: (row.error as string | null) ?? undefined,
+      inputsJson: (row.inputsJson as string | null) ?? undefined,
+      upstreamInputsJson: (row.upstreamInputsJson as string | null) ?? undefined,
     };
   }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -76,6 +76,19 @@ export interface Run {
   exitCode?: number;
   error?: string;
   triggeredBy: 'cli' | 'mcp' | 'schedule' | 'dashboard';
+  /**
+   * v0.13+: populated for runs that executed a DAG-mode agent.
+   * Pre-v0.13 rows have both undefined. Nullable in the DB (NULL ↔ undefined).
+   */
+  workflowId?: string;
+  workflowVersion?: number;
+  /**
+   * Populated when this run was created by `sua workflow replay`. Points at
+   * the original run + the node the replay started from. Rendered as a
+   * "replayed from …" breadcrumb in the dashboard.
+   */
+  replayedFromRunId?: string;
+  replayedFromNodeId?: string;
 }
 
 export interface RunRequest {


### PR DESCRIPTION
## Summary

**PR 2 of 5** for agents-as-DAGs. DB schema + CRUD for the new `agents`, `agent_versions`, and `node_executions` tables, plus four new nullable columns on `runs` for DAG-mode + replay. No runtime consumers yet — PR 3 (executor) and PR 4 (migration + CLI verbs) are what'll use these.

| PR | Status |
|---|---|
| 1 (types + YAML) | merged (#47) |
| **2 (stores)** | **this** |
| 3 (DAG executor) | next |
| 4 (migration + CLI) | after 3 |
| 5 (dashboard viz) | after 4 |

## What's in this PR

### `AgentStore` — new file [agent-store.ts](packages/core/src/agent-store.ts)

```ts
const agent = store.createAgent({ id, name, status, source, mcp, nodes }, 'cli');
const v2 = store.createNewVersion(id, updatedDag, 'dashboard', 'added retry');
store.updateAgentMeta(id, { status: 'archived' });   // doesn't bump version
store.setCurrentVersion(id, 1);                       // rollback
store.listAgents({ status: 'active', source: 'community' });
```

- `agents` — mutable metadata: name, description, status, schedule, source, mcp, `current_version` pointer, `provenance_json` (reserved for v0.15+ npm-catalog tracking per the [catalog+provenance memory](~/.claude/projects/-Users-grmeyer-repo-home-some-useful-agents/memory/project_catalog_provenance.md)), timestamps
- `agent_versions` — immutable DAG snapshots, keyed on `(agent_id, version)`, FK cascade
- `upsertAgent` is the idempotent-import primitive for PR 4: creates, updates metadata only, or bumps version based on whether the DAG actually differs

### `RunStore` extensions

- `runs` gains 4 nullable columns (migration uses `PRAGMA table_info` to stay idempotent): `workflow_id`, `workflow_version`, `replayed_from_run_id`, `replayed_from_node_id`
- New `node_executions` table — per-node records with `errorCategory`, `inputsJson`, `upstreamInputsJson`; FK cascade from `runs`
- Partial index on `errorCategory` keeps `sua workflow logs --category=timeout` fast
- `Run` type gains optional workflow + replay fields

### Shared-handle pattern

Both stores expose a static `fromHandle(db)` factory. Existing callers (`LocalProvider`, dashboard, CLI commands) use the path-based constructor as before — zero edits needed. The CLI main process and executor will use `fromHandle` so both stores share one `DatabaseSync` connection.

### DAG-vs-metadata boundary (caught in review)

`AgentVersionDag` narrowed to just the versioned bits: `id`, `nodes`, `inputs`, `author`, `tags`. Mutable fields like description / status / schedule / mcp / source live on the `agents` row and change without bumping the version. Fixed a test failure where changing just a description was incorrectly creating a new version.

## Test plan

- [x] 367 tests pass (was 338; +29 new: 22 AgentStore, 7 RunStore)
  - `AgentStore` — create, get, list (+ filters), update meta, createNewVersion, getVersion, listVersions, setCurrentVersion, upsert (same DAG → no version bump; different DAG → new version), deleteAgent, shared-handle coexistence with RunStore
  - `RunStore` — node_executions round-trip with `errorCategory`, partial update, listNodeExecutions in startedAt order, queryNodeExecutionsByCategory, FK cascade from runs, legacy-DB migration (v1 schema → auto-add workflow_id/version columns, old rows still queryable with undefined workflow fields, new rows use the new columns)
- [x] Build clean

## What ships next

PR 3: DAG executor — consumes `AgentStore.getAgent()` to load an Agent, walks `nodes` topologically, writes one `node_executions` row per node, ports trust-source propagation from the v1 chain-executor, implements the `NodeErrorCategory` assignment table from the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
