### PR TITLE
feat(dashboard): native tutorial at /help/tutorial (PR 1.5/5)

### DIFF
--- a/.changeset/dashboard-v015-tutorial.md
+++ b/.changeset/dashboard-v015-tutorial.md
@@ -1,0 +1,31 @@
+---
+"@some-useful-agents/dashboard": minor
+---
+
+**feat: dashboard-native tutorial at `/help/tutorial` (PR 1.5 of v0.15).**
+
+A guided first-run flow that replaces the "open a terminal and run `sua tutorial`" friction for users who're already in the dashboard. Step completion is derived from observable project state (agent count, run count, DAG run presence, declared secrets) — not session cookies — so refreshing re-checks reality.
+
+### Steps
+
+1. **You have a project** — done when any agent is registered. Empty-state pitches `sua init`.
+2. **Run your first agent** — done when any run exists. CTA deep-links to the friendliest starting agent (prefers a single-node v2 over a multi-node, v2 over v1).
+3. **Inspect the output** — done when a run exists AND a latest-run id is available. CTA links to the latest run.
+4. **See a multi-node DAG in action** — done when any run has `workflowId` set. Empty-state explains how to build one.
+5. **Wire up a secret** — done when any agent node declares a secret. CTA links to Settings → Secrets.
+
+### Why state-derived, not session-tracked
+
+A cookie-based wizard remembers what you *clicked*, not what's *true*. If a user clicks through to step 3 and then deletes all their runs, the cookie still says "done". Sourcing from the DB + agent store means the tutorial always reflects the current project — and a second visitor to the dashboard (or the same user on a fresh cookie) sees accurate state on first load.
+
+### Files
+
+- New: `packages/dashboard/src/views/tutorial.ts`
+- Modified: `packages/dashboard/src/routes/help.ts` (new `/help/tutorial` route handler pulls state from `agentStore` + `runStore` + `loadAgents`); `views/help.ts` (replaces the "Start here: `sua tutorial`" card with a prominent link to the dashboard tutorial, keeps the CLI command as a secondary option)
+
+### Tests
+
+3 new cases in `dashboard.test.ts` (23 → 26):
+- `/help` renders with the tutorial CTA + CLI reference
+- `/help/tutorial` marks step 1 done when agents exist, surfaces "1 of 5 complete" when no runs yet
+- `/help/tutorial` deep-links the Run CTA to the first agent id

--- a/packages/dashboard/src/assets/components.css
+++ b/packages/dashboard/src/assets/components.css
@@ -256,6 +256,24 @@
   margin-left: auto;
 }
 
+.filters__status {
+  gap: var(--space-2) !important;
+}
+
+.filters__status-row {
+  display: flex;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.filters__status-check {
+  flex-direction: row !important;
+  gap: var(--space-1) !important;
+  align-items: center;
+  color: var(--color-text);
+  font-weight: var(--weight-regular);
+}
+
 /* ---------- Pager ---------- */
 .pager {
   display: flex;

--- a/packages/dashboard/src/assets/components.css
+++ b/packages/dashboard/src/assets/components.css
@@ -419,6 +419,156 @@
   margin-bottom: var(--space-4);
 }
 
+/* ---------- Stat strip (overview tiles above lists) ---------- */
+.stat-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--space-3);
+  margin-bottom: var(--space-6);
+}
+
+.stat-tile {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-4);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  position: relative;
+  overflow: hidden;
+}
+
+.stat-tile::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 3px;
+  height: 100%;
+  background: var(--color-primary);
+}
+
+.stat-tile--ok::before { background: var(--color-ok); }
+.stat-tile--warn::before { background: var(--color-warn); }
+.stat-tile--info::before { background: var(--color-info); }
+.stat-tile--muted::before { background: var(--color-border-strong); }
+
+.stat-tile__label {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: var(--weight-semibold);
+}
+
+.stat-tile__value {
+  font-size: var(--font-size-xl);
+  font-weight: var(--weight-bold);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+}
+
+.stat-tile__hint {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  margin-top: var(--space-1);
+}
+
+/* ---------- Agent cards (grid) ---------- */
+.agent-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: var(--space-4);
+}
+
+.agent-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-6);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  transition: border-color 120ms, transform 120ms, box-shadow 120ms;
+}
+
+.agent-card:hover {
+  border-color: var(--color-primary);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+}
+
+.agent-card__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.agent-card__title {
+  font-size: var(--font-size-md);
+  font-weight: var(--weight-semibold);
+  margin: 0;
+}
+
+.agent-card__title a {
+  color: var(--color-text);
+}
+
+.agent-card__title a:hover {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.agent-card__desc {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  min-height: 2.6em;
+}
+
+.agent-card__meta {
+  display: flex;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.agent-card__meta strong {
+  color: var(--color-text);
+  font-weight: var(--weight-semibold);
+}
+
+.agent-card__footer {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-border);
+}
+
+.agent-card__last-run {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  flex: 1;
+  min-width: 0;
+}
+
+.agent-card__dag-shape {
+  font-family: var(--font-mono);
+  color: var(--color-primary);
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.1em;
+}
+
 /*
  * Legacy class-name aliases — will be removed once all view files use
  * the BEM-style forms above. Keep this block small; no new rules belong

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -245,9 +245,11 @@ describe('Dashboard v2 DAG agents', () => {
       .set('Host', `127.0.0.1:${PORT}`)
       .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
     expect(res.status).toBe(200);
-    expect(res.text).toContain('DAG agents');
+    // Cards replaced the old table+header layout in v0.15 PR 1.5.
+    // Check that v2 agents render as agent cards with the right content.
+    expect(res.text).toContain('class="agent-card"');
     expect(res.text).toContain('news-digest');
-    expect(res.text).toContain('2 nodes');
+    expect(res.text).toMatch(/<strong>2<\/strong>\s*nodes/);
   });
 
   it('renders the DAG container + Cytoscape JSON on /agents/:id', async () => {

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -392,6 +392,44 @@ describe('Dashboard static assets', () => {
   });
 });
 
+describe('Dashboard help + tutorial', () => {
+  it('GET /help renders the CLI reference page', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/help')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Help &amp; tutorial');
+    expect(res.text).toContain('Open the dashboard tutorial');
+    expect(res.text).toContain('sua workflow run');
+  });
+
+  it('GET /help/tutorial marks step 1 done when agents exist, step 2 not done with no runs', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/help/tutorial')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Dashboard tutorial');
+    // Step 1: "You have a project" — done (we scaffolded hello.yaml)
+    expect(res.text).toMatch(/You have a project[\s\S]*?badge--ok[\s\S]*?done/);
+    // Step 2: "Run your first agent" — not done yet, should show to-do badge
+    // The progress card should reflect: 1 of 5 complete
+    expect(res.text).toContain('of 5 steps complete');
+  });
+
+  it('GET /help/tutorial references the first agent by id for the Run CTA', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/help/tutorial')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    // First v1 agent is "hello" (spooky is community; v2 store is empty in this
+    // fixture). The Run CTA should link to /agents/hello.
+    expect(res.text).toContain('/agents/hello');
+  });
+});
+
 describe('Dashboard run-now gate', () => {
   it('POST /agents/hello/run submits and redirects to /runs/:id', async () => {
     const app = await makeApp();

--- a/packages/dashboard/src/routes/agents.ts
+++ b/packages/dashboard/src/routes/agents.ts
@@ -1,7 +1,7 @@
 import { Router, type Request, type Response } from 'express';
 import type { Agent, AgentDefinition, RunStatus } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
-import { renderAgentsList } from '../views/agents-list.js';
+import { renderAgentsList, type HomeStats } from '../views/agents-list.js';
 import { renderAgentDetail } from '../views/agent-detail.js';
 import { renderAgentDetailV2 } from '../views/agent-detail-v2.js';
 
@@ -21,7 +21,37 @@ agentsRouter.get('/agents', (req: Request, res: Response) => {
   }
   mergedV1.sort((a, b) => a.name.localeCompare(b.name));
   v2Agents.sort((a, b) => a.id.localeCompare(b.id));
-  res.type('html').send(renderAgentsList({ v1: mergedV1, v2: v2Agents }));
+
+  // Stats for the overview strip. One queryRuns per dimension keeps the
+  // SQL simple and the numbers honest — this page loads once per view.
+  const total = ctx.runStore.queryRuns({ limit: 1, offset: 0, statuses: [] as RunStatus[] });
+  const inFlight = ctx.runStore.queryRuns({
+    limit: 1,
+    offset: 0,
+    statuses: ['running', 'pending'] as RunStatus[],
+  });
+  // Recent runs for per-agent "last run" lookups. 100 covers realistic
+  // per-user fleets; the list view only reads the first hit per agent.
+  const recent = ctx.runStore.queryRuns({
+    limit: 100,
+    offset: 0,
+    statuses: [] as RunStatus[],
+  });
+
+  const stats: HomeStats = {
+    agents: v2Agents.length + mergedV1.length,
+    activeAgents: v2Agents.filter((a) => a.status === 'active').length + mergedV1.length,
+    totalRuns: total.total,
+    runningRuns: inFlight.total,
+    latestRunAt: recent.rows[0]?.startedAt,
+  };
+
+  res.type('html').send(renderAgentsList({
+    v1: mergedV1,
+    v2: v2Agents,
+    recentRuns: recent.rows,
+    stats,
+  }));
 });
 
 agentsRouter.get('/agents/:name', async (req: Request, res: Response) => {
@@ -53,10 +83,21 @@ agentsRouter.get('/agents/:name', async (req: Request, res: Response) => {
   const { agents } = ctx.loadAgents();
   const agent = agents.get(name);
   if (!agent) {
-    res.status(404).type('html').send(renderAgentsList({
-      v1: Array.from(agents.values()).sort((a, b) => a.name.localeCompare(b.name)),
-      v2: ctx.agentStore.listAgents().sort((a, b) => a.id.localeCompare(b.id)),
-    }));
+    const v2 = ctx.agentStore.listAgents().sort((a, b) => a.id.localeCompare(b.id));
+    const v1 = Array.from(agents.values()).sort((a, b) => a.name.localeCompare(b.name));
+    const total404 = ctx.runStore.queryRuns({ limit: 1, offset: 0, statuses: [] as RunStatus[] });
+    const inFlight404 = ctx.runStore.queryRuns({
+      limit: 1, offset: 0, statuses: ['running', 'pending'] as RunStatus[],
+    });
+    const recent404 = ctx.runStore.queryRuns({ limit: 100, offset: 0, statuses: [] as RunStatus[] });
+    const stats: HomeStats = {
+      agents: v2.length + v1.length,
+      activeAgents: v2.filter((a) => a.status === 'active').length + v1.length,
+      totalRuns: total404.total,
+      runningRuns: inFlight404.total,
+      latestRunAt: recent404.rows[0]?.startedAt,
+    };
+    res.status(404).type('html').send(renderAgentsList({ v1, v2, recentRuns: recent404.rows, stats }));
     return;
   }
 

--- a/packages/dashboard/src/routes/help.ts
+++ b/packages/dashboard/src/routes/help.ts
@@ -1,13 +1,60 @@
 import { Router, type Request, type Response } from 'express';
+import type { RunStatus } from '@some-useful-agents/core';
+import { getContext } from '../context.js';
 import { renderHelp } from '../views/help.js';
+import { renderTutorial, type TutorialState } from '../views/tutorial.js';
 
 /**
- * Static help / tutorial page. All content lives in `views/help.ts` —
- * this router only dispatches. No data dependencies; safe to render
- * without hitting the DB or secrets store.
+ * Help & tutorial routes.
+ * - `/help`: static CLI reference (no DB access).
+ * - `/help/tutorial`: dashboard-native guided flow. Step completion is
+ *   derived from observable project state, not session cookies.
  */
 export const helpRouter: Router = Router();
 
 helpRouter.get('/help', (_req: Request, res: Response) => {
   res.type('html').send(renderHelp());
+});
+
+helpRouter.get('/help/tutorial', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+
+  const v2Agents = ctx.agentStore.listAgents();
+  const { agents: v1Agents } = ctx.loadAgents();
+  const v2Ids = new Set(v2Agents.map((a) => a.id));
+  const v1OnlyCount = Array.from(v1Agents.keys()).filter((id) => !v2Ids.has(id)).length;
+  const agentCount = v2Agents.length + v1OnlyCount;
+
+  // Latest run + DAG-run detection in one query.
+  const recent = ctx.runStore.queryRuns({
+    limit: 1,
+    offset: 0,
+    statuses: [] as RunStatus[],
+  });
+  const latestRun = recent.rows[0];
+  const hasAnyRun = recent.total > 0;
+  const hasDagRun = recent.rows.some((r) => !!r.workflowId) ||
+    (hasAnyRun && ctx.runStore.queryRuns({ limit: 20, offset: 0, statuses: [] as RunStatus[] }).rows.some((r) => !!r.workflowId));
+
+  // Does any agent (v2 or v1) declare a secret?
+  const v2UsesSecrets = v2Agents.some((a) => a.nodes.some((n) => (n.secrets?.length ?? 0) > 0));
+  const v1UsesSecrets = Array.from(v1Agents.values()).some((a) => (a.secrets?.length ?? 0) > 0);
+  const usesSecrets = v2UsesSecrets || v1UsesSecrets;
+
+  // Pick the friendliest starting agent: the first v2 with a single node,
+  // else the first v2, else the first v1 name.
+  const firstAgentId = v2Agents.find((a) => a.nodes.length === 1)?.id
+    ?? v2Agents[0]?.id
+    ?? Array.from(v1Agents.keys())[0];
+
+  const state: TutorialState = {
+    agentCount,
+    hasAnyRun,
+    hasDagRun,
+    usesSecrets,
+    firstAgentId,
+    latestRunId: latestRun?.id,
+  };
+
+  res.type('html').send(renderTutorial(state));
 });

--- a/packages/dashboard/src/views/agents-list.ts
+++ b/packages/dashboard/src/views/agents-list.ts
@@ -1,8 +1,20 @@
-import type { Agent, AgentDefinition } from '@some-useful-agents/core';
+import type { Agent, AgentDefinition, Run } from '@some-useful-agents/core';
 import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
-import { typeBadge, sourceBadge } from './components.js';
+import { typeBadge, sourceBadge, formatAge } from './components.js';
+
+export interface HomeStats {
+  agents: number;
+  /** Count of agents that are `status: active` (v2 only — v1 has no status). */
+  activeAgents: number;
+  /** Total runs across all time. */
+  totalRuns: number;
+  /** Runs currently running or pending. */
+  runningRuns: number;
+  /** ISO timestamp of the most recent run's startedAt, or undefined if none. */
+  latestRunAt?: string;
+}
 
 export interface AgentsListInput {
   /** v1 YAML-loaded single-node agents, after removing any that were
@@ -10,101 +22,197 @@ export interface AgentsListInput {
   v1: AgentDefinition[];
   /** v2 DAG agents from AgentStore. */
   v2: Agent[];
+  /** Recent runs (across all agents), used to look up last-run-per-agent. */
+  recentRuns: Run[];
+  /** Overview stats for the tiles row. */
+  stats: HomeStats;
 }
 
 export function renderAgentsList(input: AgentsListInput): string {
   const hasV2 = input.v2.length > 0;
+  const hasV1 = input.v1.length > 0;
+  const v1Count = input.v1.length;
+  const totalVisible = input.v2.length + v1Count;
 
-  const v2Rows = input.v2.map((a) => html`
-    <tr>
-      <td><a href="/agents/${a.id}">${a.id}</a></td>
-      <td>${statusBadge(a.status)}</td>
-      <td>${sourceBadge(a.source)}</td>
-      <td>${String(a.nodes.length)} node${a.nodes.length === 1 ? '' : 's'}</td>
-      <td>${a.schedule ?? html`<span class="dim">—</span>`}</td>
-      <td>${a.mcp ? html`<span class="badge badge--info">mcp</span>` : html`<span class="dim">—</span>`}</td>
-      <td class="dim">${a.description ?? ''}</td>
-    </tr>
-  `);
+  // Build a `lastRun` index keyed by agent id / v1 name. Uses whatever the
+  // caller passed in `recentRuns`; we assume that list is sorted newest-first
+  // and includes enough rows to cover most active agents.
+  const lastRunByAgent = new Map<string, Run>();
+  for (const r of input.recentRuns) {
+    if (!lastRunByAgent.has(r.agentName)) lastRunByAgent.set(r.agentName, r);
+  }
 
-  const v1Rows = input.v1.map((a) => html`
+  const empty = !hasV2 && !hasV1;
+
+  const body = html`
+    ${pageHeader({
+      title: 'Agents',
+      cta: html`<a class="btn btn--ghost btn--sm" href="/help/tutorial">Open tutorial</a>`,
+    })}
+
+    ${empty ? renderEmptyState() : renderStatStrip(input.stats)}
+
+    ${hasV2 ? html`
+      <div class="agent-grid">
+        ${input.v2.map((a) => renderV2Card(a, lastRunByAgent.get(a.id))) as unknown as SafeHtml[]}
+      </div>
+    ` : html``}
+
+    ${renderV1Block(input.v1, hasV2)}
+
+    ${empty ? html`` : html`
+      <footer style="margin-top: var(--space-8); text-align: center;">
+        <p class="dim">
+          ${String(totalVisible)} agent${totalVisible === 1 ? '' : 's'} visible \u00b7
+          <a href="/help">CLI reference</a> \u00b7
+          <a href="/help/tutorial">Tutorial</a>
+        </p>
+      </footer>
+    `}
+  `;
+
+  return render(layout({ title: 'Agents', activeNav: 'agents' }, body));
+}
+
+function renderStatStrip(s: HomeStats): SafeHtml {
+  const latestHint = s.latestRunAt
+    ? `Most recent ${formatAge(s.latestRunAt)}`
+    : 'No runs yet';
+  const runningHint = s.runningRuns === 0 ? 'Nothing in flight' : 'Active now';
+
+  return html`
+    <section class="stat-strip">
+      <div class="stat-tile">
+        <span class="stat-tile__label">Agents</span>
+        <span class="stat-tile__value">${String(s.agents)}</span>
+        <span class="stat-tile__hint">${s.activeAgents === s.agents ? 'all active' : `${String(s.activeAgents)} active`}</span>
+      </div>
+      <div class="stat-tile stat-tile--info">
+        <span class="stat-tile__label">Total runs</span>
+        <span class="stat-tile__value">${String(s.totalRuns)}</span>
+        <span class="stat-tile__hint">${latestHint}</span>
+      </div>
+      <div class="stat-tile ${s.runningRuns > 0 ? 'stat-tile--ok' : 'stat-tile--muted'}">
+        <span class="stat-tile__label">In flight</span>
+        <span class="stat-tile__value">${String(s.runningRuns)}</span>
+        <span class="stat-tile__hint">${runningHint}</span>
+      </div>
+      <a class="stat-tile stat-tile--warn" href="/help/tutorial"
+         style="text-decoration: none; color: inherit;">
+        <span class="stat-tile__label">Getting started</span>
+        <span class="stat-tile__value" style="font-size: var(--font-size-md); font-weight: var(--weight-semibold);">Open the tutorial \u2192</span>
+        <span class="stat-tile__hint">Progress tracked against your project state</span>
+      </a>
+    </section>
+  `;
+}
+
+function renderEmptyState(): SafeHtml {
+  return html`
+    <section class="card" style="padding: var(--space-8) var(--space-6); text-align: center; margin-bottom: var(--space-6);">
+      <h2 style="margin-top: 0;">No agents yet</h2>
+      <p class="dim" style="max-width: 42ch; margin: 0 auto var(--space-4);">
+        An agent is a YAML file under <code>agents/</code> that describes a task sua can run.
+        Scaffold your first one with:
+      </p>
+      <pre style="display: inline-block; background: var(--color-terminal-bg); color: var(--color-terminal-fg); margin: 0 auto;">sua init &amp;&amp; sua agent new</pre>
+      <p style="margin-top: var(--space-4);">
+        <a class="btn btn--primary" href="/help/tutorial">Open the dashboard tutorial</a>
+      </p>
+    </section>
+  `;
+}
+
+function renderV2Card(a: Agent, lastRun?: Run): SafeHtml {
+  const shape = dagShape(a);
+  const runInfo = lastRun
+    ? html`<span class="agent-card__last-run">
+        Last run <span class="mono">${lastRun.status}</span> \u00b7 ${formatAge(lastRun.startedAt)}
+      </span>`
+    : html`<span class="agent-card__last-run dim">Never run</span>`;
+
+  const mcpBadge = a.mcp ? html`<span class="badge badge--info">mcp</span>` : html``;
+
+  return html`
+    <article class="agent-card">
+      <div class="agent-card__header">
+        <h3 class="agent-card__title"><a href="/agents/${a.id}">${a.id}</a></h3>
+        ${statusBadge(a.status)}
+        ${sourceBadge(a.source)}
+        ${mcpBadge}
+      </div>
+      <p class="agent-card__desc">${a.description ?? 'No description.'}</p>
+      <div class="agent-card__meta">
+        <span><strong>${String(a.nodes.length)}</strong> node${a.nodes.length === 1 ? '' : 's'}</span>
+        ${a.schedule ? html`<span>Cron <span class="mono">${a.schedule}</span></span>` : html``}
+      </div>
+      <div class="agent-card__footer">
+        <span class="agent-card__dag-shape" aria-hidden="true">${shape}</span>
+        ${runInfo}
+        <form method="POST" action="/agents/${a.id}/run" style="margin: 0;"
+              onclick="event.stopPropagation();">
+          <button type="submit" class="btn btn--primary btn--sm">Run</button>
+        </form>
+      </div>
+    </article>
+  `;
+}
+
+/**
+ * A compact mono-string visual for the DAG: one dot per node, arrows
+ * for edges in topological order. Caps at 6 nodes to avoid overflow.
+ */
+function dagShape(a: Agent): string {
+  const nodes = a.nodes.slice(0, 6);
+  if (nodes.length === 0) return '\u25cb';
+  const hasEdges = nodes.some((n) => (n.dependsOn?.length ?? 0) > 0);
+  const dots = nodes.map(() => '\u25cf');
+  const joined = hasEdges ? dots.join(' \u2192 ') : dots.join(' \u00b7 ');
+  return a.nodes.length > 6 ? `${joined} \u2026` : joined;
+}
+
+function renderV1Block(v1: AgentDefinition[], hasV2: boolean): SafeHtml {
+  if (v1.length === 0) return html``;
+  const v1Rows = v1.map((a) => html`
     <tr>
       <td><a href="/agents/${a.name}">${a.name}</a></td>
       <td><span class="badge badge--muted">v1</span></td>
       <td>${sourceBadge(a.source ?? 'local')}</td>
       <td>${typeBadge(a.type)}</td>
-      <td>${a.schedule ?? html`<span class="dim">—</span>`}</td>
-      <td>${a.mcp ? html`<span class="badge badge--info">mcp</span>` : html`<span class="dim">—</span>`}</td>
+      <td>${a.schedule ?? html`<span class="dim">\u2014</span>`}</td>
+      <td>${a.mcp ? html`<span class="badge badge--info">mcp</span>` : html`<span class="dim">\u2014</span>`}</td>
       <td class="dim">${a.description ?? ''}</td>
     </tr>
   `);
-
-  const v2Section = hasV2 ? html`
+  const table = html`
     <table class="table">
       <thead>
         <tr>
-          <th>Id</th><th>Status</th><th>Source</th>
-          <th>Nodes</th><th>Schedule</th><th>MCP</th><th>Description</th>
+          <th>Name</th><th>Kind</th><th>Source</th>
+          <th>Type</th><th>Schedule</th><th>MCP</th><th>Description</th>
         </tr>
       </thead>
-      <tbody>${v2Rows as unknown as SafeHtml[]}</tbody>
+      <tbody>${v1Rows as unknown as SafeHtml[]}</tbody>
     </table>
-  ` : html``;
-
-  // v1 YAML that hasn't been imported as a DAG yet. Collapsed by default
-  // so the migration banner and legacy table don't dominate the page for
-  // users who have already migrated. If there's no v2, v1 is the whole
-  // show and stays expanded.
-  const v1Count = input.v1.length;
-  const v1Disclosure = v1Count === 0
-    ? html``
-    : hasV2
-      ? html`
-          <details style="margin-top: var(--space-6);">
-            <summary>Show ${String(v1Count)} legacy v1 agent${v1Count === 1 ? '' : 's'}</summary>
-            <p class="dim" style="margin-top: var(--space-2);">
-              Not yet migrated. Run <code>sua workflow import --apply</code> to merge these into DAG agents.
-            </p>
-            <table class="table">
-              <thead>
-                <tr>
-                  <th>Name</th><th>Kind</th><th>Source</th>
-                  <th>Type</th><th>Schedule</th><th>MCP</th><th>Description</th>
-                </tr>
-              </thead>
-              <tbody>${v1Rows as unknown as SafeHtml[]}</tbody>
-            </table>
-          </details>
-        `
-      : html`
-          <p class="dim">
-            No DAG agents yet. These v1 YAML files will migrate on
-            <code>sua workflow import --apply</code>.
-          </p>
-          <table class="table">
-            <thead>
-              <tr>
-                <th>Name</th><th>Kind</th><th>Source</th>
-                <th>Type</th><th>Schedule</th><th>MCP</th><th>Description</th>
-              </tr>
-            </thead>
-            <tbody>${v1Rows as unknown as SafeHtml[]}</tbody>
-          </table>
-        `;
-
-  const emptyState = !hasV2 && v1Count === 0
-    ? html`<p>No agents found. Run <code>sua init</code> to scaffold a starter.</p>`
-    : html``;
-
-  return render(layout(
-    { title: 'Agents', activeNav: 'agents' },
-    html`
-      ${pageHeader({ title: 'Agents' })}
-      ${v2Section}
-      ${v1Disclosure}
-      ${emptyState}
-    `,
-  ));
+  `;
+  if (!hasV2) {
+    return html`
+      <p class="dim">
+        No DAG agents yet. These v1 YAML files will migrate on
+        <code>sua workflow import --apply</code>.
+      </p>
+      ${table}
+    `;
+  }
+  return html`
+    <details style="margin-top: var(--space-6);">
+      <summary>Show ${String(v1.length)} legacy v1 agent${v1.length === 1 ? '' : 's'}</summary>
+      <p class="dim" style="margin-top: var(--space-2);">
+        Not yet migrated. Run <code>sua workflow import --apply</code> to merge these into DAG agents.
+      </p>
+      ${table}
+    </details>
+  `;
 }
 
 function statusBadge(status: string): SafeHtml {

--- a/packages/dashboard/src/views/help.ts
+++ b/packages/dashboard/src/views/help.ts
@@ -117,11 +117,16 @@ export function renderHelp(): string {
 
     <section class="card" style="margin-bottom: var(--space-6);">
       <p class="card__title">Start here</p>
-      <p>Run the built-in interactive walkthrough from your terminal:</p>
-      <pre style="background: var(--color-terminal-bg); color: var(--color-terminal-fg); margin: var(--space-3) 0;">sua tutorial</pre>
+      <p style="margin-bottom: var(--space-3);">
+        <strong>
+          <a href="/help/tutorial" class="btn btn--primary">Open the dashboard tutorial \u2192</a>
+        </strong>
+      </p>
       <p class="dim" style="margin: 0;">
-        It scaffolds a starter agent, runs it, and shows you how to read the output.
-        Safe to run in an empty directory \u2014 no network calls, no secrets required.
+        A progress-tracked walkthrough of your project's state: registered agents, first run,
+        per-node outputs, multi-node DAGs, secrets. Each step links to the dashboard page where
+        the action happens. For a terminal-first walkthrough instead, run
+        <code>sua tutorial</code> from your project directory.
       </p>
     </section>
 

--- a/packages/dashboard/src/views/runs-list.ts
+++ b/packages/dashboard/src/views/runs-list.ts
@@ -1,6 +1,7 @@
 import type { Run, RunStatus } from '@some-useful-agents/core';
 import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
+import { pageHeader } from './page-header.js';
 import { statusBadge, formatDuration, formatAge } from './components.js';
 
 export interface RunsListOptions {
@@ -53,7 +54,7 @@ export function renderRunsList(opts: RunsListOptions): string {
 
   // Status checkboxes — more ergonomic than a multi-select for 5 values.
   const statusChecks = ALL_STATUSES.map((s) => html`
-    <label class="mono" style="flex-direction: row; gap: 0.25rem; align-items: center;">
+    <label class="filters__status-check mono">
       <input type="checkbox" name="status" value="${s}" ${filter.statuses.includes(s) ? 'checked' : ''}>
       ${s}
     </label>
@@ -79,19 +80,19 @@ export function renderRunsList(opts: RunsListOptions): string {
         Search
         <input type="text" name="q" value="${filter.q ?? ''}" placeholder="id prefix or agent name">
       </label>
-      <label style="gap: 0.35rem;">
+      <label class="filters__status">
         Status
-        <div style="display: flex; gap: 0.75rem; flex-wrap: wrap;">${statusChecks as unknown as SafeHtml[]}</div>
+        <div class="filters__status-row">${statusChecks as unknown as SafeHtml[]}</div>
       </label>
-      <button type="submit">Apply</button>
-      <a class="reset" href="/runs">Reset</a>
+      <button type="submit" class="btn btn--primary">Apply</button>
+      <a class="btn btn--ghost btn--sm filters__reset" href="/runs">Reset</a>
     </form>
   `;
 
   const table = rows.length === 0
     ? html`<p class="dim">No runs match the current filters.</p>`
     : html`
-      <table>
+      <table class="table">
         <thead>
           <tr>
             <th>ID</th><th>Agent</th><th>Status</th>
@@ -113,7 +114,12 @@ export function renderRunsList(opts: RunsListOptions): string {
     </div>
   ` : html``;
 
-  const body = html`<h1>Runs</h1>${filterBar}${table}${pager}`;
+  const body = html`
+    ${pageHeader({ title: 'Runs' })}
+    ${filterBar}
+    ${table}
+    ${pager}
+  `;
 
   return render(layout({ title: 'Runs', activeNav: 'runs' }, body));
 }

--- a/packages/dashboard/src/views/tutorial.ts
+++ b/packages/dashboard/src/views/tutorial.ts
@@ -1,0 +1,162 @@
+import { html, render, type SafeHtml } from './html.js';
+import { layout } from './layout.js';
+import { pageHeader } from './page-header.js';
+
+/**
+ * Dashboard-native replacement for `sua tutorial`. Unlike the CLI
+ * walkthrough (which is an interactive stdin/stdout flow), this is a
+ * single-page progress tracker: every step's "done" state is derived
+ * from observable project state (agents exist, runs exist, secrets
+ * store touched, etc.). That means refreshing the page tells you the
+ * real state of your project — not a cookie-remembered script.
+ */
+
+export interface TutorialState {
+  /** Total agents the project has (v1 YAML + v2 DAG, deduped by id). */
+  agentCount: number;
+  /** Whether any agent has ever been run in this project. */
+  hasAnyRun: boolean;
+  /** Whether any run's node_executions contain a DAG run (multi-node agent). */
+  hasDagRun: boolean;
+  /** Whether any agent uses at least one secret. */
+  usesSecrets: boolean;
+  /** Id of the first agent, for deep-link CTAs ("Run hello now"). */
+  firstAgentId?: string;
+  /** Id of the most recent run, for the "inspect output" step. */
+  latestRunId?: string;
+}
+
+interface Step {
+  n: number;
+  title: string;
+  done: boolean;
+  summary: SafeHtml;
+  cta?: SafeHtml;
+}
+
+export function renderTutorial(state: TutorialState): string {
+  const steps = buildSteps(state);
+  const doneCount = steps.filter((s) => s.done).length;
+  const totalCount = steps.length;
+
+  const progressCard = html`
+    <section class="card" style="margin-bottom: var(--space-6);">
+      <p class="card__title">Progress</p>
+      <p style="font-size: var(--font-size-md); margin: 0;">
+        <strong>${String(doneCount)}</strong>
+        <span class="dim"> of ${String(totalCount)} steps complete</span>
+      </p>
+      ${doneCount === totalCount
+        ? html`<p class="dim" style="margin: var(--space-2) 0 0;">
+            You've covered the basics. See <a href="/help">the full CLI reference</a> for what's next.
+          </p>`
+        : html`<p class="dim" style="margin: var(--space-2) 0 0;">
+            Each step's status is derived from your project's real state — refresh to re-check.
+          </p>`}
+    </section>
+  `;
+
+  const stepBlocks = steps.map(renderStep);
+
+  const body = html`
+    ${pageHeader({
+      title: 'Dashboard tutorial',
+      description: 'A guided first-run for the dashboard. Each step links to the page where the action happens.',
+    })}
+
+    ${progressCard}
+
+    <ol style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: var(--space-3);">
+      ${stepBlocks as unknown as SafeHtml[]}
+    </ol>
+  `;
+
+  return render(layout({ title: 'Tutorial', activeNav: 'help' }, body));
+}
+
+function buildSteps(s: TutorialState): Step[] {
+  return [
+    {
+      n: 1,
+      title: 'You have a project',
+      done: s.agentCount > 0,
+      summary: s.agentCount > 0
+        ? html`<span class="dim">${String(s.agentCount)} agent${s.agentCount === 1 ? '' : 's'} registered.</span>`
+        : html`<span class="dim">No agents yet. Run <code>sua init</code> to scaffold a starter in your project directory.</span>`,
+      cta: s.agentCount > 0
+        ? html`<a class="btn btn--sm" href="/agents">See agents</a>`
+        : undefined,
+    },
+    {
+      n: 2,
+      title: 'Run your first agent',
+      done: s.hasAnyRun,
+      summary: s.hasAnyRun
+        ? html`<span class="dim">At least one run recorded. Nice.</span>`
+        : s.firstAgentId
+          ? html`<span class="dim">Open <code>${s.firstAgentId}</code> and click <strong>Run now</strong> in the header.</span>`
+          : html`<span class="dim">Create an agent first (step 1).</span>`,
+      cta: !s.hasAnyRun && s.firstAgentId
+        ? html`<a class="btn btn--primary btn--sm" href="/agents/${s.firstAgentId}">Open ${s.firstAgentId}</a>`
+        : s.hasAnyRun
+          ? html`<a class="btn btn--sm" href="/runs">View runs</a>`
+          : undefined,
+    },
+    {
+      n: 3,
+      title: 'Inspect the output',
+      done: s.hasAnyRun && !!s.latestRunId,
+      summary: s.latestRunId
+        ? html`<span class="dim">Open the latest run to see status, duration, and per-node stdout.</span>`
+        : html`<span class="dim">Run an agent first (step 2).</span>`,
+      cta: s.latestRunId
+        ? html`<a class="btn btn--sm" href="/runs/${s.latestRunId}">Open latest run</a>`
+        : undefined,
+    },
+    {
+      n: 4,
+      title: 'See a multi-node DAG in action',
+      done: s.hasDagRun,
+      summary: s.hasDagRun
+        ? html`<span class="dim">You've executed a multi-node agent. The DAG view on each run shows node status end-to-end.</span>`
+        : html`<span class="dim">
+            Multi-node agents run nodes in topological order, passing outputs downstream. Create one
+            by chaining YAML agents with <code>dependsOn:</code>, then
+            <code>sua workflow import --apply</code> to merge them into a DAG agent.
+          </span>`,
+      cta: s.hasDagRun
+        ? html`<a class="btn btn--sm" href="/agents">Browse DAG agents</a>`
+        : html`<a class="btn btn--sm" href="/help#agents-workflows">CLI reference</a>`,
+    },
+    {
+      n: 5,
+      title: 'Wire up a secret',
+      done: s.usesSecrets,
+      summary: s.usesSecrets
+        ? html`<span class="dim">At least one agent declares a secret. Verify it's set from the Settings page.</span>`
+        : html`<span class="dim">
+            To call external APIs, declare <code>secrets: [SLACK_WEBHOOK]</code> on a node, then
+            <code>sua secrets set SLACK_WEBHOOK</code> to store the value. Nothing ever renders in the UI.
+          </span>`,
+      cta: html`<a class="btn btn--sm" href="/settings/secrets">Settings → Secrets</a>`,
+    },
+  ];
+}
+
+function renderStep(s: Step): SafeHtml {
+  const statusBadge = s.done
+    ? html`<span class="badge badge--ok">done</span>`
+    : html`<span class="badge badge--muted">to do</span>`;
+
+  return html`
+    <li class="card" style="padding: var(--space-4) var(--space-6);">
+      <div style="display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-2);">
+        <span class="mono dim" style="font-size: var(--font-size-xs);">Step ${String(s.n)}</span>
+        <strong style="font-size: var(--font-size-md);">${s.title}</strong>
+        ${statusBadge}
+        ${s.cta ? html`<span style="margin-left: auto;">${s.cta}</span>` : html``}
+      </div>
+      <div style="color: var(--color-text);">${s.summary}</div>
+    </li>
+  `;
+}


### PR DESCRIPTION
## Summary

- Adds a dashboard-native tutorial at `/help/tutorial` — 5-step guided flow whose progress is derived from observable project state (agent count, run count, DAG run presence, declared secrets), not session cookies.
- Replaces the "open a terminal and run \`sua tutorial\`" friction on `/help` with a prominent link to the in-dashboard flow. CLI tutorial kept as a secondary option.
- Each step's CTA deep-links into the dashboard page where the action happens — Agents → specific agent → its latest run → Settings → Secrets.

## Why state-derived, not session-tracked

A cookie-based wizard remembers what the user clicked, not what's true. If the user clicks through to step 3 and then deletes all their runs, the cookie still says "done". Sourcing from the DB + agent store means the tutorial always reflects the current project.

## Stacked on

[PR #57](https://github.com/gregmeyer/some-useful-agents/pull/57) — v0.15 foundation. Base branch is \`feat/dashboard-v0.15-foundation\`; rebase to \`main\` once that lands.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npx vitest run packages/dashboard\` — 26/26 pass (+3 tutorial cases)
- [x] Smoke test on \`/tmp/v14\`: shows 4/5 complete (agents, run, inspected, multi-node DAG; no secrets wired) with the expected "to do" on step 5
- [ ] Visual check in browser