### PR TITLE
fix(ci): correct the release-PR freshness comparison

### DIFF
--- a/.github/workflows/release-pr-freshness.yml
+++ b/.github/workflows/release-pr-freshness.yml
@@ -10,35 +10,35 @@ name: Release PR freshness
 # bumps versions but publishes nothing, followed by a second release PR
 # that skips a semver number.
 #
-# The existing `strict_required_status_checks_policy: true` in the main
-# branch ruleset only enforces commit-DAG-level freshness (is every main
-# commit in the PR's history?). It does NOT enforce content-level
-# freshness (are every main changeset's .md file in the PR's tree?).
-# This job fills that gap.
+# How the check works
+# ===================
+# A release PR is *fresh* iff the changesets bot rebased it off the
+# CURRENT main HEAD. We test that with `git merge-base`:
 #
-# Trigger: any push to main OR to the release branch. On every update we
-# re-evaluate: are there .changeset/*.md files on main that are missing
-# from the release branch? If so, fail; GitHub marks the release PR's
-# required check as failing, merge is blocked.
+#   merge-base(main, changeset-release/main) == main HEAD   → fresh
+#   merge-base != main HEAD                                 → stale
 #
-# Clearing the check: wait for the changesets bot to push an update
-# that includes the missing .md files, then this workflow re-runs and
-# passes. The bot does this automatically on every main push; delays are
-# usually under a minute but can stretch to several.
+# This replaces an older approach that compared the set of `.md` files
+# in .changeset/ between the two branches. That approach was broken:
+# Changesets' `changeset version` step removes the `.md` files on the
+# release branch (they get consumed into CHANGELOG + package.json
+# bumps), so the release branch LEGITIMATELY has fewer .md files than
+# main. The old check flagged every non-empty release as stale.
+#
+# When the check runs
+# ===================
+# - `push` to changeset-release/main: after the bot rewrites the
+#   release branch, verify the rewrite was built from current main.
+# - `pull_request` against main: required by the branch ruleset on
+#   every PR. For feature PRs we exit 0 trivially (the check is N/A).
+#   For the release PR (head = changeset-release/main) we run the full
+#   comparison — this is the critical path that actually blocks a
+#   partial release.
 
 on:
   push:
     branches:
-      - main
       - changeset-release/main
-  # Also run on every pull request so the check reports a status on
-  # feature PRs. The ruleset requires "Release PR is up to date with
-  # main's changesets" on every merge; without a pull_request trigger,
-  # feature PRs stayed pending forever because this workflow never ran
-  # against them. The script handles the "no release branch yet" case
-  # by exiting 0, so feature PRs pass trivially until a release PR
-  # exists — at which point they correctly report the current
-  # main-vs-release-branch state (same signal as push-to-main).
   pull_request:
     branches:
       - main
@@ -52,52 +52,49 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Compare changesets between main and changeset-release/main
+      - name: Compare release branch to main
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           set -euo pipefail
 
-          # The release branch might not exist yet (no pending release).
+          # Feature PRs don't need the freshness check — they're not the
+          # release PR. Skip the real comparison and exit 0 so the
+          # required-status-check constraint is satisfied trivially.
+          if [ "${EVENT_NAME}" = "pull_request" ] && [ "${HEAD_REF}" != "changeset-release/main" ]; then
+            echo "✅ Not the release PR (head=${HEAD_REF}). Freshness check N/A for feature PRs."
+            exit 0
+          fi
+
+          # If no release branch exists yet, nothing to compare — pass.
           if ! git show-ref --verify --quiet refs/remotes/origin/changeset-release/main; then
-            echo "No changeset-release/main branch yet — nothing to compare."
+            echo "✅ No changeset-release/main branch yet — nothing to compare."
             exit 0
           fi
 
-          # Extract the set of changeset markdown filenames on each branch.
-          # README.md and config.json are fixtures, excluded.
-          list_changesets() {
-            git ls-tree --name-only "$1" -- .changeset/ 2>/dev/null \
-              | grep -E '\.md$' \
-              | grep -v '^README\.md$' \
-              | sort
-          }
+          MAIN_SHA=$(git rev-parse origin/main)
+          RELEASE_SHA=$(git rev-parse origin/changeset-release/main)
+          BASE=$(git merge-base origin/main origin/changeset-release/main)
 
-          MAIN_CS=$(list_changesets origin/main || true)
-          RELEASE_CS=$(list_changesets origin/changeset-release/main || true)
-
-          echo "== Changesets on main =="
-          echo "${MAIN_CS:-<none>}"
-          echo ""
-          echo "== Changesets on changeset-release/main =="
-          echo "${RELEASE_CS:-<none>}"
+          echo "main HEAD:    ${MAIN_SHA}"
+          echo "release HEAD: ${RELEASE_SHA}"
+          echo "merge-base:   ${BASE}"
           echo ""
 
-          # On main, the pending set should be a SUBSET of the release branch's set.
-          # (The release branch consumes changesets on merge, so it should always
-          # have at least everything main has — plus the consumed-and-removed
-          # ones from the last merge.)
-          MISSING=$(comm -23 <(echo "$MAIN_CS") <(echo "$RELEASE_CS") || true)
-
-          if [ -z "${MISSING// /}" ]; then
-            echo "✅ Release PR is up to date: every pending changeset on main is also on changeset-release/main."
+          if [ "${BASE}" = "${MAIN_SHA}" ]; then
+            echo "✅ Release branch was built from the current main HEAD. Fresh."
             exit 0
           fi
 
-          echo "❌ Release PR is STALE. Main has changesets the release branch doesn't:"
-          echo "$MISSING" | sed 's/^/    /'
+          echo "❌ Release branch is STALE — built from ${BASE}, not current main ${MAIN_SHA}."
           echo ""
-          echo "The changesets bot will push an update to the release PR shortly. Wait for"
-          echo "that update to land, then re-run this check. Merging the release PR in its"
-          echo "current state would produce a partial release (version bumps without"
-          echo "consuming all pending changesets)."
+          echo "Commits on main the release branch hasn't picked up:"
+          git log "${BASE}..origin/main" --oneline | sed 's/^/    /'
+          echo ""
+          echo "The changesets bot will push an updated rebase to the release PR"
+          echo "shortly. Wait for that update to land, then re-run this check."
+          echo "Merging the release PR in its current state would skip those commits'"
+          echo "changesets and produce a partial release."
           exit 1


### PR DESCRIPTION
## Summary

- The previous freshness check compared \`.changeset/*.md\` files between \`main\` and \`changeset-release/main\`. That logic is broken — Changesets' bot runs \`changeset version\` when it rebuilds the release branch, which **removes** the .md files (they get consumed into CHANGELOG + package.json bumps). So the release branch legitimately has fewer .md files than main, and the old check flagged every non-empty release as stale.
- Replace with the correct invariant: a release PR is fresh iff \`merge-base(main, changeset-release/main) == main HEAD\`. If the bot rebased off current main, fresh. If main has advanced since, stale.
- Tighten the feature-PR bypass: on \`pull_request\` events where \`head != 'changeset-release/main'\`, exit 0 trivially. Only the release PR runs the full comparison.
- Remove the \`push: main\` trigger — produced confusing failing-check signals on main itself during normal bot-lag, with no merge-blocking effect to compensate.

## Why this only surfaced now

The old check existed on \`push\` triggers since 2026-04-15. Failing-check on a push doesn't block anything, so nobody noticed the flawed logic. My #59 fix added the \`pull_request\` trigger (to satisfy the new required-check rule) — now the check is gating merges for the first time, and the logic bug surfaced immediately on #57.

## Unblocks

- #57 — dashboard foundation
- #58 — tutorial + runs consistency + home cards
- Future feature PRs

Also prepares #60 (the current release PR for v0.15.0) to pass when its turn comes, since the \`merge-base\` check will correctly report "fresh" once the bot's last rebase is off current main.

## Test plan

- [x] Workflow syntax valid (YAML parses, no typos)
- [ ] This PR's own check reports ✅ (feature PR bypass)
- [ ] After merge, re-run CI on #57 and #58 — expect ✅ on the freshness check
- [ ] Next release PR cycle (post-land) should report ✅ when bot is caught up, ❌ when it isn't

## No changeset

CI-only, no runtime impact, no package affected.