### PR TITLE
feat: dashboard DAG viz + per-node execution table (PR 5/5 for agents-as-DAGs)

### DIFF
--- a/.changeset/agents-v2-dashboard.md
+++ b/.changeset/agents-v2-dashboard.md
@@ -1,0 +1,61 @@
+---
+"@some-useful-agents/dashboard": minor
+"@some-useful-agents/core": patch
+---
+
+**feat: dashboard DAG visualization + per-node execution table (PR 5 of 5 for agents-as-DAGs).**
+
+Completes the v0.13 user story: import your v1 YAML into DAG agents, run them, watch them in the dashboard with a real graph view and per-node logs.
+
+### What ships
+
+- **`/agents` page** splits into two tables: v2 "DAG agents" (from AgentStore) at the top, unmigrated v1 YAML agents below. An id that exists in both tables collapses to the v2 row; the v1 header only appears when there are v1-only agents to show.
+- **`/agents/:id`** (v2 variant) renders the DAG visually via Cytoscape.js (client-rendered from a server-supplied `<script type="application/json">` payload). Nodes are round-rectangles colored by type (shell green / claude-code magenta) with edges pointing downstream. `<noscript>` fallback lists nodes textually. "Run now" dispatches to the DAG executor; community-shell DAGs require confirmation.
+- **`/runs/:id`** gains a per-node execution table for DAG runs: status, error category, duration, exit code. The DAG viz renders here too, with nodes color-coded by their execution status (completed / failed / running / skipped / cancelled). Each row links to a per-node detail section with stderr and stdout. "Replayed from …" breadcrumb shown when present.
+- **Static assets** served from `/assets/cytoscape.min.js` + `/assets/graph-render.js` with long-cache headers. Cytoscape is resolved from `node_modules` at startup; no CDN, no bundler.
+
+### Files
+
+- New: `packages/dashboard/src/routes/assets.ts`, `views/dag-view.ts`, `views/agent-detail-v2.ts`
+- Modified: `context.ts` (adds AgentStore), `index.ts` (opens AgentStore via shared path), `routes/agents.ts` (v2-first lookup), `routes/run-now.ts` (dispatches to DAG executor for v2), `routes/runs.ts` (joins node_executions for v2 runs), `views/agents-list.ts` (two-table split), `views/run-detail.ts` (DAG + per-node table when v2)
+
+### Design constraints preserved
+
+- No CDN
+- No bundler (cytoscape vendored through npm, served from node_modules)
+- No framework (client JS = 2KB vanilla bootstrap)
+- v2 tagged-template rendering for everything HTML
+
+### Tests
+
+8 new cases in `dashboard.test.ts`:
+- v2 agents appear under a "DAG agents" header on `/agents`
+- `/agents/:id` renders the Cytoscape JSON payload with correct nodes + edges
+- v2 preferred over v1 when same id in both
+- `/runs/:id` shows per-node table + DAG for v2 runs
+- `/runs/:id` stays minimal for v1 runs (no per-node UI)
+- Replayed-from breadcrumb renders when present
+- `/assets/cytoscape.min.js` serves (~100KB+)
+- `/assets/graph-render.js` serves with correct content-type
+
+412 → 420 repo-wide.
+
+### Manual verification
+
+```bash
+sua workflow import --apply
+sua workflow run <agent-id>
+sua dashboard start --port 3000
+# /agents → DAG agents table
+# /agents/<id> → DAG rendered + node list
+# /runs/<id> → per-node table + DAG colored by node status
+```
+
+### Deferred to v0.14
+
+- Drag-and-drop DAG editing (plan's v0.14 scope)
+- Node inspector (edit secrets/inputs/env in UI)
+- Version history view + diff + rollback in UI
+- `/settings/*` tree (secrets / integrations / general)
+- Version-aware DAG rendering (currently shows current_version's DAG for all runs; a follow-up can pull the exact version the run executed)
+- `LocalProvider.submitDagRun` unification (MCP + scheduler still dispatch to v1 chain-executor — dashboard now dispatches DAG directly)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3424,6 +3424,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cytoscape": {
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
+      "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -6841,7 +6850,7 @@
     },
     "packages/cli": {
       "name": "@some-useful-agents/cli",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@some-useful-agents/core": "*",
@@ -6863,7 +6872,7 @@
     },
     "packages/core": {
       "name": "@some-useful-agents/core",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "node-cron": "^4.0.0",
@@ -6878,10 +6887,11 @@
     },
     "packages/dashboard": {
       "name": "@some-useful-agents/dashboard",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@some-useful-agents/core": "*",
+        "cytoscape": "^3.30.0",
         "express": "^5.1.0"
       },
       "devDependencies": {
@@ -6893,7 +6903,7 @@
     },
     "packages/mcp-server": {
       "name": "@some-useful-agents/mcp-server",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
@@ -6905,7 +6915,7 @@
     },
     "packages/temporal-provider": {
       "name": "@some-useful-agents/temporal-provider",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@some-useful-agents/core": "*",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@some-useful-agents/core": "*",
+    "cytoscape": "^3.30.0",
     "express": "^5.1.0"
   },
   "devDependencies": {

--- a/packages/dashboard/src/context.ts
+++ b/packages/dashboard/src/context.ts
@@ -1,4 +1,4 @@
-import type { LocalProvider, RunStore, SecretsStore, AgentDefinition } from '@some-useful-agents/core';
+import type { LocalProvider, RunStore, SecretsStore, AgentDefinition, AgentStore } from '@some-useful-agents/core';
 
 /**
  * Shared resources a request handler needs. Built once in
@@ -16,7 +16,13 @@ export interface DashboardContext {
   provider: LocalProvider;
   /** Run store reader for /runs and /runs/:id. */
   runStore: RunStore;
-  /** Loads agents on each request (no cache; cheap from YAML). */
+  /**
+   * v2 DAG-agent store reader. Dashboard prefers v2 agents when an id is
+   * present in both the YAML loader and the store (migrated agents). For
+   * v0.13 this is the read path; editing lands in v0.14.
+   */
+  agentStore: AgentStore;
+  /** Loads v1 agents on each request (no cache; cheap from YAML). */
   loadAgents: () => { agents: Map<string, AgentDefinition>; warnings: Array<{ file: string; message: string }> };
   /** Secrets store for "declared + set / missing" badges. */
   secretsStore: SecretsStore;

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -3,7 +3,7 @@ import request from 'supertest';
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { LocalProvider, RunStore, MemorySecretsStore, loadAgents } from '@some-useful-agents/core';
+import { LocalProvider, RunStore, AgentStore, MemorySecretsStore, loadAgents } from '@some-useful-agents/core';
 import { buildDashboardApp } from './index.js';
 import type { DashboardContext } from './context.js';
 import { SESSION_COOKIE } from './auth-middleware.js';
@@ -18,6 +18,7 @@ let dbPath: string;
 let agentsDir: string;
 let provider: LocalProvider;
 let runStore: RunStore;
+let agentStore: AgentStore;
 
 async function makeApp() {
   dir = mkdtempSync(join(tmpdir(), 'sua-dashboard-'));
@@ -51,6 +52,7 @@ command: echo from-the-internet
 
   const secretsStore = new MemorySecretsStore();
   runStore = new RunStore(dbPath);
+  agentStore = new AgentStore(dbPath);
   provider = new LocalProvider(dbPath, secretsStore);
   await provider.initialize();
 
@@ -60,6 +62,7 @@ command: echo from-the-internet
     port: PORT,
     provider,
     runStore,
+    agentStore,
     loadAgents: () => loadAgents({
       directories: [agentsDir, join(dir, 'agents', 'community')],
     }),
@@ -88,6 +91,7 @@ afterEach(async () => {
   // provider.shutdown() already closed its own RunStore; we opened a
   // separate one for the dashboard context, so close it too.
   try { runStore?.close(); } catch { /* already closed via same DB file */ }
+  try { agentStore?.close(); } catch { /* already closed via same DB file */ }
   if (dir) rmSync(dir, { recursive: true, force: true });
 });
 
@@ -222,6 +226,169 @@ describe('Dashboard /runs + filters', () => {
     expect(res.status).toBe(200);
     // Next link should carry the agent filter and limit.
     expect(res.text).toMatch(/href="[^"]*agent=hello[^"]*offset=2/);
+  });
+});
+
+describe('Dashboard v2 DAG agents', () => {
+  it('lists v2 agents on /agents under a "DAG agents" header', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'news-digest', name: 'News Digest', status: 'active',
+      source: 'local', mcp: false,
+      nodes: [
+        { id: 'fetch', type: 'shell', command: 'echo h' },
+        { id: 'summarize', type: 'claude-code', prompt: 'summarize {{upstream.fetch.result}}', dependsOn: ['fetch'] },
+      ],
+    }, 'cli');
+
+    const res = await request(app).get('/agents')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('DAG agents');
+    expect(res.text).toContain('news-digest');
+    expect(res.text).toContain('2 nodes');
+  });
+
+  it('renders the DAG container + Cytoscape JSON on /agents/:id', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'pipeline', name: 'Pipeline', status: 'active', source: 'local', mcp: false,
+      nodes: [
+        { id: 'fetch', type: 'shell', command: 'echo h' },
+        { id: 'post', type: 'shell', command: 'echo done', dependsOn: ['fetch'] },
+      ],
+    }, 'cli');
+
+    const res = await request(app).get('/agents/pipeline')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    // Cytoscape container
+    expect(res.text).toContain('id="dag-canvas"');
+    // Inline JSON elements
+    expect(res.text).toContain('id="dag-data"');
+    expect(res.text).toContain('"id":"fetch"');
+    expect(res.text).toContain('"id":"post"');
+    expect(res.text).toContain('"source":"fetch"');
+    expect(res.text).toContain('"target":"post"');
+    // Both static asset tags
+    expect(res.text).toContain('/assets/cytoscape.min.js');
+    expect(res.text).toContain('/assets/graph-render.js');
+  });
+
+  it('prefers v2 over v1 when both exist with the same id', async () => {
+    const app = await makeApp();
+    // `hello` exists as v1 YAML (set up in makeApp). Add a v2 hello too.
+    agentStore.createAgent({
+      id: 'hello', name: 'Hello v2', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'main', type: 'shell', command: 'echo v2' }],
+    }, 'cli');
+
+    const res = await request(app).get('/agents/hello')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    // v2 detail page includes the DAG canvas; v1 doesn't.
+    expect(res.text).toContain('id="dag-canvas"');
+  });
+});
+
+describe('Dashboard /runs/:id per-node table', () => {
+  it('shows per-node execution rows for a v2 DAG run', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'multi', name: 'Multi', status: 'active', source: 'local', mcp: false,
+      nodes: [
+        { id: 'first', type: 'shell', command: 'echo 1' },
+        { id: 'second', type: 'shell', command: 'echo 2', dependsOn: ['first'] },
+      ],
+    }, 'cli');
+
+    const now = new Date().toISOString();
+    runStore.createRun({
+      id: 'run-a', agentName: 'multi', status: 'completed', startedAt: now, triggeredBy: 'cli',
+      workflowId: 'multi', workflowVersion: 1,
+    });
+    runStore.createNodeExecution({
+      runId: 'run-a', nodeId: 'first', workflowVersion: 1,
+      status: 'completed', startedAt: now, completedAt: now, exitCode: 0, result: 'one',
+    });
+    runStore.createNodeExecution({
+      runId: 'run-a', nodeId: 'second', workflowVersion: 1,
+      status: 'failed', errorCategory: 'exit_nonzero', startedAt: now,
+      completedAt: now, exitCode: 2, error: 'boom',
+    });
+
+    const res = await request(app).get('/runs/run-a')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Per-node execution');
+    expect(res.text).toContain('first');
+    expect(res.text).toContain('second');
+    expect(res.text).toContain('exit_nonzero');
+    // The DAG viz should render here too
+    expect(res.text).toContain('id="dag-canvas"');
+  });
+
+  it('does not render the per-node table for a v1 run', async () => {
+    const app = await makeApp();
+    const now = new Date().toISOString();
+    runStore.createRun({
+      id: 'run-v1', agentName: 'hello', status: 'completed', startedAt: now, triggeredBy: 'cli',
+    });
+    const res = await request(app).get('/runs/run-v1')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).not.toContain('Per-node execution');
+    expect(res.text).not.toContain('id="dag-canvas"');
+  });
+
+  it('shows a replayed-from breadcrumb when present', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'repl', name: 'Repl', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'main', type: 'shell', command: 'echo' }],
+    }, 'cli');
+    const now = new Date().toISOString();
+    runStore.createRun({
+      id: 'repl-new', agentName: 'repl', status: 'completed', startedAt: now, triggeredBy: 'cli',
+      workflowId: 'repl', workflowVersion: 1,
+      replayedFromRunId: '00000000-0000-0000-0000-000000000001', replayedFromNodeId: 'main',
+    });
+    runStore.createNodeExecution({
+      runId: 'repl-new', nodeId: 'main', workflowVersion: 1,
+      status: 'completed', startedAt: now, completedAt: now, exitCode: 0, result: 'ok',
+    });
+    const res = await request(app).get('/runs/repl-new')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.text).toContain('Replayed from');
+    expect(res.text).toContain('main');
+  });
+});
+
+describe('Dashboard static assets', () => {
+  it('serves /assets/graph-render.js', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/assets/graph-render.js')
+      .set('Host', `127.0.0.1:${PORT}`);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/javascript/);
+    expect(res.text).toContain('cytoscape');
+    expect(res.text).toContain('dag-canvas');
+  });
+
+  it('serves /assets/cytoscape.min.js', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/assets/cytoscape.min.js')
+      .set('Host', `127.0.0.1:${PORT}`);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/javascript/);
+    // The minified bundle starts with a short license block or IIFE.
+    expect(res.text.length).toBeGreaterThan(10000); // should be ~100KB
   });
 });
 

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -3,6 +3,7 @@ import type { Server } from 'node:http';
 import {
   LocalProvider,
   RunStore,
+  AgentStore,
   EncryptedFileStore,
   loadAgents,
   readMcpToken,
@@ -17,6 +18,7 @@ import { authRouter } from './routes/auth.js';
 import { agentsRouter } from './routes/agents.js';
 import { runsRouter } from './routes/runs.js';
 import { runNowRouter } from './routes/run-now.js';
+import { assetsRouter } from './routes/assets.js';
 
 export interface StartDashboardOptions {
   port: number;
@@ -38,6 +40,8 @@ export interface StartDashboardOptions {
   provider?: LocalProvider;
   /** Optional RunStore override (tests). */
   runStore?: RunStore;
+  /** Optional AgentStore override (tests). */
+  agentStore?: AgentStore;
   /** Optional token override (tests). */
   token?: string;
 }
@@ -62,6 +66,10 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   // Public routes (no auth).
   app.use(healthRouter);
   app.use(authRouter);
+  // Static assets (cytoscape.js + graph-render.js). Unauth so the auth
+  // page itself could embed them if needed; the content is nonsecret
+  // library code and a tiny bootstrap script.
+  app.use(assetsRouter);
 
   // Everything below requires the session cookie.
   app.use(requireAuth);
@@ -94,6 +102,10 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
   }
 
   const runStore = opts.runStore ?? new RunStore(opts.dbPath);
+  // AgentStore reads v2 DAG agents from the same runs.db file. Uses its own
+  // DatabaseSync — avoids changing RunStore's constructor signature. WAL
+  // mode makes concurrent handles safe.
+  const agentStore = opts.agentStore ?? new AgentStore(opts.dbPath);
   const secretsStore = opts.secretsStore ?? new EncryptedFileStore(opts.secretsPath);
   const provider = opts.provider ?? new LocalProvider(opts.dbPath, secretsStore, {
     allowUntrustedShell: opts.allowUntrustedShell,
@@ -106,6 +118,7 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     port: opts.port,
     provider,
     runStore,
+    agentStore,
     loadAgents: () => loadAgents({ directories: opts.agentDirs }),
     secretsStore,
     allowUntrustedShell: opts.allowUntrustedShell ?? new Set(),
@@ -133,6 +146,7 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
       await new Promise<void>((resolve) => server.close(() => resolve()));
       await provider.shutdown();
       runStore.close();
+      agentStore.close();
     },
   };
 }

--- a/packages/dashboard/src/routes/agents.ts
+++ b/packages/dashboard/src/routes/agents.ts
@@ -1,31 +1,65 @@
 import { Router, type Request, type Response } from 'express';
-import type { RunStatus } from '@some-useful-agents/core';
+import type { Agent, AgentDefinition, RunStatus } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 import { renderAgentsList } from '../views/agents-list.js';
 import { renderAgentDetail } from '../views/agent-detail.js';
+import { renderAgentDetailV2 } from '../views/agent-detail-v2.js';
 
 export const agentsRouter: Router = Router();
 
 agentsRouter.get('/agents', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
-  const { agents } = ctx.loadAgents();
-  const list = Array.from(agents.values()).sort((a, b) => a.name.localeCompare(b.name));
-  res.type('html').send(renderAgentsList(list));
+  const v1Agents = ctx.loadAgents().agents;
+  const v2Agents = ctx.agentStore.listAgents();
+
+  // Unify for the list view. v2 agents take precedence when ids collide
+  // (expected post-migration: the user imported their YAML into the DB).
+  const mergedV1: AgentDefinition[] = [];
+  const v2Ids = new Set(v2Agents.map((a) => a.id));
+  for (const [id, a] of v1Agents) {
+    if (!v2Ids.has(id)) mergedV1.push(a);
+  }
+  mergedV1.sort((a, b) => a.name.localeCompare(b.name));
+  v2Agents.sort((a, b) => a.id.localeCompare(b.id));
+  res.type('html').send(renderAgentsList({ v1: mergedV1, v2: v2Agents }));
 });
 
 agentsRouter.get('/agents/:name', async (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
-  const { agents } = ctx.loadAgents();
   const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
-  const agent = agents.get(name);
-  if (!agent) {
-    res.status(404).type('html').send(renderAgentsList(
-      Array.from(agents.values()).sort((a, b) => a.name.localeCompare(b.name)),
-    ));
+
+  // Prefer v2: if this id is in the AgentStore, render the DAG view.
+  const v2Agent = ctx.agentStore.getAgent(name);
+  if (v2Agent) {
+    const { rows } = ctx.runStore.queryRuns({
+      agentName: v2Agent.id,
+      limit: 20,
+      offset: 0,
+      statuses: [] as RunStatus[],
+    });
+    const flashParam = typeof req.query.flash === 'string' ? req.query.flash : undefined;
+    const flash = flashParam ? { kind: 'error' as const, message: flashParam } : undefined;
+    const html = await renderAgentDetailV2({
+      agent: v2Agent,
+      recentRuns: rows,
+      secretsStore: ctx.secretsStore,
+      flash,
+    });
+    res.type('html').send(html);
     return;
   }
 
-  // Filter runs to just this agent, last 20.
+  // Fall back to v1 YAML-loaded agents.
+  const { agents } = ctx.loadAgents();
+  const agent = agents.get(name);
+  if (!agent) {
+    res.status(404).type('html').send(renderAgentsList({
+      v1: Array.from(agents.values()).sort((a, b) => a.name.localeCompare(b.name)),
+      v2: ctx.agentStore.listAgents().sort((a, b) => a.id.localeCompare(b.id)),
+    }));
+    return;
+  }
+
   const { rows } = ctx.runStore.queryRuns({
     agentName: agent.name,
     limit: 20,
@@ -44,3 +78,6 @@ agentsRouter.get('/agents/:name', async (req: Request, res: Response) => {
   });
   res.type('html').send(html);
 });
+
+// Export for tests
+export type { Agent, AgentDefinition };

--- a/packages/dashboard/src/routes/assets.ts
+++ b/packages/dashboard/src/routes/assets.ts
@@ -1,0 +1,150 @@
+import { Router, type Request, type Response } from 'express';
+import { readFileSync, existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Static-asset router. Serves two files:
+ *
+ *   1. /assets/cytoscape.min.js
+ *      Resolved at startup by walking up from this module to find a
+ *      node_modules/cytoscape/dist/cytoscape.min.js. Works under npm
+ *      workspaces where the package lives at the monorepo root and
+ *      under a hoisted install where it lives alongside the dashboard.
+ *
+ *   2. /assets/graph-render.js
+ *      Tiny vanilla bootstrap that reads the server-rendered DAG JSON
+ *      out of a `<script type="application/json">` tag and instantiates
+ *      cytoscape against a `<div id="dag-canvas">`.
+ *
+ * Both are read once at startup and cached in memory with a
+ * long-lived immutable Cache-Control since their contents don't
+ * change between dashboard restarts.
+ */
+
+const require = createRequire(import.meta.url);
+
+function resolveCytoscapePath(): string | undefined {
+  // Try the conventional resolve first — picks up the hoisted install
+  // if the workspace put cytoscape at the monorepo root.
+  try {
+    return require.resolve('cytoscape/dist/cytoscape.min.js');
+  } catch { /* fall through */ }
+
+  // Fallback: walk up from this file's directory looking for
+  // node_modules/cytoscape/dist/cytoscape.min.js. Covers edge cases
+  // where the workspace layout is unusual.
+  const here = dirname(fileURLToPath(import.meta.url));
+  let current = here;
+  for (let i = 0; i < 8; i++) {
+    const candidate = join(current, 'node_modules', 'cytoscape', 'dist', 'cytoscape.min.js');
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return undefined;
+}
+
+const CYTOSCAPE_PATH = resolveCytoscapePath();
+const CYTOSCAPE_JS = CYTOSCAPE_PATH ? readFileSync(CYTOSCAPE_PATH, 'utf-8') : '';
+
+/**
+ * The client-side bootstrap. Kept small and framework-free. Reads the
+ * DAG description from the page, styles nodes by type + status, and
+ * renders the graph into #dag-canvas.
+ *
+ * Visual choices are deliberately minimal — this is a monitoring
+ * surface, not an editor. Nodes are circles with their id as the label,
+ * edges are arrows pointing downstream. Colors match the CLI's
+ * type vocabulary (shell = green, claude-code = magenta).
+ */
+const GRAPH_RENDER_JS = `
+(function () {
+  var el = document.getElementById('dag-canvas');
+  var dataEl = document.getElementById('dag-data');
+  if (!el || !dataEl || typeof window.cytoscape !== 'function') return;
+
+  var payload;
+  try { payload = JSON.parse(dataEl.textContent); } catch (e) { return; }
+
+  var statusColor = {
+    completed: '#15803d',
+    failed: '#b91c1c',
+    running: '#2563eb',
+    pending: '#d97706',
+    cancelled: '#b45309',
+    skipped: '#6b7280',
+  };
+  var typeColor = {
+    shell: '#15803d',
+    'claude-code': '#a21caf',
+  };
+
+  var cy = window.cytoscape({
+    container: el,
+    elements: payload.elements,
+    style: [
+      {
+        selector: 'node',
+        style: {
+          'background-color': function (n) {
+            var s = n.data('status');
+            if (s && statusColor[s]) return statusColor[s];
+            return typeColor[n.data('type')] || '#6b7280';
+          },
+          'label': 'data(label)',
+          'color': '#fff',
+          'text-valign': 'center',
+          'text-halign': 'center',
+          'font-size': 11,
+          'width': 80,
+          'height': 40,
+          'shape': 'round-rectangle',
+          'border-width': 1,
+          'border-color': '#111',
+        },
+      },
+      {
+        selector: 'edge',
+        style: {
+          'width': 2,
+          'line-color': '#6b7280',
+          'target-arrow-color': '#6b7280',
+          'target-arrow-shape': 'triangle',
+          'curve-style': 'bezier',
+        },
+      },
+    ],
+    layout: { name: 'breadthfirst', directed: true, padding: 10, spacingFactor: 1.1 },
+  });
+
+  // Click a node → anchor into the run-detail page on the same id.
+  // No-op on /agents/:id (no target); clickable on /runs/:id via the
+  // data-nav-base attribute the server rendered alongside the div.
+  var navBase = el.getAttribute('data-nav-base');
+  if (navBase) {
+    cy.on('tap', 'node', function (evt) {
+      var nodeId = evt.target.id();
+      window.location.hash = 'node-' + encodeURIComponent(nodeId);
+    });
+  }
+})();
+`;
+
+export const assetsRouter: Router = Router();
+
+assetsRouter.get('/assets/cytoscape.min.js', (_req: Request, res: Response) => {
+  if (!CYTOSCAPE_JS) {
+    res.status(500).type('text/plain').send('cytoscape not resolved at startup');
+    return;
+  }
+  res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+  res.type('application/javascript').send(CYTOSCAPE_JS);
+});
+
+assetsRouter.get('/assets/graph-render.js', (_req: Request, res: Response) => {
+  res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+  res.type('application/javascript').send(GRAPH_RENDER_JS);
+});

--- a/packages/dashboard/src/routes/run-now.ts
+++ b/packages/dashboard/src/routes/run-now.ts
@@ -1,4 +1,5 @@
 import { Router, type Request, type Response } from 'express';
+import { executeAgentDag } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 
 export const runNowRouter: Router = Router();
@@ -6,18 +7,52 @@ export const runNowRouter: Router = Router();
 /**
  * POST /agents/:name/run — trigger an agent with YAML defaults.
  *
+ * Dispatches to the DAG executor when the agent id is a v2 agent in
+ * AgentStore; falls back to LocalProvider.submitRun for v1 YAML agents.
+ *
  * Defense layers:
  *   1. requireAuth middleware (cookie + Host + Origin) already ran.
  *   2. Agent must load; 404 otherwise.
- *   3. Community shell agents require `confirm_community_shell=yes` in the
- *      form body. Without it: flash back to the agent page with a 400.
- *   4. Provider.submitRun enforces the runtime shell-gate and all input
- *      validation (missing required, bad type, undeclared keys).
+ *   3. Community shell agents (v1) OR any agent with a community-shell
+ *      node (v2) require `confirm_community_shell=yes` in the form body.
+ *   4. Provider / executor enforces the runtime shell-gate and all input
+ *      validation.
  */
 runNowRouter.post('/agents/:name/run', async (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
-  const { agents } = ctx.loadAgents();
   const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const confirmed = body.confirm_community_shell === 'yes';
+
+  // Prefer v2 agents (post-migration).
+  const v2Agent = ctx.agentStore.getAgent(name);
+  if (v2Agent) {
+    const needsConfirm = v2Agent.source === 'community' && v2Agent.nodes.some((n) => n.type === 'shell');
+    if (needsConfirm && !confirmed) {
+      const flash = 'Community shell agents require explicit audit confirmation. Click the run button again.';
+      res.redirect(303, `/agents/${encodeURIComponent(v2Agent.id)}?flash=${encodeURIComponent(flash)}`);
+      return;
+    }
+    try {
+      const run = await executeAgentDag(
+        v2Agent,
+        { triggeredBy: 'dashboard', inputs: {} },
+        {
+          runStore: ctx.runStore,
+          secretsStore: ctx.secretsStore,
+          allowUntrustedShell: ctx.allowUntrustedShell,
+        },
+      );
+      res.redirect(303, `/runs/${encodeURIComponent(run.id)}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.redirect(303, `/agents/${encodeURIComponent(v2Agent.id)}?flash=${encodeURIComponent(message)}`);
+    }
+    return;
+  }
+
+  // Fall back to v1.
+  const { agents } = ctx.loadAgents();
   const agent = agents.get(name);
   if (!agent) {
     res.status(404).redirect(302, '/agents');
@@ -26,20 +61,13 @@ runNowRouter.post('/agents/:name/run', async (req: Request, res: Response) => {
 
   const source = agent.source ?? 'local';
   const isCommunityShell = source === 'community' && agent.type === 'shell';
-
-  if (isCommunityShell) {
-    // Form bodies are parsed by express.urlencoded() middleware on the app.
-    const body = (req.body ?? {}) as Record<string, unknown>;
-    if (body.confirm_community_shell !== 'yes') {
-      const flash = 'Community shell agents require explicit audit confirmation. Click the run button again and check the box.';
-      res.redirect(303, `/agents/${encodeURIComponent(agent.name)}?flash=${encodeURIComponent(flash)}`);
-      return;
-    }
+  if (isCommunityShell && !confirmed) {
+    const flash = 'Community shell agents require explicit audit confirmation. Click the run button again and check the box.';
+    res.redirect(303, `/agents/${encodeURIComponent(agent.name)}?flash=${encodeURIComponent(flash)}`);
+    return;
   }
 
   try {
-    // Dashboard-triggered runs use YAML defaults for inputs; no per-input
-    // form in MVP (see plan: "Running with custom inputs from the UI — out of scope").
     const run = await ctx.provider.submitRun({
       agent,
       triggeredBy: 'dashboard' as const,

--- a/packages/dashboard/src/routes/runs.ts
+++ b/packages/dashboard/src/routes/runs.ts
@@ -64,7 +64,19 @@ runsRouter.get('/runs/:id', (req: Request, res: Response) => {
   }
 
   const partial = req.query.partial === '1';
-  res.type('html').send(renderRunDetail({ run, partial }));
+
+  // v2 runs: pull per-node executions + the agent definition so the
+  // detail page can render the DAG and a per-node breakdown. The DAG
+  // uses the current version from the store; a follow-up PR could pull
+  // the exact version the run executed against if users expect to see
+  // old DAGs for old runs. For v0.13 "current version" is good enough.
+  let nodeExecutions, agent;
+  if (run.workflowId) {
+    nodeExecutions = ctx.runStore.listNodeExecutions(id);
+    agent = ctx.agentStore.getAgent(run.workflowId) ?? undefined;
+  }
+
+  res.type('html').send(renderRunDetail({ run, partial, nodeExecutions, agent }));
 });
 
 function parseIntOr(v: unknown, fallback: number): number {

--- a/packages/dashboard/src/views/agent-detail-v2.ts
+++ b/packages/dashboard/src/views/agent-detail-v2.ts
@@ -1,0 +1,152 @@
+import type { Agent, Run, SecretsStore } from '@some-useful-agents/core';
+import { html, render, type SafeHtml } from './html.js';
+import { layout } from './layout.js';
+import { sourceBadge, statusBadge, formatDuration, formatAge } from './components.js';
+import { renderDagView, renderDagFallback } from './dag-view.js';
+
+export async function renderAgentDetailV2(args: {
+  agent: Agent;
+  recentRuns: Run[];
+  secretsStore: SecretsStore;
+  flash?: { kind: 'error' | 'info'; message: string };
+}): Promise<string> {
+  const { agent, recentRuns, secretsStore, flash } = args;
+  const source = agent.source;
+  const hasCommunityShellNode = source === 'community' && agent.nodes.some((n) => n.type === 'shell');
+
+  // Secrets status per-node; presence-only, never reveals values.
+  const secretRows: SafeHtml[] = [];
+  const seenSecrets = new Set<string>();
+  for (const node of agent.nodes) {
+    for (const name of node.secrets ?? []) {
+      const key = `${node.id}:${name}`;
+      if (seenSecrets.has(key)) continue;
+      seenSecrets.add(key);
+      let present: 'ok' | 'missing' | 'unknown';
+      try {
+        present = (await secretsStore.has(name)) ? 'ok' : 'missing';
+      } catch {
+        present = 'unknown';
+      }
+      const badge = present === 'ok'
+        ? html`<span class="badge badge-ok">set</span>`
+        : present === 'missing'
+        ? html`<span class="badge badge-err">missing</span>`
+        : html`<span class="badge badge-warn">unknown (store locked)</span>`;
+      secretRows.push(html`<tr><td class="mono">${node.id}</td><td class="mono">${name}</td><td>${badge}</td></tr>`);
+    }
+  }
+
+  const runRows = recentRuns.map((r) => html`
+    <tr>
+      <td><a href="/runs/${r.id}" class="mono">${r.id.slice(0, 8)}</a></td>
+      <td>${statusBadge(r.status)}</td>
+      <td class="dim">${formatAge(r.startedAt)}</td>
+      <td class="dim">${formatDuration(r.startedAt, r.completedAt)}</td>
+      <td class="dim">${r.triggeredBy}</td>
+    </tr>
+  `);
+
+  // Run-now button — the v1 view's community-shell modal is adequate; for
+  // v0.13 we ship a simplified version: direct POST for non-community,
+  // a warning banner + inline confirmation for community. Full modal
+  // parity with v1 view can come in v0.14 once editing lands.
+  const runNowButton = hasCommunityShellNode
+    ? html`
+        <form method="POST" action="/agents/${agent.id}/run">
+          <input type="hidden" name="confirm_community_shell" value="yes">
+          <button type="submit" class="run-now run-now-warn" onclick="return confirm('This agent contains community shell nodes. Run anyway?');">
+            Run now (community — confirmation required)
+          </button>
+        </form>
+      `
+    : html`
+        <form method="POST" action="/agents/${agent.id}/run" style="display: inline;">
+          <button type="submit" class="run-now">Run now</button>
+        </form>
+      `;
+
+  const warningBanner = source === 'community'
+    ? html`<div class="community-banner">
+        <strong>Community agent.</strong> Read the DAG below before running. See
+        <a href="https://github.com/gregmeyer/some-useful-agents/blob/main/docs/SECURITY.md#trust-model">docs/SECURITY.md</a> for the trust model.
+      </div>`
+    : html``;
+
+  // Describe each node in a compact table below the DAG viz.
+  const nodeRows = agent.nodes.map((n) => {
+    const body = n.type === 'shell' ? oneLine(n.command ?? '') : oneLine(n.prompt ?? '');
+    const deps = n.dependsOn?.length ? n.dependsOn.join(', ') : html`<span class="dim">—</span>`;
+    const secrets = n.secrets?.length ? n.secrets.join(', ') : html`<span class="dim">—</span>`;
+    return html`
+      <tr id="node-${n.id}">
+        <td class="mono">${n.id}</td>
+        <td>${n.type === 'shell' ? html`<span class="badge badge-ok">shell</span>` : html`<span class="badge badge-info">claude-code</span>`}</td>
+        <td class="mono">${deps}</td>
+        <td class="mono">${secrets}</td>
+        <td class="dim">${body}</td>
+      </tr>
+    `;
+  });
+
+  const body = html`
+    <h1>${agent.id} ${vStatusBadge(agent.status)} ${sourceBadge(source)}</h1>
+    ${warningBanner}
+    <p class="dim">${agent.description ?? 'No description.'}</p>
+
+    <div style="margin: 1rem 0;">${runNowButton}</div>
+
+    <h2>DAG</h2>
+    ${renderDagFallback(agent)}
+    ${renderDagView({ agent })}
+
+    <h2>Nodes</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Id</th><th>Type</th><th>Depends on</th><th>Secrets</th><th>Body</th>
+        </tr>
+      </thead>
+      <tbody>${nodeRows as unknown as SafeHtml[]}</tbody>
+    </table>
+
+    <h2>Metadata</h2>
+    <dl class="kv">
+      <dt>Version</dt><dd class="mono">${String(agent.version)}</dd>
+      <dt>Schedule</dt><dd>${agent.schedule ?? html`<span class="dim">none</span>`}</dd>
+      <dt>Exposed via MCP</dt><dd>${agent.mcp ? 'yes' : 'no'}</dd>
+    </dl>
+
+    ${secretRows.length > 0 ? html`
+      <h2>Secrets</h2>
+      <table>
+        <thead><tr><th>Node</th><th>Secret</th><th>Status</th></tr></thead>
+        <tbody>${secretRows}</tbody>
+      </table>
+    ` : html``}
+
+    <h2>Recent runs</h2>
+    ${recentRuns.length === 0
+      ? html`<p class="dim">No runs yet.</p>`
+      : html`<table>
+          <thead><tr><th>ID</th><th>Status</th><th>Started</th><th>Duration</th><th>Triggered</th></tr></thead>
+          <tbody>${runRows as unknown as SafeHtml[]}</tbody>
+        </table>`}
+  `;
+
+  return render(layout({ title: agent.id, activeNav: 'agents', flash }, body));
+}
+
+function vStatusBadge(status: string): SafeHtml {
+  const kind = status === 'active' ? 'badge-ok'
+    : status === 'paused' ? 'badge-warn'
+    : status === 'archived' ? 'badge-muted'
+    : 'badge-info';
+  return html`<span class="badge ${kind}">${status}</span>`;
+}
+
+function oneLine(text: string, max = 120): string {
+  const collapsed = text.replace(/\s+/g, ' ').trim();
+  if (collapsed.length <= max) return collapsed;
+  return collapsed.slice(0, max - 1) + '…';
+}

--- a/packages/dashboard/src/views/agents-list.ts
+++ b/packages/dashboard/src/views/agents-list.ts
@@ -1,36 +1,83 @@
-import type { AgentDefinition } from '@some-useful-agents/core';
+import type { Agent, AgentDefinition } from '@some-useful-agents/core';
 import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { typeBadge, sourceBadge } from './components.js';
 
-export function renderAgentsList(agents: AgentDefinition[]): string {
-  const rows = agents.map((a) => html`
+export interface AgentsListInput {
+  /** v1 YAML-loaded single-node agents, after removing any that were
+   *  superseded by a v2 DAG with the same id. */
+  v1: AgentDefinition[];
+  /** v2 DAG agents from AgentStore. */
+  v2: Agent[];
+}
+
+export function renderAgentsList(input: AgentsListInput): string {
+  const hasV2 = input.v2.length > 0;
+
+  const v2Rows = input.v2.map((a) => html`
     <tr>
-      <td><a href="/agents/${a.name}">${a.name}</a></td>
-      <td>${typeBadge(a.type)}</td>
-      <td>${sourceBadge(a.source ?? 'local')}</td>
+      <td><a href="/agents/${a.id}">${a.id}</a></td>
+      <td>${statusBadge(a.status)}</td>
+      <td>${sourceBadge(a.source)}</td>
+      <td>${String(a.nodes.length)} node${a.nodes.length === 1 ? '' : 's'}</td>
       <td>${a.schedule ?? html`<span class="dim">—</span>`}</td>
       <td>${a.mcp ? html`<span class="badge badge-info">mcp</span>` : html`<span class="dim">—</span>`}</td>
       <td class="dim">${a.description ?? ''}</td>
     </tr>
   `);
 
-  const body = agents.length === 0
-    ? html`<p>No agents found. Run <code>sua init</code> to scaffold a starter.</p>`
+  const v1Rows = input.v1.map((a) => html`
+    <tr>
+      <td><a href="/agents/${a.name}">${a.name}</a></td>
+      <td><span class="badge badge-muted">v1</span></td>
+      <td>${sourceBadge(a.source ?? 'local')}</td>
+      <td>${typeBadge(a.type)}</td>
+      <td>${a.schedule ?? html`<span class="dim">—</span>`}</td>
+      <td>${a.mcp ? html`<span class="badge badge-info">mcp</span>` : html`<span class="dim">—</span>`}</td>
+      <td class="dim">${a.description ?? ''}</td>
+    </tr>
+  `);
+
+  const v2Section = hasV2 ? html`
+    <h2>DAG agents</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Id</th><th>Status</th><th>Source</th>
+          <th>Nodes</th><th>Schedule</th><th>MCP</th><th>Description</th>
+        </tr>
+      </thead>
+      <tbody>${v2Rows as unknown as SafeHtml[]}</tbody>
+    </table>
+  ` : html``;
+
+  const v1Header = hasV2 ? html`<h2>v1 YAML agents</h2><p class="dim">Not yet migrated. Run <code>sua workflow import --apply</code> to merge into DAGs.</p>` : html``;
+  const v1Section = input.v1.length === 0
+    ? (hasV2 ? html`` : html`<p>No agents found. Run <code>sua init</code> to scaffold a starter.</p>`)
     : html`
+      ${v1Header}
       <table>
         <thead>
           <tr>
-            <th>Name</th><th>Type</th><th>Source</th>
-            <th>Schedule</th><th>MCP</th><th>Description</th>
+            <th>Name</th><th>Kind</th><th>Source</th>
+            <th>Type</th><th>Schedule</th><th>MCP</th><th>Description</th>
           </tr>
         </thead>
-        <tbody>${rows as unknown as SafeHtml[]}</tbody>
+        <tbody>${v1Rows as unknown as SafeHtml[]}</tbody>
       </table>
     `;
 
   return render(layout(
     { title: 'Agents', activeNav: 'agents' },
-    html`<h1>Agents</h1>${body}`,
+    html`<h1>Agents</h1>${v2Section}${v1Section}`,
   ));
+}
+
+function statusBadge(status: string): SafeHtml {
+  const kind = status === 'active' ? 'badge-ok'
+    : status === 'paused' ? 'badge-warn'
+    : status === 'archived' ? 'badge-muted'
+    : status === 'draft' ? 'badge-info'
+    : 'badge-muted';
+  return html`<span class="badge ${kind}">${status}</span>`;
 }

--- a/packages/dashboard/src/views/dag-view.ts
+++ b/packages/dashboard/src/views/dag-view.ts
@@ -1,0 +1,97 @@
+import type { Agent, AgentNode, NodeExecutionRecord } from '@some-useful-agents/core';
+import { html, unsafeHtml, type SafeHtml } from './html.js';
+
+/**
+ * Render the DAG of an agent as a Cytoscape container + inline JSON +
+ * script tags that pull cytoscape + our tiny bootstrap.
+ *
+ * The payload shape is the Cytoscape "elements" format. Node status (if
+ * provided via `nodeExecs`) colors the node; without it, we color by
+ * node type (shell vs claude-code).
+ */
+export function renderDagView(args: {
+  agent: Agent;
+  /** Optional — when rendering /runs/:id we know the per-node status. */
+  nodeExecs?: NodeExecutionRecord[];
+  /** Optional — makes nodes clickable to scroll to their detail section. */
+  navBase?: string;
+}): SafeHtml {
+  const { agent, nodeExecs, navBase } = args;
+  const execByNodeId = new Map<string, NodeExecutionRecord>();
+  for (const e of nodeExecs ?? []) execByNodeId.set(e.nodeId, e);
+
+  const elements = buildElements(agent.nodes, execByNodeId);
+  const payload = JSON.stringify({ elements });
+  const navAttr = navBase ? ` data-nav-base="${escapeAttr(navBase)}"` : '';
+
+  return html`
+    <div style="margin: 1rem 0;">
+      <div
+        id="dag-canvas"
+        style="width: 100%; height: 320px; border: 1px solid var(--border); border-radius: 0.5rem; background: #fff;"
+        ${unsafeHtml(navAttr)}
+      ></div>
+      <script id="dag-data" type="application/json">${unsafeHtml(escapeScriptTag(payload))}</script>
+      <script src="/assets/cytoscape.min.js"></script>
+      <script src="/assets/graph-render.js"></script>
+    </div>
+  `;
+}
+
+/**
+ * Text-only fallback for when cytoscape fails to load (blocked, offline,
+ * etc.) Renders the nodes as a simple list with their dependencies so the
+ * page stays useful without JS.
+ */
+export function renderDagFallback(agent: Agent): SafeHtml {
+  const rows = agent.nodes.map((n) => {
+    const deps = n.dependsOn?.length ? ` ← ${n.dependsOn.join(', ')}` : '';
+    return html`<li><code>${n.id}</code> <span class="dim">(${n.type})${deps}</span></li>`;
+  });
+  return html`
+    <noscript>
+      <div class="flash flash-info">
+        DAG graph requires JavaScript. Node list:
+        <ul>${rows as unknown as SafeHtml[]}</ul>
+      </div>
+    </noscript>
+  `;
+}
+
+function buildElements(nodes: AgentNode[], execByNodeId: Map<string, NodeExecutionRecord>): unknown[] {
+  const out: unknown[] = [];
+  for (const n of nodes) {
+    const exec = execByNodeId.get(n.id);
+    out.push({
+      data: {
+        id: n.id,
+        label: n.id,
+        type: n.type,
+        status: exec?.status,
+      },
+    });
+    for (const dep of n.dependsOn ?? []) {
+      out.push({
+        data: {
+          id: `${dep}->${n.id}`,
+          source: dep,
+          target: n.id,
+        },
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Escape characters that would break out of a `<script type="application/json">`
+ * tag. The payload is user-controlled via the DAG fields; `</script>` inside
+ * would end the script block and let following HTML execute.
+ */
+function escapeScriptTag(json: string): string {
+  return json.replace(/<\/script/gi, '<\\/script');
+}
+
+function escapeAttr(value: string): string {
+  return value.replace(/["&<>]/g, (c) => ({ '"': '&quot;', '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c] ?? c));
+}

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -1,21 +1,55 @@
-import type { Run } from '@some-useful-agents/core';
-import { html, render, unsafeHtml } from './html.js';
+import type { Agent, NodeExecutionRecord, Run } from '@some-useful-agents/core';
+import { html, render, unsafeHtml, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { statusBadge, outputFrame, formatDuration } from './components.js';
+import { renderDagView, renderDagFallback } from './dag-view.js';
 
 export interface RunDetailOptions {
   run: Run;
   /** If true, render ONLY the updatable fragment (for the 2s poll). */
   partial?: boolean;
+  /** v2 per-node executions, present when `run.workflowId` is set. */
+  nodeExecutions?: NodeExecutionRecord[];
+  /** v2 agent definition at the run's version, for DAG rendering + node labels. */
+  agent?: Agent;
 }
 
 export function renderRunDetail(opts: RunDetailOptions): string {
-  const { run, partial } = opts;
+  const { run, partial, nodeExecutions, agent } = opts;
   const inProgress = run.status === 'running' || run.status === 'pending';
 
-  // Run id is a UUID — safe to inline in an attribute without re-escaping
-  // because it contains only [a-f0-9-]. Asserted where the value is minted.
+  // Run id is a UUID — safe to inline in an attribute without re-escaping.
   const pollAttr = inProgress ? unsafeHtml(` data-run-in-progress="${run.id}"`) : unsafeHtml('');
+
+  const isDagRun = run.workflowId && nodeExecutions && agent;
+
+  const replayedFrom = run.replayedFromRunId ? html`
+    <dt>Replayed from</dt>
+    <dd class="mono">
+      <a href="/runs/${run.replayedFromRunId}">${run.replayedFromRunId.slice(0, 8)}</a>
+      <span class="dim"> @ ${run.replayedFromNodeId ?? ''}</span>
+    </dd>
+  ` : html``;
+
+  const dagSection = isDagRun ? html`
+    <h2>DAG</h2>
+    ${renderDagFallback(agent)}
+    ${renderDagView({ agent, nodeExecs: nodeExecutions, navBase: `/runs/${run.id}` })}
+  ` : html``;
+
+  const nodeTable = isDagRun ? html`
+    <h2>Per-node execution</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Node</th><th>Status</th><th>Category</th>
+          <th>Started</th><th>Duration</th><th>Exit</th>
+        </tr>
+      </thead>
+      <tbody>${renderNodeExecRows(nodeExecutions!)}</tbody>
+    </table>
+    ${renderNodeDetails(nodeExecutions!, run)}
+  ` : html``;
 
   const fragment = html`
     <div data-run-container${pollAttr}>
@@ -24,12 +58,13 @@ export function renderRunDetail(opts: RunDetailOptions): string {
         ${statusBadge(run.status)}
       </h1>
       <dl class="kv">
-        <dt>Agent</dt><dd><a href="/agents/${run.agentName}">${run.agentName}</a></dd>
+        <dt>Agent</dt><dd><a href="/agents/${run.agentName}">${run.agentName}</a>${run.workflowVersion ? html` <span class="dim">v${String(run.workflowVersion)}</span>` : html``}</dd>
         <dt>Started</dt><dd class="mono">${run.startedAt}</dd>
         <dt>Completed</dt><dd class="mono">${run.completedAt ?? html`<span class="dim">in progress</span>`}</dd>
         <dt>Duration</dt><dd>${formatDuration(run.startedAt, run.completedAt)}</dd>
         <dt>Exit code</dt><dd class="mono">${run.exitCode !== undefined ? String(run.exitCode) : ''}</dd>
         <dt>Triggered by</dt><dd>${run.triggeredBy}</dd>
+        ${replayedFrom}
       </dl>
 
       ${run.error ? html`
@@ -37,8 +72,13 @@ export function renderRunDetail(opts: RunDetailOptions): string {
         <div class="flash flash-error">${run.error}</div>
       ` : html``}
 
-      <h2>Output</h2>
-      ${run.result ? outputFrame(run.result) : html`<p class="dim">No output yet.</p>`}
+      ${dagSection}
+      ${nodeTable}
+
+      ${isDagRun ? html`` : html`
+        <h2>Output</h2>
+        ${run.result ? outputFrame(run.result) : html`<p class="dim">No output yet.</p>`}
+      `}
     </div>
   `;
 
@@ -47,4 +87,42 @@ export function renderRunDetail(opts: RunDetailOptions): string {
   }
 
   return render(layout({ title: `Run ${run.id.slice(0, 8)}`, activeNav: 'runs' }, fragment));
+}
+
+function renderNodeExecRows(execs: NodeExecutionRecord[]): SafeHtml {
+  const rows = execs.map((e) => html`
+    <tr>
+      <td><a href="#node-${e.nodeId}" class="mono">${e.nodeId}</a></td>
+      <td>${statusBadge(e.status)}</td>
+      <td>${e.errorCategory ? html`<span class="badge badge-err">${e.errorCategory}</span>` : html`<span class="dim">—</span>`}</td>
+      <td class="dim mono">${e.startedAt}</td>
+      <td class="dim">${formatDuration(e.startedAt, e.completedAt)}</td>
+      <td class="mono">${e.exitCode !== undefined ? String(e.exitCode) : html`<span class="dim">—</span>`}</td>
+    </tr>
+  `);
+  return rows as unknown as SafeHtml;
+}
+
+function renderNodeDetails(execs: NodeExecutionRecord[], run: Run): SafeHtml {
+  const sections = execs.map((e) => {
+    const hasError = e.error !== undefined;
+    const hasResult = e.result !== undefined && e.result.length > 0;
+    if (!hasError && !hasResult) return html``;
+    return html`
+      <div id="node-${e.nodeId}" style="margin: 1.5rem 0;">
+        <h3>
+          <span class="mono">${e.nodeId}</span>
+          ${statusBadge(e.status)}
+          ${e.errorCategory ? html`<span class="badge badge-err">${e.errorCategory}</span>` : html``}
+        </h3>
+        ${e.error ? html`<div class="flash flash-error">${e.error}</div>` : html``}
+        ${e.result ? html`
+          <h4 class="dim">stdout</h4>
+          ${outputFrame(e.result)}
+        ` : html``}
+      </div>
+    `;
+  });
+  void run;
+  return sections as unknown as SafeHtml;
 }


### PR DESCRIPTION
## Summary

**PR 5 of 5** for agents-as-DAGs. Closes the v0.13 user story: users can now see their DAG agents rendered as real graphs in the dashboard, inspect per-node execution logs, and trigger run-now that dispatches to the DAG executor.

| PR | Status |
|---|---|
| 1 (types + YAML) | merged (#47) |
| 2 (stores) | merged (#49) |
| 3 (DAG executor) | merged (#50) |
| 4 (migration + CLI) | merged (#51) |
| **5 (dashboard viz)** | **this** |

## What's new

### `/agents` page
Splits into **two tables**: v2 DAG agents at top, unmigrated v1 YAML agents below. Id collisions collapse to the v2 row.

### `/agents/:id` (v2 variant)
Cytoscape.js DAG rendered client-side from server-supplied JSON in a `<script type="application/json">` tag.
- Nodes: round-rectangles colored by type (shell green, claude-code magenta)
- Edges: arrows pointing downstream
- `<noscript>` fallback lists nodes textually
- Node table below the DAG with id / type / dependsOn / secrets / body preview
- **Run now** dispatches to `executeAgentDag`; community-shell DAGs require confirmation

### `/runs/:id` for v2 DAG runs
- **Per-node execution table** with `errorCategory` badges when a node fails
- DAG viz colors nodes by execution status (completed/failed/running/skipped/cancelled)
- Per-node detail sections with stderr and stdout
- **"Replayed from …" breadcrumb** when present, linking back to the original run

v1 runs stay minimal — no per-node UI, no DAG viz.

### Static assets
- `/assets/cytoscape.min.js` — resolved from `node_modules/cytoscape/dist/` at startup, served with long-cache
- `/assets/graph-render.js` — 2KB vanilla JS bootstrap that reads DAG JSON + instantiates Cytoscape

## Design constraints preserved

- No CDN
- No bundler (cytoscape vendored through npm, served from node_modules)
- No framework
- Tagged-template rendering for everything HTML

Cytoscape adds ~424KB served once + cached immutably. The rest of the dashboard remains tagged-template + inlined CSS/JS as in v0.12.

## Test plan

- [x] 420 tests pass (was 412; +8 new in `dashboard.test.ts`)
- [x] Build clean
- [x] Manual end-to-end: scaffolded fetch→summarize chain, imported, ran, confirmed:
  - `/agents` renders DAG agents section with correct node count
  - `/agents/:id` serves Cytoscape JSON payload with proper nodes + edges
  - `/runs/:id` shows per-node table with correct status + category
  - Both assets serve with correct content-type
  - Malicious `Host` still 403s

## Merge + release sequence

After #52 merges:
1. Release PR auto-updates to include all 5 agents-as-DAGs changesets
2. That release PR → v0.13.0 on npm with the full feature set:
   - Agent v2 types + YAML round-trip
   - `agents` / `agent_versions` / `node_executions` tables
   - DAG executor with per-node records + error categorization
   - v1 YAML migration (auto-merge chains into DAG-agents)
   - `sua workflow` command tree + replay-from-node
   - Dashboard DAG viz + per-node execution table

## Deferred to v0.14

- Drag-and-drop DAG editing
- Node inspector (edit secrets / inputs / env in UI)
- Version history view + diff + rollback
- `/settings/*` tree (secrets / integrations / general)
- Version-aware DAG rendering (runs currently show current_version's DAG)
- `LocalProvider.submitDagRun` unification (MCP + scheduler still dispatch to v1 chain-executor; dashboard dispatches DAG directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
