### PR TITLE
feat(dashboard): version history + status toggle + rollback (re-ship of orphaned #63)

### DIFF
--- a/.changeset/dashboard-v015-versions-status.md
+++ b/.changeset/dashboard-v015-versions-status.md
@@ -1,0 +1,45 @@
+---
+"@some-useful-agents/dashboard": minor
+---
+
+**feat: agent version history + status toggle + rollback (PR 2 of 5 for v0.15).**
+
+Makes the "every save = new version" story visible and actionable. Users can now see the full history of an agent's DAG, rollback to any prior version, and toggle an agent's lifecycle state from the UI — no more dropping to the CLI for `sua workflow status`.
+
+### What ships
+
+- **Status dropdown** on the agent detail inspector aside — `active` / `paused` / `draft` / `archived`. Writes through `POST /agents/:id/status` → `agentStore.updateAgentMeta`. Same values the CLI accepts.
+- **`GET /agents/:id/versions`** — table of every version with creation time, author, commit message, and a rollback button per non-current row. Current version is highlighted.
+- **`GET /agents/:id/versions/:version`** — single-version viewer showing the DAG as it was at that point in time, with a "Rollback to this version" primary CTA.
+- **`POST /agents/:id/rollback`** — reconstructs the target version's DAG and calls `createNewVersion` to produce a NEW version whose structure matches the target. Append-only: nothing is deleted, rollback is itself a versioned event.
+- Agent detail inspector gains:
+  - A **"history →"** link next to the version field
+  - A **"Versions"** button in the action row
+  - (Already had "+ Add node" from PR 1.6)
+
+### Design choices
+
+- **Rollback creates, doesn't mutate.** The alternative — setting `current_version` back to v1 — would hide the rollback from history. Creating a new v3 that matches v1's DAG is auditable and reversible.
+- **Status is metadata, not a version.** `updateAgentMeta` doesn't bump the version because status isn't part of the DAG schema. Only structural changes produce new versions.
+- **No diff view yet.** Showing a side-by-side DAG diff between v1 and v2 requires editor context to be useful; deferred to PR 3. For now, the single-version view shows each version's DAG in isolation.
+- **No general-purpose `POST /agents/:id/save` endpoint yet.** Without the editable inspector (PR 3) there's no UI to trigger it, and designing the API without a consumer risks getting it wrong. Lands alongside PR 3.
+
+### Files
+
+- New: `packages/dashboard/src/views/versions.ts`
+- New: `packages/dashboard/src/routes/versions.ts` (versions list, single version, rollback, status)
+- Modified: `views/agent-detail-v2.ts` (inspector aside now has Status section + versions links), `index.ts` (mounts the new router)
+
+### Tests
+
+48 total (41 → 48; +7 new):
+- `/agents/:id/versions` lists all versions with current marked
+- `/agents/:id/versions/:version` renders the DAG as it was at that version
+- Rollback creates a new version matching the target DAG, with a "Rollback to vN" commit message
+- Rollback rejects invalid target version (404)
+- Status toggle changes status + rejects invalid enum values
+- Agent detail renders the status dropdown form + versions link
+
+### Plan
+
+Remaining v0.15 PRs: **3 (inspector editing + drag-drop) → 4 (settings CRUD + passphrase modal + MCP token rotate) → 5 (replay UI + states/microcopy polish)**.

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -687,6 +687,136 @@ describe('Dashboard contextual back link (PR 1.6)', () => {
   });
 });
 
+describe('Dashboard version history + status toggle (PR 2)', () => {
+  async function seedTwoVersionAgent(id = 'ver-test') {
+    agentStore.createAgent({
+      id, name: 'Ver Test', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'a', type: 'shell', command: 'echo v1' }],
+    }, 'cli', 'initial import');
+    agentStore.createNewVersion(id, {
+      id, name: 'Ver Test', status: 'active', source: 'local', mcp: false,
+      nodes: [
+        { id: 'a', type: 'shell', command: 'echo v1' },
+        { id: 'b', type: 'shell', command: 'echo v2', dependsOn: ['a'] },
+      ],
+    }, 'dashboard', 'added node b');
+  }
+
+  it('GET /agents/:id/versions lists all versions with current marked', async () => {
+    const app = await makeApp();
+    await seedTwoVersionAgent();
+    const res = await request(app).get('/agents/ver-test/versions')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('ver-test');
+    expect(res.text).toContain('v1');
+    expect(res.text).toContain('v2');
+    expect(res.text).toContain('initial import');
+    expect(res.text).toContain('added node b');
+    // v2 is current (most recent), so current badge shows there.
+    expect(res.text).toMatch(/v2[\s\S]*?badge--ok[\s\S]*?current/);
+  });
+
+  it('GET /agents/:id/versions/:version renders the DAG as it was', async () => {
+    const app = await makeApp();
+    await seedTwoVersionAgent();
+    const res = await request(app).get('/agents/ver-test/versions/1')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    // v1 only had node "a", not "b".
+    expect(res.text).toMatch(/<td class="mono">a<\/td>/);
+    expect(res.text).not.toMatch(/<td class="mono">b<\/td>/);
+  });
+
+  it('POST /agents/:id/rollback creates a new version matching the target DAG', async () => {
+    const app = await makeApp();
+    await seedTwoVersionAgent();
+    const res = await request(app)
+      .post('/agents/ver-test/rollback')
+      .type('form')
+      .send({ targetVersion: '1' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/^\/agents\/ver-test\/versions\?flash=/);
+
+    // A v3 should now exist, identical to v1's DAG (single node "a").
+    const updated = agentStore.getAgent('ver-test');
+    expect(updated!.version).toBe(3);
+    expect(updated!.nodes).toHaveLength(1);
+    expect(updated!.nodes[0].id).toBe('a');
+    const v3 = agentStore.getVersion('ver-test', 3);
+    expect(v3!.commitMessage).toBe('Rollback to v1');
+  });
+
+  it('POST /agents/:id/rollback rejects an invalid target', async () => {
+    const app = await makeApp();
+    await seedTwoVersionAgent();
+    const res = await request(app)
+      .post('/agents/ver-test/rollback')
+      .type('form')
+      .send({ targetVersion: '99' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(decodeURIComponent(res.headers.location)).toMatch(/v99 not found/);
+    // No new version was created.
+    expect(agentStore.getAgent('ver-test')!.version).toBe(2);
+  });
+
+  it('POST /agents/:id/status toggles agent status', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'status-test', name: 'X', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'n', type: 'shell', command: 'echo' }],
+    }, 'cli');
+
+    const res = await request(app)
+      .post('/agents/status-test/status')
+      .type('form')
+      .send({ newStatus: 'paused' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(agentStore.getAgent('status-test')!.status).toBe('paused');
+  });
+
+  it('POST /agents/:id/status rejects an invalid status enum', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'status-test-2', name: 'X', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'n', type: 'shell', command: 'echo' }],
+    }, 'cli');
+
+    const res = await request(app)
+      .post('/agents/status-test-2/status')
+      .type('form')
+      .send({ newStatus: 'banana' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(decodeURIComponent(res.headers.location)).toMatch(/Invalid status/);
+    // Status unchanged.
+    expect(agentStore.getAgent('status-test-2')!.status).toBe('active');
+  });
+
+  it('agent detail renders the status dropdown + version history link', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'detail-ver', name: 'X', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'n', type: 'shell', command: 'echo' }],
+    }, 'cli');
+    const res = await request(app).get('/agents/detail-ver')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('action="/agents/detail-ver/status"');
+    expect(res.text).toContain('/agents/detail-ver/versions');
+  });
+});
+
 describe('Dashboard run-now gate', () => {
   it('POST /agents/hello/run submits and redirects to /runs/:id', async () => {
     const app = await makeApp();

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -21,6 +21,7 @@ import { runNowRouter } from './routes/run-now.js';
 import { assetsRouter } from './routes/assets.js';
 import { settingsRouter } from './routes/settings.js';
 import { helpRouter } from './routes/help.js';
+import { versionsRouter } from './routes/versions.js';
 
 export interface StartDashboardOptions {
   port: number;
@@ -84,6 +85,7 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   app.use(runNowRouter);
   app.use(settingsRouter);
   app.use(helpRouter);
+  app.use(versionsRouter);
 
   // Catch-all 404 for authenticated routes.
   app.use((_req, res) => {

--- a/packages/dashboard/src/routes/versions.ts
+++ b/packages/dashboard/src/routes/versions.ts
@@ -1,0 +1,148 @@
+import { Router, type Request, type Response } from 'express';
+import { getContext } from '../context.js';
+import { renderVersionsList, renderVersionDetail } from '../views/versions.js';
+
+/**
+ * Version history + rollback routes for v2 DAG agents.
+ *
+ * - `GET  /agents/:id/versions`           — list all versions of an agent
+ * - `GET  /agents/:id/versions/:version`  — view a single version's DAG
+ * - `POST /agents/:id/rollback`           — create a new version whose DAG matches a target version's
+ * - `POST /agents/:id/status`             — change agent status (active/paused/archived/draft)
+ *
+ * All routes are under `requireAuth`; POST routes rely on the Origin +
+ * Host checks in auth-middleware.ts as the CSRF defence (Origin is the
+ * same posture as run-now.ts).
+ *
+ * Rollback always creates a *new* version (via `createNewVersion`),
+ * never mutates pointer-only. Keeps `agent_versions` append-only so a
+ * rollback is itself a historical event you can audit or reverse.
+ */
+
+const VALID_STATUSES = new Set(['active', 'paused', 'archived', 'draft']);
+
+export const versionsRouter: Router = Router();
+
+versionsRouter.get('/agents/:id/versions', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const agent = ctx.agentStore.getAgent(id);
+  if (!agent) {
+    res.status(404).redirect(303, '/agents');
+    return;
+  }
+  const versions = ctx.agentStore.listVersions(id);
+  const flashParam = typeof req.query.flash === 'string' ? req.query.flash : undefined;
+  const flash = flashParam ? { kind: 'ok' as const, message: flashParam } : undefined;
+  res.type('html').send(renderVersionsList({ agent, versions, flash }));
+});
+
+versionsRouter.get('/agents/:id/versions/:version', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const versionRaw = Array.isArray(req.params.version) ? req.params.version[0] : req.params.version;
+  const versionNum = Number.parseInt(versionRaw, 10);
+  if (!Number.isFinite(versionNum) || versionNum < 1) {
+    res.status(404).redirect(303, `/agents/${encodeURIComponent(id)}/versions`);
+    return;
+  }
+  const agent = ctx.agentStore.getAgent(id);
+  if (!agent) {
+    res.status(404).redirect(303, '/agents');
+    return;
+  }
+  const version = ctx.agentStore.getVersion(id, versionNum);
+  if (!version) {
+    res.status(404).redirect(303, `/agents/${encodeURIComponent(id)}/versions`);
+    return;
+  }
+  res.type('html').send(renderVersionDetail({ agent, version }));
+});
+
+versionsRouter.post('/agents/:id/rollback', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const targetRaw = body.targetVersion;
+  const target = typeof targetRaw === 'string' ? Number.parseInt(targetRaw, 10) : Number.NaN;
+
+  if (!Number.isFinite(target) || target < 1) {
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/versions?flash=${encodeURIComponent('Invalid target version.')}`);
+    return;
+  }
+
+  const agent = ctx.agentStore.getAgent(id);
+  if (!agent) {
+    res.status(404).redirect(303, '/agents');
+    return;
+  }
+  if (target === agent.version) {
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/versions?flash=${encodeURIComponent(`Already on v${target}. Nothing to roll back.`)}`);
+    return;
+  }
+
+  const targetVersion = ctx.agentStore.getVersion(id, target);
+  if (!targetVersion) {
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/versions?flash=${encodeURIComponent(`Version v${target} not found.`)}`);
+    return;
+  }
+
+  try {
+    // Reconstruct an Agent shape from the target version's DAG + the
+    // current agent's metadata (status, schedule, etc. aren't part of
+    // the DAG, so they carry over unchanged on rollback).
+    ctx.agentStore.createNewVersion(
+      id,
+      {
+        id: agent.id,
+        name: agent.name,
+        description: agent.description,
+        status: agent.status,
+        schedule: agent.schedule,
+        source: agent.source,
+        mcp: agent.mcp,
+        nodes: targetVersion.dag.nodes,
+        inputs: targetVersion.dag.inputs,
+        author: targetVersion.dag.author,
+        tags: targetVersion.dag.tags,
+      },
+      'dashboard',
+      `Rollback to v${target}`,
+    );
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/versions?flash=${encodeURIComponent(`Rolled back to v${target} (created a new version).`)}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/versions?flash=${encodeURIComponent(`Rollback failed: ${msg}`)}`);
+  }
+});
+
+versionsRouter.post('/agents/:id/status', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const newStatus = typeof body.newStatus === 'string' ? body.newStatus : undefined;
+
+  if (!newStatus || !VALID_STATUSES.has(newStatus)) {
+    res.redirect(303, `/agents/${encodeURIComponent(id)}?flash=${encodeURIComponent(`Invalid status. Must be one of: ${[...VALID_STATUSES].join(', ')}.`)}`);
+    return;
+  }
+
+  const agent = ctx.agentStore.getAgent(id);
+  if (!agent) {
+    res.status(404).redirect(303, '/agents');
+    return;
+  }
+
+  if (agent.status === newStatus) {
+    res.redirect(303, `/agents/${encodeURIComponent(id)}?flash=${encodeURIComponent(`Already ${newStatus}.`)}`);
+    return;
+  }
+
+  try {
+    ctx.agentStore.updateAgentMeta(id, { status: newStatus as 'active' | 'paused' | 'archived' | 'draft' });
+    res.redirect(303, `/agents/${encodeURIComponent(id)}?flash=${encodeURIComponent(`Status set to "${newStatus}".`)}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/agents/${encodeURIComponent(id)}?flash=${encodeURIComponent(`Status change failed: ${msg}`)}`);
+  }
+});

--- a/packages/dashboard/src/views/agent-detail-v2.ts
+++ b/packages/dashboard/src/views/agent-detail-v2.ts
@@ -1,5 +1,5 @@
 import type { Agent, Run, SecretsStore } from '@some-useful-agents/core';
-import { html, render, type SafeHtml } from './html.js';
+import { html, render, unsafeHtml, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader, type PageHeaderBack } from './page-header.js';
 import { sourceBadge, statusBadge, formatDuration, formatAge } from './components.js';
@@ -131,9 +131,26 @@ export async function renderAgentDetailV2(args: {
       </header>
 
       <section class="inspector__section">
+        <h4>Status</h4>
+        <form method="POST" action="/agents/${agent.id}/status" style="display: flex; gap: var(--space-2); align-items: center;">
+          <select name="newStatus" style="padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm);">
+            ${statusOption('active', agent.status)}
+            ${statusOption('paused', agent.status)}
+            ${statusOption('draft', agent.status)}
+            ${statusOption('archived', agent.status)}
+          </select>
+          <button type="submit" class="btn btn--sm">Apply</button>
+        </form>
+      </section>
+
+      <section class="inspector__section">
         <h4>Metadata</h4>
         <dl class="kv">
-          <dt>Version</dt><dd class="mono">v${String(agent.version)}</dd>
+          <dt>Version</dt>
+          <dd class="mono">
+            v${String(agent.version)}
+            <a href="/agents/${agent.id}/versions" class="dim" style="margin-left: var(--space-2); font-size: var(--font-size-xs);">history \u2192</a>
+          </dd>
           <dt>Schedule</dt><dd>${agent.schedule ?? html`<span class="dim">none</span>`}</dd>
           <dt>MCP</dt><dd>${agent.mcp ? 'exposed' : html`<span class="dim">not exposed</span>`}</dd>
           <dt>Nodes</dt><dd>${String(agent.nodes.length)}</dd>
@@ -149,7 +166,7 @@ export async function renderAgentDetailV2(args: {
 
       <div class="inspector__actions" style="flex-wrap: wrap;">
         <a class="btn btn--primary btn--sm" href="/agents/${agent.id}/add-node">+ Add node</a>
-        <a class="btn btn--sm" href="#nodes">Jump to nodes</a>
+        <a class="btn btn--sm" href="/agents/${agent.id}/versions">Versions</a>
         <a class="btn btn--sm" href="#runs">Recent runs</a>
       </div>
     </aside>
@@ -219,6 +236,11 @@ function vStatusBadge(status: string): SafeHtml {
     : status === 'archived' ? 'badge--muted'
     : 'badge--info';
   return html`<span class="badge ${kind}">${status}</span>`;
+}
+
+function statusOption(value: string, current: string): SafeHtml {
+  const selected = value === current ? unsafeHtml(' selected') : unsafeHtml('');
+  return html`<option value="${value}"${selected}>${value}</option>`;
 }
 
 function oneLine(text: string, max = 120): string {

--- a/packages/dashboard/src/views/versions.ts
+++ b/packages/dashboard/src/views/versions.ts
@@ -1,0 +1,145 @@
+import type { Agent, AgentVersion } from '@some-useful-agents/core';
+import { html, render, unsafeHtml, type SafeHtml } from './html.js';
+import { layout } from './layout.js';
+import { pageHeader } from './page-header.js';
+import { formatAge } from './components.js';
+
+/**
+ * Render the version history list for a single agent. Each row links to
+ * the single-version viewer and — for any row that isn't currently
+ * active — offers a "Rollback to v<N>" form that POSTs to the rollback
+ * endpoint. Rollback always creates a NEW version (not a pointer move)
+ * so the history stays append-only.
+ */
+export function renderVersionsList(args: {
+  agent: Agent;
+  versions: AgentVersion[];
+  flash?: { kind: 'error' | 'info' | 'ok'; message: string };
+}): string {
+  const { agent, versions, flash } = args;
+
+  const rows = versions.map((v) => {
+    const isCurrent = v.version === agent.version;
+    const rollbackButton = isCurrent
+      ? html`<span class="dim subtle">current</span>`
+      : html`
+          <form method="POST" action="/agents/${agent.id}/rollback" style="margin: 0;">
+            <input type="hidden" name="targetVersion" value="${String(v.version)}">
+            <button type="submit" class="btn btn--sm"
+              onclick="return confirm('Rollback agent \\'${agent.id}\\' to v${String(v.version)}? This creates a new version whose DAG matches v${String(v.version)}; nothing is deleted.');">
+              Rollback to v${String(v.version)}
+            </button>
+          </form>
+        `;
+    return html`
+      <tr ${isCurrent ? unsafeHtml('style="background: var(--color-surface-raised);"') : unsafeHtml('')}>
+        <td>
+          <a href="/agents/${agent.id}/versions/${String(v.version)}" class="mono">
+            v${String(v.version)}
+          </a>
+          ${isCurrent ? html` <span class="badge badge--ok">current</span>` : html``}
+        </td>
+        <td class="dim">${formatAge(v.createdAt)}</td>
+        <td class="mono dim">${v.createdBy}</td>
+        <td class="dim">${v.commitMessage ?? ''}</td>
+        <td>${rollbackButton}</td>
+      </tr>
+    `;
+  });
+
+  const body = html`
+    ${pageHeader({
+      title: `${agent.id} \u2014 versions`,
+      back: { href: `/agents/${agent.id}`, label: `Back to ${agent.id}` },
+      description: `Every save creates a new version. ${String(versions.length)} total, v${String(agent.version)} is current.`,
+    })}
+
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Version</th>
+          <th>Created</th>
+          <th>By</th>
+          <th>Commit message</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>${rows as unknown as SafeHtml[]}</tbody>
+    </table>
+  `;
+
+  return render(layout({ title: `${agent.id} versions`, activeNav: 'agents', flash }, body));
+}
+
+/**
+ * Render a single agent version — the DAG as it was at that point in
+ * time, plus a "Rollback to this version" action (disabled on current).
+ */
+export function renderVersionDetail(args: {
+  agent: Agent;
+  version: AgentVersion;
+}): string {
+  const { agent, version } = args;
+  const isCurrent = version.version === agent.version;
+  const dag = version.dag;
+
+  const nodeRows = dag.nodes.map((n) => {
+    const body = n.type === 'shell' ? oneLine(n.command ?? '') : oneLine(n.prompt ?? '');
+    const deps = n.dependsOn?.length ? n.dependsOn.join(', ') : html`<span class="dim">\u2014</span>`;
+    const typeClass = n.type === 'shell' ? 'badge--ok' : 'badge--info';
+    return html`
+      <tr>
+        <td class="mono">${n.id}</td>
+        <td><span class="badge ${typeClass}">${n.type}</span></td>
+        <td class="mono">${deps}</td>
+        <td class="dim">${body}</td>
+      </tr>
+    `;
+  });
+
+  const headerCta = isCurrent
+    ? html`<span class="badge badge--ok">current</span>`
+    : html`
+        <form method="POST" action="/agents/${agent.id}/rollback" style="margin: 0;">
+          <input type="hidden" name="targetVersion" value="${String(version.version)}">
+          <button type="submit" class="btn btn--primary"
+            onclick="return confirm('Rollback agent \\'${agent.id}\\' to v${String(version.version)}?');">
+            Rollback to this version
+          </button>
+        </form>
+      `;
+
+  const body = html`
+    ${pageHeader({
+      title: `${agent.id} \u2014 v${String(version.version)}`,
+      back: { href: `/agents/${agent.id}/versions`, label: `Back to versions` },
+      cta: headerCta,
+      description: `Created ${formatAge(version.createdAt)} by ${version.createdBy}${version.commitMessage ? ` \u2014 \u201c${version.commitMessage}\u201d` : ''}.`,
+    })}
+
+    <section>
+      <h2>Nodes at this version</h2>
+      <table class="table">
+        <thead>
+          <tr><th>Id</th><th>Type</th><th>Depends on</th><th>Body</th></tr>
+        </thead>
+        <tbody>${nodeRows as unknown as SafeHtml[]}</tbody>
+      </table>
+    </section>
+
+    ${dag.inputs && Object.keys(dag.inputs).length > 0 ? html`
+      <section style="margin-top: var(--space-6);">
+        <h2>Inputs</h2>
+        <pre>${JSON.stringify(dag.inputs, null, 2)}</pre>
+      </section>
+    ` : html``}
+  `;
+
+  return render(layout({ title: `${agent.id} v${String(version.version)}`, activeNav: 'agents' }, body));
+}
+
+function oneLine(text: string, max = 120): string {
+  const collapsed = text.replace(/\s+/g, ' ').trim();
+  if (collapsed.length <= max) return collapsed;
+  return collapsed.slice(0, max - 1) + '\u2026';
+}


### PR DESCRIPTION
## Summary

- PR #63 was marked merged on GitHub but its content never actually landed on main — it was stacked on #62's branch, which GitHub deleted when #62 merged, so #63's merge commit went nowhere useful.
- This PR re-opens the same content (rebased on current main) so it can land cleanly.

## What ships (same as #63)

- \`POST /agents/:id/status\` — status toggle dropdown on the inspector aside (active/paused/draft/archived).
- \`GET /agents/:id/versions\` — version history list with per-row rollback.
- \`GET /agents/:id/versions/:version\` — single-version viewer with rollback CTA.
- \`POST /agents/:id/rollback\` — creates a new version whose DAG matches the target; append-only history.
- Inspector aside on agent detail gains "history →" link + Versions button.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npx vitest run packages/dashboard\` — 48/48 pass
- [ ] Visual review in browser

## Note

If you prefer to keep #63's merged-state history, I can close this PR and you can just cherry-pick manually — but re-opening is the lowest-friction fix.