### PR TITLE
fix(cli): sua workflow import fails hard on YAML parse errors by default

### DIFF
--- a/.changeset/workflow-import-strict.md
+++ b/.changeset/workflow-import-strict.md
@@ -1,0 +1,27 @@
+---
+"@some-useful-agents/cli": minor
+---
+
+**fix: `sua workflow import` fails hard on YAML parse errors by default.**
+
+Before: a single unparseable YAML file (bad shell quoting, invalid escape, schema violation) would silently drop that agent from the migration, printing a warning but continuing. When downstream agents used `dependsOn:` to reference the dropped agent, the chain silently broke — `post` would land as a single-node DAG instead of being merged into the `fetch → summarize → post` chain. Silent data loss on migration day is the worst possible shape.
+
+Now:
+
+- `sua workflow import` (with or without `--apply`) separates directory-level noise (missing optional `agents/examples/`) from file-level errors on actual YAML files
+- File-level errors ABORT the migration with a clear list of which files failed and why
+- `--allow-broken` opts into the old behavior (proceed anyway, drop the broken files) for users who know what they're skipping
+
+```bash
+sua workflow import --apply
+# If any YAML file fails to parse:
+#   ❌  3 YAML file(s) failed to load. These agents would be silently dropped
+#       from the migration, which usually breaks dependsOn chains ...
+#     ✖ agents/local/summarize.yaml
+#         Invalid YAML: Invalid escape sequence \{ at line 3, column 87
+#   → exit 1
+```
+
+No changes to the successful-migration path. Users with clean YAML see the same output they did before.
+
+Prompted by a real incident during v0.14 bring-up where a `"\{print ...}"` double-quoted shell command inside YAML silently broke a three-node chain.

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -76,15 +76,66 @@ workflowCommand
   .description('Scan v1 YAML agents + merge chains into v2 DAG agents in the run DB')
   .argument('[dir]', 'Root directory containing agents/ (defaults to current project)')
   .option('--apply', 'Commit the migration. Without this flag, prints the plan and exits.')
-  .action(async (dir: string | undefined, options: { apply?: boolean }) => {
+  .option(
+    '--allow-broken',
+    'Proceed even when some YAML files failed to parse or validate. Without this flag, ' +
+      'any file-level error aborts the migration. Use only when you know what you are ignoring.',
+  )
+  .action(async (dir: string | undefined, options: { apply?: boolean; allowBroken?: boolean }) => {
     const config = loadConfig();
     const dirs = getAgentDirs(config);
     const directories = dir ? [dir] : dirs.all;
 
     // Load via the existing v1 loader (picks up local + community + examples).
     const { agents: v1Agents, warnings } = loadAgents({ directories });
-    if (warnings.length > 0) {
-      for (const w of warnings) ui.warn(`${w.file}: ${w.message}`);
+
+    // Separate directory-level noise (missing optional dir, unreadable dir) from
+    // file-level errors (parse failure, schema rejection, empty file). A file-
+    // level error means we silently dropped a YAML file the user wrote; that
+    // usually breaks `dependsOn` graphs in non-obvious ways, which is exactly
+    // what ate time during the v0.13 bring-up on 2026-04-15 (shell quoting in
+    // a double-quoted YAML string skipped `summarize`, leaving `post`'s
+    // `dependsOn: [summarize]` dangling and the migration silently dropped the
+    // chain link).
+    const fileLevelWarnings = warnings.filter(
+      (w) => /\.(ya?ml(\.disabled)?)$/i.test(w.file),
+    );
+    const dirLevelWarnings = warnings.filter(
+      (w) => !/\.(ya?ml(\.disabled)?)$/i.test(w.file),
+    );
+
+    // Directory-level noise is informational — keep warning loud but advisory.
+    for (const w of dirLevelWarnings) ui.warn(`${w.file}: ${w.message}`);
+
+    // File-level problems are a hard error by default.
+    if (fileLevelWarnings.length > 0) {
+      ui.fail(
+        `${fileLevelWarnings.length} YAML file(s) failed to load. ` +
+          `These agents would be silently dropped from the migration, which usually breaks ` +
+          `dependsOn chains without any further signal. Fix the files or re-run with --allow-broken.`,
+      );
+      for (const w of fileLevelWarnings) {
+        console.error(`  ${chalk.red('✖')} ${w.file}`);
+        // w.message often wraps multi-line YAML parser output; indent it so
+        // the grouping stays visible.
+        const indented = w.message.split('\n').map((l) => `      ${l}`).join('\n');
+        console.error(indented);
+      }
+      if (!options.allowBroken) {
+        console.error('');
+        console.error(
+          ui.dim(
+            'To proceed anyway (skipping these agents), re-run with --allow-broken. ' +
+              'Be aware that any `dependsOn` pointing at a skipped agent will produce a ' +
+              'missing-dependency warning and land as a single-node DAG instead of a chain.',
+          ),
+        );
+        process.exit(1);
+      }
+      ui.warn(
+        `--allow-broken was set; proceeding with ${v1Agents.size} loadable agent(s) ` +
+          `and dropping ${fileLevelWarnings.length} broken one(s).`,
+      );
     }
 
     // Detect `.disabled` siblings: agent-loader doesn't list them, but


### PR DESCRIPTION
## Summary

`sua workflow import` now aborts on YAML parse errors by default. Was silent-drop-and-continue; now fails with a listed summary. `--allow-broken` keeps the old behavior for users who know what they're skipping.

## The incident this fixes

v0.14 bring-up today: I handed you a `summarize.yaml` with `command: "echo ... awk \{print ...}"`. `\{` isn't a valid escape in double-quoted YAML, so the loader dropped the file. Migration logged a warning and proceeded. `post` depended on `summarize`, lost its referent, and landed as a single-node DAG. The user saw:

```
⚠️  Invalid YAML: Invalid escape sequence \{ ...
✅  Migration applied: 3 imported, 0 unchanged.
⚠️  [missing-dependency] Agent "post" dependsOn "summarize" ...
```

Success ticks mixed in with two warnings that together mean "your chain is broken but we kept going." Not OK.

## Behavior now

### Default — file errors abort

```
$ sua workflow import --apply
⚠️  /path/agents/examples: Directory does not exist        ← dir noise stays advisory
❌  1 YAML file(s) failed to load. These agents would be
    silently dropped from the migration, which usually
    breaks dependsOn chains without any further signal.
    Fix the files or re-run with --allow-broken.
  ✖ agents/local/broken.yaml
      Invalid YAML: Invalid escape sequence \{ at line 3, column 16:

      command: "echo \{print \"hi\"}"
                     ^

To proceed anyway (skipping these agents), re-run with --allow-broken.
Be aware that any `dependsOn` pointing at a skipped agent will produce
a missing-dependency warning and land as a single-node DAG instead of
a chain.

# exit 1
```

### Opt-in — `--allow-broken`

```
$ sua workflow import --apply --allow-broken
⚠️  /path/agents/examples: Directory does not exist
⚠️  --allow-broken was set; proceeding with 2 loadable agent(s) and
    dropping 1 broken one(s).
✅  Migration applied: 2 imported, 0 unchanged.

# exit 0
```

Same output as pre-fix, but now it's an explicit choice.

### Happy path — unchanged

Users with clean YAML see exactly what they saw before.

## Why "directory doesn't exist" stays advisory

Empty `agents/examples/` or `agents/community/` directories are the default shape of a fresh `sua init` workspace. If we made those hard errors too, every first-run import would fail. Directory warnings stay as `ui.warn` lines.

## Separator

The file/directory split is done via regex against the warning's `file` field:

```ts
const fileLevelWarnings = warnings.filter(
  (w) => /\.(ya?ml(\.disabled)?)$/i.test(w.file),
);
```

Anything ending in `.yaml` / `.yml` / `.yaml.disabled` / `.yml.disabled` = file-level. Anything else = directory-level.

## Test plan

- [x] 420 tests still pass
- [x] Manual: broken YAML → default aborts with exit 1, --allow-broken succeeds
- [x] Manual: clean YAML → same successful output as before
- [x] Manual: `--apply` and dry-run (no `--apply`) both gate through the same abort check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
