### PR TITLE
feat(dashboard): node edit + delete (PR 3a/5 for v0.15)

### DIFF
--- a/.changeset/dashboard-v015-node-edit.md
+++ b/.changeset/dashboard-v015-node-edit.md
@@ -1,0 +1,43 @@
+---
+"@some-useful-agents/dashboard": minor
+---
+
+**feat: node edit + delete in the dashboard (PR 3a of 5 for v0.15).**
+
+Closes the last big create/edit gap: users can now modify existing nodes and remove them without dropping to YAML or the CLI. Every change becomes a new version in the audit history.
+
+### What ships
+
+- **`GET /agents/:id/nodes/:nodeId/edit`** — form pre-filled with the node's current state (type, command/prompt, dependsOn). Node id is **read-only** — renaming would break every `{{upstream.<id>.result}}` / `$UPSTREAM_<ID>_RESULT` reference in the same agent. Users who want a different id delete + re-create.
+- **`POST /agents/:id/nodes/:nodeId/edit`** — validates + writes a new version via `createNewVersion`. Commit message is auto-set to `Edited node "<id>"`. Cycle guard re-runs server-side; the form's picker already hides downstream nodes but a hand-crafted POST can't bypass it.
+- **`POST /agents/:id/nodes/:nodeId/delete`** — removes the node + creates a new version. Refuses if:
+  - Any other node depends on this one (clear flash: `Cannot delete "fetch" — "digest" depends on it.`)
+  - The agent has only one node (delete the agent itself from the CLI instead)
+- **Inline Edit + Delete buttons** on every row of the agent detail Nodes table.
+
+### Design notes
+
+- **Node ids are immutable.** The form shows them in a disabled input with a hint explaining why. Rename becomes delete-and-recreate.
+- **Downstream-dep check on delete is explicit, not cascading.** Auto-trimming dependents' `dependsOn` would silently reshape the DAG; a loud refusal makes the user confront the consequence.
+- **Cycle guard uses colored-DFS.** Faster than re-running the full Zod schema for one topology check; re-validates only the edge under consideration.
+- **Fields not yet editable from the UI** (inputs, secrets, env, envAllowlist, allowedTools, model, maxTurns, timeout, redactSecrets) are preserved on edit — the form keeps them untouched, so editing a shell node's command doesn't wipe its secrets. Those land in PR 3b (the richer inspector) alongside drag-drop.
+
+### Files
+
+- New: `packages/dashboard/src/views/agent-edit-node.ts`
+- Modified: `packages/dashboard/src/routes/agents.ts` (GET + POST for /edit, POST for /delete, plus `hasCycleAfterEdit` helper); `views/agent-detail-v2.ts` (Edit/Delete buttons on node rows + new Actions column)
+
+### Tests
+
+55 total (48 → 55; +7 new):
+- GET edit pre-fills the form + id input is read-only
+- POST edit updates the node + bumps the version + leaves downstream alone
+- POST edit refuses a cycle-producing dependsOn with a 400
+- POST delete refuses when any node depends on the target
+- POST delete removes the node + bumps the version when nobody depends on it
+- POST delete refuses to remove the last node (1-node agent)
+- Agent detail renders Edit + Delete buttons on every row
+
+### Plan
+
+Remaining v0.15 PRs: **3b (DAG drag-drop visual, deferred as its own PR) → 4 (settings CRUD + passphrase modal + MCP rotate) → 5 (replay UI + polish)**. v0.16 plan for structured outputs + Claude/Codex AI-assist comes after v0.15 wraps.

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -817,6 +817,122 @@ describe('Dashboard version history + status toggle (PR 2)', () => {
   });
 });
 
+describe('Dashboard node edit + delete (PR 3a)', () => {
+  async function seedChainAgent(id = 'chain-edit') {
+    agentStore.createAgent({
+      id, name: 'Chain', status: 'active', source: 'local', mcp: false,
+      nodes: [
+        { id: 'a', type: 'shell', command: 'echo a' },
+        { id: 'b', type: 'shell', command: 'echo b', dependsOn: ['a'] },
+      ],
+    }, 'cli');
+  }
+
+  it('GET /agents/:id/nodes/:nodeId/edit pre-fills the form with node state', async () => {
+    const app = await makeApp();
+    await seedChainAgent();
+    const res = await request(app).get('/agents/chain-edit/nodes/a/edit')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Edit a');
+    expect(res.text).toContain('echo a');
+    // Id input is read-only.
+    expect(res.text).toMatch(/readonly[^>]*value="a"/);
+  });
+
+  it('POST edit updates the node and bumps the version', async () => {
+    const app = await makeApp();
+    await seedChainAgent();
+    const res = await request(app)
+      .post('/agents/chain-edit/nodes/a/edit')
+      .type('form')
+      .send({ type: 'shell', command: 'echo CHANGED' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/^\/agents\/chain-edit\?flash=/);
+
+    const updated = agentStore.getAgent('chain-edit')!;
+    expect(updated.version).toBe(2);
+    const a = updated.nodes.find((n) => n.id === 'a')!;
+    expect(a.command).toBe('echo CHANGED');
+    // Downstream node b left alone.
+    const b = updated.nodes.find((n) => n.id === 'b')!;
+    expect(b.command).toBe('echo b');
+    expect(b.dependsOn).toEqual(['a']);
+  });
+
+  it('POST edit refuses a cycle-producing dependsOn', async () => {
+    const app = await makeApp();
+    await seedChainAgent();
+    // Try to make "a" depend on "b" (which already depends on "a").
+    const res = await request(app)
+      .post('/agents/chain-edit/nodes/a/edit')
+      .type('form')
+      .send({ type: 'shell', command: 'echo a', dependsOn: 'b' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(400);
+    expect(res.text).toMatch(/cycle/i);
+    expect(agentStore.getAgent('chain-edit')!.version).toBe(1);
+  });
+
+  it('POST delete refuses when a downstream depends on the node', async () => {
+    const app = await makeApp();
+    await seedChainAgent();
+    const res = await request(app)
+      .post('/agents/chain-edit/nodes/a/delete')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(decodeURIComponent(res.headers.location)).toMatch(/"b" depends on it/);
+    // Nothing removed.
+    expect(agentStore.getAgent('chain-edit')!.nodes).toHaveLength(2);
+  });
+
+  it('POST delete removes the node when nobody depends on it', async () => {
+    const app = await makeApp();
+    await seedChainAgent();
+    const res = await request(app)
+      .post('/agents/chain-edit/nodes/b/delete')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(decodeURIComponent(res.headers.location)).toMatch(/Deleted "b"/);
+    const updated = agentStore.getAgent('chain-edit')!;
+    expect(updated.nodes).toHaveLength(1);
+    expect(updated.nodes[0].id).toBe('a');
+    expect(updated.version).toBe(2);
+  });
+
+  it('POST delete refuses to remove the last node', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'solo', name: 'Solo', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'only', type: 'shell', command: 'echo' }],
+    }, 'cli');
+    const res = await request(app)
+      .post('/agents/solo/nodes/only/delete')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(decodeURIComponent(res.headers.location)).toMatch(/last node/);
+  });
+
+  it('agent detail renders Edit + Delete buttons on every node row', async () => {
+    const app = await makeApp();
+    await seedChainAgent();
+    const res = await request(app).get('/agents/chain-edit')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('/agents/chain-edit/nodes/a/edit');
+    expect(res.text).toContain('/agents/chain-edit/nodes/b/edit');
+    expect(res.text).toContain('action="/agents/chain-edit/nodes/a/delete"');
+  });
+});
+
 describe('Dashboard run-now gate', () => {
   it('POST /agents/hello/run submits and redirects to /runs/:id', async () => {
     const app = await makeApp();

--- a/packages/dashboard/src/routes/agents.ts
+++ b/packages/dashboard/src/routes/agents.ts
@@ -6,6 +6,7 @@ import { renderAgentDetail } from '../views/agent-detail.js';
 import { renderAgentDetailV2 } from '../views/agent-detail-v2.js';
 import { renderAgentNew, type AgentNewFormValues } from '../views/agent-new.js';
 import { renderAgentAddNode, type AddNodeFormValues } from '../views/agent-add-node.js';
+import { renderAgentEditNode, type EditNodeFormValues } from '../views/agent-edit-node.js';
 import { deriveBack } from '../views/page-header.js';
 
 export const agentsRouter: Router = Router();
@@ -225,6 +226,224 @@ agentsRouter.post('/agents/:name/add-node', (req: Request, res: Response) => {
     }));
   }
 });
+
+/**
+ * GET  /agents/:name/nodes/:nodeId/edit    — form pre-filled with node's state
+ * POST /agents/:name/nodes/:nodeId/edit    — validate + write new agent version
+ * POST /agents/:name/nodes/:nodeId/delete  — remove the node (rejects if any
+ *                                             other node depends on it; users
+ *                                             delete downstream first)
+ *
+ * Node ids are immutable across edits — renaming would break every
+ * downstream `{{upstream.<id>.result}}` / `$UPSTREAM_<ID>_RESULT`
+ * reference. Users who want a different id delete + recreate.
+ */
+agentsRouter.get('/agents/:name/nodes/:nodeId/edit', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
+  const nodeId = Array.isArray(req.params.nodeId) ? req.params.nodeId[0] : req.params.nodeId;
+  const agent = ctx.agentStore.getAgent(name);
+  if (!agent) {
+    res.status(404).redirect(303, '/agents');
+    return;
+  }
+  const node = agent.nodes.find((n) => n.id === nodeId);
+  if (!node) {
+    res.status(404).redirect(303, `/agents/${encodeURIComponent(agent.id)}?flash=${encodeURIComponent(`Node "${nodeId}" not found.`)}`);
+    return;
+  }
+  res.type('html').send(renderAgentEditNode({ agent, node }));
+});
+
+agentsRouter.post('/agents/:name/nodes/:nodeId/edit', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
+  const nodeId = Array.isArray(req.params.nodeId) ? req.params.nodeId[0] : req.params.nodeId;
+  const agent = ctx.agentStore.getAgent(name);
+  if (!agent) {
+    res.status(404).redirect(303, '/agents');
+    return;
+  }
+  const node = agent.nodes.find((n) => n.id === nodeId);
+  if (!node) {
+    res.status(404).redirect(303, `/agents/${encodeURIComponent(agent.id)}`);
+    return;
+  }
+
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const rawDeps = body.dependsOn;
+  const dependsOn: string[] = Array.isArray(rawDeps)
+    ? rawDeps.filter((d): d is string => typeof d === 'string')
+    : typeof rawDeps === 'string' ? [rawDeps] : [];
+
+  const values: EditNodeFormValues = {
+    type: body.type === 'claude-code' ? 'claude-code' : 'shell',
+    command: typeof body.command === 'string' ? body.command : undefined,
+    prompt: typeof body.prompt === 'string' ? body.prompt : undefined,
+    dependsOn,
+  };
+
+  // Every declared dependency must be a node that's not the current
+  // node itself, not a downstream (cycle), and exists.
+  const existingIds = new Set(agent.nodes.map((n) => n.id));
+  if (dependsOn.includes(nodeId)) {
+    res.status(400).type('html').send(renderAgentEditNode({
+      agent, node, values, error: 'A node cannot depend on itself.',
+    }));
+    return;
+  }
+  const badDep = dependsOn.find((d) => !existingIds.has(d));
+  if (badDep) {
+    res.status(400).type('html').send(renderAgentEditNode({
+      agent, node, values, error: `Unknown upstream node: "${badDep}".`,
+    }));
+    return;
+  }
+  // Cycle guard: the view already filters downstreams from the picker,
+  // but a hand-crafted POST could bypass it. Re-check.
+  if (hasCycleAfterEdit(agent, nodeId, dependsOn)) {
+    res.status(400).type('html').send(renderAgentEditNode({
+      agent, node, values, error: 'Those dependencies would create a cycle in the DAG.',
+    }));
+    return;
+  }
+  if (values.type === 'shell' && (!values.command || values.command.trim() === '')) {
+    res.status(400).type('html').send(renderAgentEditNode({
+      agent, node, values, error: 'Shell nodes need a command.',
+    }));
+    return;
+  }
+  if (values.type === 'claude-code' && (!values.prompt || values.prompt.trim() === '')) {
+    res.status(400).type('html').send(renderAgentEditNode({
+      agent, node, values, error: 'Claude-Code nodes need a prompt.',
+    }));
+    return;
+  }
+
+  // Build the updated node. Preserve any fields we don't let the form
+  // edit (inputs, secrets, env, envAllowlist, allowedTools, model,
+  // maxTurns, timeout, redactSecrets, position) — those come back in
+  // a follow-up when the inspector can render them.
+  const updatedNode = values.type === 'shell'
+    ? { ...node, type: 'shell' as const, command: values.command!, prompt: undefined, ...(dependsOn.length > 0 ? { dependsOn } : { dependsOn: undefined }) }
+    : { ...node, type: 'claude-code' as const, prompt: values.prompt!, command: undefined, ...(dependsOn.length > 0 ? { dependsOn } : { dependsOn: undefined }) };
+
+  const updatedNodes = agent.nodes.map((n) => n.id === nodeId ? updatedNode : n);
+
+  try {
+    ctx.agentStore.createNewVersion(
+      agent.id,
+      {
+        id: agent.id,
+        name: agent.name,
+        description: agent.description,
+        status: agent.status,
+        schedule: agent.schedule,
+        source: agent.source,
+        mcp: agent.mcp,
+        nodes: updatedNodes,
+        inputs: agent.inputs,
+        author: agent.author,
+        tags: agent.tags,
+      },
+      'dashboard',
+      `Edited node "${nodeId}"`,
+    );
+    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}?flash=${encodeURIComponent(`Updated "${nodeId}". New version created.`)}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.status(400).type('html').send(renderAgentEditNode({
+      agent, node, values, error: `Save failed: ${msg}`,
+    }));
+  }
+});
+
+agentsRouter.post('/agents/:name/nodes/:nodeId/delete', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
+  const nodeId = Array.isArray(req.params.nodeId) ? req.params.nodeId[0] : req.params.nodeId;
+  const agent = ctx.agentStore.getAgent(name);
+  if (!agent) {
+    res.status(404).redirect(303, '/agents');
+    return;
+  }
+  if (!agent.nodes.some((n) => n.id === nodeId)) {
+    res.status(404).redirect(303, `/agents/${encodeURIComponent(agent.id)}`);
+    return;
+  }
+
+  // Refuse if anyone depends on this node. Explicit is better than
+  // auto-trimming dependsOn — user may be surprised to discover their
+  // downstream node silently lost an input.
+  const dependents = agent.nodes.filter((n) => n.dependsOn?.includes(nodeId));
+  if (dependents.length > 0) {
+    const names = dependents.map((n) => `"${n.id}"`).join(', ');
+    const msg = `Cannot delete "${nodeId}" \u2014 ${names} depend${dependents.length === 1 ? 's' : ''} on it. Delete or edit ${dependents.length === 1 ? 'it' : 'them'} first.`;
+    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}?flash=${encodeURIComponent(msg)}`);
+    return;
+  }
+
+  if (agent.nodes.length === 1) {
+    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}?flash=${encodeURIComponent('Cannot delete the last node. Delete the agent itself from the CLI if you want to remove it entirely.')}`);
+    return;
+  }
+
+  const updatedNodes = agent.nodes.filter((n) => n.id !== nodeId);
+  try {
+    ctx.agentStore.createNewVersion(
+      agent.id,
+      {
+        id: agent.id,
+        name: agent.name,
+        description: agent.description,
+        status: agent.status,
+        schedule: agent.schedule,
+        source: agent.source,
+        mcp: agent.mcp,
+        nodes: updatedNodes,
+        inputs: agent.inputs,
+        author: agent.author,
+        tags: agent.tags,
+      },
+      'dashboard',
+      `Deleted node "${nodeId}"`,
+    );
+    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}?flash=${encodeURIComponent(`Deleted "${nodeId}". New version created.`)}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}?flash=${encodeURIComponent(`Delete failed: ${msg}`)}`);
+  }
+});
+
+/**
+ * Cycle guard used by the edit route. Simulates the edit and walks the
+ * DAG from each root — if we revisit a node, the graph has a cycle.
+ */
+function hasCycleAfterEdit(agent: Agent, editedNodeId: string, newDependsOn: string[]): boolean {
+  const depsByNode = new Map<string, string[]>();
+  for (const n of agent.nodes) {
+    depsByNode.set(n.id, n.id === editedNodeId ? newDependsOn : (n.dependsOn ?? []));
+  }
+  const white = new Set(depsByNode.keys());
+  const gray = new Set<string>();
+  const black = new Set<string>();
+  function visit(id: string): boolean {
+    if (black.has(id)) return false;
+    if (gray.has(id)) return true;
+    gray.add(id);
+    white.delete(id);
+    for (const d of depsByNode.get(id) ?? []) {
+      if (visit(d)) return true;
+    }
+    gray.delete(id);
+    black.add(id);
+    return false;
+  }
+  for (const id of [...white]) {
+    if (visit(id)) return true;
+  }
+  return false;
+}
 
 agentsRouter.get('/agents', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);

--- a/packages/dashboard/src/views/agent-detail-v2.ts
+++ b/packages/dashboard/src/views/agent-detail-v2.ts
@@ -87,7 +87,9 @@ export async function renderAgentDetailV2(args: {
       </div>`
     : html``;
 
-  // Per-node table below the DAG — preserves the v0.14 detail view.
+  // Per-node table below the DAG. Each row gets Edit + Delete actions
+  // that POST to the node-edit routes (PR 3). Delete is refused server-side
+  // if any downstream node depends on this one.
   const nodeRows = agent.nodes.map((n) => {
     const body = n.type === 'shell' ? oneLine(n.command ?? '') : oneLine(n.prompt ?? '');
     const deps = n.dependsOn?.length ? n.dependsOn.join(', ') : html`<span class="dim">—</span>`;
@@ -99,6 +101,13 @@ export async function renderAgentDetailV2(args: {
         <td class="mono">${deps}</td>
         <td class="mono">${secrets}</td>
         <td class="dim">${body}</td>
+        <td style="white-space: nowrap;">
+          <a class="btn btn--sm" href="/agents/${agent.id}/nodes/${n.id}/edit">Edit</a>
+          <form method="POST" action="/agents/${agent.id}/nodes/${n.id}/delete" style="display: inline; margin: 0;"
+                onsubmit="return confirm('Delete node \\'${n.id}\\'?');">
+            <button type="submit" class="btn btn--sm btn--ghost" style="color: var(--color-err);">Delete</button>
+          </form>
+        </td>
       </tr>
     `;
   });
@@ -193,7 +202,7 @@ export async function renderAgentDetailV2(args: {
           <table class="table">
             <thead>
               <tr>
-                <th>Id</th><th>Type</th><th>Depends on</th><th>Secrets</th><th>Body</th>
+                <th>Id</th><th>Type</th><th>Depends on</th><th>Secrets</th><th>Body</th><th></th>
               </tr>
             </thead>
             <tbody>${nodeRows as unknown as SafeHtml[]}</tbody>

--- a/packages/dashboard/src/views/agent-edit-node.ts
+++ b/packages/dashboard/src/views/agent-edit-node.ts
@@ -1,0 +1,148 @@
+import type { Agent, AgentNode } from '@some-useful-agents/core';
+import { html, render, unsafeHtml, type SafeHtml } from './html.js';
+import { layout } from './layout.js';
+import { pageHeader } from './page-header.js';
+
+export interface EditNodeFormValues {
+  type?: 'shell' | 'claude-code';
+  command?: string;
+  prompt?: string;
+  dependsOn?: string[];
+}
+
+/**
+ * Render the edit form for an existing node in a v2 agent. The node id
+ * is shown read-only — renaming would break every downstream
+ * `{{upstream.<id>.result}}` / `$UPSTREAM_<ID>_RESULT` reference in the
+ * same agent. Users who want a different id delete + recreate.
+ *
+ * Saving produces a new agent version (via `createNewVersion`).
+ */
+export function renderAgentEditNode(args: {
+  agent: Agent;
+  node: AgentNode;
+  values?: EditNodeFormValues;
+  error?: string;
+}): string {
+  const { agent, node, values: submitted, error } = args;
+
+  // Fall back to the node's current values if nothing's been submitted.
+  const v: EditNodeFormValues = {
+    type: submitted?.type ?? node.type,
+    command: submitted?.command ?? (node.type === 'shell' ? node.command : ''),
+    prompt: submitted?.prompt ?? (node.type === 'claude-code' ? node.prompt : ''),
+    dependsOn: submitted?.dependsOn ?? node.dependsOn ?? [],
+  };
+  const isShell = v.type === 'shell';
+  const isClaude = v.type === 'claude-code';
+  const selectedDeps = new Set(v.dependsOn);
+
+  // You can depend on any OTHER node in the same agent (never on yourself).
+  // Also exclude nodes that transitively depend on this one — would be a
+  // cycle. We compute the set of downstream ids via a simple BFS.
+  const downstreamIds = collectDownstream(agent, node.id);
+  const pickableUpstreams = agent.nodes.filter((n) => n.id !== node.id && !downstreamIds.has(n.id));
+
+  const depToggles = pickableUpstreams.map((n) => html`
+    <label style="display: inline-flex; align-items: center; gap: var(--space-1); margin-right: var(--space-3); font-weight: var(--weight-regular); font-size: var(--font-size-sm);">
+      <input type="checkbox" name="dependsOn" value="${n.id}" ${selectedDeps.has(n.id) ? 'checked' : ''}>
+      <code>${n.id}</code>
+    </label>
+  `);
+
+  const errorBlock = error
+    ? html`<div class="flash flash--error">${error}</div>`
+    : html``;
+
+  const headerCta = html`
+    <form method="POST" action="/agents/${agent.id}/nodes/${node.id}/delete" style="margin: 0;">
+      <button type="submit" class="btn btn--warn"
+        onclick="return confirm('Delete node \\'${node.id}\\'? Refuses if any downstream node depends on it. Saving creates a new agent version.');">
+        Delete node
+      </button>
+    </form>
+  `;
+
+  const body = html`
+    ${pageHeader({
+      title: `Edit ${node.id}`,
+      back: { href: `/agents/${agent.id}`, label: `Back to ${agent.id}` },
+      cta: headerCta,
+      description: `Saving creates a new version of ${agent.id} (currently v${String(agent.version)}).`,
+    })}
+
+    ${errorBlock}
+
+    <form method="POST" action="/agents/${agent.id}/nodes/${node.id}/edit" class="card" style="max-width: 680px;">
+      <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-4);">
+        <strong>Node id</strong>
+        <input type="text" readonly value="${node.id}" style="${INPUT_STYLE} background: var(--color-surface-raised); color: var(--color-text-muted);">
+        <span class="dim" style="font-size: var(--font-size-xs);">Immutable. Renaming would break every <code>{{upstream.${node.id}.result}}</code> reference in this agent. Delete + re-create if you need a different id.</span>
+      </label>
+
+      <fieldset style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--space-3); margin-bottom: var(--space-4);">
+        <legend style="padding: 0 var(--space-2); font-size: var(--font-size-xs); font-weight: var(--weight-semibold); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em;">Type</legend>
+        <label style="display: flex; align-items: center; gap: var(--space-2); margin-bottom: var(--space-2);">
+          <input type="radio" name="type" value="shell" ${isShell ? 'checked' : ''}>
+          <span><strong>Shell</strong> <span class="dim">\u2014 uses <code>$UPSTREAM_&lt;ID&gt;_RESULT</code> env vars.</span></span>
+        </label>
+        <label style="display: flex; align-items: center; gap: var(--space-2);">
+          <input type="radio" name="type" value="claude-code" ${isClaude ? 'checked' : ''}>
+          <span><strong>Claude Code</strong> <span class="dim">\u2014 uses <code>{{upstream.&lt;id&gt;.result}}</code> templates.</span></span>
+        </label>
+      </fieldset>
+
+      <fieldset style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--space-3); margin-bottom: var(--space-4);">
+        <legend style="padding: 0 var(--space-2); font-size: var(--font-size-xs); font-weight: var(--weight-semibold); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em;">Depends on</legend>
+        <p class="dim" style="margin: 0 0 var(--space-2); font-size: var(--font-size-xs);">Pick upstream nodes. Downstream nodes + self are excluded to prevent cycles.</p>
+        ${pickableUpstreams.length === 0
+          ? html`<span class="dim" style="font-size: var(--font-size-xs);">No eligible upstream nodes.</span>`
+          : html`<div>${depToggles as unknown as SafeHtml[]}</div>`}
+      </fieldset>
+
+      <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-4);">
+        <strong>Command <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-xs);">(shell only)</span></strong>
+        <textarea name="command" rows="4" style="${TEXTAREA_STYLE}">${v.command ?? ''}</textarea>
+      </label>
+
+      <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-6);">
+        <strong>Prompt <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-xs);">(claude-code only)</span></strong>
+        <textarea name="prompt" rows="4" style="${TEXTAREA_STYLE}">${v.prompt ?? ''}</textarea>
+      </label>
+
+      <div style="display: flex; gap: var(--space-2); justify-content: flex-end;">
+        <a class="btn btn--ghost" href="/agents/${agent.id}">Cancel</a>
+        <button type="submit" class="btn btn--primary">Save changes</button>
+      </div>
+    </form>
+  `;
+
+  return render(layout({ title: `Edit ${node.id} \u2014 ${agent.id}`, activeNav: 'agents' }, body));
+}
+
+/**
+ * BFS over the agent's DAG from `startId`, collecting every node that
+ * transitively depends on it. Used to disallow dependsOn choices that
+ * would create a cycle.
+ */
+function collectDownstream(agent: Agent, startId: string): Set<string> {
+  const down = new Set<string>();
+  const frontier = [startId];
+  while (frontier.length > 0) {
+    const cur = frontier.pop()!;
+    for (const n of agent.nodes) {
+      if (n.dependsOn?.includes(cur) && !down.has(n.id)) {
+        down.add(n.id);
+        frontier.push(n.id);
+      }
+    }
+  }
+  return down;
+}
+
+const INPUT_STYLE: SafeHtml = unsafeHtml(
+  'padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm); font-family: inherit;',
+);
+const TEXTAREA_STYLE: SafeHtml = unsafeHtml(
+  'padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-family: var(--font-mono); font-size: var(--font-size-xs); resize: vertical;',
+);


### PR DESCRIPTION
## Summary

- Users can now modify existing nodes and remove them from the dashboard. Every edit creates a new agent version in the audit history.
- New routes: \`GET /agents/:id/nodes/:nodeId/edit\`, \`POST /agents/:id/nodes/:nodeId/edit\`, \`POST /agents/:id/nodes/:nodeId/delete\`.
- Agent detail Nodes table grows Edit + Delete buttons on every row.
- Server-side cycle guard (colored-DFS) catches cycle-producing \`dependsOn\` edits; the form's picker already hides downstreams but a hand-crafted POST is re-validated.

## Design notes

- **Node ids are immutable.** Renaming would break every \`{{upstream.<id>.result}}\` / \`$UPSTREAM_<ID>_RESULT\` reference in the same agent. The form shows id as a disabled input with a hint explaining why.
- **Downstream-dep check on delete is explicit, not cascading.** Auto-trimming dependents' \`dependsOn\` would silently reshape the DAG; a loud refusal is better.
- **Fields not yet editable from the UI** (inputs, secrets, env, envAllowlist, allowedTools, model, maxTurns, timeout, redactSecrets) are preserved on save — editing a command won't wipe its secrets. The richer inspector + these fields land in PR 3b alongside drag-drop.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npx vitest run packages/dashboard\` — 55/55 (48 → 55, +7 new)
- [x] Manual smoke test: edit \`hello\`'s greet command, verify v2 created and Recent runs keep working; try deleting a node with downstream (refused); delete downstream first, then upstream succeeds
- [ ] Visual review in browser