### PR TITLE
feat(dashboard): connected tutorial + in-UI create surface + DAG polish (PR 1.6/5)

### DIFF
--- a/.changeset/dashboard-v016-tutorial-connected.md
+++ b/.changeset/dashboard-v016-tutorial-connected.md
@@ -1,0 +1,44 @@
+---
+"@some-useful-agents/dashboard": minor
+---
+
+**feat: connected tutorial + in-UI create surface + DAG polish (PR 1.6 of v0.15).**
+
+Closes the gap from v0.15.0's first pass: the tutorial was a read-only status tracker and every "create X" step dead-ended at the CLI. This PR makes the dashboard an actual create surface.
+
+### What ships
+
+- **`/agents/new`** — dashboard form that creates single-node v2 DAG agents via `agentStore.createAgent`. Validates id, name, command/prompt. No terminal handoff.
+- **`/agents/:id/add-node`** — form that appends a node to an existing agent, bumps to a new agent version via `upsertAgent`. Supports multi-node DAG authoring from the UI with a `dependsOn` checkbox set limited to existing node ids. Post-submit stays on the same form with a "Added X" flash so users can chain another node; "Done here — view DAG" exits to the agent detail.
+- **Active tutorial at `/help/tutorial`** — every step now has an inline action button, not a nav link:
+  - Step 1: "Create hello agent" button → POST scaffolds a minimal single-node agent → redirects to `/agents/hello?from=tutorial` so the user immediately sees the DAG + composition.
+  - Step 2: "Run <first-agent> now" button → POST runs it inline, flashes the user onto the run detail.
+  - Step 4: "Scaffold demo DAG" button → creates a 2-node fetch→digest demo → redirects to `/agents/demo-digest`.
+  - Every step shows a **"Will create" preview card** up front so the user sees the DAG shape + commands BEFORE clicking the button.
+- **Multi-hop back navigation** — new `?from=<origin>` query propagates through POST redirects (tutorial → agent detail → run detail). Back link label reflects the *original* origin, not the immediate Referer. Handles the "I ran hello from the tutorial, now the run detail should offer Back to tutorial" case.
+- **DAG viewer unified + collapsible** — fixed a styling inconsistency where `/runs/:id` and `/agents/:id` rendered the DAG with different chrome (one used inline styles overriding the design-system class). Canvas now uses a dot-grid background, softer status/type tints, thinner edges, mono label font. Wrapped in a `<details open>` so deep pages can collapse the viz without scrolling past it.
+- **Multi-node agent cards** on `/agents` gain an inline `<details>` revealing each node's id + type + command snippet without navigating away.
+- **Contextual back link** on run detail — reads `Referer` (falls back to query param, same-origin only) and renders "← Back to runs / tutorial / agents / <agent-id>" above the page title. Off-host referers are ignored.
+- **Available variables panel** on the add-node form — lists every upstream node with its claude-code template syntax (`{{upstream.<id>.result}}`) and shell env-var form (`$UPSTREAM_<ID>_RESULT`) so authors don't have to remember. Notes that structured outputs arrive in v0.16.
+- **`docs/templating.md`** — reference doc for the current templating vocabulary plus a forward-looking sketch of the v0.16 structured-outputs expansion.
+
+### Files
+
+- New: `packages/dashboard/src/views/{agent-new,agent-add-node,tutorial}.ts`
+- New: `packages/dashboard/src/routes/help.ts` scaffold endpoints (POST `/help/tutorial/scaffold-hello`, POST `/help/tutorial/scaffold-demo-dag`)
+- New: `docs/templating.md`
+- Modified: `views/{agents-list,agent-detail-v2,run-detail,dag-view,page-header}.ts`, `routes/{agents,runs,run-now,help,assets}.ts`, `assets/{components,screens}.css`
+- `page-header.ts` grows a `deriveBack(referer, host, fromParam)` helper the routes use to produce the contextual link.
+
+### Tests
+
+41 total (35 → 41; +6 new):
+- Scaffold endpoints create + are idempotent + show inline action buttons
+- `/agents/new` renders form, creates on POST, rejects invalid id + dup id + missing prompt-for-claude-code
+- `/agents/:id/add-node` renders with current nodes, appends + bumps version, rejects unknown upstream, rejects duplicate node id
+- Back link renders for same-origin Referer, omitted for off-host
+
+### Notes
+
+- The AI-assist idea ("Suggest with Claude" / "Write with Codex") is scoped to v0.16 alongside structured outputs — it needs the declared-outputs schema to have useful context. Plan file coming.
+- `/agents/new` creates single-node agents only. The chain flow (`/agents/:id/add-node`) covers multi-node authoring. Real inline drag-drop + version diff lands in PR 3 of v0.15.

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1,0 +1,90 @@
+# Templating reference
+
+This page defines the template variables sua substitutes into node commands and prompts at run time.
+
+- Agents declare nodes; nodes declare dependencies.
+- At run time, each node's body is substituted with values from **agent inputs** (supplied at `sua workflow run --input`) and **upstream node outputs** (the stdout of each `dependsOn` node).
+- Two syntaxes coexist: **`{{handlebars}}`** for claude-code prompts, **`$ENV_VARS`** for shell commands.
+
+## Agent-level inputs
+
+Passed to `sua workflow run <agent> --input KEY=value`.
+
+| Node type | Syntax | Example |
+|---|---|---|
+| `claude-code` | `{{inputs.KEY}}` | `Summarise the {{inputs.TOPIC}} headlines.` |
+| `shell` | `$KEY` (as regular env var) | `curl -s "$BASE_URL/items"` |
+
+Every `{{inputs.X}}` reference must match a declared input on the agent — typos fail the schema at save time.
+
+## Upstream node outputs
+
+Every node in the current node's `dependsOn` list exposes its stdout under `upstream.<id>`.
+
+| Node type | Syntax | Example |
+|---|---|---|
+| `claude-code` | `{{upstream.<nodeId>.result}}` | `Summarise: {{upstream.fetch.result}}` |
+| `shell` | `$UPSTREAM_<NODEID>_RESULT` (uppercase, hyphens → underscores) | `echo "got: $UPSTREAM_FETCH_RESULT"` |
+
+Notes:
+
+- `upstream` is a **reserved keyword**, not a placeholder for an agent name.
+- `<nodeId>` is the upstream **node's id**, scoped to the same agent.
+- `.result` is the **full stdout as a single string**. No sub-paths today — for structured access, emit JSON and parse it downstream (`echo "$UPSTREAM_FETCH_RESULT" | jq .count`).
+- A node can only reference upstreams it declares in `dependsOn`. Unknown references fail the schema.
+
+## What the executor guarantees today
+
+For every node, the runtime provides:
+
+- **Shell nodes:** `$UPSTREAM_<ID>_RESULT` per declared upstream + `$<INPUT_NAME>` per declared agent input. The rest of the env is filtered to the `envAllowlist` plus the node's explicit `env:` + `secrets:` lists.
+- **Claude-code nodes:** `{{inputs.X}}` and `{{upstream.X.result}}` interpolated in the prompt before the call. `allowedTools` gates which tools Claude can invoke.
+
+## Execution vocabulary — current surface
+
+What's available today:
+
+```
+{{inputs.<NAME>}}              # agent-level runtime input (claude-code)
+$<NAME>                        # same, as env var (shell)
+{{upstream.<nodeId>.result}}   # upstream stdout (claude-code)
+$UPSTREAM_<NODEID>_RESULT      # same, as env var (shell)
+```
+
+That's it. Everything else the executor knows is not yet addressable from a template.
+
+## Planned expansion (v0.16.0 — `structured-outputs-v0.16.md`)
+
+The v0.16 release replaces "stdout is a string" with **structured, declared outputs per node**. Shape under discussion:
+
+```yaml
+- id: fetch
+  type: shell
+  command: curl -s https://api.example.com/items
+  outputs:
+    status:    { type: number, from: exit_code }
+    body:      { type: json,   from: stdout }
+    duration_ms: { type: number, from: runtime }
+```
+
+Template syntax becomes path-based and validated:
+
+```
+{{upstream.fetch.body.items[0].title}}   # traverses the JSON-typed output
+{{upstream.fetch.status}}                # declared scalar
+{{upstream.fetch.exit_code}}             # built-in per-node scalar
+{{upstream.fetch.duration_ms}}           # built-in per-node scalar
+```
+
+Standard execution vocabulary available to every node (reserved namespace):
+
+```
+{{run.id}}, {{run.agent}}, {{run.triggered_by}}
+{{node.id}}, {{node.attempt}}
+{{now}}, {{date}}
+{{upstream.<id>.stderr}}, {{upstream.<id>.exit_code}}, {{upstream.<id>.duration_ms}}
+```
+
+Backwards compatibility: `{{upstream.<id>.result}}` stays as a synonym for "full stdout as string" so existing agents keep working.
+
+Plus: AI-assisted template authoring ("Suggest with Claude", "Write with Codex") on the dashboard forms — the editor already knows each upstream's declared outputs, so the AI gets real context.

--- a/packages/dashboard/src/assets/components.css
+++ b/packages/dashboard/src/assets/components.css
@@ -70,6 +70,17 @@
   font-size: var(--font-size-sm);
 }
 
+.page-header__back {
+  flex-basis: 100%;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  margin: 0 0 calc(var(--space-1) * -1);
+}
+
+.page-header__back:hover {
+  color: var(--color-primary);
+}
+
 /* ---------- Card / surface ---------- */
 .card {
   background: var(--color-surface);
@@ -567,6 +578,41 @@
   color: var(--color-primary);
   font-size: var(--font-size-xs);
   letter-spacing: 0.1em;
+}
+
+.agent-card__nodes {
+  margin: calc(var(--space-2) * -1) 0 0;
+  font-size: var(--font-size-xs);
+}
+
+.agent-card__nodes > summary {
+  color: var(--color-primary);
+  font-weight: var(--weight-medium);
+  padding: 0;
+}
+
+.agent-card__nodes > summary:hover {
+  text-decoration: underline;
+}
+
+.agent-card__node-list {
+  margin: var(--space-2) 0 0;
+  padding-left: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.agent-card__node-list > li {
+  padding-left: var(--space-1);
+}
+
+.agent-card__node-body {
+  font-size: var(--font-size-xs);
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /*

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -156,8 +156,52 @@ main.main--wide {
 
 .dag-frame__canvas {
   width: 100%;
-  height: 420px;
+  height: 320px;
+  background-color: var(--color-surface-raised);
+  background-image: radial-gradient(circle, var(--color-border) 0.5px, transparent 0.5px);
+  background-size: 16px 16px;
+}
+
+/* Collapse/expand affordance for the DAG viewer. Reuses the design-system
+ * `.dag-frame` card chrome but adds a summary row on top. */
+.dag-disclosure {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+
+.dag-disclosure__summary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
   background: var(--color-surface-raised);
+  border-bottom: 1px solid var(--color-border);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  list-style: none;
+}
+
+.dag-disclosure__summary::before {
+  content: "\25b8";
+  color: var(--color-text-muted);
+  transition: transform 120ms;
+}
+
+.dag-disclosure[open] > .dag-disclosure__summary::before {
+  transform: rotate(90deg);
+}
+
+.dag-disclosure__summary::-webkit-details-marker { display: none; }
+
+.dag-disclosure:not([open]) > .dag-disclosure__summary {
+  border-bottom: none;
+}
+
+.dag-disclosure__body {
+  display: block;
 }
 
 /* ---------- Run detail ---------- */

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -432,6 +432,261 @@ describe('Dashboard help + tutorial', () => {
   });
 });
 
+describe('Dashboard tutorial scaffold endpoints (PR 1.6)', () => {
+  it('POST /help/tutorial/scaffold-hello creates a hello agent in AgentStore', async () => {
+    const app = await makeApp();
+    // Sanity: hello doesn't yet exist in the v2 store.
+    expect(agentStore.getAgent('hello')).toBeFalsy();
+
+    const res = await request(app)
+      .post('/help/tutorial/scaffold-hello')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    // Redirects to the agent detail page so the user sees the DAG +
+    // composition immediately, not a flash on the tutorial page. The
+    // ?from=tutorial query carries multi-hop origin context so the
+    // eventual run detail's back link says "Back to tutorial".
+    expect(res.headers.location).toMatch(/^\/agents\/hello\?from=tutorial&flash=/);
+
+    const created = agentStore.getAgent('hello');
+    expect(created).toBeDefined();
+    expect(created!.nodes).toHaveLength(1);
+    expect(created!.nodes[0].type).toBe('shell');
+    expect(created!.source).toBe('local');
+  });
+
+  it('POST /help/tutorial/scaffold-demo-dag creates a 2-node DAG with fetch -> digest', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post('/help/tutorial/scaffold-demo-dag')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+
+    const created = agentStore.getAgent('demo-digest');
+    expect(created).toBeDefined();
+    expect(created!.nodes).toHaveLength(2);
+    expect(created!.nodes[0].id).toBe('fetch');
+    expect(created!.nodes[1].id).toBe('digest');
+    expect(created!.nodes[1].dependsOn).toEqual(['fetch']);
+  });
+
+  it('POST /help/tutorial/scaffold-hello is idempotent — second call surfaces a flash, no duplicate', async () => {
+    const app = await makeApp();
+    await request(app).post('/help/tutorial/scaffold-hello')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    const res2 = await request(app).post('/help/tutorial/scaffold-hello')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res2.status).toBe(303);
+    expect(decodeURIComponent(res2.headers.location)).toMatch(/already exists/);
+    // Still exactly one agent with that id.
+    expect(agentStore.listAgents().filter((a) => a.id === 'hello')).toHaveLength(1);
+  });
+
+  it('GET /help/tutorial shows inline action buttons (not just navigation links)', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/help/tutorial')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    // Step 2 when no runs: a real POST form to run the first agent.
+    expect(res.text).toMatch(/action="\/agents\/hello\/run"/);
+    // Step 4 when no DAG run: a scaffold-dag button.
+    expect(res.text).toContain('/help/tutorial/scaffold-demo-dag');
+  });
+});
+
+describe('Dashboard /agents/new create form (PR 1.6)', () => {
+  it('GET /agents/new renders the form', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/agents/new')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('New agent');
+    expect(res.text).toContain('name="id"');
+    expect(res.text).toContain('name="command"');
+    expect(res.text).toContain('name="prompt"');
+  });
+
+  it('POST /agents/new creates a single-node shell agent and redirects', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post('/agents/new')
+      .type('form')
+      .send({ id: 'test-echo', name: 'Test Echo', type: 'shell', command: 'echo hi' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    // After creation we land on the add-node form so the user can chain
+    // a downstream node, with a fromCreate flag for the friendlier copy.
+    expect(res.headers.location).toMatch(/^\/agents\/test-echo\/add-node\?fromCreate=1$/);
+
+    const created = agentStore.getAgent('test-echo');
+    expect(created).toBeDefined();
+    expect(created!.name).toBe('Test Echo');
+    expect(created!.nodes[0].type).toBe('shell');
+    expect(created!.nodes[0].command).toBe('echo hi');
+  });
+
+  it('POST /agents/new rejects invalid id with 400 + re-rendered form', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post('/agents/new')
+      .type('form')
+      .send({ id: 'Invalid ID!', name: 'x', type: 'shell', command: 'echo' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(400);
+    expect(res.text).toMatch(/Id must be lowercase/);
+    // Form re-populates with user's attempt so they don't lose input.
+    expect(res.text).toContain('Invalid ID!');
+  });
+
+  it('POST /agents/new rejects duplicate id', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'already-here', name: 'X', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'n', type: 'shell', command: 'echo' }],
+    }, 'cli');
+
+    const res = await request(app)
+      .post('/agents/new')
+      .type('form')
+      .send({ id: 'already-here', name: 'Y', type: 'shell', command: 'echo' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(400);
+    expect(res.text).toMatch(/already exists/);
+  });
+
+  it('POST /agents/new for claude-code type requires prompt', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post('/agents/new')
+      .type('form')
+      .send({ id: 'needs-prompt', name: 'x', type: 'claude-code', prompt: '' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(400);
+    expect(res.text).toMatch(/Claude-Code agents need a prompt/);
+  });
+});
+
+describe('Dashboard /agents/:id/add-node chain flow (PR 1.6)', () => {
+  it('GET /agents/:id/add-node renders the form with current nodes listed', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'chain-base', name: 'X', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'first', type: 'shell', command: 'echo hi' }],
+    }, 'cli');
+
+    const res = await request(app).get('/agents/chain-base/add-node')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Add node to chain-base');
+    expect(res.text).toContain('first');
+    // The dependsOn checkbox for the existing node should be present.
+    expect(res.text).toMatch(/name="dependsOn" value="first"/);
+  });
+
+  it('POST /agents/:id/add-node appends a downstream node and bumps version', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'chain', name: 'X', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'a', type: 'shell', command: 'echo a' }],
+    }, 'cli');
+
+    const res = await request(app)
+      .post('/agents/chain/add-node')
+      .type('form')
+      .send({ id: 'b', type: 'shell', command: 'echo b', dependsOn: 'a' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/^\/agents\/chain\/add-node\?flash=/);
+
+    const updated = agentStore.getAgent('chain');
+    expect(updated).toBeDefined();
+    expect(updated!.nodes).toHaveLength(2);
+    expect(updated!.nodes[1].id).toBe('b');
+    expect(updated!.nodes[1].dependsOn).toEqual(['a']);
+    // upsertAgent created a new version when the DAG changed.
+    expect(updated!.version).toBe(2);
+  });
+
+  it('POST /agents/:id/add-node rejects unknown upstream node', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'chain2', name: 'X', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
+    }, 'cli');
+
+    const res = await request(app)
+      .post('/agents/chain2/add-node')
+      .type('form')
+      .send({ id: 'b', type: 'shell', command: 'echo', dependsOn: 'nonexistent' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(400);
+    expect(res.text).toMatch(/Unknown upstream node/);
+  });
+
+  it('POST /agents/:id/add-node rejects duplicate node id within the agent', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'chain3', name: 'X', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
+    }, 'cli');
+
+    const res = await request(app)
+      .post('/agents/chain3/add-node')
+      .type('form')
+      .send({ id: 'a', type: 'shell', command: 'echo' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(400);
+    expect(res.text).toMatch(/already exists/);
+  });
+});
+
+describe('Dashboard contextual back link (PR 1.6)', () => {
+  it('renders a "Back to runs" link on /runs/:id when Referer is /runs', async () => {
+    const app = await makeApp();
+    runStore.createRun({
+      id: 'back-test', agentName: 'hello', status: 'completed',
+      startedAt: new Date().toISOString(), triggeredBy: 'cli',
+    });
+
+    const res = await request(app).get('/runs/back-test')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Referer', `http://127.0.0.1:${PORT}/runs?status=completed`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('page-header__back');
+    expect(res.text).toContain('Back to runs');
+  });
+
+  it('omits the back link when the Referer is off-host', async () => {
+    const app = await makeApp();
+    runStore.createRun({
+      id: 'back-test-2', agentName: 'hello', status: 'completed',
+      startedAt: new Date().toISOString(), triggeredBy: 'cli',
+    });
+
+    const res = await request(app).get('/runs/back-test-2')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Referer', 'http://evil.example.com/some-page')
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).not.toContain('page-header__back');
+  });
+});
+
 describe('Dashboard run-now gate', () => {
   it('POST /agents/hello/run submits and redirects to /runs/:id', async () => {
     const app = await makeApp();

--- a/packages/dashboard/src/routes/agents.ts
+++ b/packages/dashboard/src/routes/agents.ts
@@ -4,8 +4,227 @@ import { getContext } from '../context.js';
 import { renderAgentsList, type HomeStats } from '../views/agents-list.js';
 import { renderAgentDetail } from '../views/agent-detail.js';
 import { renderAgentDetailV2 } from '../views/agent-detail-v2.js';
+import { renderAgentNew, type AgentNewFormValues } from '../views/agent-new.js';
+import { renderAgentAddNode, type AddNodeFormValues } from '../views/agent-add-node.js';
+import { deriveBack } from '../views/page-header.js';
 
 export const agentsRouter: Router = Router();
+
+const AGENT_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+/**
+ * GET  /agents/new — show the create-agent form.
+ * POST /agents/new — create a single-node v2 DAG agent via AgentStore.
+ *
+ * The dashboard was missing any in-UI create path until this route; every
+ * "make a new agent" instruction dead-ended at `sua agent new` in the
+ * terminal. This brings the create flow into the dashboard for the most
+ * common case (single-node agent); multi-node DAGs still need the CLI
+ * or the tutorial's scaffold-demo-dag button until the drag-drop editor
+ * lands in PR 3.
+ *
+ * Registered BEFORE `/agents/:name` so Express matches this exact path
+ * first instead of treating "new" as an agent id.
+ */
+agentsRouter.get('/agents/new', (_req: Request, res: Response) => {
+  res.type('html').send(renderAgentNew({}));
+});
+
+agentsRouter.post('/agents/new', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const body = (req.body ?? {}) as Record<string, unknown>;
+
+  const values: AgentNewFormValues = {
+    id: typeof body.id === 'string' ? body.id.trim() : undefined,
+    name: typeof body.name === 'string' ? body.name.trim() : undefined,
+    description: typeof body.description === 'string' ? body.description.trim() : undefined,
+    type: body.type === 'claude-code' ? 'claude-code' : 'shell',
+    command: typeof body.command === 'string' ? body.command : undefined,
+    prompt: typeof body.prompt === 'string' ? body.prompt : undefined,
+  };
+
+  // Validate in order of what the user typed top-to-bottom so the error
+  // points at the first thing wrong rather than a buried field.
+  if (!values.id || !AGENT_ID_RE.test(values.id)) {
+    res.status(400).type('html').send(renderAgentNew({
+      values,
+      error: 'Id must be lowercase letters, digits, or hyphens, starting with a letter or digit.',
+    }));
+    return;
+  }
+  if (!values.name) {
+    res.status(400).type('html').send(renderAgentNew({
+      values,
+      error: 'Name is required.',
+    }));
+    return;
+  }
+  if (ctx.agentStore.getAgent(values.id)) {
+    res.status(400).type('html').send(renderAgentNew({
+      values,
+      error: `An agent with id "${values.id}" already exists.`,
+    }));
+    return;
+  }
+  if (values.type === 'shell' && (!values.command || values.command.trim() === '')) {
+    res.status(400).type('html').send(renderAgentNew({
+      values,
+      error: 'Shell agents need a command.',
+    }));
+    return;
+  }
+  if (values.type === 'claude-code' && (!values.prompt || values.prompt.trim() === '')) {
+    res.status(400).type('html').send(renderAgentNew({
+      values,
+      error: 'Claude-Code agents need a prompt.',
+    }));
+    return;
+  }
+
+  try {
+    ctx.agentStore.createAgent(
+      {
+        id: values.id,
+        name: values.name,
+        description: values.description || undefined,
+        status: 'active',
+        source: 'local',
+        mcp: false,
+        nodes: [
+          values.type === 'shell'
+            ? { id: 'main', type: 'shell', command: values.command! }
+            : { id: 'main', type: 'claude-code', prompt: values.prompt! },
+        ],
+      },
+      'dashboard',
+      'Created via /agents/new',
+    );
+    // Land on the add-node form with a flag — gives the user the option
+    // to chain another node downstream right away, or click "Done" to
+    // jump straight to the agent detail. Replaces the v0.15-PR1.6 flow
+    // that redirected to /agents/:id alone.
+    res.redirect(303, `/agents/${encodeURIComponent(values.id)}/add-node?fromCreate=1`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.status(400).type('html').send(renderAgentNew({
+      values,
+      error: `Create failed: ${msg}`,
+    }));
+  }
+});
+
+/**
+ * GET  /agents/:name/add-node — form to append a node to an existing
+ *                               v2 agent. v1 agents are not editable;
+ *                               redirects to the v1 detail page.
+ * POST /agents/:name/add-node — append the node, bump to a new agent
+ *                               version via upsertAgent, redirect back
+ *                               to this same form so the user can chain
+ *                               another node if they want.
+ *
+ * Registered alongside the rest of the agent routes so Express resolves
+ * paths consistently.
+ */
+const NODE_ID_RE = /^[a-z0-9][a-z0-9_-]*$/;
+
+agentsRouter.get('/agents/:name/add-node', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
+  const agent = ctx.agentStore.getAgent(name);
+  if (!agent) {
+    res.status(404).redirect(303, '/agents');
+    return;
+  }
+  const fromCreate = req.query.fromCreate === '1';
+  const flashParam = typeof req.query.flash === 'string' ? req.query.flash : undefined;
+  res.type('html').send(renderAgentAddNode({ agent, fromCreate, flash: flashParam }));
+});
+
+agentsRouter.post('/agents/:name/add-node', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
+  const agent = ctx.agentStore.getAgent(name);
+  if (!agent) {
+    res.status(404).redirect(303, '/agents');
+    return;
+  }
+
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const rawDeps = body.dependsOn;
+  const dependsOn: string[] = Array.isArray(rawDeps)
+    ? rawDeps.filter((d): d is string => typeof d === 'string')
+    : typeof rawDeps === 'string' ? [rawDeps] : [];
+
+  const values: AddNodeFormValues = {
+    id: typeof body.id === 'string' ? body.id.trim() : undefined,
+    type: body.type === 'claude-code' ? 'claude-code' : 'shell',
+    command: typeof body.command === 'string' ? body.command : undefined,
+    prompt: typeof body.prompt === 'string' ? body.prompt : undefined,
+    dependsOn,
+  };
+
+  // Validate.
+  if (!values.id || !NODE_ID_RE.test(values.id)) {
+    res.status(400).type('html').send(renderAgentAddNode({
+      agent, values, error: 'Node id must be lowercase letters, digits, hyphens, or underscores.',
+    }));
+    return;
+  }
+  if (agent.nodes.some((n) => n.id === values.id)) {
+    res.status(400).type('html').send(renderAgentAddNode({
+      agent, values, error: `A node with id "${values.id}" already exists in this agent.`,
+    }));
+    return;
+  }
+  // Every declared dependency must be a real node in this agent.
+  const existingIds = new Set(agent.nodes.map((n) => n.id));
+  const badDep = dependsOn.find((d) => !existingIds.has(d));
+  if (badDep) {
+    res.status(400).type('html').send(renderAgentAddNode({
+      agent, values, error: `Unknown upstream node: "${badDep}".`,
+    }));
+    return;
+  }
+  if (values.type === 'shell' && (!values.command || values.command.trim() === '')) {
+    res.status(400).type('html').send(renderAgentAddNode({
+      agent, values, error: 'Shell nodes need a command.',
+    }));
+    return;
+  }
+  if (values.type === 'claude-code' && (!values.prompt || values.prompt.trim() === '')) {
+    res.status(400).type('html').send(renderAgentAddNode({
+      agent, values, error: 'Claude-Code nodes need a prompt.',
+    }));
+    return;
+  }
+
+  const newNode = values.type === 'shell'
+    ? { id: values.id, type: 'shell' as const, command: values.command!, ...(dependsOn.length > 0 ? { dependsOn } : {}) }
+    : { id: values.id, type: 'claude-code' as const, prompt: values.prompt!, ...(dependsOn.length > 0 ? { dependsOn } : {}) };
+
+  try {
+    ctx.agentStore.upsertAgent(
+      {
+        id: agent.id,
+        name: agent.name,
+        description: agent.description,
+        status: agent.status,
+        schedule: agent.schedule,
+        source: agent.source,
+        mcp: agent.mcp,
+        nodes: [...agent.nodes, newNode],
+      },
+      'dashboard',
+      `Added node "${values.id}" via dashboard`,
+    );
+    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/add-node?flash=${encodeURIComponent(`Added "${values.id}". Add another or click Done.`)}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.status(400).type('html').send(renderAgentAddNode({
+      agent, values, error: `Save failed: ${msg}`,
+    }));
+  }
+});
 
 agentsRouter.get('/agents', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
@@ -68,12 +287,19 @@ agentsRouter.get('/agents/:name', async (req: Request, res: Response) => {
       statuses: [] as RunStatus[],
     });
     const flashParam = typeof req.query.flash === 'string' ? req.query.flash : undefined;
-    const flash = flashParam ? { kind: 'error' as const, message: flashParam } : undefined;
+    const fromParam = typeof req.query.from === 'string' ? req.query.from : undefined;
+    // Messages passed via ?flash= from scaffold redirects are informational;
+    // anything surfaced by a failed mutation route sends ?error= instead.
+    const flash = flashParam ? { kind: 'ok' as const, message: flashParam } : undefined;
+    const referer = typeof req.headers.referer === 'string' ? req.headers.referer : undefined;
+    const back = deriveBack(referer, `127.0.0.1:${ctx.port}`, fromParam);
     const html = await renderAgentDetailV2({
       agent: v2Agent,
       recentRuns: rows,
       secretsStore: ctx.secretsStore,
       flash,
+      back,
+      from: fromParam,
     });
     res.type('html').send(html);
     return;

--- a/packages/dashboard/src/routes/assets.ts
+++ b/packages/dashboard/src/routes/assets.ts
@@ -80,10 +80,15 @@ const DASHBOARD_CSS = loadDashboardCss();
  * DAG description from the page, styles nodes by type + status, and
  * renders the graph into #dag-canvas.
  *
- * Visual choices are deliberately minimal — this is a monitoring
- * surface, not an editor. Nodes are circles with their id as the label,
- * edges are arrows pointing downstream. Colors match the CLI's
- * type vocabulary (shell = green, claude-code = magenta).
+ * Style maps to the dashboard design tokens (tokens.css) — colors are
+ * inlined as hex because Cytoscape can't read CSS variables, but they
+ * track the same palette. When we change tokens.css, mirror here.
+ *
+ * Two visual states:
+ *   - agent detail (no status data): node tinted by TYPE — soft fill,
+ *     colored border + label.
+ *   - run detail (status data per node): node tinted by STATUS — same
+ *     pattern, status colors override type.
  */
 const GRAPH_RENDER_JS = `
 (function () {
@@ -94,18 +99,32 @@ const GRAPH_RENDER_JS = `
   var payload;
   try { payload = JSON.parse(dataEl.textContent); } catch (e) { return; }
 
-  var statusColor = {
-    completed: '#15803d',
-    failed: '#b91c1c',
-    running: '#2563eb',
-    pending: '#d97706',
-    cancelled: '#b45309',
-    skipped: '#6b7280',
+  // Status tints — mirror tokens.css (--color-*-soft for fill, --color-*
+  // for border + text). Run-detail nodes use these.
+  var statusStyle = {
+    completed: { fill: '#dcfce7', border: '#15803d', text: '#166534' },
+    failed:    { fill: '#fee2e2', border: '#b91c1c', text: '#991b1b' },
+    running:   { fill: '#dbeafe', border: '#2563eb', text: '#1d4ed8' },
+    pending:   { fill: '#fef3c7', border: '#b45309', text: '#92400e' },
+    cancelled: { fill: '#fef3c7', border: '#b45309', text: '#92400e' },
+    skipped:   { fill: '#f3f4f6', border: '#9ca3af', text: '#6b7280' },
   };
-  var typeColor = {
-    shell: '#15803d',
-    'claude-code': '#a21caf',
+  // Type tints — agent-detail nodes (no status) use these. Both shell
+  // and claude-code stay in the project's accent palette so the DAG
+  // viz blends with the rest of the dashboard chrome.
+  var typeStyle = {
+    shell:         { fill: '#dcfce7', border: '#15803d', text: '#166534' },
+    'claude-code': { fill: '#dbeafe', border: '#2563eb', text: '#1d4ed8' },
   };
+  var defaultStyle = { fill: '#f9fafb', border: '#d1d5db', text: '#374151' };
+
+  function pick(n, key) {
+    var s = n.data('status');
+    if (s && statusStyle[s]) return statusStyle[s][key];
+    var t = n.data('type');
+    if (t && typeStyle[t]) return typeStyle[t][key];
+    return defaultStyle[key];
+  }
 
   var cy = window.cytoscape({
     container: el,
@@ -114,36 +133,48 @@ const GRAPH_RENDER_JS = `
       {
         selector: 'node',
         style: {
-          'background-color': function (n) {
-            var s = n.data('status');
-            if (s && statusColor[s]) return statusColor[s];
-            return typeColor[n.data('type')] || '#6b7280';
-          },
+          'background-color': function (n) { return pick(n, 'fill'); },
+          'border-color':     function (n) { return pick(n, 'border'); },
+          'color':            function (n) { return pick(n, 'text'); },
           'label': 'data(label)',
-          'color': '#fff',
           'text-valign': 'center',
           'text-halign': 'center',
-          'font-size': 11,
-          'width': 80,
-          'height': 40,
+          'font-family': 'ui-monospace, SFMono-Regular, Menlo, monospace',
+          'font-size': 10,
+          'font-weight': 600,
+          'width': 'label',
+          'height': 26,
+          'padding': '10px',
           'shape': 'round-rectangle',
           'border-width': 1,
-          'border-color': '#111',
+          'corner-radius': '6px',
         },
       },
       {
         selector: 'edge',
         style: {
-          'width': 2,
-          'line-color': '#6b7280',
-          'target-arrow-color': '#6b7280',
+          'width': 1.25,
+          'line-color': '#d1d5db',
+          'target-arrow-color': '#9ca3af',
           'target-arrow-shape': 'triangle',
+          'arrow-scale': 0.9,
           'curve-style': 'bezier',
         },
       },
     ],
-    layout: { name: 'breadthfirst', directed: true, padding: 10, spacingFactor: 1.1 },
+    layout: {
+      name: 'breadthfirst',
+      directed: true,
+      padding: 18,
+      spacingFactor: 1.25,
+      grid: false,
+    },
+    autoungrabify: true,
+    userZoomingEnabled: false,
+    userPanningEnabled: false,
+    boxSelectionEnabled: false,
   });
+  cy.fit(undefined, 18);
 
   // Click a node → anchor into the run-detail page on the same id.
   // No-op on /agents/:id (no target); clickable on /runs/:id via the
@@ -170,7 +201,10 @@ assetsRouter.get('/assets/cytoscape.min.js', (_req: Request, res: Response) => {
 });
 
 assetsRouter.get('/assets/graph-render.js', (_req: Request, res: Response) => {
-  res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+  // Short cache (5m) for our own bootstrap — during local dev we tweak
+  // node styling and want changes visible on refresh without a hard
+  // reload. Cytoscape itself stays on immutable since it's vendored.
+  res.setHeader('Cache-Control', 'public, max-age=300');
   res.type('application/javascript').send(GRAPH_RENDER_JS);
 });
 

--- a/packages/dashboard/src/routes/help.ts
+++ b/packages/dashboard/src/routes/help.ts
@@ -6,9 +6,16 @@ import { renderTutorial, type TutorialState } from '../views/tutorial.js';
 
 /**
  * Help & tutorial routes.
- * - `/help`: static CLI reference (no DB access).
- * - `/help/tutorial`: dashboard-native guided flow. Step completion is
- *   derived from observable project state, not session cookies.
+ * - `GET /help`: static CLI reference (no DB access).
+ * - `GET /help/tutorial`: dashboard-native guided flow. Step completion is
+ *   derived from observable project state, not session cookies. Each step
+ *   has an inline action button; no terminal handoff for the happy path.
+ * - `POST /help/tutorial/scaffold-hello`: one-click creation of a minimal
+ *   single-node `hello` agent via the in-process AgentStore API. Same
+ *   outcome as `sua agent new` with default answers, minus the terminal
+ *   prompts.
+ * - `POST /help/tutorial/scaffold-demo-dag`: creates a two-node fetch → summary
+ *   DAG for step 4 ("see multi-node in action"). Id is `demo-digest`.
  */
 export const helpRouter: Router = Router();
 
@@ -17,6 +24,88 @@ helpRouter.get('/help', (_req: Request, res: Response) => {
 });
 
 helpRouter.get('/help/tutorial', (req: Request, res: Response) => {
+  res.type('html').send(renderTutorial(collectTutorialState(req)));
+});
+
+helpRouter.post('/help/tutorial/scaffold-hello', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+
+  if (ctx.agentStore.getAgent('hello')) {
+    res.redirect(303, `/help/tutorial?flash=${encodeURIComponent('Agent "hello" already exists.')}`);
+    return;
+  }
+
+  try {
+    ctx.agentStore.createAgent(
+      {
+        id: 'hello',
+        name: 'Hello',
+        description: 'A minimal starter agent created from the dashboard tutorial.',
+        status: 'active',
+        source: 'local',
+        mcp: false,
+        nodes: [{
+          id: 'greet',
+          type: 'shell',
+          command: "echo 'Hello from some-useful-agents!'",
+        }],
+      },
+      'dashboard',
+      'Scaffolded from /help/tutorial',
+    );
+    // Redirect to the agent detail so the user sees the DAG, the node,
+    // the command — not just a flash that says "done." The contextual
+    // back link picks up "/help/tutorial" from the Referer and shows a
+    // "Back to tutorial" affordance.
+    res.redirect(303, `/agents/hello?from=tutorial&flash=${encodeURIComponent('Created from the tutorial. Click Run now to execute it.')}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/help/tutorial?flash=${encodeURIComponent(`Scaffold failed: ${msg}`)}`);
+  }
+});
+
+helpRouter.post('/help/tutorial/scaffold-demo-dag', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+
+  if (ctx.agentStore.getAgent('demo-digest')) {
+    res.redirect(303, `/help/tutorial?flash=${encodeURIComponent('Agent "demo-digest" already exists.')}`);
+    return;
+  }
+
+  try {
+    ctx.agentStore.createAgent(
+      {
+        id: 'demo-digest',
+        name: 'Demo Digest',
+        description: 'Two-node DAG: fetch stub output, then count items. Scaffolded from the tutorial.',
+        status: 'active',
+        source: 'local',
+        mcp: false,
+        nodes: [
+          {
+            id: 'fetch',
+            type: 'shell',
+            command: "echo 'item-1 item-2 item-3'",
+          },
+          {
+            id: 'digest',
+            type: 'shell',
+            command: 'echo "Summary of:" && echo "$UPSTREAM_FETCH_RESULT" | wc -w | awk \'{print "  " $1 " items"}\'',
+            dependsOn: ['fetch'],
+          },
+        ],
+      },
+      'dashboard',
+      'Scaffolded demo DAG from /help/tutorial',
+    );
+    res.redirect(303, `/agents/demo-digest?from=tutorial&flash=${encodeURIComponent('Two-node DAG created. Click Run now to see multi-node execution.')}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/help/tutorial?flash=${encodeURIComponent(`Scaffold failed: ${msg}`)}`);
+  }
+});
+
+function collectTutorialState(req: Request): TutorialState & { flash?: string } {
   const ctx = getContext(req.app.locals);
 
   const v2Agents = ctx.agentStore.listAgents();
@@ -25,36 +114,38 @@ helpRouter.get('/help/tutorial', (req: Request, res: Response) => {
   const v1OnlyCount = Array.from(v1Agents.keys()).filter((id) => !v2Ids.has(id)).length;
   const agentCount = v2Agents.length + v1OnlyCount;
 
-  // Latest run + DAG-run detection in one query.
   const recent = ctx.runStore.queryRuns({
-    limit: 1,
+    limit: 20,
     offset: 0,
     statuses: [] as RunStatus[],
   });
   const latestRun = recent.rows[0];
   const hasAnyRun = recent.total > 0;
-  const hasDagRun = recent.rows.some((r) => !!r.workflowId) ||
-    (hasAnyRun && ctx.runStore.queryRuns({ limit: 20, offset: 0, statuses: [] as RunStatus[] }).rows.some((r) => !!r.workflowId));
+  const hasDagRun = recent.rows.some((r) => !!r.workflowId);
 
-  // Does any agent (v2 or v1) declare a secret?
   const v2UsesSecrets = v2Agents.some((a) => a.nodes.some((n) => (n.secrets?.length ?? 0) > 0));
   const v1UsesSecrets = Array.from(v1Agents.values()).some((a) => (a.secrets?.length ?? 0) > 0);
   const usesSecrets = v2UsesSecrets || v1UsesSecrets;
 
-  // Pick the friendliest starting agent: the first v2 with a single node,
-  // else the first v2, else the first v1 name.
+  const hasHelloAgent = !!ctx.agentStore.getAgent('hello');
+  const hasDemoDag = !!ctx.agentStore.getAgent('demo-digest');
+
+  // Pick the friendliest starting agent: prefer single-node v2, then any v2, then v1.
   const firstAgentId = v2Agents.find((a) => a.nodes.length === 1)?.id
     ?? v2Agents[0]?.id
     ?? Array.from(v1Agents.keys())[0];
 
-  const state: TutorialState = {
+  const flash = typeof req.query.flash === 'string' ? req.query.flash : undefined;
+
+  return {
     agentCount,
     hasAnyRun,
     hasDagRun,
     usesSecrets,
     firstAgentId,
     latestRunId: latestRun?.id,
+    hasHelloAgent,
+    hasDemoDag,
+    flash,
   };
-
-  res.type('html').send(renderTutorial(state));
-});
+}

--- a/packages/dashboard/src/routes/run-now.ts
+++ b/packages/dashboard/src/routes/run-now.ts
@@ -23,6 +23,12 @@ runNowRouter.post('/agents/:name/run', async (req: Request, res: Response) => {
   const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
   const body = (req.body ?? {}) as Record<string, unknown>;
   const confirmed = body.confirm_community_shell === 'yes';
+  // Origin marker for multi-hop back-link context. Propagated into
+  // the redirect URL so the run detail's "Back to …" label reflects
+  // where the user started (tutorial, runs list, etc.), not just the
+  // immediate Referer.
+  const fromParam = typeof body.from === 'string' && body.from.length > 0 ? body.from : undefined;
+  const fromSuffix = fromParam ? `?from=${encodeURIComponent(fromParam)}` : '';
 
   // Prefer v2 agents (post-migration).
   const v2Agent = ctx.agentStore.getAgent(name);
@@ -43,7 +49,7 @@ runNowRouter.post('/agents/:name/run', async (req: Request, res: Response) => {
           allowUntrustedShell: ctx.allowUntrustedShell,
         },
       );
-      res.redirect(303, `/runs/${encodeURIComponent(run.id)}`);
+      res.redirect(303, `/runs/${encodeURIComponent(run.id)}${fromSuffix}`);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       res.redirect(303, `/agents/${encodeURIComponent(v2Agent.id)}?flash=${encodeURIComponent(message)}`);

--- a/packages/dashboard/src/routes/runs.ts
+++ b/packages/dashboard/src/routes/runs.ts
@@ -3,6 +3,7 @@ import type { RunStatus } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 import { renderRunsList } from '../views/runs-list.js';
 import { renderRunDetail } from '../views/run-detail.js';
+import { deriveBack } from '../views/page-header.js';
 
 const VALID_STATUSES: RunStatus[] = ['pending', 'running', 'completed', 'failed', 'cancelled'];
 const VALID_STATUS_SET = new Set<string>(VALID_STATUSES);
@@ -76,7 +77,14 @@ runsRouter.get('/runs/:id', (req: Request, res: Response) => {
     agent = ctx.agentStore.getAgent(run.workflowId) ?? undefined;
   }
 
-  res.type('html').send(renderRunDetail({ run, partial, nodeExecutions, agent }));
+  // Contextual back link — ?from=tutorial (or similar) takes priority
+  // over the Referer because it was threaded through the POST redirect
+  // from the originating page and survives multi-hop flows.
+  const referer = typeof req.headers.referer === 'string' ? req.headers.referer : undefined;
+  const expectedHost = `127.0.0.1:${ctx.port}`;
+  const back = deriveBack(referer, expectedHost, req.query.from);
+
+  res.type('html').send(renderRunDetail({ run, partial, nodeExecutions, agent, back }));
 });
 
 function parseIntOr(v: unknown, fallback: number): number {

--- a/packages/dashboard/src/views/agent-add-node.ts
+++ b/packages/dashboard/src/views/agent-add-node.ts
@@ -1,0 +1,215 @@
+import type { Agent } from '@some-useful-agents/core';
+import { html, render, unsafeHtml, type SafeHtml } from './html.js';
+import { layout } from './layout.js';
+import { pageHeader } from './page-header.js';
+
+/**
+ * Render a reference card listing everything the author can inject into
+ * the new node's command or prompt. Covers:
+ *   - upstream node outputs (both shell env-var and claude-code template forms)
+ *   - the current run-time vocabulary (`result` is all we have today;
+ *     structured fields like `exit_code`, `duration_ms`, and JSON paths
+ *     arrive in v0.16 — see docs/templating.md)
+ *
+ * Panel is static content; no JS. Users read, copy-paste.
+ */
+function availableVariablesPanel(agent: Agent): SafeHtml {
+  if (agent.nodes.length === 0) {
+    return html`
+      <details class="card card--muted" style="margin-bottom: var(--space-4);">
+        <summary>Available variables</summary>
+        <p class="dim" style="margin: var(--space-2) 0 0;">This agent has no nodes yet. Once upstream nodes exist, their outputs will appear here.</p>
+      </details>
+    `;
+  }
+
+  const upstreamRows = agent.nodes.map((n) => html`
+    <tr>
+      <td class="mono">${n.id}</td>
+      <td><code>{{upstream.${n.id}.result}}</code></td>
+      <td><code>$UPSTREAM_${n.id.toUpperCase().replace(/-/g, '_')}_RESULT</code></td>
+    </tr>
+  `);
+
+  return html`
+    <details class="card card--muted" style="margin-bottom: var(--space-4);">
+      <summary>Available variables <span class="dim" style="font-weight: var(--weight-regular);">(click to expand)</span></summary>
+      <div style="margin-top: var(--space-3);">
+        <p class="card__title" style="margin-top: 0;">Upstream node outputs</p>
+        <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-2);">
+          Only upstream nodes you mark in <em>Depends on</em> above are actually resolvable at run time. The value is the full stdout of that node as a single string.
+        </p>
+        <table class="table" style="font-size: var(--font-size-xs); margin-bottom: var(--space-3);">
+          <thead>
+            <tr>
+              <th>Upstream</th>
+              <th>Claude-code template</th>
+              <th>Shell env var</th>
+            </tr>
+          </thead>
+          <tbody>${upstreamRows as unknown as SafeHtml[]}</tbody>
+        </table>
+        <p class="dim" style="font-size: var(--font-size-xs); margin: 0;">
+          Structured outputs with declared variables (<code>{{upstream.fetch.json.items[0].title}}</code>, <code>{{upstream.fetch.exit_code}}</code>, etc.) arrive in v0.16.
+          See <a href="https://github.com/gregmeyer/some-useful-agents/blob/main/docs/templating.md" target="_blank" rel="noreferrer">docs/templating.md</a> for the full reference.
+        </p>
+      </div>
+    </details>
+  `;
+}
+
+export interface AddNodeFormValues {
+  id?: string;
+  type?: 'shell' | 'claude-code';
+  command?: string;
+  prompt?: string;
+  /** Selected upstream node ids (multi-select). */
+  dependsOn?: string[];
+}
+
+/**
+ * Render the "add a node to this agent" form. Lists the agent's current
+ * nodes so the user can see what they're extending, then a form with a
+ * dependsOn multi-select limited to existing ids.
+ *
+ * After submit, the route appends the node and bumps to a new version
+ * (via agentStore.upsertAgent), then redirects back to this same form
+ * with a flash so the user can chain another node if they want.
+ */
+export function renderAgentAddNode(args: {
+  agent: Agent;
+  values?: AddNodeFormValues;
+  error?: string;
+  flash?: string;
+  /** True if the user just landed here from /agents/new — surface a "Done" hint. */
+  fromCreate?: boolean;
+}): string {
+  const { agent, values: v = {}, error, flash, fromCreate } = args;
+  const type = v.type ?? 'shell';
+  const isShell = type === 'shell';
+  const isClaude = type === 'claude-code';
+  const selectedDeps = new Set(v.dependsOn ?? []);
+
+  const errorBlock = error
+    ? html`<div class="flash flash--error">${error}</div>`
+    : html``;
+  const flashBlock = flash
+    ? html`<div class="flash flash--ok">${flash}</div>`
+    : html``;
+
+  // Existing-nodes summary card. Stays simple — read-only list.
+  const existingNodesCard = html`
+    <section class="card" style="margin-bottom: var(--space-4);">
+      <p class="card__title">Current nodes (v${String(agent.version)})</p>
+      <ul style="margin: 0; padding-left: var(--space-6);">
+        ${agent.nodes.map((n) => html`
+          <li>
+            <code>${n.id}</code>
+            <span class="dim">\u2014 ${n.type}${n.dependsOn?.length ? ` (depends on: ${n.dependsOn.join(', ')})` : ''}</span>
+          </li>
+        `) as unknown as SafeHtml[]}
+      </ul>
+    </section>
+  `;
+
+  // Dependency checkboxes — each existing node id becomes a toggle.
+  const depToggles = agent.nodes.map((n) => html`
+    <label style="display: inline-flex; align-items: center; gap: var(--space-1); margin-right: var(--space-3); font-weight: var(--weight-regular); font-size: var(--font-size-sm);">
+      <input type="checkbox" name="dependsOn" value="${n.id}" ${selectedDeps.has(n.id) ? 'checked' : ''}>
+      <code>${n.id}</code>
+    </label>
+  `);
+
+  // Default the new node's id to a sensible suggestion, but only when the
+  // user hasn't typed anything yet.
+  const suggestedId = v.id ?? suggestNextNodeId(agent);
+
+  const headerCta = html`
+    <span style="display: inline-flex; gap: var(--space-2);">
+      <a class="btn btn--ghost btn--sm" href="/agents/${agent.id}">Done \u2014 view DAG</a>
+    </span>
+  `;
+
+  const body = html`
+    ${pageHeader({
+      title: `Add node to ${agent.id}`,
+      cta: headerCta,
+      description: fromCreate
+        ? 'Just created the agent. Want to chain another node downstream? Add it here, or click Done to finish.'
+        : 'Append a node to this agent. Saving creates a new version (the previous version stays in history).',
+    })}
+
+    ${flashBlock}
+    ${errorBlock}
+
+    ${existingNodesCard}
+
+    <form method="POST" action="/agents/${agent.id}/add-node" class="card" style="max-width: 680px;">
+      <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-4);">
+        <strong>Node id</strong>
+        <input type="text" name="id" required pattern="[a-z0-9][a-z0-9_-]*"
+               value="${suggestedId}"
+               placeholder="next-step"
+               style="${INPUT_STYLE}">
+        <span class="dim" style="font-size: var(--font-size-xs);">Lowercase, hyphens or underscores. Must be unique within this agent.</span>
+      </label>
+
+      <fieldset style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--space-3); margin-bottom: var(--space-4);">
+        <legend style="padding: 0 var(--space-2); font-size: var(--font-size-xs); font-weight: var(--weight-semibold); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em;">Type</legend>
+        <label style="display: flex; align-items: center; gap: var(--space-2); margin-bottom: var(--space-2);">
+          <input type="radio" name="type" value="shell" ${isShell ? 'checked' : ''}>
+          <span><strong>Shell</strong> <span class="dim">\u2014 runs a command. Upstream outputs come in as <code>$UPSTREAM_&lt;NODEID&gt;_RESULT</code> env vars.</span></span>
+        </label>
+        <label style="display: flex; align-items: center; gap: var(--space-2);">
+          <input type="radio" name="type" value="claude-code" ${isClaude ? 'checked' : ''}>
+          <span><strong>Claude Code</strong> <span class="dim">\u2014 runs a prompt. Upstream outputs interpolate via <code>{{upstream.&lt;nodeId&gt;.result}}</code>.</span></span>
+        </label>
+      </fieldset>
+
+      <fieldset style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--space-3); margin-bottom: var(--space-4);">
+        <legend style="padding: 0 var(--space-2); font-size: var(--font-size-xs); font-weight: var(--weight-semibold); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em;">Depends on</legend>
+        <p class="dim" style="margin: 0 0 var(--space-2); font-size: var(--font-size-xs);">Pick zero or more upstream nodes. The new node runs after all of them complete.</p>
+        ${depToggles as unknown as SafeHtml[]}
+      </fieldset>
+
+      ${availableVariablesPanel(agent)}
+
+      <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-4);">
+        <strong>Command <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-xs);">(shell only)</span></strong>
+        <textarea name="command" rows="4" placeholder='echo "$UPSTREAM_FETCH_RESULT" | wc -w' style="${TEXTAREA_STYLE}">${v.command ?? ''}</textarea>
+      </label>
+
+      <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-6);">
+        <strong>Prompt <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-xs);">(claude-code only)</span></strong>
+        <textarea name="prompt" rows="4" placeholder='Summarise: {{upstream.fetch.result}}' style="${TEXTAREA_STYLE}">${v.prompt ?? ''}</textarea>
+      </label>
+
+      <div style="display: flex; gap: var(--space-2); justify-content: flex-end; align-items: center;">
+        <a class="btn btn--ghost" href="/agents/${agent.id}">Cancel</a>
+        <a class="btn" href="/agents/${agent.id}">Done here \u2014 view DAG</a>
+        <button type="submit" class="btn btn--primary">Add node</button>
+      </div>
+    </form>
+  `;
+
+  return render(layout({ title: `Add node \u2014 ${agent.id}`, activeNav: 'agents' }, body));
+}
+
+/**
+ * Suggest a node id that doesn't collide. Defaults to "main" for empty
+ * agents (shouldn't happen — they always have at least one) or
+ * "step-2", "step-3", ... numbered after current count.
+ */
+function suggestNextNodeId(agent: Agent): string {
+  const existing = new Set(agent.nodes.map((n) => n.id));
+  let n = agent.nodes.length + 1;
+  while (existing.has(`step-${n}`)) n++;
+  return `step-${n}`;
+}
+
+const INPUT_STYLE: SafeHtml = unsafeHtml(
+  'padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm); font-family: inherit;',
+);
+const TEXTAREA_STYLE: SafeHtml = unsafeHtml(
+  'padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-family: var(--font-mono); font-size: var(--font-size-xs); resize: vertical;',
+);

--- a/packages/dashboard/src/views/agent-detail-v2.ts
+++ b/packages/dashboard/src/views/agent-detail-v2.ts
@@ -1,7 +1,7 @@
 import type { Agent, Run, SecretsStore } from '@some-useful-agents/core';
 import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
-import { pageHeader } from './page-header.js';
+import { pageHeader, type PageHeaderBack } from './page-header.js';
 import { sourceBadge, statusBadge, formatDuration, formatAge } from './components.js';
 import { renderDagView, renderDagFallback } from './dag-view.js';
 
@@ -10,8 +10,17 @@ export async function renderAgentDetailV2(args: {
   recentRuns: Run[];
   secretsStore: SecretsStore;
   flash?: { kind: 'error' | 'info' | 'ok'; message: string };
+  /** Contextual back link ("Back to tutorial", "Back to runs", etc.). */
+  back?: PageHeaderBack;
+  /**
+   * Origin-marker propagated via ?from=… query param. When set, we
+   * thread it through the Run-now form as a hidden field so the run
+   * detail page knows the user's original origin was (e.g.) the
+   * tutorial — not just the immediate Referer.
+   */
+  from?: string;
 }): Promise<string> {
-  const { agent, recentRuns, secretsStore, flash } = args;
+  const { agent, recentRuns, secretsStore, flash, back, from } = args;
   const source = agent.source;
   const hasCommunityShellNode = source === 'community' && agent.nodes.some((n) => n.type === 'shell');
 
@@ -50,10 +59,14 @@ export async function renderAgentDetailV2(args: {
     }
   }
 
+  const fromHidden = from
+    ? html`<input type="hidden" name="from" value="${from}">`
+    : html``;
   const runNowButton = hasCommunityShellNode
     ? html`
         <form method="POST" action="/agents/${agent.id}/run">
           <input type="hidden" name="confirm_community_shell" value="yes">
+          ${fromHidden}
           <button type="submit" class="btn btn--warn"
             onclick="return confirm('This agent contains community shell nodes. Run anyway?');">
             Run now (community)
@@ -62,6 +75,7 @@ export async function renderAgentDetailV2(args: {
       `
     : html`
         <form method="POST" action="/agents/${agent.id}/run" style="display: inline;">
+          ${fromHidden}
           <button type="submit" class="btn btn--primary">Run now</button>
         </form>
       `;
@@ -133,7 +147,8 @@ export async function renderAgentDetailV2(args: {
         </div>
       </section>
 
-      <div class="inspector__actions">
+      <div class="inspector__actions" style="flex-wrap: wrap;">
+        <a class="btn btn--primary btn--sm" href="/agents/${agent.id}/add-node">+ Add node</a>
         <a class="btn btn--sm" href="#nodes">Jump to nodes</a>
         <a class="btn btn--sm" href="#runs">Recent runs</a>
       </div>
@@ -146,16 +161,15 @@ export async function renderAgentDetailV2(args: {
       meta: [vStatusBadge(agent.status), sourceBadge(source)],
       cta: runNowButton,
       description: agent.description ?? undefined,
+      back,
     })}
 
     ${warningBanner}
 
     <div class="agent-detail">
       <div class="agent-detail__main">
-        <section class="dag-frame">
-          ${renderDagFallback(agent)}
-          ${renderDagView({ agent })}
-        </section>
+        ${renderDagFallback(agent)}
+        ${renderDagView({ agent })}
 
         <section id="nodes">
           <h2>Nodes</h2>

--- a/packages/dashboard/src/views/agent-new.ts
+++ b/packages/dashboard/src/views/agent-new.ts
@@ -1,0 +1,96 @@
+import { html, render, unsafeHtml, type SafeHtml } from './html.js';
+import { layout } from './layout.js';
+import { pageHeader } from './page-header.js';
+
+export interface AgentNewFormValues {
+  id?: string;
+  name?: string;
+  description?: string;
+  type?: 'shell' | 'claude-code';
+  command?: string;
+  prompt?: string;
+}
+
+/**
+ * Render the "create agent" form. Pre-fills any submitted values so the
+ * user doesn't lose their input on validation failure.
+ */
+export function renderAgentNew(args: {
+  values?: AgentNewFormValues;
+  error?: string;
+}): string {
+  const v = args.values ?? {};
+  const type = v.type ?? 'shell';
+  const isShell = type === 'shell';
+  const isClaude = type === 'claude-code';
+
+  const errorBlock = args.error
+    ? html`<div class="flash flash--error">${args.error}</div>`
+    : html``;
+
+  const body = html`
+    ${pageHeader({
+      title: 'New agent',
+      description: 'Create a single-node v2 DAG agent. For multi-node DAGs, create each node as its own agent, then chain them via the tutorial or CLI.',
+    })}
+
+    ${errorBlock}
+
+    <form method="POST" action="/agents/new" class="card" style="max-width: 680px;">
+      <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-4);">
+        <strong>Id</strong>
+        <input type="text" name="id" required pattern="[a-z0-9][a-z0-9-]*"
+               value="${v.id ?? ''}"
+               placeholder="my-agent"
+               style="${INPUT_STYLE}">
+        <span class="dim" style="font-size: var(--font-size-xs);">Lowercase letters, digits, and hyphens. Must start with a letter or digit.</span>
+      </label>
+
+      <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-4);">
+        <strong>Name</strong>
+        <input type="text" name="name" required value="${v.name ?? ''}" style="${INPUT_STYLE}">
+      </label>
+
+      <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-4);">
+        <strong>Description</strong>
+        <input type="text" name="description" value="${v.description ?? ''}" style="${INPUT_STYLE}">
+      </label>
+
+      <fieldset style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--space-3); margin-bottom: var(--space-4);">
+        <legend style="padding: 0 var(--space-2); font-size: var(--font-size-xs); font-weight: var(--weight-semibold); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em;">Type</legend>
+        <label style="display: flex; align-items: center; gap: var(--space-2); margin-bottom: var(--space-2);">
+          <input type="radio" name="type" value="shell" ${isShell ? 'checked' : ''}>
+          <span><strong>Shell</strong> <span class="dim">\u2014 runs an arbitrary command locally</span></span>
+        </label>
+        <label style="display: flex; align-items: center; gap: var(--space-2);">
+          <input type="radio" name="type" value="claude-code" ${isClaude ? 'checked' : ''}>
+          <span><strong>Claude Code</strong> <span class="dim">\u2014 runs a Claude Code prompt</span></span>
+        </label>
+      </fieldset>
+
+      <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-4);">
+        <strong>Command <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-xs);">(shell agents only)</span></strong>
+        <textarea name="command" rows="4" placeholder="echo hello" style="${TEXTAREA_STYLE}">${v.command ?? ''}</textarea>
+      </label>
+
+      <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-6);">
+        <strong>Prompt <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-xs);">(claude-code agents only)</span></strong>
+        <textarea name="prompt" rows="4" placeholder="Summarise the attached text." style="${TEXTAREA_STYLE}">${v.prompt ?? ''}</textarea>
+      </label>
+
+      <div style="display: flex; gap: var(--space-2); justify-content: flex-end;">
+        <a class="btn" href="/agents">Cancel</a>
+        <button type="submit" class="btn btn--primary">Create agent</button>
+      </div>
+    </form>
+  `;
+
+  return render(layout({ title: 'New agent', activeNav: 'agents' }, body));
+}
+
+const INPUT_STYLE: SafeHtml = unsafeHtml(
+  'padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm); font-family: inherit;',
+);
+const TEXTAREA_STYLE: SafeHtml = unsafeHtml(
+  'padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-family: var(--font-mono); font-size: var(--font-size-xs); resize: vertical;',
+);

--- a/packages/dashboard/src/views/agents-list.ts
+++ b/packages/dashboard/src/views/agents-list.ts
@@ -47,7 +47,12 @@ export function renderAgentsList(input: AgentsListInput): string {
   const body = html`
     ${pageHeader({
       title: 'Agents',
-      cta: html`<a class="btn btn--ghost btn--sm" href="/help/tutorial">Open tutorial</a>`,
+      cta: html`
+        <span style="display: inline-flex; gap: var(--space-2);">
+          <a class="btn btn--ghost btn--sm" href="/help/tutorial">Tutorial</a>
+          <a class="btn btn--primary btn--sm" href="/agents/new">New agent</a>
+        </span>
+      `,
     })}
 
     ${empty ? renderEmptyState() : renderStatStrip(input.stats)}
@@ -111,13 +116,16 @@ function renderEmptyState(): SafeHtml {
   return html`
     <section class="card" style="padding: var(--space-8) var(--space-6); text-align: center; margin-bottom: var(--space-6);">
       <h2 style="margin-top: 0;">No agents yet</h2>
-      <p class="dim" style="max-width: 42ch; margin: 0 auto var(--space-4);">
-        An agent is a YAML file under <code>agents/</code> that describes a task sua can run.
-        Scaffold your first one with:
+      <p class="dim" style="max-width: 48ch; margin: 0 auto var(--space-4);">
+        An agent is a named task sua can run. Create one right now from the dashboard,
+        or follow the guided tutorial.
       </p>
-      <pre style="display: inline-block; background: var(--color-terminal-bg); color: var(--color-terminal-fg); margin: 0 auto;">sua init &amp;&amp; sua agent new</pre>
-      <p style="margin-top: var(--space-4);">
-        <a class="btn btn--primary" href="/help/tutorial">Open the dashboard tutorial</a>
+      <p style="display: flex; gap: var(--space-3); justify-content: center; margin: 0;">
+        <a class="btn btn--primary" href="/agents/new">New agent</a>
+        <a class="btn" href="/help/tutorial">Open tutorial</a>
+      </p>
+      <p class="dim" style="margin-top: var(--space-4); font-size: var(--font-size-xs);">
+        Prefer the terminal? <code>sua init &amp;&amp; sua agent new</code>
       </p>
     </section>
   `;
@@ -133,6 +141,34 @@ function renderV2Card(a: Agent, lastRun?: Run): SafeHtml {
 
   const mcpBadge = a.mcp ? html`<span class="badge badge--info">mcp</span>` : html``;
 
+  // Multi-node agents get an inline <details> to reveal each node without
+  // having to click through to the agent detail page. Single-node agents
+  // skip the disclosure entirely — nothing meaningful to reveal.
+  const nodesDisclosure = a.nodes.length > 1
+    ? html`
+      <details class="agent-card__nodes">
+        <summary>Show ${String(a.nodes.length)} nodes</summary>
+        <ol class="agent-card__node-list">
+          ${a.nodes.map((n) => {
+            const body = n.type === 'shell' ? oneLine(n.command ?? '') : oneLine(n.prompt ?? '');
+            const typeClass = n.type === 'shell' ? 'badge--ok' : 'badge--info';
+            const deps = n.dependsOn?.length ? html`<span class="dim" style="font-size: var(--font-size-xs);"> \u2190 ${n.dependsOn.join(', ')}</span>` : html``;
+            return html`
+              <li>
+                <div style="display: flex; align-items: center; gap: var(--space-1); flex-wrap: wrap;">
+                  <code>${n.id}</code>
+                  <span class="badge ${typeClass}">${n.type}</span>
+                  ${deps}
+                </div>
+                <div class="mono dim agent-card__node-body">${body}</div>
+              </li>
+            `;
+          }) as unknown as SafeHtml[]}
+        </ol>
+      </details>
+    `
+    : html``;
+
   return html`
     <article class="agent-card">
       <div class="agent-card__header">
@@ -146,6 +182,7 @@ function renderV2Card(a: Agent, lastRun?: Run): SafeHtml {
         <span><strong>${String(a.nodes.length)}</strong> node${a.nodes.length === 1 ? '' : 's'}</span>
         ${a.schedule ? html`<span>Cron <span class="mono">${a.schedule}</span></span>` : html``}
       </div>
+      ${nodesDisclosure}
       <div class="agent-card__footer">
         <span class="agent-card__dag-shape" aria-hidden="true">${shape}</span>
         ${runInfo}
@@ -156,6 +193,12 @@ function renderV2Card(a: Agent, lastRun?: Run): SafeHtml {
       </div>
     </article>
   `;
+}
+
+function oneLine(text: string, max = 80): string {
+  const collapsed = text.replace(/\s+/g, ' ').trim();
+  if (collapsed.length <= max) return collapsed;
+  return collapsed.slice(0, max - 1) + '\u2026';
 }
 
 /**

--- a/packages/dashboard/src/views/dag-view.ts
+++ b/packages/dashboard/src/views/dag-view.ts
@@ -24,17 +24,23 @@ export function renderDagView(args: {
   const payload = JSON.stringify({ elements });
   const navAttr = navBase ? ` data-nav-base="${escapeAttr(navBase)}"` : '';
 
+  // Wrap the canvas in <details open> so users can collapse the DAG viz
+  // when a deep run detail has scrolled past the structural view they
+  // already saw on /agents/:id. The summary mirrors the other
+  // collapsible-section styling (.run-node, .agent-card__nodes).
   return html`
-    <div style="margin: 1rem 0;">
-      <div
-        id="dag-canvas"
-        style="width: 100%; height: 320px; border: 1px solid var(--border); border-radius: 0.5rem; background: #fff;"
-        ${unsafeHtml(navAttr)}
-      ></div>
-      <script id="dag-data" type="application/json">${unsafeHtml(escapeScriptTag(payload))}</script>
-      <script src="/assets/cytoscape.min.js"></script>
-      <script src="/assets/graph-render.js"></script>
-    </div>
+    <details class="dag-disclosure" open>
+      <summary class="dag-disclosure__summary">
+        <span>DAG</span>
+        <span class="dim" style="font-size: var(--font-size-xs);">${String(agent.nodes.length)} node${agent.nodes.length === 1 ? '' : 's'}</span>
+      </summary>
+      <div class="dag-disclosure__body">
+        <div id="dag-canvas" class="dag-frame__canvas"${unsafeHtml(navAttr)}></div>
+        <script id="dag-data" type="application/json">${unsafeHtml(escapeScriptTag(payload))}</script>
+        <script src="/assets/cytoscape.min.js"></script>
+        <script src="/assets/graph-render.js"></script>
+      </div>
+    </details>
   `;
 }
 

--- a/packages/dashboard/src/views/page-header.ts
+++ b/packages/dashboard/src/views/page-header.ts
@@ -1,5 +1,12 @@
 import { html, unsafeHtml, type SafeHtml } from './html.js';
 
+export interface PageHeaderBack {
+  /** Where the back link goes (relative URL on this dashboard). */
+  href: string;
+  /** Display label, e.g. "Back to runs" or "Back to demo-digest". */
+  label: string;
+}
+
 export interface PageHeaderOptions {
   title: string;
   /** Badges rendered next to the title (status, source, type, etc.). */
@@ -8,14 +15,21 @@ export interface PageHeaderOptions {
   cta?: SafeHtml;
   /** Optional full-width description below the title row. */
   description?: string;
+  /** Contextual back link rendered above the title. */
+  back?: PageHeaderBack;
 }
 
 /**
  * Consistent header for every detail screen. The primary CTA is
  * right-aligned so the user's eye always finds the main action in the
- * same place regardless of screen.
+ * same place regardless of screen. An optional contextual back link
+ * sits above the title — derived from the request's Referer header by
+ * the caller, so it labels the actual page the user came from.
  */
 export function pageHeader(opts: PageHeaderOptions): SafeHtml {
+  const backBlock = opts.back
+    ? html`<a class="page-header__back" href="${opts.back.href}">\u2190 ${opts.back.label}</a>`
+    : unsafeHtml('');
   const metaBlock = opts.meta && opts.meta.length > 0
     ? html`<div class="page-header__meta">${opts.meta as unknown as SafeHtml[]}</div>`
     : unsafeHtml('');
@@ -28,10 +42,68 @@ export function pageHeader(opts: PageHeaderOptions): SafeHtml {
 
   return html`
     <header class="page-header">
+      ${backBlock}
       <h1>${opts.title}</h1>
       ${metaBlock}
       ${ctaBlock}
       ${descBlock}
     </header>
   `;
+}
+
+/**
+ * Pattern-match a Referer URL to a labeled back-link, optionally
+ * overridden by an explicit `from` query param.
+ *
+ * `fromParam` is a lightweight way to carry context across multiple
+ * hops (e.g. tutorial → agent detail → run-now → run detail). The
+ * Referer header only remembers the immediate predecessor; a
+ * `?from=tutorial` param, propagated through POST redirects, carries
+ * the originating page through N hops.
+ *
+ * Accepted `fromParam` values:
+ *   - 'tutorial' → Back to tutorial
+ *   - 'runs'     → Back to runs
+ *   - 'agents'   → Back to agents
+ * Unknown values fall back to Referer-based detection.
+ *
+ * Usage:
+ *   const back = deriveBack(req.headers.referer, expectedHost, req.query.from);
+ *   pageHeader({ title, back, ... });
+ */
+export function deriveBack(
+  referer: string | undefined,
+  expectedHost: string | undefined,
+  fromParam?: unknown,
+): PageHeaderBack | undefined {
+  // Explicit overrides take precedence over Referer. They're set by
+  // callers who know they originated from a specific place.
+  if (typeof fromParam === 'string') {
+    if (fromParam === 'tutorial') return { href: '/help/tutorial', label: 'Back to tutorial' };
+    if (fromParam === 'runs') return { href: '/runs', label: 'Back to runs' };
+    if (fromParam === 'agents') return { href: '/agents', label: 'Back to agents' };
+  }
+
+  if (!referer || !expectedHost) return undefined;
+  let url: URL;
+  try {
+    url = new URL(referer);
+  } catch {
+    return undefined;
+  }
+  if (url.host !== expectedHost) return undefined;
+
+  const path = url.pathname;
+  if (path === '/' || path === '/agents') return { href: '/agents', label: 'Back to agents' };
+  if (path === '/runs') return { href: '/runs' + (url.search || ''), label: 'Back to runs' };
+  if (path.startsWith('/runs/')) return { href: path, label: 'Back to that run' };
+  if (path === '/help') return { href: '/help', label: 'Back to help' };
+  if (path === '/help/tutorial') return { href: '/help/tutorial', label: 'Back to tutorial' };
+  if (path.startsWith('/settings')) return { href: path, label: 'Back to settings' };
+  // /agents/<id> — best-effort label using the path slug.
+  const agentMatch = path.match(/^\/agents\/([a-z0-9][a-z0-9-]*)$/);
+  if (agentMatch) return { href: path, label: `Back to ${agentMatch[1]}` };
+  // /agents/<id>/add-node etc. — generic.
+  if (path.startsWith('/agents/')) return { href: path, label: 'Back' };
+  return undefined;
 }

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -1,7 +1,7 @@
 import type { Agent, NodeExecutionRecord, Run } from '@some-useful-agents/core';
 import { html, render, unsafeHtml, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
-import { pageHeader } from './page-header.js';
+import { pageHeader, type PageHeaderBack } from './page-header.js';
 import { statusBadge, outputFrame, formatDuration } from './components.js';
 import { renderDagView, renderDagFallback } from './dag-view.js';
 
@@ -13,10 +13,12 @@ export interface RunDetailOptions {
   nodeExecutions?: NodeExecutionRecord[];
   /** v2 agent definition at the run's version, for DAG rendering + node labels. */
   agent?: Agent;
+  /** Contextual back link derived from the request's Referer header. */
+  back?: PageHeaderBack;
 }
 
 export function renderRunDetail(opts: RunDetailOptions): string {
-  const { run, partial, nodeExecutions, agent } = opts;
+  const { run, partial, nodeExecutions, agent, back } = opts;
   const inProgress = run.status === 'running' || run.status === 'pending';
 
   // Run id is a UUID — safe to inline in an attribute without re-escaping.
@@ -33,10 +35,8 @@ export function renderRunDetail(opts: RunDetailOptions): string {
   ` : html``;
 
   const dagSection = isDagRun ? html`
-    <section class="dag-frame">
-      ${renderDagFallback(agent)}
-      ${renderDagView({ agent, nodeExecs: nodeExecutions, navBase: `/runs/${run.id}` })}
-    </section>
+    ${renderDagFallback(agent)}
+    ${renderDagView({ agent, nodeExecs: nodeExecutions, navBase: `/runs/${run.id}` })}
   ` : html``;
 
   // Per-node execution as click-expandable cards (one <details> per node).
@@ -53,6 +53,7 @@ export function renderRunDetail(opts: RunDetailOptions): string {
     : pageHeader({
         title: `Run ${run.id.slice(0, 8)}`,
         meta: [statusBadge(run.status)],
+        back,
       });
 
   const fragment = html`

--- a/packages/dashboard/src/views/tutorial.ts
+++ b/packages/dashboard/src/views/tutorial.ts
@@ -3,12 +3,11 @@ import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
 
 /**
- * Dashboard-native replacement for `sua tutorial`. Unlike the CLI
- * walkthrough (which is an interactive stdin/stdout flow), this is a
- * single-page progress tracker: every step's "done" state is derived
- * from observable project state (agents exist, runs exist, secrets
- * store touched, etc.). That means refreshing the page tells you the
- * real state of your project — not a cookie-remembered script.
+ * Dashboard-native replacement for `sua tutorial`. Each step has an
+ * inline action button that does the thing — no "open a terminal and
+ * run X" handoffs. Step completion is derived from observable project
+ * state (agents exist, runs exist, secrets declared, etc.) so a refresh
+ * always reflects reality, not a cookie-remembered script.
  */
 
 export interface TutorialState {
@@ -16,14 +15,20 @@ export interface TutorialState {
   agentCount: number;
   /** Whether any agent has ever been run in this project. */
   hasAnyRun: boolean;
-  /** Whether any run's node_executions contain a DAG run (multi-node agent). */
+  /** Whether any run has a workflowId (i.e. it executed a multi-node DAG). */
   hasDagRun: boolean;
   /** Whether any agent uses at least one secret. */
   usesSecrets: boolean;
-  /** Id of the first agent, for deep-link CTAs ("Run hello now"). */
+  /** Id of the friendliest starting agent (single-node v2 preferred). */
   firstAgentId?: string;
   /** Id of the most recent run, for the "inspect output" step. */
   latestRunId?: string;
+  /** Whether the tutorial's scaffolded `hello` agent is already in the DB. */
+  hasHelloAgent: boolean;
+  /** Whether the tutorial's scaffolded `demo-digest` 2-node DAG is in the DB. */
+  hasDemoDag: boolean;
+  /** Optional flash message from a scaffold action (success or error). */
+  flash?: string;
 }
 
 interface Step {
@@ -31,27 +36,32 @@ interface Step {
   title: string;
   done: boolean;
   summary: SafeHtml;
-  cta?: SafeHtml;
+  action?: SafeHtml;
 }
 
 export function renderTutorial(state: TutorialState): string {
   const steps = buildSteps(state);
   const doneCount = steps.filter((s) => s.done).length;
   const totalCount = steps.length;
+  const allDone = doneCount === totalCount;
 
-  const progressCard = html`
+  const flashBlock = state.flash
+    ? html`<div class="flash flash--info">${state.flash}</div>`
+    : html``;
+
+  const progress = html`
     <section class="card" style="margin-bottom: var(--space-6);">
       <p class="card__title">Progress</p>
       <p style="font-size: var(--font-size-md); margin: 0;">
         <strong>${String(doneCount)}</strong>
         <span class="dim"> of ${String(totalCount)} steps complete</span>
       </p>
-      ${doneCount === totalCount
+      ${allDone
         ? html`<p class="dim" style="margin: var(--space-2) 0 0;">
             You've covered the basics. See <a href="/help">the full CLI reference</a> for what's next.
           </p>`
         : html`<p class="dim" style="margin: var(--space-2) 0 0;">
-            Each step's status is derived from your project's real state — refresh to re-check.
+            Each step's status reflects your project's real state. Actions below run right here \u2014 no terminal required.
           </p>`}
     </section>
   `;
@@ -61,10 +71,10 @@ export function renderTutorial(state: TutorialState): string {
   const body = html`
     ${pageHeader({
       title: 'Dashboard tutorial',
-      description: 'A guided first-run for the dashboard. Each step links to the page where the action happens.',
+      description: 'A guided first-run for the dashboard. Each step has an inline action.',
     })}
-
-    ${progressCard}
+    ${flashBlock}
+    ${progress}
 
     <ol style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: var(--space-3);">
       ${stepBlocks as unknown as SafeHtml[]}
@@ -76,72 +86,208 @@ export function renderTutorial(state: TutorialState): string {
 
 function buildSteps(s: TutorialState): Step[] {
   return [
-    {
-      n: 1,
-      title: 'You have a project',
-      done: s.agentCount > 0,
-      summary: s.agentCount > 0
-        ? html`<span class="dim">${String(s.agentCount)} agent${s.agentCount === 1 ? '' : 's'} registered.</span>`
-        : html`<span class="dim">No agents yet. Run <code>sua init</code> to scaffold a starter in your project directory.</span>`,
-      cta: s.agentCount > 0
-        ? html`<a class="btn btn--sm" href="/agents">See agents</a>`
-        : undefined,
-    },
-    {
-      n: 2,
-      title: 'Run your first agent',
-      done: s.hasAnyRun,
-      summary: s.hasAnyRun
-        ? html`<span class="dim">At least one run recorded. Nice.</span>`
-        : s.firstAgentId
-          ? html`<span class="dim">Open <code>${s.firstAgentId}</code> and click <strong>Run now</strong> in the header.</span>`
-          : html`<span class="dim">Create an agent first (step 1).</span>`,
-      cta: !s.hasAnyRun && s.firstAgentId
-        ? html`<a class="btn btn--primary btn--sm" href="/agents/${s.firstAgentId}">Open ${s.firstAgentId}</a>`
-        : s.hasAnyRun
-          ? html`<a class="btn btn--sm" href="/runs">View runs</a>`
-          : undefined,
-    },
-    {
-      n: 3,
-      title: 'Inspect the output',
-      done: s.hasAnyRun && !!s.latestRunId,
-      summary: s.latestRunId
-        ? html`<span class="dim">Open the latest run to see status, duration, and per-node stdout.</span>`
-        : html`<span class="dim">Run an agent first (step 2).</span>`,
-      cta: s.latestRunId
-        ? html`<a class="btn btn--sm" href="/runs/${s.latestRunId}">Open latest run</a>`
-        : undefined,
-    },
-    {
-      n: 4,
-      title: 'See a multi-node DAG in action',
-      done: s.hasDagRun,
-      summary: s.hasDagRun
-        ? html`<span class="dim">You've executed a multi-node agent. The DAG view on each run shows node status end-to-end.</span>`
-        : html`<span class="dim">
-            Multi-node agents run nodes in topological order, passing outputs downstream. Create one
-            by chaining YAML agents with <code>dependsOn:</code>, then
-            <code>sua workflow import --apply</code> to merge them into a DAG agent.
-          </span>`,
-      cta: s.hasDagRun
-        ? html`<a class="btn btn--sm" href="/agents">Browse DAG agents</a>`
-        : html`<a class="btn btn--sm" href="/help#agents-workflows">CLI reference</a>`,
-    },
-    {
-      n: 5,
-      title: 'Wire up a secret',
-      done: s.usesSecrets,
-      summary: s.usesSecrets
-        ? html`<span class="dim">At least one agent declares a secret. Verify it's set from the Settings page.</span>`
-        : html`<span class="dim">
-            To call external APIs, declare <code>secrets: [SLACK_WEBHOOK]</code> on a node, then
-            <code>sua secrets set SLACK_WEBHOOK</code> to store the value. Nothing ever renders in the UI.
-          </span>`,
-      cta: html`<a class="btn btn--sm" href="/settings/secrets">Settings → Secrets</a>`,
-    },
+    step1HaveProject(s),
+    step2RunAnAgent(s),
+    step3InspectOutput(s),
+    step4MultiNodeDag(s),
+    step5WireUpSecret(s),
   ];
 }
+
+// ─── Step 1 ──────────────────────────────────────────────────────────
+// "You have a project" — done when any agent is registered. Empty-state
+// previews exactly what the scaffold-hello action will create, then the
+// button does it; the redirect lands on /agents/hello so the user
+// actually sees what they made instead of a flash on this same page.
+function step1HaveProject(s: TutorialState): Step {
+  const done = s.agentCount > 0;
+
+  let summary: SafeHtml;
+  if (done) {
+    summary = html`<span class="dim">${String(s.agentCount)} agent${s.agentCount === 1 ? '' : 's'} registered. <a href="/agents">See them all \u2192</a></span>`;
+  } else {
+    summary = html`
+      <div class="dim" style="margin-bottom: var(--space-3);">You have no agents yet. The button below will create a minimal one-node agent so you have something to run.</div>
+      ${scaffoldPreview({
+        kind: 'agent',
+        id: 'hello',
+        description: 'A minimal starter agent.',
+        nodes: [{ id: 'greet', type: 'shell', body: "echo 'Hello from some-useful-agents!'" }],
+      })}
+    `;
+  }
+
+  let action: SafeHtml | undefined;
+  if (done) {
+    action = html`<a class="btn btn--sm" href="/agents">See agents \u2192</a>`;
+  } else {
+    action = html`
+      <form method="POST" action="/help/tutorial/scaffold-hello" style="margin: 0; display: inline;">
+        <button type="submit" class="btn btn--primary btn--sm">Create "hello" agent</button>
+      </form>
+    `;
+  }
+
+  return { n: 1, title: 'You have a project', done, summary, action };
+}
+
+// ─── Step 2 ──────────────────────────────────────────────────────────
+// "Run your first agent" — done when any run exists. Action is a real
+// Run-now form for the friendliest starting agent; no navigation needed.
+function step2RunAnAgent(s: TutorialState): Step {
+  const done = s.hasAnyRun;
+  const summary = done
+    ? html`<span class="dim">You've executed at least one run. Next: read its output.</span>`
+    : s.firstAgentId
+      ? html`<span class="dim">Click below to run <code>${s.firstAgentId}</code>. You'll land on the run detail page with stdout.</span>`
+      : html`<span class="dim">Create an agent first (step 1).</span>`;
+
+  let action: SafeHtml | undefined;
+  if (done) {
+    action = html`<a class="btn btn--sm" href="/runs">View runs \u2192</a>`;
+  } else if (s.firstAgentId) {
+    action = html`
+      <form method="POST" action="/agents/${s.firstAgentId}/run" style="margin: 0; display: inline;">
+        <input type="hidden" name="from" value="tutorial">
+        <button type="submit" class="btn btn--primary btn--sm">Run ${s.firstAgentId} now</button>
+      </form>
+    `;
+  }
+
+  return { n: 2, title: 'Run your first agent', done, summary, action };
+}
+
+// ─── Step 3 ──────────────────────────────────────────────────────────
+// "Inspect the output" — done when a run exists AND we have its id.
+// Action deep-links to the latest run's detail page.
+function step3InspectOutput(s: TutorialState): Step {
+  const done = s.hasAnyRun && !!s.latestRunId;
+  const summary = s.latestRunId
+    ? html`<span class="dim">Open the latest run to see per-node stdout, status, duration, and any errors.</span>`
+    : html`<span class="dim">Run an agent first (step 2).</span>`;
+
+  const action = s.latestRunId
+    ? html`<a class="btn btn--primary btn--sm" href="/runs/${s.latestRunId}">Open latest run \u2192</a>`
+    : undefined;
+
+  return { n: 3, title: 'Inspect the output', done, summary, action };
+}
+
+// ─── Step 4 ──────────────────────────────────────────────────────────
+// "Multi-node DAG" — done when any run had workflowId. Action scaffolds
+// a 2-node demo agent (fetch → summarize) the user can run immediately.
+function step4MultiNodeDag(s: TutorialState): Step {
+  const done = s.hasDagRun;
+
+  let summary: SafeHtml;
+  let action: SafeHtml | undefined;
+
+  if (done) {
+    summary = html`<span class="dim">You've executed a multi-node agent. The DAG viz on each run shows node-level status.</span>`;
+    action = html`<a class="btn btn--sm" href="/agents">Browse DAG agents \u2192</a>`;
+  } else if (s.hasDemoDag) {
+    summary = html`<span class="dim">The <code>demo-digest</code> 2-node DAG is already scaffolded. <a href="/agents/demo-digest">View its DAG</a> or run it.</span>`;
+    action = html`
+      <form method="POST" action="/agents/demo-digest/run" style="margin: 0; display: inline;">
+        <input type="hidden" name="from" value="tutorial">
+        <button type="submit" class="btn btn--primary btn--sm">Run demo-digest</button>
+      </form>
+    `;
+  } else {
+    summary = html`
+      <div class="dim" style="margin-bottom: var(--space-3);">Multi-node agents run nodes in topological order, passing each node's stdout to its downstream as an env var. Here's what you'll create:</div>
+      ${scaffoldPreview({
+        kind: 'agent',
+        id: 'demo-digest',
+        description: 'fetch \u2192 digest. The first node emits some text; the second counts its words.',
+        nodes: [
+          { id: 'fetch', type: 'shell', body: "echo 'item-1 item-2 item-3'" },
+          { id: 'digest', type: 'shell', body: 'echo "Summary of:" && echo "$UPSTREAM_FETCH_RESULT" | wc -w', dependsOn: ['fetch'] },
+        ],
+      })}
+    `;
+    action = html`
+      <form method="POST" action="/help/tutorial/scaffold-demo-dag" style="margin: 0; display: inline;">
+        <button type="submit" class="btn btn--primary btn--sm">Scaffold demo DAG</button>
+      </form>
+    `;
+  }
+
+  return { n: 4, title: 'See a multi-node DAG in action', done, summary, action };
+}
+
+// ─── Step 5 ──────────────────────────────────────────────────────────
+// "Wire up a secret" — done when any agent declares a secret. Real CRUD
+// form lands in v0.15 PR 4; for now the action links to the placeholder
+// and the CLI command stays as the fallback.
+function step5WireUpSecret(s: TutorialState): Step {
+  const done = s.usesSecrets;
+  const summary = done
+    ? html`<span class="dim">At least one agent declares a secret. Verify it's set on the Settings page.</span>`
+    : html`
+        <span class="dim">
+          Declare <code>secrets: [SLACK_WEBHOOK]</code> on a node, then store the value with
+          <code>sua secrets set SLACK_WEBHOOK</code>. Dashboard CRUD for secrets lands in the next v0.15 PR.
+        </span>
+      `;
+
+  const action = html`<a class="btn btn--sm" href="/settings/secrets">Open Settings \u2192 Secrets</a>`;
+
+  return { n: 5, title: 'Wire up a secret', done, summary, action };
+}
+
+// ─── Preview helper ──────────────────────────────────────────────────
+
+interface ScaffoldNode {
+  id: string;
+  type: 'shell' | 'claude-code';
+  body: string;
+  dependsOn?: string[];
+}
+interface ScaffoldPreviewArgs {
+  kind: 'agent';
+  id: string;
+  description: string;
+  nodes: ScaffoldNode[];
+}
+
+/**
+ * Compact, inline preview of what a scaffold action will create. Sets
+ * expectations BEFORE the user clicks the button — so they're not just
+ * trusting an opaque "Create X" button to do something sensible.
+ */
+function scaffoldPreview(p: ScaffoldPreviewArgs): SafeHtml {
+  const nodeRows = p.nodes.map((n) => {
+    const depsLabel = n.dependsOn?.length
+      ? html` <span class="dim" style="font-size: var(--font-size-xs);">\u2190 depends on: ${n.dependsOn.join(', ')}</span>`
+      : html``;
+    return html`
+      <li style="margin-bottom: var(--space-2);">
+        <div>
+          <code>${n.id}</code>
+          <span class="badge badge--${n.type === 'shell' ? 'ok' : 'info'}" style="margin-left: var(--space-1);">${n.type}</span>
+          ${depsLabel}
+        </div>
+        <pre style="margin: var(--space-1) 0 0; padding: var(--space-2) var(--space-3); font-size: var(--font-size-xs); background: var(--color-surface-raised); border-radius: var(--radius-sm); overflow-x: auto;">${n.body}</pre>
+      </li>
+    `;
+  });
+
+  return html`
+    <div class="card card--muted" style="margin-top: var(--space-2);">
+      <div style="display: flex; align-items: baseline; gap: var(--space-2); margin-bottom: var(--space-2);">
+        <span class="card__title" style="margin: 0;">Will create</span>
+        <code style="font-size: var(--font-size-sm);">${p.id}</code>
+        <span class="dim" style="font-size: var(--font-size-xs);">\u2014 ${p.description}</span>
+      </div>
+      <ol style="margin: 0; padding-left: var(--space-6);">
+        ${nodeRows as unknown as SafeHtml[]}
+      </ol>
+    </div>
+  `;
+}
+
+// ─── Renderer ────────────────────────────────────────────────────────
 
 function renderStep(s: Step): SafeHtml {
   const statusBadge = s.done
@@ -150,11 +296,11 @@ function renderStep(s: Step): SafeHtml {
 
   return html`
     <li class="card" style="padding: var(--space-4) var(--space-6);">
-      <div style="display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-2);">
+      <div style="display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-2); flex-wrap: wrap;">
         <span class="mono dim" style="font-size: var(--font-size-xs);">Step ${String(s.n)}</span>
         <strong style="font-size: var(--font-size-md);">${s.title}</strong>
         ${statusBadge}
-        ${s.cta ? html`<span style="margin-left: auto;">${s.cta}</span>` : html``}
+        ${s.action ? html`<span style="margin-left: auto;">${s.action}</span>` : html``}
       </div>
       <div style="color: var(--color-text);">${s.summary}</div>
     </li>


### PR DESCRIPTION
## Summary

- v0.15.0 shipped a dashboard that could read agents but not create or edit them; every "make a new X" step dead-ended at the CLI. This PR makes the dashboard an actual create surface.
- **New routes:** \`/agents/new\` (create single-node agent), \`/agents/:id/add-node\` (append node + bump version), \`POST /help/tutorial/scaffold-hello\` + \`POST /help/tutorial/scaffold-demo-dag\` (one-click scaffolds).
- **Tutorial is now active:** each step has an inline action button + a "Will create" preview card before you click. Multi-hop \`?from=tutorial\` param propagates through POST redirects so the run detail's back link says "Back to tutorial" (not "Back to hello").
- **DAG viewer unified** between \`/agents/:id\` and \`/runs/:id\` (\`dag-view.ts\` was overriding with inline styles), softer tints, mono labels, wrapped in a collapsible \`<details open>\`.
- **Available variables panel** on the add-node form documents current templating syntax. \`docs/templating.md\` added with forward-looking v0.16 structured-outputs sketch.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npx vitest run packages/dashboard\` — 41/41 (35 → 41, +6 new cases)
- [x] Manual smoke test end-to-end against \`/tmp/sua-v15-test\`:
  - Empty state → New agent form → create → lands on add-node form with friendly "just created" message
  - Add a second node depending on the first → new version on the agent
  - Tutorial flow: scaffold hello → run from tutorial → run detail back link says "Back to tutorial"
  - Multi-node agent card on \`/agents\` expands to show nodes inline
  - DAG viewer collapses via the disclosure summary
- [ ] Visual review in browser

## Notes

- AI-assist ("Suggest with Claude" / "Write with Codex" on form fields) is scoped to v0.16 alongside structured outputs — needs the declared-outputs schema to have useful context. Plan file \`structured-outputs-v0.16.md\` coming right after this lands.
- Single-node creation via \`/agents/new\`; multi-node via \`/agents/:id/add-node\`. Real inline DAG drag-drop + version diff lands in PR 3 of v0.15.