### PR TITLE
feat(dashboard): settings CRUD + passphrase modal + MCP rotate (PR 4/5)

### DIFF
--- a/.changeset/dashboard-v015-settings-crud.md
+++ b/.changeset/dashboard-v015-settings-crud.md
@@ -1,0 +1,48 @@
+---
+"@some-useful-agents/dashboard": minor
+"@some-useful-agents/cli": patch
+---
+
+**feat: settings CRUD in the dashboard — secrets + MCP token rotation (PR 4 of 5 for v0.15).**
+
+Moves the last CLI-only admin surfaces into the dashboard so operators can manage secrets and rotate the MCP bearer token without leaving the browser. Unblocks v0.16 AI-assist, whose Anthropic API key needs the `/settings/secrets` surface to have a home.
+
+### What ships
+
+- **`/settings/secrets`** — list declared secret names (values never rendered), set a new secret, delete an existing one. Agent-declared secrets that aren't yet set are called out in a "Declared by agents but not set" list so missing config is visible without running `sua doctor`.
+- **Passphrase unlock flow** — when the store is `v2` passphrase-protected, the page renders a dedicated unlock form instead of the list. A correct passphrase is cached in dashboard-process memory for the rest of the session; never written to disk, cookies, or sessionStorage. A "Lock now" button clears it.
+- **`/settings/general`** — MCP token fingerprint (first 8 chars), retention-policy display, path block showing the run DB, secrets file, and MCP token file so users know where sua is reading and writing.
+- **MCP token rotation** — one-click rotate from `/settings/general`. The handler writes a fresh token to `~/.sua/mcp-token`, updates the in-process auth check, re-mints the dashboard session cookie so the operator stays signed in, and reveals the new value exactly once. Existing MCP clients (Claude Desktop) break until they're updated — the confirm dialog spells that out.
+- **`/settings/integrations`** — placeholder unchanged in behaviour, with copy updated to reflect that integrations are a later-release feature.
+
+### Design notes
+
+- **Origin check is the CSRF defence.** Every POST under `/settings/*` flows through `requireAuth`, which already rejects non-loopback `Origin` headers. No second CSRF token layer needed.
+- **Passphrase never persisted.** Cached in a closure on the `SecretsSession` instance, cleared on `lock()` and at process shutdown. Dashboards that crash or restart require re-unlock — intentional.
+- **Declared-secrets discovery tolerates broken YAML.** A malformed agent file must not prevent the settings page from rendering; `collectDeclaredSecrets` swallows loader errors and falls back to what the v2 store knows.
+- **Rotated token is shown inline, not via flash.** `?rotated=<token>` in the redirect URL renders once on `/settings/general`; we accept that a browser back/reload can re-display it because the dashboard is a local loopback and the user asked to see it.
+
+### Files
+
+- New: `packages/dashboard/src/secrets-session.ts` (SecretsSession interface + `EncryptedFileSecretsSession` + `MemorySecretsSession` for tests), `packages/dashboard/src/views/settings-secrets.ts`, `packages/dashboard/src/views/settings-general.ts`, `packages/dashboard/src/secrets-session.test.ts`
+- Modified: `packages/dashboard/src/routes/settings.ts` (real CRUD + unlock/lock/rotate routes), `context.ts` (tokenPath, secretsPath, dbPath, retentionDays, rotateToken, secretsSession), `index.ts` (wire new context fields + construct the session), `views/js.ts` (add `[data-confirm]` submit handler), `assets/screens.css` (settings-form styles), `packages/cli/src/commands/dashboard.ts` (pass retentionDays)
+
+### Tests
+
+75 dashboard tests total (55 → 75; +20 new):
+- Unlock form gates the list when passphrase-protected + locked
+- Wrong passphrase is rejected; correct passphrase unlocks the session
+- `POST /settings/secrets/set` validates the `^[A-Z_][A-Z0-9_]*$` name pattern, rejects writes while locked, and stores + redirects on success
+- `POST /settings/secrets/delete` removes a stored secret
+- `POST /settings/secrets/lock` clears the cached passphrase
+- Cross-origin POST to `/settings/secrets/set` is refused (Origin check)
+- `/settings/general` renders the token fingerprint + retention + paths and never leaks the full token
+- `POST /settings/general/rotate-mcp-token` rotates, re-mints the session cookie, updates `ctx.token`, and reveals the new value once
+- After rotation, the old cookie is rejected and the new one authenticates
+- `/settings/integrations` renders placeholder copy
+- `EncryptedFileSecretsSession` round-trips through a real file, enforces passphrase gating, and throws when writing while locked
+- `MemorySecretsSession` simulates the passphrase-protected flow for dashboard tests
+
+### Plan
+
+Remaining v0.15 PR: **5 (replay UI + microcopy polish + changeset release for the v0.15-follow-on bundle)**. v0.16 structured-outputs work comes after v0.15 wraps.

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { startDashboardServer } from '@some-useful-agents/dashboard';
-import { loadConfig, getAgentDirs, getDbPath, getSecretsPath } from '../config.js';
+import { loadConfig, getAgentDirs, getDbPath, getSecretsPath, getRetentionDays } from '../config.js';
 import * as ui from '../ui.js';
 
 function collectName(value: string, previous: string[]): string[] {
@@ -55,6 +55,7 @@ of scope for this release — wrap in launchd / systemd if you need it.
         agentDirs: dirs.all,
         dbPath: getDbPath(config),
         secretsPath: getSecretsPath(config),
+        retentionDays: getRetentionDays(config),
         allowUntrustedShell: new Set(options.allowUntrustedShell),
       });
     } catch (err) {

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -254,3 +254,49 @@ main.main--wide {
   border: 1px dashed var(--color-border-strong);
   border-radius: var(--radius-md);
 }
+
+/* Settings forms — used by /settings/secrets unlock + set flows. */
+.settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+
+.settings-form__label {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  font-weight: var(--weight-medium);
+  margin-top: var(--space-2);
+}
+
+.settings-form input[type="text"],
+.settings-form input[type="password"] {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-mono);
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.settings-form input[type="text"]:focus,
+.settings-form input[type="password"]:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: var(--shadow-focus);
+}
+
+.settings-form__actions {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+
+.settings-missing {
+  margin: 0;
+  padding-left: var(--space-5);
+  color: var(--color-warn);
+  font-size: var(--font-size-sm);
+}

--- a/packages/dashboard/src/context.ts
+++ b/packages/dashboard/src/context.ts
@@ -1,4 +1,5 @@
 import type { LocalProvider, RunStore, SecretsStore, AgentDefinition, AgentStore } from '@some-useful-agents/core';
+import type { SecretsSession } from './secrets-session.js';
 
 /**
  * Shared resources a request handler needs. Built once in
@@ -26,6 +27,39 @@ export interface DashboardContext {
   loadAgents: () => { agents: Map<string, AgentDefinition>; warnings: Array<{ file: string; message: string }> };
   /** Secrets store for "declared + set / missing" badges. */
   secretsStore: SecretsStore;
+  /**
+   * Write-capable secrets session. Adds a passphrase cache on top of
+   * the raw store so /settings/secrets can unlock once per process
+   * rather than prompting per write. Memory-only, never persisted.
+   */
+  secretsSession: SecretsSession;
+  /**
+   * On-disk path to the MCP bearer token file. Used by the "rotate
+   * token" endpoint on /settings/general.
+   */
+  tokenPath: string;
+  /**
+   * Run-history retention in days. Read-only for v0.15; editing
+   * sua.config.json from the dashboard is a v0.16 item.
+   */
+  retentionDays: number;
+  /**
+   * Path to the run DB. Displayed on /settings/general so users know
+   * where sua is writing.
+   */
+  dbPath: string;
+  /**
+   * Path to the encrypted secrets file. Displayed on /settings/general
+   * and used to re-derive the secrets session if needed.
+   */
+  secretsPath: string;
+  /**
+   * Rotate the MCP bearer token. Defaults to `rotateMcpToken(tokenPath)`;
+   * tests inject a stub that doesn't write to `~/.sua/mcp-token`.
+   * Mutating callers must also update `ctx.token` so the auth
+   * middleware's constant-time compare sees the new value.
+   */
+  rotateToken: () => string;
   /** When true, the dashboard allows POSTs that would execute community shell. */
   allowUntrustedShell: Set<string>;
   /** Called to validate agent-supplied inputs at run-now time. Defaults built into LocalProvider. */

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -8,6 +8,7 @@ import { buildDashboardApp } from './index.js';
 import type { DashboardContext } from './context.js';
 import { SESSION_COOKIE } from './auth-middleware.js';
 import { buildLoopbackAllowlist } from '@some-useful-agents/core';
+import { MemorySecretsSession } from './secrets-session.js';
 
 const TOKEN = 'a'.repeat(64);
 const PORT = 3999;
@@ -20,7 +21,13 @@ let provider: LocalProvider;
 let runStore: RunStore;
 let agentStore: AgentStore;
 
-async function makeApp() {
+interface AppOverrides {
+  secretsSession?: MemorySecretsSession;
+  rotateToken?: () => string;
+  retentionDays?: number;
+}
+
+async function makeAppWithCtx(overrides: AppOverrides = {}) {
   dir = mkdtempSync(join(tmpdir(), 'sua-dashboard-'));
   dbPath = join(dir, 'runs.db');
   agentsDir = join(dir, 'agents', 'local');
@@ -56,6 +63,8 @@ command: echo from-the-internet
   provider = new LocalProvider(dbPath, secretsStore);
   await provider.initialize();
 
+  const secretsSession = overrides.secretsSession ?? new MemorySecretsSession({ backing: secretsStore });
+
   const ctx: DashboardContext = {
     token: TOKEN,
     allowlist: buildLoopbackAllowlist(PORT),
@@ -67,10 +76,21 @@ command: echo from-the-internet
       directories: [agentsDir, join(dir, 'agents', 'community')],
     }),
     secretsStore,
+    secretsSession,
+    tokenPath: join(dir, 'mcp-token'),
+    retentionDays: overrides.retentionDays ?? 30,
+    dbPath,
+    secretsPath: join(dir, 'secrets.enc'),
+    rotateToken: overrides.rotateToken ?? (() => 'r'.repeat(64)),
     allowUntrustedShell: new Set(),
   };
 
-  return buildDashboardApp(ctx);
+  return { app: buildDashboardApp(ctx), ctx };
+}
+
+async function makeApp(overrides: AppOverrides = {}) {
+  const { app } = await makeAppWithCtx(overrides);
+  return app;
 }
 
 beforeEach(async () => {
@@ -966,5 +986,217 @@ describe('Dashboard run-now gate', () => {
     // and flashed back. Redirect back to the agent page with flash.
     expect(res.status).toBe(303);
     expect(res.headers.location).toMatch(/^\/agents\/spooky\?flash=/);
+  });
+});
+
+describe('Dashboard /settings/secrets CRUD', () => {
+  function absentStatus() {
+    return { exists: false, obfuscatedFallback: false, mode: 'absent' as const };
+  }
+  function passphraseStatus() {
+    return { exists: true, version: 2 as const, obfuscatedFallback: false, mode: 'passphrase' as const };
+  }
+
+  it('GET /settings redirects to /settings/secrets', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/settings')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toBe('/settings/secrets');
+  });
+
+  it('GET /settings/secrets shows unlock form when passphrase-protected and locked', async () => {
+    const session = new MemorySecretsSession({
+      status: passphraseStatus(),
+      correctPassphrase: 'correct horse',
+    });
+    const app = await makeApp({ secretsSession: session });
+    const res = await request(app).get('/settings/secrets')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Secrets (locked)');
+    expect(res.text).toMatch(/action="\/settings\/secrets\/unlock"/);
+    // The list and set-secret form MUST NOT render while locked.
+    expect(res.text).not.toContain('action="/settings/secrets/set"');
+  });
+
+  it('POST /settings/secrets/unlock rejects wrong passphrase', async () => {
+    const session = new MemorySecretsSession({
+      status: passphraseStatus(),
+      correctPassphrase: 'correct horse',
+    });
+    const app = await makeApp({ secretsSession: session });
+    const res = await request(app).post('/settings/secrets/unlock')
+      .type('form')
+      .send({ passphrase: 'wrong' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/^\/settings\/secrets\?unlockError=/);
+    expect(session.isUnlocked()).toBe(false);
+  });
+
+  it('POST /settings/secrets/unlock with the right passphrase unlocks the session', async () => {
+    const session = new MemorySecretsSession({
+      status: passphraseStatus(),
+      correctPassphrase: 'correct horse',
+    });
+    const app = await makeApp({ secretsSession: session });
+    const res = await request(app).post('/settings/secrets/unlock')
+      .type('form')
+      .send({ passphrase: 'correct horse' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/^\/settings\/secrets\?flash=/);
+    expect(session.isUnlocked()).toBe(true);
+  });
+
+  it('POST /settings/secrets/set rejects invalid names', async () => {
+    const session = new MemorySecretsSession({ status: absentStatus() });
+    const app = await makeApp({ secretsSession: session });
+    const res = await request(app).post('/settings/secrets/set')
+      .type('form')
+      .send({ name: 'lower_case', value: 'v' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/^\/settings\/secrets\?setError=/);
+    expect(await session.listNames()).toEqual([]);
+  });
+
+  it('POST /settings/secrets/set rejects writes to a locked store', async () => {
+    const session = new MemorySecretsSession({
+      status: passphraseStatus(),
+      correctPassphrase: 'x',
+    });
+    const app = await makeApp({ secretsSession: session });
+    const res = await request(app).post('/settings/secrets/set')
+      .type('form')
+      .send({ name: 'GOOD_NAME', value: 'v' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/setError=/);
+    expect(await session.listNames()).toEqual([]);
+  });
+
+  it('POST /settings/secrets/set stores a secret when unlocked', async () => {
+    const session = new MemorySecretsSession({ status: absentStatus() });
+    const app = await makeApp({ secretsSession: session });
+    const res = await request(app).post('/settings/secrets/set')
+      .type('form')
+      .send({ name: 'MY_API_KEY', value: 'sk-123' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/^\/settings\/secrets\?flash=/);
+    expect(await session.listNames()).toEqual(['MY_API_KEY']);
+  });
+
+  it('POST /settings/secrets/delete removes a secret', async () => {
+    const session = new MemorySecretsSession({ status: absentStatus() });
+    await session.setSecret('DOOMED', 'v');
+    const app = await makeApp({ secretsSession: session });
+    const res = await request(app).post('/settings/secrets/delete')
+      .type('form')
+      .send({ name: 'DOOMED' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(await session.listNames()).toEqual([]);
+  });
+
+  it('POST /settings/secrets/lock clears the session passphrase', async () => {
+    const session = new MemorySecretsSession({
+      status: passphraseStatus(),
+      correctPassphrase: 'ok',
+    });
+    await session.unlock('ok');
+    expect(session.isUnlocked()).toBe(true);
+    const app = await makeApp({ secretsSession: session });
+    await request(app).post('/settings/secrets/lock')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(session.isUnlocked()).toBe(false);
+  });
+
+  it('rejects a cross-origin POST to /settings/secrets/set (CSRF defense)', async () => {
+    const session = new MemorySecretsSession({ status: absentStatus() });
+    const app = await makeApp({ secretsSession: session });
+    const res = await request(app).post('/settings/secrets/set')
+      .type('form')
+      .send({ name: 'X', value: 'v' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Origin', 'http://evil.example.com')
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(403);
+    expect(await session.listNames()).toEqual([]);
+  });
+});
+
+describe('Dashboard /settings/general', () => {
+  it('renders MCP token fingerprint, retention, and paths', async () => {
+    const app = await makeApp({ retentionDays: 7 });
+    const res = await request(app).get('/settings/general')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    // First 8 chars of TOKEN (32 'a's); full token never rendered.
+    expect(res.text).toContain('aaaaaaaa');
+    expect(res.text).not.toContain(TOKEN);
+    expect(res.text).toContain('<strong>7</strong> days');
+    expect(res.text).toContain('/settings/general/rotate-mcp-token');
+  });
+
+  it('POST rotate-mcp-token rotates, updates session cookie, reveals new token once', async () => {
+    const newToken = 'c'.repeat(64);
+    const { app, ctx } = await makeAppWithCtx({ rotateToken: () => newToken });
+    const res = await request(app).post('/settings/general/rotate-mcp-token')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(new RegExp(`rotated=${newToken}`));
+    // Cookie was re-minted so the current browser stays signed in.
+    const setCookie = res.headers['set-cookie'] as unknown as string[] | string | undefined;
+    const cookieStr = Array.isArray(setCookie) ? setCookie.join('\n') : setCookie;
+    expect(cookieStr).toMatch(new RegExp(`${SESSION_COOKIE}=${newToken}`));
+    // ctx.token must point at the new value — otherwise subsequent
+    // middleware calls would 401 and force a re-auth.
+    expect(ctx.token).toBe(newToken);
+  });
+
+  it('after rotation, the old cookie is rejected and the new one works', async () => {
+    const newToken = 'c'.repeat(64);
+    const { app } = await makeAppWithCtx({ rotateToken: () => newToken });
+    await request(app).post('/settings/general/rotate-mcp-token')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    const oldCookieRes = await request(app).get('/agents')
+      .set('Accept', 'text/html')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(oldCookieRes.status).toBe(302);
+    expect(oldCookieRes.headers.location).toBe('/auth');
+
+    const newCookieRes = await request(app).get('/agents')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${newToken}`);
+    expect(newCookieRes.status).toBe(200);
+  });
+});
+
+describe('Dashboard /settings/integrations', () => {
+  it('renders placeholder copy', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/settings/integrations')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Integrations');
+    expect(res.text).toContain('coming in a later release');
   });
 });

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -8,10 +8,12 @@ import {
   loadAgents,
   readMcpToken,
   getMcpTokenPath,
+  rotateMcpToken,
   buildLoopbackAllowlist,
   type SecretsStore,
 } from '@some-useful-agents/core';
 import type { DashboardContext } from './context.js';
+import { EncryptedFileSecretsSession } from './secrets-session.js';
 import { requireAuth } from './auth-middleware.js';
 import { healthRouter } from './routes/health.js';
 import { authRouter } from './routes/auth.js';
@@ -37,6 +39,8 @@ export interface StartDashboardOptions {
   tokenPath?: string;
   /** Community shell agents the operator has pre-allowed. */
   allowUntrustedShell?: Set<string>;
+  /** Run-history retention in days (shown on /settings/general). Defaults to 30. */
+  retentionDays?: number;
   /** Optional SecretsStore override (tests). */
   secretsStore?: SecretsStore;
   /** Optional LocalProvider override (tests). */
@@ -118,6 +122,8 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
   });
   await provider.initialize();
 
+  const secretsSession = new EncryptedFileSecretsSession(opts.secretsPath);
+
   const ctx: DashboardContext = {
     token,
     allowlist: buildLoopbackAllowlist(opts.port),
@@ -127,6 +133,12 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     agentStore,
     loadAgents: () => loadAgents({ directories: opts.agentDirs }),
     secretsStore,
+    secretsSession,
+    tokenPath,
+    retentionDays: opts.retentionDays ?? 30,
+    dbPath: opts.dbPath,
+    secretsPath: opts.secretsPath,
+    rotateToken: () => rotateMcpToken(tokenPath),
     allowUntrustedShell: opts.allowUntrustedShell ?? new Set(),
   };
 

--- a/packages/dashboard/src/routes/settings.ts
+++ b/packages/dashboard/src/routes/settings.ts
@@ -1,54 +1,239 @@
 import { Router, type Request, type Response } from 'express';
 import { html } from '../views/html.js';
 import { renderSettingsShell } from '../views/settings-shell.js';
+import { renderSettingsSecrets } from '../views/settings-secrets.js';
+import { renderSettingsGeneral } from '../views/settings-general.js';
+import { getContext, type DashboardContext } from '../context.js';
+import { SESSION_COOKIE } from '../auth-middleware.js';
 
-/**
- * Settings routes. This PR ships the shell + placeholder tab content;
- * /settings/secrets CRUD, passphrase modal, MCP token rotation, and
- * retention display arrive in PR 4 of v0.15.
- */
 export const settingsRouter: Router = Router();
+
+const SECRET_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
 
 settingsRouter.get('/settings', (_req: Request, res: Response) => {
   res.redirect(303, '/settings/secrets');
 });
 
-settingsRouter.get('/settings/secrets', (_req: Request, res: Response) => {
-  const body = html`
-    <div class="card">
-      <p class="card__title">Secrets</p>
-      <p>Manage encrypted secrets referenced by agent nodes. Values are
-        never rendered here.</p>
-      <p class="dim">Coming in the next v0.15 PR: list declared secrets,
-        set/delete from the UI, passphrase-gated flows for protected stores.</p>
-    </div>
-  `;
-  res.type('html').send(renderSettingsShell({ active: 'secrets', body }));
+settingsRouter.get('/settings/secrets', async (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const { flash, unlockError, setError } = readQueryBanners(req);
+
+  const status = ctx.secretsSession.inspect();
+  const isUnlocked = ctx.secretsSession.isUnlocked();
+  const names = isUnlocked ? await ctx.secretsSession.listNames() : [];
+  const declared = collectDeclaredSecrets(ctx);
+  const missing = [...declared].filter((n) => !names.includes(n)).sort();
+
+  const body = renderSettingsSecrets({
+    status,
+    isUnlocked,
+    names,
+    missing,
+    unlockError,
+    setError,
+    setNameValue: typeof req.query.name === 'string' ? req.query.name : undefined,
+  });
+  res.type('html').send(renderSettingsShell({ active: 'secrets', body, flash }));
 });
 
-settingsRouter.get('/settings/integrations', (_req: Request, res: Response) => {
+settingsRouter.post('/settings/secrets/unlock', async (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const passphrase = typeof body.passphrase === 'string' ? body.passphrase : '';
+
+  if (passphrase.length === 0) {
+    redirectWith(res, '/settings/secrets', 'unlockError', 'Passphrase is required.');
+    return;
+  }
+
+  const ok = await ctx.secretsSession.unlock(passphrase);
+  if (!ok) {
+    redirectWith(res, '/settings/secrets', 'unlockError', 'Wrong passphrase.');
+    return;
+  }
+  redirectWith(res, '/settings/secrets', 'flash', 'Unlocked for this session.');
+});
+
+settingsRouter.post('/settings/secrets/lock', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  ctx.secretsSession.lock();
+  redirectWith(res, '/settings/secrets', 'flash', 'Locked.');
+});
+
+settingsRouter.post('/settings/secrets/set', async (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  const value = typeof body.value === 'string' ? body.value : '';
+
+  if (!SECRET_NAME_RE.test(name)) {
+    redirectWith(
+      res,
+      '/settings/secrets',
+      'setError',
+      `Invalid name "${name}". Must be uppercase letters, digits, or underscores (e.g. MY_API_KEY).`,
+      { name },
+    );
+    return;
+  }
+  if (value.length === 0) {
+    redirectWith(res, '/settings/secrets', 'setError', 'Value is required.', { name });
+    return;
+  }
+  if (!ctx.secretsSession.isUnlocked()) {
+    redirectWith(res, '/settings/secrets', 'setError', 'Store is locked. Unlock before writing.', { name });
+    return;
+  }
+
+  try {
+    await ctx.secretsSession.setSecret(name, value);
+    redirectWith(res, '/settings/secrets', 'flash', `Saved ${name}.`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    redirectWith(res, '/settings/secrets', 'setError', `Save failed: ${msg}`, { name });
+  }
+});
+
+settingsRouter.post('/settings/secrets/delete', async (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  if (!SECRET_NAME_RE.test(name)) {
+    redirectWith(res, '/settings/secrets', 'setError', `Invalid name "${name}".`);
+    return;
+  }
+  if (!ctx.secretsSession.isUnlocked()) {
+    redirectWith(res, '/settings/secrets', 'setError', 'Store is locked. Unlock before deleting.');
+    return;
+  }
+
+  try {
+    await ctx.secretsSession.deleteSecret(name);
+    redirectWith(res, '/settings/secrets', 'flash', `Deleted ${name}.`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    redirectWith(res, '/settings/secrets', 'setError', `Delete failed: ${msg}`);
+  }
+});
+
+settingsRouter.get('/settings/integrations', (req: Request, res: Response) => {
+  const { flash } = readQueryBanners(req);
   const body = html`
     <div class="settings-empty">
       <h3 style="margin-top: 0;">Integrations</h3>
-      <p>Integrations are coming in v0.16.</p>
+      <p>Integrations are coming in a later release.</p>
       <p class="dim">Today, external services are wired up through
         secrets (e.g. <code>SLACK_WEBHOOK</code>) referenced from agent nodes.
         Integrations will add a metadata layer on top so agents can
         reference named services instead of raw secret names.</p>
     </div>
   `;
-  res.type('html').send(renderSettingsShell({ active: 'integrations', body }));
+  res.type('html').send(renderSettingsShell({ active: 'integrations', body, flash }));
 });
 
-settingsRouter.get('/settings/general', (_req: Request, res: Response) => {
-  const body = html`
-    <div class="card">
-      <p class="card__title">General</p>
-      <p>Dashboard-wide settings.</p>
-      <p class="dim">Coming in the next v0.15 PR: rotate the MCP bearer
-        token, view retention policy, show the paths sua is reading
-        config and data from.</p>
-    </div>
-  `;
-  res.type('html').send(renderSettingsShell({ active: 'general', body }));
+settingsRouter.get('/settings/general', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const { flash } = readQueryBanners(req);
+  const rotatedToken = typeof req.query.rotated === 'string' ? req.query.rotated : undefined;
+  const body = renderSettingsGeneral({
+    tokenFingerprint: ctx.token.slice(0, 8),
+    tokenPath: ctx.tokenPath,
+    secretsPath: ctx.secretsPath,
+    dbPath: ctx.dbPath,
+    retentionDays: ctx.retentionDays,
+    rotatedToken,
+  });
+  res.type('html').send(renderSettingsShell({ active: 'general', body, flash }));
 });
+
+settingsRouter.post('/settings/general/rotate-mcp-token', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  // Rotating the file in-place invalidates every existing MCP client
+  // cookie including the one we're serving the response with. Re-cookie
+  // this browser at the same time so the operator doesn't get bounced
+  // to /auth on their next click. The freshly rotated value is rendered
+  // once on /settings/general — we never re-display it after that.
+  let newToken: string;
+  try {
+    newToken = ctx.rotateToken();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    redirectWith(res, '/settings/general', 'flash', `Rotation failed: ${msg}`);
+    return;
+  }
+
+  updateToken(ctx, newToken);
+  res.cookie(SESSION_COOKIE, newToken, {
+    httpOnly: true,
+    sameSite: 'strict',
+    path: '/',
+  });
+  res.redirect(303, `/settings/general?rotated=${encodeURIComponent(newToken)}&flash=${encodeURIComponent('Rotated bearer token. Update any MCP clients to use the new value.')}`);
+});
+
+/**
+ * Parse `?flash=` (success) and `?error=` / `?unlockError=` / `?setError=`
+ * (failure) query params into render-ready structures.
+ */
+function readQueryBanners(req: Request): {
+  flash?: { kind: 'error' | 'ok' | 'info'; message: string };
+  unlockError?: string;
+  setError?: string;
+} {
+  const flashVal = typeof req.query.flash === 'string' ? req.query.flash : undefined;
+  const errorVal = typeof req.query.error === 'string' ? req.query.error : undefined;
+  const unlockError = typeof req.query.unlockError === 'string' ? req.query.unlockError : undefined;
+  const setError = typeof req.query.setError === 'string' ? req.query.setError : undefined;
+  const flash = errorVal
+    ? { kind: 'error' as const, message: errorVal }
+    : flashVal
+      ? { kind: 'ok' as const, message: flashVal }
+      : undefined;
+  return { flash, unlockError, setError };
+}
+
+/**
+ * 303-redirect back to a settings page with a query-encoded banner. The
+ * `extra` map lets callers preserve form field values (e.g. name= on a
+ * failed /set) so the user doesn't retype them.
+ */
+function redirectWith(
+  res: Response,
+  path: string,
+  kind: 'flash' | 'unlockError' | 'setError',
+  message: string,
+  extra: Record<string, string> = {},
+): void {
+  const params = new URLSearchParams();
+  params.set(kind, message);
+  for (const [k, v] of Object.entries(extra)) params.set(k, v);
+  res.redirect(303, `${path}?${params.toString()}`);
+}
+
+function collectDeclaredSecrets(ctx: DashboardContext): Set<string> {
+  const declared = new Set<string>();
+  try {
+    const { agents } = ctx.loadAgents();
+    for (const [, a] of agents) {
+      for (const s of a.secrets ?? []) declared.add(s);
+    }
+  } catch {
+    // Broken YAML on disk shouldn't prevent the Settings page from rendering.
+  }
+  try {
+    for (const agent of ctx.agentStore.listAgents()) {
+      for (const node of agent.nodes) {
+        for (const s of node.secrets ?? []) declared.add(s);
+      }
+    }
+  } catch {
+    // Same — tolerate a failing store read so Settings still renders.
+  }
+  return declared;
+}
+
+/** Mutate the live auth-check token in app.locals. Keeps the middleware
+ *  in lockstep with the on-disk file after a rotation. */
+function updateToken(ctx: DashboardContext, newToken: string): void {
+  ctx.token = newToken;
+}

--- a/packages/dashboard/src/secrets-session.test.ts
+++ b/packages/dashboard/src/secrets-session.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { EncryptedFileSecretsSession, MemorySecretsSession } from './secrets-session.js';
+
+let dir: string;
+let secretsPath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'sua-secrets-session-'));
+  secretsPath = join(dir, 'secrets.enc');
+});
+
+afterEach(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('EncryptedFileSecretsSession', () => {
+  it('treats an absent store as not requiring a passphrase', () => {
+    const s = new EncryptedFileSecretsSession(secretsPath);
+    expect(s.inspect().mode).toBe('absent');
+    expect(s.requiresPassphrase()).toBe(false);
+    expect(s.isUnlocked()).toBe(true);
+  });
+
+  it('round-trips a secret through a hostname-obfuscated store', async () => {
+    const s = new EncryptedFileSecretsSession(secretsPath);
+    await s.setSecret('MY_KEY', 'abc');
+    expect(await s.listNames()).toEqual(['MY_KEY']);
+    expect(s.inspect().exists).toBe(true);
+
+    const reopened = new EncryptedFileSecretsSession(secretsPath);
+    expect(await reopened.listNames()).toEqual(['MY_KEY']);
+  });
+
+  it('requires unlock for a passphrase-protected store and rejects bad passphrases', async () => {
+    // Seed a passphrase-protected store via a session that already knows the passphrase.
+    // Simplest way without reaching into core internals: set SUA_SECRETS_PASSPHRASE
+    // for the initial write, then clear it and prove the session blocks reads.
+    const prev = process.env.SUA_SECRETS_PASSPHRASE;
+    try {
+      process.env.SUA_SECRETS_PASSPHRASE = 'correct';
+      const writer = new EncryptedFileSecretsSession(secretsPath);
+      await writer.setSecret('API_KEY', 'sk-1');
+    } finally {
+      process.env.SUA_SECRETS_PASSPHRASE = prev;
+    }
+
+    const s = new EncryptedFileSecretsSession(secretsPath);
+    expect(s.requiresPassphrase()).toBe(true);
+    expect(s.isUnlocked()).toBe(false);
+    expect(await s.listNames()).toEqual([]);
+
+    expect(await s.unlock('wrong')).toBe(false);
+    expect(s.isUnlocked()).toBe(false);
+
+    expect(await s.unlock('correct')).toBe(true);
+    expect(s.isUnlocked()).toBe(true);
+    expect(await s.listNames()).toEqual(['API_KEY']);
+
+    s.lock();
+    expect(s.isUnlocked()).toBe(false);
+    expect(await s.listNames()).toEqual([]);
+  });
+
+  it('throws on write when the passphrase-protected store is locked', async () => {
+    const prev = process.env.SUA_SECRETS_PASSPHRASE;
+    try {
+      process.env.SUA_SECRETS_PASSPHRASE = 'pp';
+      const writer = new EncryptedFileSecretsSession(secretsPath);
+      await writer.setSecret('SEED', 'v');
+    } finally {
+      process.env.SUA_SECRETS_PASSPHRASE = prev;
+    }
+
+    const s = new EncryptedFileSecretsSession(secretsPath);
+    await expect(s.setSecret('OTHER', 'v')).rejects.toThrow(/locked/i);
+  });
+});
+
+describe('MemorySecretsSession', () => {
+  it('simulates a passphrase-protected store that unlocks on the correct passphrase', async () => {
+    const s = new MemorySecretsSession({
+      status: { exists: true, version: 2, obfuscatedFallback: false, mode: 'passphrase' },
+      correctPassphrase: 'ok',
+    });
+    expect(s.isUnlocked()).toBe(false);
+    expect(await s.unlock('nope')).toBe(false);
+    expect(await s.unlock('ok')).toBe(true);
+    expect(s.isUnlocked()).toBe(true);
+  });
+
+  it('throws on set/delete while locked', async () => {
+    const s = new MemorySecretsSession({
+      status: { exists: true, version: 2, obfuscatedFallback: false, mode: 'passphrase' },
+      correctPassphrase: 'ok',
+    });
+    await expect(s.setSecret('X', 'v')).rejects.toThrow(/locked/i);
+    await expect(s.deleteSecret('X')).rejects.toThrow(/locked/i);
+  });
+});

--- a/packages/dashboard/src/secrets-session.ts
+++ b/packages/dashboard/src/secrets-session.ts
@@ -1,0 +1,192 @@
+import {
+  EncryptedFileStore,
+  inspectSecretsFile,
+  MemorySecretsStore,
+  type SecretsStore,
+  type SecretsStoreStatus,
+} from '@some-useful-agents/core';
+
+/**
+ * Dashboard-side wrapper around the secrets store. Adds a session-cached
+ * passphrase so the UI can unlock once per dashboard process and
+ * subsequent writes skip re-prompting. The cache lives in process memory
+ * only — never persisted to disk, cleared on shutdown.
+ *
+ * Reads that don't need decryption (inspect) work regardless of unlock
+ * state; list/set/delete throw when the underlying store is passphrase-
+ * protected and the session is still locked.
+ */
+export interface SecretsSession {
+  /** Current on-disk status (file exists? mode?). Never decrypts. */
+  inspect(): SecretsStoreStatus;
+  /** Whether a user-supplied passphrase is required for writes/reads. */
+  requiresPassphrase(): boolean;
+  /** Whether the session currently has what it needs to read + write. */
+  isUnlocked(): boolean;
+  /** Attempt to unlock using `pass`. Returns true on success. */
+  unlock(pass: string): Promise<boolean>;
+  /** Clear the cached passphrase. */
+  lock(): void;
+  /** List declared secret names. Returns [] if locked or absent. */
+  listNames(): Promise<string[]>;
+  /** Write a secret. Throws if locked or mode requires a passphrase we lack. */
+  setSecret(name: string, value: string): Promise<void>;
+  /** Delete a secret. Throws if locked. */
+  deleteSecret(name: string): Promise<void>;
+}
+
+/**
+ * Production session backed by the encrypted file store at `secretsPath`.
+ * Reads `inspect()` from the file header on every call — so an external
+ * `sua secrets migrate` (or manual file swap) is reflected immediately.
+ */
+export class EncryptedFileSecretsSession implements SecretsSession {
+  private passphrase: string | undefined;
+
+  constructor(private readonly secretsPath: string) {}
+
+  inspect(): SecretsStoreStatus {
+    return inspectSecretsFile(this.secretsPath);
+  }
+
+  requiresPassphrase(): boolean {
+    return this.inspect().mode === 'passphrase';
+  }
+
+  isUnlocked(): boolean {
+    if (!this.requiresPassphrase()) return true;
+    return this.passphrase !== undefined;
+  }
+
+  async unlock(pass: string): Promise<boolean> {
+    if (pass.length === 0) return false;
+    try {
+      const probe = new EncryptedFileStore(this.secretsPath, { passphrase: pass });
+      await probe.list();
+      this.passphrase = pass;
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  lock(): void {
+    this.passphrase = undefined;
+  }
+
+  async listNames(): Promise<string[]> {
+    const store = this.readStore();
+    if (!store) return [];
+    return store.list();
+  }
+
+  async setSecret(name: string, value: string): Promise<void> {
+    await this.writeStore().set(name, value);
+  }
+
+  async deleteSecret(name: string): Promise<void> {
+    await this.writeStore().delete(name);
+  }
+
+  private readStore(): EncryptedFileStore | undefined {
+    const status = this.inspect();
+    if (!status.exists) return undefined;
+    if (status.mode === 'passphrase') {
+      if (!this.passphrase) return undefined;
+      return new EncryptedFileStore(this.secretsPath, { passphrase: this.passphrase });
+    }
+    // hostname-obfuscated: readable with no passphrase
+    return new EncryptedFileStore(this.secretsPath, { onWarn: () => {} });
+  }
+
+  private writeStore(): EncryptedFileStore {
+    const status = this.inspect();
+    if (status.mode === 'passphrase') {
+      if (!this.passphrase) {
+        throw new Error('Secrets store is locked. Unlock it before writing.');
+      }
+      return new EncryptedFileStore(this.secretsPath, { passphrase: this.passphrase });
+    }
+    // Absent or hostname-obfuscated: allow legacy-fallback writes so a
+    // fresh install without a passphrase can still store a secret. The
+    // underlying store emits its own warning on first write.
+    return new EncryptedFileStore(this.secretsPath, {
+      allowLegacyFallback: true,
+      onWarn: () => {},
+    });
+  }
+}
+
+/**
+ * Test-friendly session. `status` is mutable so tests can simulate a
+ * passphrase-protected store without writing a real `secrets.enc`.
+ * `correctPassphrase` is the value `unlock()` accepts; `undefined`
+ * means unlock always fails.
+ */
+export class MemorySecretsSession implements SecretsSession {
+  private readonly backing: SecretsStore;
+  private unlocked: boolean;
+  public status: SecretsStoreStatus;
+
+  constructor(opts: {
+    backing?: SecretsStore;
+    status?: SecretsStoreStatus;
+    correctPassphrase?: string;
+  } = {}) {
+    this.backing = opts.backing ?? new MemorySecretsStore();
+    this.status = opts.status ?? { exists: false, obfuscatedFallback: false, mode: 'absent' };
+    this.unlocked = this.status.mode !== 'passphrase';
+    this.correctPassphrase = opts.correctPassphrase;
+  }
+
+  private readonly correctPassphrase: string | undefined;
+
+  inspect(): SecretsStoreStatus {
+    return this.status;
+  }
+
+  requiresPassphrase(): boolean {
+    return this.status.mode === 'passphrase';
+  }
+
+  isUnlocked(): boolean {
+    return !this.requiresPassphrase() || this.unlocked;
+  }
+
+  async unlock(pass: string): Promise<boolean> {
+    if (this.correctPassphrase === undefined) return false;
+    if (pass === this.correctPassphrase) {
+      this.unlocked = true;
+      return true;
+    }
+    return false;
+  }
+
+  lock(): void {
+    this.unlocked = false;
+  }
+
+  async listNames(): Promise<string[]> {
+    if (!this.isUnlocked()) return [];
+    return this.backing.list();
+  }
+
+  async setSecret(name: string, value: string): Promise<void> {
+    if (!this.isUnlocked()) {
+      throw new Error('Secrets store is locked.');
+    }
+    await this.backing.set(name, value);
+    // Writing transitions an 'absent' store to 'passphrase' mode in
+    // reality; mirror that here so tests see the real flow.
+    if (this.status.mode === 'absent') {
+      this.status = { exists: true, version: 2, obfuscatedFallback: false, mode: 'hostname-obfuscated' };
+    }
+  }
+
+  async deleteSecret(name: string): Promise<void> {
+    if (!this.isUnlocked()) {
+      throw new Error('Secrets store is locked.');
+    }
+    await this.backing.delete(name);
+  }
+}

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -29,6 +29,17 @@ export const DASHBOARD_JS = `
     }
   });
 
+  // Confirm-before-submit for forms with [data-confirm]. Used on
+  // destructive settings actions (delete secret, rotate MCP token).
+  document.addEventListener('submit', function (e) {
+    var form = e.target;
+    if (!form || !form.matches || !form.matches('form[data-confirm]')) return;
+    var msg = form.getAttribute('data-confirm');
+    if (msg && !window.confirm(msg)) {
+      e.preventDefault();
+    }
+  });
+
   // Auto-poll for in-progress runs
   var runDetail = document.querySelector('[data-run-in-progress]');
   if (runDetail) {

--- a/packages/dashboard/src/views/settings-general.ts
+++ b/packages/dashboard/src/views/settings-general.ts
@@ -1,0 +1,81 @@
+import { html, unsafeHtml, type SafeHtml } from './html.js';
+
+export interface SettingsGeneralArgs {
+  /** First 8 hex chars of the current MCP token. Full value never rendered. */
+  tokenFingerprint: string;
+  /** Absolute paths shown so users know where sua reads + writes. */
+  tokenPath: string;
+  secretsPath: string;
+  dbPath: string;
+  /** Full MCP token to reveal exactly once, right after rotation. */
+  rotatedToken?: string;
+  retentionDays: number;
+}
+
+/**
+ * Render the `/settings/general` body.
+ *
+ * Tables stopped being a good fit once the "freshly rotated token"
+ * card needs a one-off reveal block — kept each setting as its own
+ * card so the rotate flow has a natural place to surface the new
+ * value without interrupting the list layout.
+ */
+export function renderSettingsGeneral(args: SettingsGeneralArgs): SafeHtml {
+  return html`
+    <div class="card">
+      <p class="card__title">MCP bearer token</p>
+      <p class="dim">
+        The dashboard shares this token with the MCP server at
+        <code>${args.tokenPath}</code>. Rotating it generates a fresh
+        secret, invalidates existing MCP client configs, and resets
+        this dashboard's session cookie to the new value.
+      </p>
+      <dl class="kv" style="margin-top: var(--space-3);">
+        <dt>Fingerprint</dt>
+        <dd class="mono">${args.tokenFingerprint}…</dd>
+        <dt>Path</dt>
+        <dd class="mono">${args.tokenPath}</dd>
+      </dl>
+      ${renderRotatedBanner(args.rotatedToken)}
+      <form action="/settings/general/rotate-mcp-token" method="post" style="margin-top: var(--space-3);"
+        data-confirm="Rotate the MCP bearer token? Existing Claude Desktop / MCP client configs will stop working until you update them.">
+        <button type="submit" class="btn btn--warn">Rotate token</button>
+      </form>
+    </div>
+
+    <div class="card">
+      <p class="card__title">Retention</p>
+      <p>Run history older than <strong>${args.retentionDays}</strong> day${args.retentionDays === 1 ? '' : 's'} is deleted at process startup.</p>
+      <p class="dim">
+        Edit <code>sua.config.json</code> (<code>runRetentionDays</code>)
+        to change this. In-UI editing is queued for a later release.
+      </p>
+    </div>
+
+    <div class="card">
+      <p class="card__title">Paths</p>
+      <dl class="kv">
+        <dt>Run database</dt>
+        <dd class="mono">${args.dbPath}</dd>
+        <dt>Secrets file</dt>
+        <dd class="mono">${args.secretsPath}</dd>
+        <dt>MCP token</dt>
+        <dd class="mono">${args.tokenPath}</dd>
+      </dl>
+    </div>
+  `;
+}
+
+function renderRotatedBanner(token: string | undefined): SafeHtml {
+  if (!token) return unsafeHtml('');
+  return html`
+    <div class="flash flash--ok" style="margin-top: var(--space-3);">
+      <p style="margin: 0 0 var(--space-2);"><strong>New token:</strong></p>
+      <p class="mono" style="word-break: break-all; margin: 0;">${token}</p>
+      <p class="dim" style="margin-top: var(--space-2); margin-bottom: 0;">
+        Copy it now — this is the only time it will be displayed.
+        Update your MCP client config and restart any <code>sua mcp start</code>.
+      </p>
+    </div>
+  `;
+}

--- a/packages/dashboard/src/views/settings-secrets.ts
+++ b/packages/dashboard/src/views/settings-secrets.ts
@@ -1,0 +1,180 @@
+import type { SecretsStoreStatus } from '@some-useful-agents/core';
+import { html, unsafeHtml, type SafeHtml } from './html.js';
+
+export interface SettingsSecretsArgs {
+  status: SecretsStoreStatus;
+  isUnlocked: boolean;
+  /** Sorted secret names (values never rendered). Empty when locked. */
+  names: string[];
+  /** Agent-declared secret names that are not yet set. */
+  missing: string[];
+  /** Inline error (validation / unlock failure), rendered inside the relevant card. */
+  unlockError?: string;
+  setError?: string;
+  /** Preserve the `name` field when a `set` form round-trips with an error. */
+  setNameValue?: string;
+}
+
+/**
+ * Render the `/settings/secrets` body. Three states:
+ *   1. Store is passphrase-protected and the session is locked → unlock form only
+ *   2. Store is unlocked (or doesn't need unlocking) → list + set form + delete
+ *   3. Store is absent → invite to create by setting the first secret
+ *
+ * Values are never rendered. Delete is a POST with a confirm handler
+ * wired via the shared dashboard JS. Set uses type=password so the
+ * value doesn't echo to the screen while typing.
+ */
+export function renderSettingsSecrets(args: SettingsSecretsArgs): SafeHtml {
+  const modeLabel = formatModeLabel(args.status);
+  const modeBadge = modeBadgeFor(args.status);
+
+  if (args.status.mode === 'passphrase' && !args.isUnlocked) {
+    return html`
+      <div class="card">
+        <p class="card__title">Secrets (locked)</p>
+        <p>
+          Your secrets store is passphrase-protected. Enter the passphrase
+          to unlock for this dashboard session. It stays in memory only —
+          nothing is written to disk or cookies.
+        </p>
+        ${unlockErrorBlock(args.unlockError)}
+        <form action="/settings/secrets/unlock" method="post" class="settings-form">
+          <label class="settings-form__label" for="passphrase">Passphrase</label>
+          <input id="passphrase" name="passphrase" type="password" autocomplete="current-password" required autofocus>
+          <div class="settings-form__actions">
+            <button type="submit" class="btn btn--primary">Unlock</button>
+          </div>
+        </form>
+        <p class="dim" style="margin-top: var(--space-4);">
+          <strong>Store mode:</strong> ${modeBadge} ${modeLabel}
+        </p>
+      </div>
+    `;
+  }
+
+  return html`
+    <div class="card">
+      <p class="card__title">Stored secrets</p>
+      <p class="dim">${secretsSummary(args.names.length, args.status, args.isUnlocked)}</p>
+      ${renderNamesTable(args.names)}
+      ${args.missing.length > 0 ? renderMissingList(args.missing) : unsafeHtml('')}
+    </div>
+
+    <div class="card">
+      <p class="card__title">Set a secret</p>
+      <p class="dim">
+        Names must be uppercase letters, digits, or underscores and start
+        with a letter or underscore (e.g. <code>SLACK_WEBHOOK</code>).
+        Values are written encrypted; never echoed back.
+      </p>
+      ${setErrorBlock(args.setError)}
+      <form action="/settings/secrets/set" method="post" class="settings-form">
+        <label class="settings-form__label" for="secret-name">Name</label>
+        <input id="secret-name" name="name" type="text" required
+          pattern="[A-Z_][A-Z0-9_]*"
+          placeholder="MY_API_KEY"
+          value="${args.setNameValue ?? ''}"
+          autocapitalize="off" autocorrect="off" spellcheck="false">
+
+        <label class="settings-form__label" for="secret-value">Value</label>
+        <input id="secret-value" name="value" type="password" required autocomplete="off">
+
+        <div class="settings-form__actions">
+          <button type="submit" class="btn btn--primary">Save secret</button>
+        </div>
+      </form>
+    </div>
+
+    <div class="card">
+      <p class="card__title">Session</p>
+      <p class="dim">
+        <strong>Store mode:</strong> ${modeBadge} ${modeLabel}
+      </p>
+      ${args.status.mode === 'passphrase'
+        ? html`
+          <form action="/settings/secrets/lock" method="post" style="margin-top: var(--space-3);">
+            <button type="submit" class="btn btn--ghost">Lock now</button>
+          </form>`
+        : unsafeHtml('')}
+    </div>
+  `;
+}
+
+function renderNamesTable(names: string[]): SafeHtml {
+  if (names.length === 0) {
+    return html`<p class="settings-empty" style="margin-top: var(--space-3);">No secrets set yet.</p>`;
+  }
+  const rows = names.map((n) => html`
+    <tr>
+      <td class="mono">${n}</td>
+      <td style="text-align: right;">
+        <form action="/settings/secrets/delete" method="post"
+          data-confirm="Delete secret ${n}? Agents that reference it will fail until it's set again.">
+          <input type="hidden" name="name" value="${n}">
+          <button type="submit" class="btn btn--sm btn--ghost">Delete</button>
+        </form>
+      </td>
+    </tr>
+  `);
+  return html`
+    <table class="table" style="margin-top: var(--space-3);">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th style="text-align: right;">Action</th>
+        </tr>
+      </thead>
+      <tbody>${rows as unknown as SafeHtml[]}</tbody>
+    </table>
+  `;
+}
+
+function renderMissingList(missing: string[]): SafeHtml {
+  const items = missing.map((n) => html`<li class="mono">${n}</li>`);
+  return html`
+    <div style="margin-top: var(--space-4);">
+      <p class="card__title" style="margin-bottom: var(--space-2);">Declared by agents but not set</p>
+      <ul class="settings-missing">${items as unknown as SafeHtml[]}</ul>
+    </div>
+  `;
+}
+
+function unlockErrorBlock(err: string | undefined): SafeHtml {
+  if (!err) return unsafeHtml('');
+  return html`<div class="flash flash--error" style="margin-bottom: var(--space-3);">${err}</div>`;
+}
+
+function setErrorBlock(err: string | undefined): SafeHtml {
+  if (!err) return unsafeHtml('');
+  return html`<div class="flash flash--error" style="margin-bottom: var(--space-3);">${err}</div>`;
+}
+
+function secretsSummary(count: number, status: SecretsStoreStatus, isUnlocked: boolean): string {
+  if (!status.exists) return 'No store yet — set your first secret below to create one.';
+  if (!isUnlocked) return 'Store is locked. Unlock to view names.';
+  return `${count} secret${count === 1 ? '' : 's'} stored. Values are encrypted at rest; only names are shown here.`;
+}
+
+function formatModeLabel(status: SecretsStoreStatus): string {
+  switch (status.mode) {
+    case 'passphrase':
+      return 'passphrase-protected (v2)';
+    case 'hostname-obfuscated':
+      return status.version === 1
+        ? 'legacy v1 (hostname-obfuscated, not encrypted)'
+        : 'hostname-obfuscated fallback (not real encryption)';
+    case 'absent':
+      return 'no store file yet';
+  }
+}
+
+function modeBadgeFor(status: SecretsStoreStatus): SafeHtml {
+  if (status.mode === 'passphrase') {
+    return html`<span class="badge badge--ok">encrypted</span>`;
+  }
+  if (status.mode === 'hostname-obfuscated') {
+    return html`<span class="badge badge--warn">fallback</span>`;
+  }
+  return html`<span class="badge badge--muted">absent</span>`;
+}


### PR DESCRIPTION
## Summary

- `/settings/secrets` — list declared names (values never rendered), set, delete, plus a passphrase unlock flow. Passphrase cached in dashboard-process memory only; never persisted to disk, cookies, or sessionStorage. Missing agent-declared secrets surfaced inline.
- `/settings/general` — one-click MCP bearer token rotation that re-mints the dashboard session cookie so the operator stays signed in, reveals the new token once, and prints the fingerprint + retention policy + data paths.
- `/settings/integrations` — placeholder copy polish (no behaviour change).
- Unblocks v0.16 AI-assist, whose Anthropic API key needs the settings surface to have a home.

## Design notes

- Origin check in `requireAuth` is the CSRF defence — no second token layer needed.
- New `SecretsSession` abstraction wraps `EncryptedFileStore` with a per-process passphrase cache (interface + file-backed impl for prod, memory-backed for tests).
- Rotate flow updates `ctx.token` in-place and `Set-Cookie`s the new value on the same 303, so the middleware's constant-time compare stays in lockstep.
- Declared-secrets discovery tolerates broken YAML — a malformed agent file must not take down the settings page.

## Test plan

- [x] 75/75 dashboard tests pass (55 → 75; +20 new covering unlock gate, wrong/right passphrase, set/delete validation + happy path, lock, cross-origin refusal, rotate-and-cookie-reswap, post-rotate old-cookie rejection + new-cookie acceptance, integrations placeholder, `EncryptedFileSecretsSession` file round-trip + locked-write rejection).
- [x] 472/472 workspace tests pass.
- [x] `npm run lint` clean.
- [x] `npm run build` clean.
- [ ] Smoke in a scratch project: `sua dashboard start` → `/settings/secrets` unlock → set a secret → delete it → `/settings/general` rotate → confirm the cookie stays valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)