### PR TITLE
feat(dashboard): replay on DAG click + node dialog + template palette (PR 5/5)

### DIFF
--- a/.changeset/dashboard-v015-replay-polish.md
+++ b/.changeset/dashboard-v015-replay-polish.md
@@ -1,0 +1,64 @@
+---
+"@some-useful-agents/dashboard": minor
+---
+
+**feat: replay on DAG click + node action dialog + template palette + polish (PR 5 of 5, closes v0.15).**
+
+Turns the DAG viz into the primary interaction surface (not a decoration above a table), adds a command-palette style autocomplete to node command/prompt textareas, and tightens the empty/error states the earlier PRs in this bundle didn't quite nail.
+
+### Node action dialog
+
+- **Click any DAG node** on `/runs/:id` or `/agents/:id` to open an action dialog. Dialog shows the node's id, type badge, status badge (run detail only), depends-on list, and duration — plus context-specific action buttons.
+- **On `/runs/:id`** (terminal runs only): "Replay from here" button POSTs to `/runs/<priorRunId>/replay` with the clicked node as `fromNodeId`. Community shell agents add a confirm prompt + the audit flag. "Jump to details" scrolls to the per-node card below.
+- **On `/agents/:id`**: "Edit node" link jumps into `/agents/:id/nodes/:nodeId/edit`. When a latest completed run exists, "Replay from here" points at that run for one-click re-execution.
+- Uses the browser-native `<dialog>` element so ESC + backdrop clicks + focus return are free.
+- Replaces the misleading "Click a node to inspect it" inspector hint — the interaction now actually exists and the hint tells the truth.
+- Below-DAG "Replay" form is now a `<noscript>` fallback for users without JS.
+
+### Template palette (autocomplete for `$` and `{{`)
+
+- Typing `$` in a **shell** textarea opens a floating palette with every available env-var injection:
+  - `$UPSTREAM_<ID>_RESULT` for each other node in the agent
+  - `$<INPUT>` for every declared agent-level input
+  - `$<SECRET>` for every secret declared on the node
+- Typing `{{` in a **claude-code** prompt textarea opens the same idea with template refs:
+  - `{{upstream.<id>.result}}` per upstream node
+  - `{{inputs.<NAME>}}` per agent input
+- Keyboard: Up/Down to navigate, Enter/Tab to insert, Esc to close. Substring match + position-scored ranking.
+- Suggestions are computed server-side from the agent's node list + declared inputs + per-node secrets, embedded as a JSON payload in a `<script type="application/json">` tag — same pattern Cytoscape uses for its element payload.
+- Wired into both `/agents/:id/add-node` and `/agents/:id/nodes/:nodeId/edit`. Friendly inline hint below each textarea.
+
+### Replay / empty / error polish
+
+- `POST /runs/:id/replay` — validates prior run is a v2 DAG run + agent exists + node is valid; dispatches `executeAgentDag` with `replayFrom`; 303s to the NEW run's page on success, flashes back to the prior run on failure.
+- `/runs` with zero runs renders a dedicated "No runs yet" card pointing to the Agents page + CLI. `/runs?agent=ghost` (filters + no matches) renders "No runs match" + a Reset filters link.
+- `/runs/<missing>` 303-redirects to `/runs` with a flash explaining the run may have been pruned by the retention policy. No more raw `<p>` fallback.
+- `/runs/:id` surfaces flash banners for replay errors via an error-vs-ok regex classifier in the route.
+
+### Design notes
+
+- **Dialog chosen over popover.** The browser-native `<dialog>` element handles ESC, backdrop clicks, and focus return without extra JS. Building a custom popover positioned over a Cytoscape canvas gets messy fast.
+- **Replay always redirects to a new run.** Even on executor-side validation failure (missing upstream snapshot), the executor creates a failed run row for the audit trail. The dashboard flashes back to the prior run's page for those cases to keep the flow consistent.
+- **Palette doesn't filter by `dependsOn:` checkboxes.** Users can type a reference to a node they haven't yet marked as an upstream; save-time Zod validation catches it. Wiring the palette to live checkbox state adds complexity without clear value — the "helpful error at save" path already exists.
+- **Palette is inline JS, not a new asset.** The handler is ~180 lines; adding a second `/assets/*.js` file for it adds a network round-trip without material benefit. When the palette grows (v0.16 structured-outputs will add path completions), promote to its own asset file.
+
+### Files
+
+- New: `packages/dashboard/src/routes/run-mutations.ts` (replay route), `packages/dashboard/src/views/template-palette.ts` (suggestions helper + payload renderer)
+- Modified: `views/dag-view.ts` (replay/editBase props + `<dialog>` shell), `routes/assets.ts` (node-click dialog logic in `graph-render.js` + additional per-node data), `views/run-detail.ts` (replay context + noscript fallback, removed inline replay form), `views/agent-detail-v2.ts` (editBase + replay wiring + honest hint), `views/agent-add-node.ts` + `views/agent-edit-node.ts` (palette wiring), `views/js.ts` (palette client), `routes/runs.ts` (flash classification + 303 on missing run), `views/runs-list.ts` (empty-state split), `assets/screens.css` (dialog + palette styles), `index.ts` (wire run-mutations router)
+
+### Tests
+
+87 dashboard tests total (75 → 87; +12 new):
+- DAG wires `data-replay-run-id` on completed v2 runs + `<dialog>` shell present + click-hint rendered
+- No replay wiring on in-progress runs
+- Agent detail wires edit-base + replay-latest + replaced misleading inspector hint
+- `POST /replay` — missing node, unknown node, valid node, cross-origin refusal
+- `GET /runs/<missing>` redirect
+- Empty / filtered empty states
+- Palette JSON payload on add-node form (all candidate upstreams)
+- Palette JSON payload on edit-node form excludes the node under edit
+
+### Plan
+
+v0.15 is feature-complete with this PR. Release work (changeset consolidation, CHANGELOG polish, version bump) happens via the Changesets release PR (#64). Post-v0.15: see `~/.claude/plans/agents-as-packages.md` and `~/.claude/plans/dashboard-revamp.md` for where this is heading.

--- a/packages/dashboard/src/assets/components.css
+++ b/packages/dashboard/src/assets/components.css
@@ -615,6 +615,78 @@
   white-space: nowrap;
 }
 
+/* DAG mini-cards inside the agent card's expansion. Each card is
+ * indented by its topological depth (--depth, set inline) so the
+ * expansion reflects the DAG shape. A left-edge rail hints at the
+ * parent/child relationship without a full graph widget. */
+.agent-card__dag {
+  margin-top: var(--space-2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.agent-card__node {
+  position: relative;
+  padding: var(--space-2) var(--space-3) var(--space-2) calc(var(--space-3) + var(--depth, 0) * 1.25rem);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  display: flex;
+  gap: var(--space-2);
+  transition: border-color 120ms;
+}
+
+.agent-card__node[data-depth="0"] {
+  background: var(--color-surface-raised);
+}
+
+.agent-card__node:hover {
+  border-color: var(--color-primary);
+}
+
+.agent-card__node-rail {
+  position: absolute;
+  top: 0;
+  left: calc(var(--space-2) + (var(--depth, 0) - 1) * 1.25rem + 0.5rem);
+  bottom: 0;
+  width: 2px;
+  background: var(--color-primary);
+  border-radius: 1px;
+  opacity: 0.4;
+  display: none;
+}
+
+.agent-card__node[data-depth]:not([data-depth="0"]) .agent-card__node-rail {
+  display: block;
+}
+
+.agent-card__node-body-wrap {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.agent-card__node-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.agent-card__node-id {
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+}
+
+.agent-card__node-dep {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+}
+
 /*
  * Legacy class-name aliases — will be removed once all view files use
  * the BEM-style forms above. Keep this block small; no new rules belong

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -507,6 +507,20 @@ main.main--wide {
   color: var(--color-warn);
 }
 
+/* Node-type fields on the add/edit-node forms. The field not matching
+ * the selected type radio is greyed out but remains in the DOM — the
+ * server still sees both, but the UI nudges the user toward editing
+ * only the one that matters for the selected type. */
+.node-field--inactive {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.node-field--inactive textarea {
+  background: var(--color-surface-raised);
+  color: var(--color-text-muted);
+}
+
 /* Template palette — command/prompt textarea autocomplete for $ and {{ */
 .template-palette {
   display: none;

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -366,9 +366,9 @@ main.main--wide {
  * element so the browser handles ESC + backdrop clicks + focus return. */
 .node-dialog {
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-lg);
   padding: 0;
-  max-width: 28rem;
+  max-width: 32rem;
   width: 90%;
   box-shadow: var(--shadow-md);
   background: var(--color-surface);
@@ -376,14 +376,15 @@ main.main--wide {
 }
 
 .node-dialog::backdrop {
-  background: rgb(0 0 0 / 0.35);
+  background: rgb(15 23 42 / 0.45);
+  backdrop-filter: blur(1px);
 }
 
 .node-dialog__form {
-  padding: var(--space-4) var(--space-5);
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
 }
 
 .node-dialog__header {
@@ -391,31 +392,91 @@ main.main--wide {
   align-items: center;
   gap: var(--space-2);
   flex-wrap: wrap;
+  padding: var(--space-4) var(--space-5);
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface-raised);
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
 }
 
 .node-dialog__id {
   font-size: var(--font-size-md);
   font-weight: var(--weight-semibold);
+  color: var(--color-text);
 }
 
 .node-dialog__close {
   margin-left: auto;
   background: transparent;
   border: 0;
-  font-size: var(--font-size-lg);
+  width: 1.75rem;
+  height: 1.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-md);
   line-height: 1;
   color: var(--color-text-muted);
   cursor: pointer;
-  padding: 0 var(--space-2);
+  padding: 0;
 }
 
 .node-dialog__close:hover {
   color: var(--color-text);
+  background: var(--color-border);
+}
+
+.node-dialog__close:focus,
+.node-dialog__close:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--color-primary);
 }
 
 .node-dialog__meta {
   margin: 0;
-  grid-template-columns: 8rem 1fr;
+  padding: var(--space-4) var(--space-5) 0;
+  grid-template-columns: 7rem 1fr;
+  row-gap: var(--space-2);
+}
+
+.node-dialog__meta dt {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: var(--weight-semibold);
+}
+
+.node-dialog__meta dd {
+  margin: 0;
+  color: var(--color-text);
+  font-size: var(--font-size-sm);
+}
+
+.node-dialog__explain {
+  padding: var(--space-4) var(--space-5) 0;
+  color: var(--color-text);
+}
+
+.node-dialog__explain:empty {
+  display: none;
+}
+
+.node-dialog__explain-text {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+.node-dialog__warn {
+  margin: var(--space-3) 0 0;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-sm);
+  color: var(--color-warn);
+  background: var(--color-warn-soft);
+  border-radius: var(--radius-sm);
+  line-height: 1.4;
 }
 
 .node-dialog__actions {
@@ -423,8 +484,27 @@ main.main--wide {
   gap: var(--space-2);
   flex-wrap: wrap;
   justify-content: flex-end;
-  padding-top: var(--space-2);
+  align-items: center;
+  padding: var(--space-4) var(--space-5);
+  margin-top: var(--space-4);
   border-top: 1px solid var(--color-border);
+  background: var(--color-surface-raised);
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+}
+
+.node-dialog__replay-form {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0;
+}
+
+.node-dialog__audit {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--font-size-xs);
+  color: var(--color-warn);
 }
 
 /* Template palette — command/prompt textarea autocomplete for $ and {{ */

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -196,6 +196,13 @@ main.main--wide {
 
 .dag-disclosure__summary::-webkit-details-marker { display: none; }
 
+.dag-disclosure__hint {
+  margin-left: auto;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  font-weight: var(--weight-regular);
+}
+
 .dag-disclosure:not([open]) > .dag-disclosure__summary {
   border-bottom: none;
 }
@@ -299,4 +306,176 @@ main.main--wide {
   padding-left: var(--space-5);
   color: var(--color-warn);
   font-size: var(--font-size-sm);
+}
+
+/* Replay form — lives on terminal v2 run detail pages. */
+.replay-form-section {
+  margin-top: var(--space-6);
+  padding: var(--space-4) var(--space-6);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.replay-form-section h2 {
+  margin: 0 0 var(--space-2);
+  font-size: var(--font-size-md);
+}
+
+.replay-form {
+  display: flex;
+  gap: var(--space-3);
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: var(--space-3);
+}
+
+.replay-form label {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  font-weight: var(--weight-medium);
+}
+
+.replay-form select {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-mono);
+  background: var(--color-surface);
+  color: var(--color-text);
+  min-width: 14rem;
+}
+
+.replay-form select:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: var(--shadow-focus);
+}
+
+.replay-form__confirm {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-warn);
+  flex-basis: 100%;
+}
+
+/* Node-action dialog — opens on DAG node click. Uses the native <dialog>
+ * element so the browser handles ESC + backdrop clicks + focus return. */
+.node-dialog {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 0;
+  max-width: 28rem;
+  width: 90%;
+  box-shadow: var(--shadow-md);
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.node-dialog::backdrop {
+  background: rgb(0 0 0 / 0.35);
+}
+
+.node-dialog__form {
+  padding: var(--space-4) var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.node-dialog__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.node-dialog__id {
+  font-size: var(--font-size-md);
+  font-weight: var(--weight-semibold);
+}
+
+.node-dialog__close {
+  margin-left: auto;
+  background: transparent;
+  border: 0;
+  font-size: var(--font-size-lg);
+  line-height: 1;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: 0 var(--space-2);
+}
+
+.node-dialog__close:hover {
+  color: var(--color-text);
+}
+
+.node-dialog__meta {
+  margin: 0;
+  grid-template-columns: 8rem 1fr;
+}
+
+.node-dialog__actions {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--color-border);
+}
+
+/* Template palette — command/prompt textarea autocomplete for $ and {{ */
+.template-palette {
+  display: none;
+  position: absolute;
+  z-index: 100;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-md);
+  max-height: 18rem;
+  overflow-y: auto;
+  padding: var(--space-1) 0;
+  min-width: 18rem;
+}
+
+.template-palette__item {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+}
+
+.template-palette__item.is-selected,
+.template-palette__item:hover {
+  background: var(--color-surface-raised);
+}
+
+.template-palette__label {
+  font-size: var(--font-size-xs);
+  color: var(--color-text);
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+.template-palette__hint {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  flex: 1 1 auto;
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.template-palette__empty {
+  padding: var(--space-3);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  text-align: center;
 }

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -180,7 +180,9 @@ describe('Dashboard /runs + filters', () => {
       .set('Host', `127.0.0.1:${PORT}`)
       .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
     expect(res.status).toBe(200);
-    expect(res.text).toContain('No runs match');
+    // Dedicated "No runs yet" state (PR 5 polish) — was "No runs match"
+    // which didn't read right for a fresh install with no filters set.
+    expect(res.text).toContain('No runs yet');
   });
 
   it('filters by agent via query string', async () => {
@@ -1198,5 +1200,216 @@ describe('Dashboard /settings/integrations', () => {
     expect(res.status).toBe(200);
     expect(res.text).toContain('Integrations');
     expect(res.text).toContain('coming in a later release');
+  });
+});
+
+describe('Dashboard /runs/:id/replay (PR 5)', () => {
+  async function seedTwoNodeAgentWithRun(agentId = 'replay-test') {
+    agentStore.createAgent({
+      id: agentId, name: 'Replay Test', status: 'active', source: 'local', mcp: false,
+      nodes: [
+        { id: 'fetch', type: 'shell', command: 'echo fetched' },
+        { id: 'summarize', type: 'shell', command: 'echo summary', dependsOn: ['fetch'] },
+      ],
+    }, 'cli', 'seed');
+
+    const priorRunId = 'prior-run-1';
+    runStore.createRun({
+      id: priorRunId, agentName: agentId, status: 'completed',
+      startedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(),
+      triggeredBy: 'cli',
+      workflowId: agentId,
+      workflowVersion: 1,
+    });
+    runStore.createNodeExecution({
+      runId: priorRunId, nodeId: 'fetch', workflowVersion: 1,
+      status: 'completed', startedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(), exitCode: 0, result: 'fetched',
+    });
+    runStore.createNodeExecution({
+      runId: priorRunId, nodeId: 'summarize', workflowVersion: 1,
+      status: 'completed', startedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(), exitCode: 0, result: 'summary',
+    });
+    return { agentId, priorRunId };
+  }
+
+  it('wires the DAG for replay on a completed v2 run', async () => {
+    const app = await makeApp();
+    const { priorRunId } = await seedTwoNodeAgentWithRun();
+    const res = await request(app).get(`/runs/${priorRunId}`)
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    // The DAG canvas carries the replay run id so the client-side
+    // dialog can POST /runs/:id/replay when the user clicks a node.
+    expect(res.text).toContain(`data-replay-run-id="${priorRunId}"`);
+    // The <dialog> shell the client populates on node-tap.
+    expect(res.text).toContain('id="dag-node-dialog"');
+    // The click hint tells the user the interaction is available.
+    expect(res.text).toContain('Click a node to replay');
+    // No-JS fallback form is wrapped in <noscript>.
+    expect(res.text).toMatch(/<noscript>[\s\S]*action="\/runs\/[^"]+\/replay"/);
+  });
+
+  it('omits replay wiring on in-progress runs', async () => {
+    const app = await makeApp();
+    const { agentId } = await seedTwoNodeAgentWithRun('replay-running');
+    const runningId = 'running-run';
+    runStore.createRun({
+      id: runningId, agentName: agentId, status: 'running',
+      startedAt: new Date().toISOString(), triggeredBy: 'cli',
+      workflowId: agentId, workflowVersion: 1,
+    });
+    const res = await request(app).get(`/runs/${runningId}`)
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    // No replay wiring while a run is still running — neither the
+    // canvas attribute nor the fallback form.
+    expect(res.text).not.toContain('data-replay-run-id');
+    expect(res.text).not.toMatch(/action="[^"]*\/replay"/);
+  });
+
+  it('agent detail wires the DAG for edit + replay-latest', async () => {
+    const app = await makeApp();
+    const { agentId } = await seedTwoNodeAgentWithRun('replay-agent-detail');
+    const res = await request(app).get(`/agents/${agentId}`)
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    // Edit-from-DAG and replay-latest-from-DAG both present.
+    expect(res.text).toContain(`data-edit-base="/agents/${agentId}/nodes"`);
+    expect(res.text).toMatch(/data-replay-run-id="prior-run-1"/);
+    // Stale "Click a node to inspect it" copy is gone; new honest hint
+    // reflects the interaction.
+    expect(res.text).not.toContain('Click a node to inspect it');
+    expect(res.text).toContain('Click a DAG node for its actions');
+  });
+
+  it('POST /runs/:id/replay with a missing fromNodeId flashes an error', async () => {
+    const app = await makeApp();
+    const { priorRunId } = await seedTwoNodeAgentWithRun();
+    const res = await request(app).post(`/runs/${priorRunId}/replay`)
+      .type('form')
+      .send({})
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toBe(`/runs/${priorRunId}?flash=${encodeURIComponent('Pick a node to replay from.')}`);
+  });
+
+  it('POST /runs/:id/replay with an unknown node flashes an error', async () => {
+    const app = await makeApp();
+    const { priorRunId } = await seedTwoNodeAgentWithRun();
+    const res = await request(app).post(`/runs/${priorRunId}/replay`)
+      .type('form')
+      .send({ fromNodeId: 'ghost-node' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(new RegExp(`^/runs/${priorRunId}\\?flash=`));
+    expect(decodeURIComponent(res.headers.location)).toContain('not in agent');
+  });
+
+  it('POST /runs/:id/replay dispatches + redirects to the new run', async () => {
+    const app = await makeApp();
+    const { priorRunId } = await seedTwoNodeAgentWithRun();
+    const res = await request(app).post(`/runs/${priorRunId}/replay`)
+      .type('form')
+      .send({ fromNodeId: 'summarize' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    // Replay redirects to the NEW run id — not the prior one.
+    expect(res.headers.location).toMatch(/^\/runs\/[^/?]+\?flash=/);
+    expect(res.headers.location).not.toContain(priorRunId);
+    expect(decodeURIComponent(res.headers.location)).toContain('Replayed from "summarize"');
+  });
+
+  it('POST /runs/:id/replay rejects cross-origin POSTs (CSRF defense)', async () => {
+    const app = await makeApp();
+    const { priorRunId } = await seedTwoNodeAgentWithRun();
+    const res = await request(app).post(`/runs/${priorRunId}/replay`)
+      .type('form')
+      .send({ fromNodeId: 'summarize' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Origin', 'http://evil.example.com')
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('GET /runs/<missing> redirects to /runs with a flash', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/runs/does-not-exist')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/^\/runs\?flash=/);
+    expect(decodeURIComponent(res.headers.location)).toContain('not found');
+  });
+
+  it('empty /runs renders the "No runs yet" state when nothing exists', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/runs')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('No runs yet');
+  });
+
+  it('filtered /runs with no matches renders "No runs match"', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/runs?agent=ghost')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('No runs match');
+    expect(res.text).toContain('Reset filters');
+  });
+});
+
+describe('Dashboard template palette (PR 5)', () => {
+  async function seedTwoNodeAgent(id = 'palette-test') {
+    agentStore.createAgent({
+      id, name: 'Palette Test', status: 'active', source: 'local', mcp: false,
+      nodes: [
+        { id: 'fetch', type: 'shell', command: 'echo hi' },
+        { id: 'summarize', type: 'shell', command: 'echo bye', dependsOn: ['fetch'] },
+      ],
+    }, 'cli', 'seed');
+    return id;
+  }
+
+  it('add-node form embeds the palette suggestions payload', async () => {
+    const app = await makeApp();
+    const id = await seedTwoNodeAgent();
+    const res = await request(app).get(`/agents/${id}/add-node`)
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    // Both textareas are marked with their palette mode.
+    expect(res.text).toContain('data-template-palette="shell"');
+    expect(res.text).toContain('data-template-palette="claude"');
+    // The JSON payload carries every node id as a candidate upstream.
+    expect(res.text).toContain('<script id="palette-add-node" type="application/json">');
+    expect(res.text).toMatch(/"upstreams":\s*\["fetch","summarize"\]/);
+    // Friendly affordance hint is visible to the user.
+    expect(res.text).toContain('Type <code>$</code>');
+    expect(res.text).toContain('Type <code>{{</code>');
+  });
+
+  it('edit-node palette excludes the node itself from upstream suggestions', async () => {
+    const app = await makeApp();
+    const id = await seedTwoNodeAgent('palette-edit-test');
+    const res = await request(app).get(`/agents/${id}/nodes/fetch/edit`)
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    // Fetching the "fetch" node's edit form — the palette payload must
+    // not offer "fetch" as a self-reference candidate.
+    expect(res.text).toContain('<script id="palette-edit-node" type="application/json">');
+    expect(res.text).toMatch(/"upstreams":\s*\["summarize"\]/);
   });
 });

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -1248,7 +1248,7 @@ describe('Dashboard /runs/:id/replay (PR 5)', () => {
     // The <dialog> shell the client populates on node-tap.
     expect(res.text).toContain('id="dag-node-dialog"');
     // The click hint tells the user the interaction is available.
-    expect(res.text).toContain('Click a node to replay');
+    expect(res.text).toContain('Click a node to see its actions');
     // No-JS fallback form is wrapped in <noscript>.
     expect(res.text).toMatch(/<noscript>[\s\S]*action="\/runs\/[^"]+\/replay"/);
   });
@@ -1282,10 +1282,12 @@ describe('Dashboard /runs/:id/replay (PR 5)', () => {
     // Edit-from-DAG and replay-latest-from-DAG both present.
     expect(res.text).toContain(`data-edit-base="/agents/${agentId}/nodes"`);
     expect(res.text).toMatch(/data-replay-run-id="prior-run-1"/);
-    // Stale "Click a node to inspect it" copy is gone; new honest hint
-    // reflects the interaction.
+    // Stale "Click a node to inspect it" + "Click a DAG node for its
+    // actions" copy is gone. Only the DAG's own hint survives — the
+    // Overview sidebar doesn't pretend to respond to node clicks.
     expect(res.text).not.toContain('Click a node to inspect it');
-    expect(res.text).toContain('Click a DAG node for its actions');
+    expect(res.text).not.toContain('Click a DAG node for its actions');
+    expect(res.text).toContain('Click a node to see its actions');
   });
 
   it('POST /runs/:id/replay with a missing fromNodeId flashes an error', async () => {

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -20,6 +20,7 @@ import { authRouter } from './routes/auth.js';
 import { agentsRouter } from './routes/agents.js';
 import { runsRouter } from './routes/runs.js';
 import { runNowRouter } from './routes/run-now.js';
+import { runMutationsRouter } from './routes/run-mutations.js';
 import { assetsRouter } from './routes/assets.js';
 import { settingsRouter } from './routes/settings.js';
 import { helpRouter } from './routes/help.js';
@@ -87,6 +88,7 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   app.use(agentsRouter);
   app.use(runsRouter);
   app.use(runNowRouter);
+  app.use(runMutationsRouter);
   app.use(settingsRouter);
   app.use(helpRouter);
   app.use(versionsRouter);

--- a/packages/dashboard/src/routes/assets.ts
+++ b/packages/dashboard/src/routes/assets.ts
@@ -205,6 +205,35 @@ const GRAPH_RENDER_JS = `
     return span;
   }
 
+  // Count nodes downstream of the tapped one so the dialog's "what
+  // will happen" summary can say, e.g., "2 downstream nodes will re-run".
+  function countDownstream(startId) {
+    var visited = {};
+    var stack = [startId];
+    while (stack.length) {
+      var cur = stack.pop();
+      cy.edges('[source = "' + cur + '"]').forEach(function (e) {
+        var t = e.target().id();
+        if (!visited[t]) { visited[t] = true; stack.push(t); }
+      });
+    }
+    // startId itself isn't in visited (it's not downstream of itself).
+    return Object.keys(visited).length;
+  }
+
+  function countUpstream(startId) {
+    var visited = {};
+    var stack = [startId];
+    while (stack.length) {
+      var cur = stack.pop();
+      cy.edges('[target = "' + cur + '"]').forEach(function (e) {
+        var s = e.source().id();
+        if (!visited[s]) { visited[s] = true; stack.push(s); }
+      });
+    }
+    return Object.keys(visited).length;
+  }
+
   function openDialog(data) {
     if (!dialogSupported) return false;
     var idEl = dialog.querySelector('[data-node-id]');
@@ -212,6 +241,7 @@ const GRAPH_RENDER_JS = `
     var statusEl = dialog.querySelector('[data-node-status]');
     var depsEl = dialog.querySelector('[data-node-deps]');
     var durEl = dialog.querySelector('[data-node-duration]');
+    var explainEl = dialog.querySelector('[data-node-explain]');
     var actionsEl = dialog.querySelector('[data-node-actions]');
 
     idEl.textContent = data.id;
@@ -235,7 +265,40 @@ const GRAPH_RENDER_JS = `
     depsEl.textContent = data.dependsOn && data.dependsOn.length > 0 ? data.dependsOn : '—';
     durEl.textContent = fmtDuration(data.startedAt, data.completedAt);
 
+    explainEl.innerHTML = '';
     actionsEl.innerHTML = '';
+
+    // Explainer + action row depend on context. Replay-capable surfaces
+    // (run detail with a terminal run, agent detail with a prior run)
+    // show a "what will happen" summary above the buttons so the user
+    // can commit without a second native-confirm popup.
+    var hasReplay = !!replayRunId;
+    if (hasReplay) {
+      var ups = countUpstream(data.id);
+      var downs = countDownstream(data.id);
+      var explainText = 'Replay will reuse outputs from ' + ups + ' upstream node' + (ups === 1 ? '' : 's') +
+        ' and re-run this node plus ' + downs + ' downstream node' + (downs === 1 ? '' : 's') + '.';
+      var p = document.createElement('p');
+      p.className = 'node-dialog__explain-text';
+      p.textContent = explainText;
+      explainEl.appendChild(p);
+
+      if (replayCommunity) {
+        var warn = document.createElement('p');
+        warn.className = 'node-dialog__warn';
+        warn.textContent = 'This agent contains community shell nodes. Confirm you\\'ve audited the command before replaying.';
+        explainEl.appendChild(warn);
+      }
+    }
+
+    // Cancel is always offered so the dialog is dismissable without
+    // hunting for the × button. The method="dialog" form means this
+    // just closes the dialog without a submit.
+    var cancel = document.createElement('button');
+    cancel.type = 'submit';
+    cancel.className = 'btn btn--sm btn--ghost';
+    cancel.textContent = 'Cancel';
+    actionsEl.appendChild(cancel);
 
     if (editBase) {
       var edit = document.createElement('a');
@@ -245,41 +308,6 @@ const GRAPH_RENDER_JS = `
       actionsEl.appendChild(edit);
     }
 
-    if (replayRunId) {
-      var form = document.createElement('form');
-      form.method = 'POST';
-      form.action = '/runs/' + encodeURIComponent(replayRunId) + '/replay';
-      form.style.display = 'inline';
-
-      var fromInput = document.createElement('input');
-      fromInput.type = 'hidden';
-      fromInput.name = 'fromNodeId';
-      fromInput.value = data.id;
-      form.appendChild(fromInput);
-
-      if (replayCommunity) {
-        var confirmInput = document.createElement('input');
-        confirmInput.type = 'hidden';
-        confirmInput.name = 'confirm_community_shell';
-        confirmInput.value = 'yes';
-        form.appendChild(confirmInput);
-      }
-
-      var btn = document.createElement('button');
-      btn.type = 'submit';
-      btn.className = 'btn btn--sm btn--primary';
-      btn.textContent = replayCommunity ? 'Replay from here (community)' : 'Replay from here';
-      btn.addEventListener('click', function (e) {
-        var msg = 'Replay from "' + data.id + '"? Upstream outputs will be reused and this node plus downstream nodes will re-run.';
-        if (replayCommunity) {
-          msg += '\\n\\nThis agent contains community shell nodes. Continue?';
-        }
-        if (!window.confirm(msg)) e.preventDefault();
-      });
-      form.appendChild(btn);
-      actionsEl.appendChild(form);
-    }
-
     if (navBase) {
       var jump = document.createElement('a');
       jump.className = 'btn btn--sm btn--ghost';
@@ -287,6 +315,49 @@ const GRAPH_RENDER_JS = `
       jump.href = '#node-' + encodeURIComponent(data.id);
       jump.addEventListener('click', function () { dialog.close(); });
       actionsEl.appendChild(jump);
+    }
+
+    if (hasReplay) {
+      // Replay is a real POST form, separate from the method="dialog"
+      // cancel form wrapping everything else. Stick it inline so the
+      // button lives in the same row as Cancel/Edit/Jump. For community
+      // shell agents, an explicit checkbox inside the form has to be
+      // ticked before the button enables — no reliance on a native
+      // confirm() popup.
+      var form = document.createElement('form');
+      form.method = 'POST';
+      form.action = '/runs/' + encodeURIComponent(replayRunId) + '/replay';
+      form.className = 'node-dialog__replay-form';
+
+      var fromInput = document.createElement('input');
+      fromInput.type = 'hidden';
+      fromInput.name = 'fromNodeId';
+      fromInput.value = data.id;
+      form.appendChild(fromInput);
+
+      var btn = document.createElement('button');
+      btn.type = 'submit';
+      btn.className = 'btn btn--sm btn--primary';
+      btn.textContent = 'Replay from here';
+
+      if (replayCommunity) {
+        var auditLabel = document.createElement('label');
+        auditLabel.className = 'node-dialog__audit';
+        var auditInput = document.createElement('input');
+        auditInput.type = 'checkbox';
+        auditInput.name = 'confirm_community_shell';
+        auditInput.value = 'yes';
+        auditInput.addEventListener('change', function () { btn.disabled = !auditInput.checked; });
+        auditLabel.appendChild(auditInput);
+        auditLabel.appendChild(document.createTextNode(' I audited this community shell agent'));
+        form.appendChild(auditLabel);
+        btn.disabled = true;
+        btn.className = 'btn btn--sm btn--warn';
+        btn.textContent = 'Replay (community)';
+      }
+
+      form.appendChild(btn);
+      actionsEl.appendChild(form);
     }
 
     dialog.showModal();

--- a/packages/dashboard/src/routes/assets.ts
+++ b/packages/dashboard/src/routes/assets.ts
@@ -176,16 +176,140 @@ const GRAPH_RENDER_JS = `
   });
   cy.fit(undefined, 18);
 
-  // Click a node → anchor into the run-detail page on the same id.
-  // No-op on /agents/:id (no target); clickable on /runs/:id via the
-  // data-nav-base attribute the server rendered alongside the div.
+  // Click a node → open the node-action dialog with Edit + Replay buttons
+  // and metadata pulled from the same Cytoscape payload. When no dialog
+  // is present (older templates), fall back to hash-scrolling the per-node
+  // card below via data-nav-base.
   var navBase = el.getAttribute('data-nav-base');
-  if (navBase) {
-    cy.on('tap', 'node', function (evt) {
-      var nodeId = evt.target.id();
-      window.location.hash = 'node-' + encodeURIComponent(nodeId);
-    });
+  var replayRunId = el.getAttribute('data-replay-run-id');
+  var replayCommunity = el.getAttribute('data-replay-community') === '1';
+  var editBase = el.getAttribute('data-edit-base');
+  var dialog = document.getElementById('dag-node-dialog');
+  var dialogSupported = dialog && typeof dialog.showModal === 'function';
+
+  function fmtDuration(startedAt, completedAt) {
+    if (!startedAt || !completedAt) return '—';
+    var ms = new Date(completedAt).getTime() - new Date(startedAt).getTime();
+    if (!isFinite(ms) || ms < 0) return '—';
+    if (ms < 1000) return ms + 'ms';
+    if (ms < 60000) return (ms / 1000).toFixed(1) + 's';
+    var m = Math.floor(ms / 60000);
+    var s = Math.floor((ms % 60000) / 1000);
+    return m + 'm' + s + 's';
   }
+
+  function badge(kind, text) {
+    var span = document.createElement('span');
+    span.className = 'badge badge--' + kind;
+    span.textContent = text;
+    return span;
+  }
+
+  function openDialog(data) {
+    if (!dialogSupported) return false;
+    var idEl = dialog.querySelector('[data-node-id]');
+    var typeEl = dialog.querySelector('[data-node-type]');
+    var statusEl = dialog.querySelector('[data-node-status]');
+    var depsEl = dialog.querySelector('[data-node-deps]');
+    var durEl = dialog.querySelector('[data-node-duration]');
+    var actionsEl = dialog.querySelector('[data-node-actions]');
+
+    idEl.textContent = data.id;
+
+    typeEl.innerHTML = '';
+    if (data.type) {
+      var tKind = data.type === 'shell' ? 'ok' : data.type === 'claude-code' ? 'info' : 'muted';
+      typeEl.appendChild(badge(tKind, data.type));
+    }
+
+    statusEl.innerHTML = '';
+    if (data.status) {
+      var sKind = data.status === 'completed' ? 'ok'
+        : data.status === 'failed' ? 'err'
+        : data.status === 'running' || data.status === 'pending' ? 'info'
+        : data.status === 'cancelled' ? 'warn'
+        : 'muted';
+      statusEl.appendChild(badge(sKind, data.status));
+    }
+
+    depsEl.textContent = data.dependsOn && data.dependsOn.length > 0 ? data.dependsOn : '—';
+    durEl.textContent = fmtDuration(data.startedAt, data.completedAt);
+
+    actionsEl.innerHTML = '';
+
+    if (editBase) {
+      var edit = document.createElement('a');
+      edit.className = 'btn btn--sm';
+      edit.textContent = 'Edit node';
+      edit.href = editBase + '/' + encodeURIComponent(data.id) + '/edit';
+      actionsEl.appendChild(edit);
+    }
+
+    if (replayRunId) {
+      var form = document.createElement('form');
+      form.method = 'POST';
+      form.action = '/runs/' + encodeURIComponent(replayRunId) + '/replay';
+      form.style.display = 'inline';
+
+      var fromInput = document.createElement('input');
+      fromInput.type = 'hidden';
+      fromInput.name = 'fromNodeId';
+      fromInput.value = data.id;
+      form.appendChild(fromInput);
+
+      if (replayCommunity) {
+        var confirmInput = document.createElement('input');
+        confirmInput.type = 'hidden';
+        confirmInput.name = 'confirm_community_shell';
+        confirmInput.value = 'yes';
+        form.appendChild(confirmInput);
+      }
+
+      var btn = document.createElement('button');
+      btn.type = 'submit';
+      btn.className = 'btn btn--sm btn--primary';
+      btn.textContent = replayCommunity ? 'Replay from here (community)' : 'Replay from here';
+      btn.addEventListener('click', function (e) {
+        var msg = 'Replay from "' + data.id + '"? Upstream outputs will be reused and this node plus downstream nodes will re-run.';
+        if (replayCommunity) {
+          msg += '\\n\\nThis agent contains community shell nodes. Continue?';
+        }
+        if (!window.confirm(msg)) e.preventDefault();
+      });
+      form.appendChild(btn);
+      actionsEl.appendChild(form);
+    }
+
+    if (navBase) {
+      var jump = document.createElement('a');
+      jump.className = 'btn btn--sm btn--ghost';
+      jump.textContent = 'Jump to details';
+      jump.href = '#node-' + encodeURIComponent(data.id);
+      jump.addEventListener('click', function () { dialog.close(); });
+      actionsEl.appendChild(jump);
+    }
+
+    dialog.showModal();
+    return true;
+  }
+
+  cy.on('tap', 'node', function (evt) {
+    var n = evt.target;
+    var data = {
+      id: n.id(),
+      label: n.data('label'),
+      type: n.data('type'),
+      status: n.data('status'),
+      dependsOn: n.data('dependsOn') || '',
+      startedAt: n.data('startedAt'),
+      completedAt: n.data('completedAt'),
+      exitCode: n.data('exitCode'),
+    };
+    if (!openDialog(data)) {
+      // No dialog support (really old browser): fall back to hash-scroll.
+      if (navBase) window.location.hash = 'node-' + encodeURIComponent(data.id);
+    }
+  });
 })();
 `;
 

--- a/packages/dashboard/src/routes/run-mutations.ts
+++ b/packages/dashboard/src/routes/run-mutations.ts
@@ -1,0 +1,82 @@
+import { Router, type Request, type Response } from 'express';
+import { executeAgentDag } from '@some-useful-agents/core';
+import { getContext } from '../context.js';
+
+export const runMutationsRouter: Router = Router();
+
+/**
+ * POST /runs/:id/replay — re-execute an agent starting from a specific
+ * node, reusing stored upstream outputs from the prior run.
+ *
+ * Mirrors `sua workflow replay <runId> --from <nodeId>`. The executor
+ * validates that every node upstream of `fromNodeId` completed in the
+ * prior run — a failed upstream or a missing snapshot causes a helpful
+ * error, flashed back on the prior run's page.
+ *
+ * Defense layers (on top of requireAuth cookie + Host + Origin):
+ *   1. Prior run must exist + be a v2 DAG run (workflow_id set).
+ *   2. Agent the prior run references must still be in AgentStore.
+ *   3. Community shell agents require `confirm_community_shell=yes`.
+ */
+runMutationsRouter.post('/runs/:id/replay', async (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const fromNodeId = typeof body.fromNodeId === 'string' ? body.fromNodeId.trim() : '';
+  const confirmed = body.confirm_community_shell === 'yes';
+
+  if (fromNodeId.length === 0) {
+    res.redirect(303, `/runs/${encodeURIComponent(id)}?flash=${encodeURIComponent('Pick a node to replay from.')}`);
+    return;
+  }
+
+  const priorRun = ctx.runStore.getRun(id);
+  if (!priorRun) {
+    res.status(404).redirect(303, '/runs');
+    return;
+  }
+  if (!priorRun.workflowId) {
+    res.redirect(303, `/runs/${encodeURIComponent(id)}?flash=${encodeURIComponent('Replay only works on v2 DAG runs.')}`);
+    return;
+  }
+
+  const agent = ctx.agentStore.getAgent(priorRun.workflowId);
+  if (!agent) {
+    res.redirect(303, `/runs/${encodeURIComponent(id)}?flash=${encodeURIComponent(`Agent "${priorRun.workflowId}" not found in store.`)}`);
+    return;
+  }
+
+  // Cheap guard: reject pivot ids that don't exist in the current agent
+  // version before calling the executor. The executor does this too, but
+  // catching here gives a faster flash without touching the run store.
+  if (!agent.nodes.some((n) => n.id === fromNodeId)) {
+    res.redirect(303, `/runs/${encodeURIComponent(id)}?flash=${encodeURIComponent(`Node "${fromNodeId}" not in agent "${agent.id}".`)}`);
+    return;
+  }
+
+  const needsConfirm = agent.source === 'community' && agent.nodes.some((n) => n.type === 'shell');
+  if (needsConfirm && !confirmed) {
+    res.redirect(303, `/runs/${encodeURIComponent(id)}?flash=${encodeURIComponent('Community shell replays need explicit confirmation.')}`);
+    return;
+  }
+
+  try {
+    const replay = await executeAgentDag(
+      agent,
+      {
+        triggeredBy: 'dashboard',
+        inputs: {},
+        replayFrom: { priorRunId: id, fromNodeId },
+      },
+      {
+        runStore: ctx.runStore,
+        secretsStore: ctx.secretsStore,
+        allowUntrustedShell: ctx.allowUntrustedShell,
+      },
+    );
+    res.redirect(303, `/runs/${encodeURIComponent(replay.id)}?flash=${encodeURIComponent(`Replayed from "${fromNodeId}".`)}`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/runs/${encodeURIComponent(id)}?flash=${encodeURIComponent(`Replay failed: ${message}`)}`);
+  }
+});

--- a/packages/dashboard/src/routes/runs.ts
+++ b/packages/dashboard/src/routes/runs.ts
@@ -13,6 +13,9 @@ export const runsRouter: Router = Router();
 runsRouter.get('/runs', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
 
+  const flashParam = typeof req.query.flash === 'string' ? req.query.flash : undefined;
+  const flash = flashParam ? { kind: 'error' as const, message: flashParam } : undefined;
+
   const agent = typeof req.query.agent === 'string' && req.query.agent.length > 0
     ? req.query.agent : undefined;
   const triggeredBy = typeof req.query.triggeredBy === 'string' && req.query.triggeredBy.length > 0
@@ -52,6 +55,7 @@ runsRouter.get('/runs', (req: Request, res: Response) => {
     offset,
     filter: { agent, statuses, triggeredBy, q },
     distinct,
+    flash,
   }));
 });
 
@@ -60,7 +64,7 @@ runsRouter.get('/runs/:id', (req: Request, res: Response) => {
   const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
   const run = ctx.runStore.getRun(id);
   if (!run) {
-    res.status(404).type('html').send(`<p>Run ${escapeAttr(id)} not found. <a href="/runs">Back</a></p>`);
+    res.status(404).redirect(303, `/runs?flash=${encodeURIComponent(`Run "${id}" not found. It may have been pruned by the retention policy.`)}`);
     return;
   }
 
@@ -84,15 +88,22 @@ runsRouter.get('/runs/:id', (req: Request, res: Response) => {
   const expectedHost = `127.0.0.1:${ctx.port}`;
   const back = deriveBack(referer, expectedHost, req.query.from);
 
-  res.type('html').send(renderRunDetail({ run, partial, nodeExecutions, agent, back }));
+  // Flash from replay POSTs or run-now redirects. Failed replays
+  // 303-redirect back to the prior run with ?flash=; successful replays
+  // 303 to the NEW run's page and include a "Replayed from …" note.
+  const flashParam = typeof req.query.flash === 'string' ? req.query.flash : undefined;
+  const isError = flashParam
+    ? /replay failed|not found|not in agent|needs|required|only works/i.test(flashParam)
+    : false;
+  const flash = flashParam
+    ? { kind: isError ? ('error' as const) : ('ok' as const), message: flashParam }
+    : undefined;
+
+  res.type('html').send(renderRunDetail({ run, partial, nodeExecutions, agent, back, flash }));
 });
 
 function parseIntOr(v: unknown, fallback: number): number {
   if (typeof v !== 'string') return fallback;
   const n = Number.parseInt(v, 10);
   return Number.isFinite(n) && n >= 0 ? n : fallback;
-}
-
-function escapeAttr(s: string): string {
-  return s.replace(/[<>"&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '"': '&quot;', '&': '&amp;' }[c] ?? c));
 }

--- a/packages/dashboard/src/views/agent-add-node.ts
+++ b/packages/dashboard/src/views/agent-add-node.ts
@@ -175,7 +175,7 @@ export function renderAgentAddNode(args: {
 
       ${availableVariablesPanel(agent)}
 
-      <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-4);">
+      <label class="node-field" data-node-field="shell" style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-4);">
         <strong>Command <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-xs);">(shell only)</span></strong>
         <textarea name="command" rows="4" placeholder='echo "$UPSTREAM_FETCH_RESULT" | wc -w'
           style="${TEXTAREA_STYLE}"
@@ -184,7 +184,7 @@ export function renderAgentAddNode(args: {
         <span class="dim" style="font-size: var(--font-size-xs);">Type <code>$</code> for available env vars.</span>
       </label>
 
-      <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-6);">
+      <label class="node-field" data-node-field="claude-code" style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-6);">
         <strong>Prompt <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-xs);">(claude-code only)</span></strong>
         <textarea name="prompt" rows="4" placeholder='Summarise: {{upstream.fetch.result}}'
           style="${TEXTAREA_STYLE}"

--- a/packages/dashboard/src/views/agent-add-node.ts
+++ b/packages/dashboard/src/views/agent-add-node.ts
@@ -2,6 +2,7 @@ import type { Agent } from '@some-useful-agents/core';
 import { html, render, unsafeHtml, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
+import { computePaletteSuggestions, renderPalettePayload } from './template-palette.js';
 
 /**
  * Render a reference card listing everything the author can inject into
@@ -176,13 +177,23 @@ export function renderAgentAddNode(args: {
 
       <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-4);">
         <strong>Command <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-xs);">(shell only)</span></strong>
-        <textarea name="command" rows="4" placeholder='echo "$UPSTREAM_FETCH_RESULT" | wc -w' style="${TEXTAREA_STYLE}">${v.command ?? ''}</textarea>
+        <textarea name="command" rows="4" placeholder='echo "$UPSTREAM_FETCH_RESULT" | wc -w'
+          style="${TEXTAREA_STYLE}"
+          data-template-palette="shell"
+          data-palette-source="palette-add-node">${v.command ?? ''}</textarea>
+        <span class="dim" style="font-size: var(--font-size-xs);">Type <code>$</code> for available env vars.</span>
       </label>
 
       <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-6);">
         <strong>Prompt <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-xs);">(claude-code only)</span></strong>
-        <textarea name="prompt" rows="4" placeholder='Summarise: {{upstream.fetch.result}}' style="${TEXTAREA_STYLE}">${v.prompt ?? ''}</textarea>
+        <textarea name="prompt" rows="4" placeholder='Summarise: {{upstream.fetch.result}}'
+          style="${TEXTAREA_STYLE}"
+          data-template-palette="claude"
+          data-palette-source="palette-add-node">${v.prompt ?? ''}</textarea>
+        <span class="dim" style="font-size: var(--font-size-xs);">Type <code>{{</code> for available template refs.</span>
       </label>
+
+      ${renderPalettePayload('palette-add-node', computePaletteSuggestions(agent))}
 
       <div style="display: flex; gap: var(--space-2); justify-content: flex-end; align-items: center;">
         <a class="btn btn--ghost" href="/agents/${agent.id}">Cancel</a>

--- a/packages/dashboard/src/views/agent-detail-v2.ts
+++ b/packages/dashboard/src/views/agent-detail-v2.ts
@@ -143,7 +143,6 @@ export async function renderAgentDetailV2(args: {
     <aside class="inspector" id="inspector">
       <header class="inspector__header">
         <h2 class="inspector__title">Overview</h2>
-        <span class="inspector__hint">Click a DAG node for its actions</span>
       </header>
 
       <section class="inspector__section">

--- a/packages/dashboard/src/views/agent-detail-v2.ts
+++ b/packages/dashboard/src/views/agent-detail-v2.ts
@@ -130,13 +130,20 @@ export async function renderAgentDetailV2(args: {
         ${secretsUnknown > 0 ? html`<span class="badge badge--warn">${String(secretsUnknown)} locked</span>` : html``}
       `;
 
+  // Latest completed run powers the DAG's "Replay from here" node-click
+  // action. Without one, clicking a node still opens the action dialog
+  // (Edit node is always offered) but the replay button is absent.
+  const latestCompletedRun = recentRuns.find((r) => r.status === 'completed');
+
   // Inspector (right-column) default state: agent-level summary card.
-  // Editable inspector + node-selection states arrive in PR 3 (v0.15).
+  // Node inspection happens via a dialog triggered by clicks on the
+  // DAG viz — not this panel. The inspector stays as an agent-scoped
+  // overview.
   const inspector = html`
     <aside class="inspector" id="inspector">
       <header class="inspector__header">
         <h2 class="inspector__title">Overview</h2>
-        <span class="inspector__hint">Click a node to inspect it</span>
+        <span class="inspector__hint">Click a DAG node for its actions</span>
       </header>
 
       <section class="inspector__section">
@@ -195,7 +202,16 @@ export async function renderAgentDetailV2(args: {
     <div class="agent-detail">
       <div class="agent-detail__main">
         ${renderDagFallback(agent)}
-        ${renderDagView({ agent })}
+        ${renderDagView({
+          agent,
+          editBase: `/agents/${agent.id}/nodes`,
+          replay: latestCompletedRun
+            ? {
+                priorRunId: latestCompletedRun.id,
+                requiresCommunityConfirm: hasCommunityShellNode,
+              }
+            : undefined,
+        })}
 
         <section id="nodes">
           <h2>Nodes</h2>

--- a/packages/dashboard/src/views/agent-edit-node.ts
+++ b/packages/dashboard/src/views/agent-edit-node.ts
@@ -101,7 +101,7 @@ export function renderAgentEditNode(args: {
           : html`<div>${depToggles as unknown as SafeHtml[]}</div>`}
       </fieldset>
 
-      <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-4);">
+      <label class="node-field" data-node-field="shell" style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-4);">
         <strong>Command <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-xs);">(shell only)</span></strong>
         <textarea name="command" rows="4"
           style="${TEXTAREA_STYLE}"
@@ -110,7 +110,7 @@ export function renderAgentEditNode(args: {
         <span class="dim" style="font-size: var(--font-size-xs);">Type <code>$</code> for available env vars.</span>
       </label>
 
-      <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-6);">
+      <label class="node-field" data-node-field="claude-code" style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-6);">
         <strong>Prompt <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-xs);">(claude-code only)</span></strong>
         <textarea name="prompt" rows="4"
           style="${TEXTAREA_STYLE}"

--- a/packages/dashboard/src/views/agent-edit-node.ts
+++ b/packages/dashboard/src/views/agent-edit-node.ts
@@ -2,6 +2,7 @@ import type { Agent, AgentNode } from '@some-useful-agents/core';
 import { html, render, unsafeHtml, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
+import { computePaletteSuggestions, renderPalettePayload } from './template-palette.js';
 
 export interface EditNodeFormValues {
   type?: 'shell' | 'claude-code';
@@ -102,13 +103,29 @@ export function renderAgentEditNode(args: {
 
       <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-4);">
         <strong>Command <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-xs);">(shell only)</span></strong>
-        <textarea name="command" rows="4" style="${TEXTAREA_STYLE}">${v.command ?? ''}</textarea>
+        <textarea name="command" rows="4"
+          style="${TEXTAREA_STYLE}"
+          data-template-palette="shell"
+          data-palette-source="palette-edit-node">${v.command ?? ''}</textarea>
+        <span class="dim" style="font-size: var(--font-size-xs);">Type <code>$</code> for available env vars.</span>
       </label>
 
       <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-6);">
         <strong>Prompt <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-xs);">(claude-code only)</span></strong>
-        <textarea name="prompt" rows="4" style="${TEXTAREA_STYLE}">${v.prompt ?? ''}</textarea>
+        <textarea name="prompt" rows="4"
+          style="${TEXTAREA_STYLE}"
+          data-template-palette="claude"
+          data-palette-source="palette-edit-node">${v.prompt ?? ''}</textarea>
+        <span class="dim" style="font-size: var(--font-size-xs);">Type <code>{{</code> for available template refs.</span>
       </label>
+
+      ${renderPalettePayload(
+        'palette-edit-node',
+        computePaletteSuggestions(agent, {
+          excludeNodeId: node.id,
+          nodeSecrets: node.secrets,
+        }),
+      )}
 
       <div style="display: flex; gap: var(--space-2); justify-content: flex-end;">
         <a class="btn btn--ghost" href="/agents/${agent.id}">Cancel</a>

--- a/packages/dashboard/src/views/agents-list.ts
+++ b/packages/dashboard/src/views/agents-list.ts
@@ -141,30 +141,17 @@ function renderV2Card(a: Agent, lastRun?: Run): SafeHtml {
 
   const mcpBadge = a.mcp ? html`<span class="badge badge--info">mcp</span>` : html``;
 
-  // Multi-node agents get an inline <details> to reveal each node without
-  // having to click through to the agent detail page. Single-node agents
-  // skip the disclosure entirely — nothing meaningful to reveal.
+  // Multi-node agents get an inline <details> that reveals the DAG as
+  // mini-cards indented by topological depth. Downstream nodes sit
+  // visually under their upstreams so the reveal mirrors the actual DAG
+  // rather than a flat list that ignores the edges.
   const nodesDisclosure = a.nodes.length > 1
     ? html`
       <details class="agent-card__nodes">
         <summary>Show ${String(a.nodes.length)} nodes</summary>
-        <ol class="agent-card__node-list">
-          ${a.nodes.map((n) => {
-            const body = n.type === 'shell' ? oneLine(n.command ?? '') : oneLine(n.prompt ?? '');
-            const typeClass = n.type === 'shell' ? 'badge--ok' : 'badge--info';
-            const deps = n.dependsOn?.length ? html`<span class="dim" style="font-size: var(--font-size-xs);"> \u2190 ${n.dependsOn.join(', ')}</span>` : html``;
-            return html`
-              <li>
-                <div style="display: flex; align-items: center; gap: var(--space-1); flex-wrap: wrap;">
-                  <code>${n.id}</code>
-                  <span class="badge ${typeClass}">${n.type}</span>
-                  ${deps}
-                </div>
-                <div class="mono dim agent-card__node-body">${body}</div>
-              </li>
-            `;
-          }) as unknown as SafeHtml[]}
-        </ol>
+        <div class="agent-card__dag">
+          ${renderDagMiniCards(a) as unknown as SafeHtml}
+        </div>
       </details>
     `
     : html``;
@@ -193,6 +180,83 @@ function renderV2Card(a: Agent, lastRun?: Run): SafeHtml {
       </div>
     </article>
   `;
+}
+
+/**
+ * Render each node of a multi-node agent as a mini-card, indented by
+ * its topological depth so the expansion visually reflects the DAG
+ * shape — upstream nodes at depth 0 (flush left), their downstream
+ * neighbours at depth 1, etc. Siblings at the same depth stack
+ * vertically in id order.
+ *
+ * A small connector rail on the left hints at the parent/child
+ * relationship without turning the card into a full graph widget.
+ */
+function renderDagMiniCards(a: Agent): SafeHtml {
+  const depthById = computeNodeDepths(a);
+  const sorted = [...a.nodes].sort((n1, n2) => {
+    const d1 = depthById.get(n1.id) ?? 0;
+    const d2 = depthById.get(n2.id) ?? 0;
+    if (d1 !== d2) return d1 - d2;
+    return n1.id.localeCompare(n2.id);
+  });
+
+  const cards = sorted.map((n) => {
+    const depth = depthById.get(n.id) ?? 0;
+    const body = n.type === 'shell' ? oneLine(n.command ?? '') : oneLine(n.prompt ?? '');
+    const typeClass = n.type === 'shell' ? 'badge--ok' : 'badge--info';
+    const deps = n.dependsOn?.length
+      ? html`<span class="agent-card__node-dep">\u2190 ${n.dependsOn.join(', ')}</span>`
+      : html``;
+    // Inline --depth so each card can use it for padding + the left rail.
+    return html`
+      <div class="agent-card__node" style="--depth: ${String(depth)};" data-depth="${String(depth)}">
+        <div class="agent-card__node-rail" aria-hidden="true"></div>
+        <div class="agent-card__node-body-wrap">
+          <div class="agent-card__node-head">
+            <code class="agent-card__node-id">${n.id}</code>
+            <span class="badge ${typeClass}">${n.type}</span>
+            ${deps}
+          </div>
+          <div class="mono dim agent-card__node-body">${body}</div>
+        </div>
+      </div>
+    `;
+  });
+  return cards as unknown as SafeHtml;
+}
+
+/**
+ * Longest-path depth per node (roots = 0, their immediate children = 1,
+ * etc.). Iterative memoisation with cycle guard — cycles aren't legal in
+ * a v2 DAG but defensive handling keeps a broken agent from crashing the
+ * render.
+ */
+function computeNodeDepths(a: Agent): Map<string, number> {
+  const byId = new Map(a.nodes.map((n) => [n.id, n]));
+  const memo = new Map<string, number>();
+  const seen = new Set<string>();
+
+  function depth(id: string): number {
+    if (memo.has(id)) return memo.get(id)!;
+    if (seen.has(id)) return 0;
+    seen.add(id);
+    const node = byId.get(id);
+    if (!node || !node.dependsOn || node.dependsOn.length === 0) {
+      memo.set(id, 0);
+      return 0;
+    }
+    let max = 0;
+    for (const dep of node.dependsOn) {
+      const d = depth(dep);
+      if (d + 1 > max) max = d + 1;
+    }
+    memo.set(id, max);
+    return max;
+  }
+
+  for (const n of a.nodes) depth(n.id);
+  return memo;
 }
 
 function oneLine(text: string, max = 80): string {

--- a/packages/dashboard/src/views/dag-view.ts
+++ b/packages/dashboard/src/views/dag-view.ts
@@ -52,11 +52,9 @@ export function renderDagView(args: {
   // when a deep run detail has scrolled past the structural view they
   // already saw on /agents/:id. The summary mirrors the other
   // collapsible-section styling (.run-node, .agent-card__nodes).
-  const hintText = replay
-    ? 'Click a node to replay from there \u2192'
-    : editBase
-      ? 'Click a node to inspect or edit it \u2192'
-      : '';
+  const hintText = replay || editBase
+    ? 'Click a node to see its actions \u2192'
+    : '';
   const hint = hintText
     ? html`<span class="dag-disclosure__hint">${hintText}</span>`
     : unsafeHtml('');
@@ -70,9 +68,12 @@ export function renderDagView(args: {
       <div class="dag-disclosure__body">
         <div id="dag-canvas" class="dag-frame__canvas"${unsafeHtml(navAttr)}${unsafeHtml(replayAttr)}${unsafeHtml(editAttr)}></div>
         <script id="dag-data" type="application/json">${unsafeHtml(escapeScriptTag(payload))}</script>
-        <script src="/assets/cytoscape.min.js"></script>
-        <script src="/assets/graph-render.js"></script>
 
+        <!-- Dialog rendered BEFORE the scripts so the IIFE's initial
+             getElementById lookup finds the element. Order matters:
+             synchronous <script src> tags run at parse time, and any
+             element declared after them is still invisible to the
+             first lookup inside graph-render.js. -->
         <dialog id="dag-node-dialog" class="node-dialog">
           <form method="dialog" class="node-dialog__form">
             <header class="node-dialog__header">
@@ -85,9 +86,13 @@ export function renderDagView(args: {
               <dt>Depends on</dt><dd class="mono" data-node-deps></dd>
               <dt>Duration</dt><dd class="mono" data-node-duration></dd>
             </dl>
+            <div class="node-dialog__explain" data-node-explain></div>
             <div class="node-dialog__actions" data-node-actions></div>
           </form>
         </dialog>
+
+        <script src="/assets/cytoscape.min.js"></script>
+        <script src="/assets/graph-render.js"></script>
       </div>
     </details>
   `;

--- a/packages/dashboard/src/views/dag-view.ts
+++ b/packages/dashboard/src/views/dag-view.ts
@@ -15,30 +15,79 @@ export function renderDagView(args: {
   nodeExecs?: NodeExecutionRecord[];
   /** Optional — makes nodes clickable to scroll to their detail section. */
   navBase?: string;
+  /**
+   * When set, the per-node action dialog includes "Replay from here",
+   * POSTing `fromNodeId` to `/runs/<priorRunId>/replay`. Used on the
+   * run-detail page (priorRunId = this run) and on the agent-detail
+   * page (priorRunId = the most-recent completed run for this agent).
+   */
+  replay?: {
+    priorRunId: string;
+    /** When the agent has community shell nodes, the node-click replay
+     *  needs the same audit-confirm flag as `POST /agents/:id/run`. */
+    requiresCommunityConfirm?: boolean;
+  };
+  /**
+   * When set, the per-node action dialog includes "Edit node"
+   * (href = `${editBase}/${nodeId}/edit`). Used on the agent-detail
+   * page so the user can jump straight from the DAG viz into the
+   * node-edit form — replaces the misleading "click a node to
+   * inspect it" hint the inspector used to show.
+   */
+  editBase?: string;
 }): SafeHtml {
-  const { agent, nodeExecs, navBase } = args;
+  const { agent, nodeExecs, navBase, replay, editBase } = args;
   const execByNodeId = new Map<string, NodeExecutionRecord>();
   for (const e of nodeExecs ?? []) execByNodeId.set(e.nodeId, e);
 
   const elements = buildElements(agent.nodes, execByNodeId);
   const payload = JSON.stringify({ elements });
   const navAttr = navBase ? ` data-nav-base="${escapeAttr(navBase)}"` : '';
+  const replayAttr = replay
+    ? ` data-replay-run-id="${escapeAttr(replay.priorRunId)}"${replay.requiresCommunityConfirm ? ' data-replay-community="1"' : ''}`
+    : '';
+  const editAttr = editBase ? ` data-edit-base="${escapeAttr(editBase)}"` : '';
 
   // Wrap the canvas in <details open> so users can collapse the DAG viz
   // when a deep run detail has scrolled past the structural view they
   // already saw on /agents/:id. The summary mirrors the other
   // collapsible-section styling (.run-node, .agent-card__nodes).
+  const hintText = replay
+    ? 'Click a node to replay from there \u2192'
+    : editBase
+      ? 'Click a node to inspect or edit it \u2192'
+      : '';
+  const hint = hintText
+    ? html`<span class="dag-disclosure__hint">${hintText}</span>`
+    : unsafeHtml('');
   return html`
     <details class="dag-disclosure" open>
       <summary class="dag-disclosure__summary">
         <span>DAG</span>
         <span class="dim" style="font-size: var(--font-size-xs);">${String(agent.nodes.length)} node${agent.nodes.length === 1 ? '' : 's'}</span>
+        ${hint}
       </summary>
       <div class="dag-disclosure__body">
-        <div id="dag-canvas" class="dag-frame__canvas"${unsafeHtml(navAttr)}></div>
+        <div id="dag-canvas" class="dag-frame__canvas"${unsafeHtml(navAttr)}${unsafeHtml(replayAttr)}${unsafeHtml(editAttr)}></div>
         <script id="dag-data" type="application/json">${unsafeHtml(escapeScriptTag(payload))}</script>
         <script src="/assets/cytoscape.min.js"></script>
         <script src="/assets/graph-render.js"></script>
+
+        <dialog id="dag-node-dialog" class="node-dialog">
+          <form method="dialog" class="node-dialog__form">
+            <header class="node-dialog__header">
+              <span class="mono node-dialog__id" data-node-id></span>
+              <span data-node-type></span>
+              <span data-node-status></span>
+              <button type="submit" class="node-dialog__close" aria-label="Close">\u00d7</button>
+            </header>
+            <dl class="kv node-dialog__meta">
+              <dt>Depends on</dt><dd class="mono" data-node-deps></dd>
+              <dt>Duration</dt><dd class="mono" data-node-duration></dd>
+            </dl>
+            <div class="node-dialog__actions" data-node-actions></div>
+          </form>
+        </dialog>
       </div>
     </details>
   `;
@@ -74,6 +123,13 @@ function buildElements(nodes: AgentNode[], execByNodeId: Map<string, NodeExecuti
         label: n.id,
         type: n.type,
         status: exec?.status,
+        // Per-node metadata surfaced by the node-click dialog. Kept on
+        // the element so the client bootstrap can render without a
+        // second fetch.
+        dependsOn: (n.dependsOn ?? []).join(', '),
+        startedAt: exec?.startedAt,
+        completedAt: exec?.completedAt,
+        exitCode: exec?.exitCode,
       },
     });
     for (const dep of n.dependsOn ?? []) {

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -29,6 +29,41 @@ export const DASHBOARD_JS = `
     }
   });
 
+  // Grey-out the inactive node-type field (Command vs Prompt) based on
+  // which <input type="radio" name="type"> is selected. The form still
+  // submits both fields — the server validates against the selected
+  // type — but visually the irrelevant one is dimmed and disabled for
+  // input so users don't waste time editing it.
+  (function () {
+    function syncFields() {
+      var checked = document.querySelector('input[type="radio"][name="type"]:checked');
+      if (!checked) return;
+      var active = checked.value;
+      var fields = document.querySelectorAll('[data-node-field]');
+      for (var i = 0; i < fields.length; i++) {
+        var f = fields[i];
+        if (f.getAttribute('data-node-field') === active) {
+          f.classList.remove('node-field--inactive');
+        } else {
+          f.classList.add('node-field--inactive');
+        }
+      }
+    }
+    document.addEventListener('change', function (e) {
+      var t = e.target;
+      if (t && t.matches && t.matches('input[type="radio"][name="type"]')) {
+        syncFields();
+      }
+    });
+    // Run once on DOMContentLoaded so the initial render reflects the
+    // pre-checked radio.
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', syncFields);
+    } else {
+      syncFields();
+    }
+  })();
+
   // ESC closes any open custom-modal backdrop (community-shell confirm,
   // run-now audit). Native <dialog> elements already close on ESC via
   // the browser's cancel event; this fills the gap for the older
@@ -171,6 +206,7 @@ export const DASHBOARD_JS = `
     }
 
     function positionPalette(textarea) {
+      ensurePalette();
       var rect = textarea.getBoundingClientRect();
       palette.style.left = Math.round(rect.left + window.scrollX) + 'px';
       palette.style.top = Math.round(rect.bottom + window.scrollY + 4) + 'px';

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -29,6 +29,19 @@ export const DASHBOARD_JS = `
     }
   });
 
+  // ESC closes any open custom-modal backdrop (community-shell confirm,
+  // run-now audit). Native <dialog> elements already close on ESC via
+  // the browser's cancel event; this fills the gap for the older
+  // .modal-backdrop pattern we still use in a few places.
+  document.addEventListener('keydown', function (e) {
+    if (e.key !== 'Escape') return;
+    var open = document.querySelector('.modal-backdrop.is-open, .modal-backdrop.open');
+    if (open) {
+      open.classList.remove('is-open');
+      open.classList.remove('open');
+    }
+  });
+
   // Confirm-before-submit for forms with [data-confirm]. Used on
   // destructive settings actions (delete secret, rotate MCP token).
   document.addEventListener('submit', function (e) {

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -40,6 +40,257 @@ export const DASHBOARD_JS = `
     }
   });
 
+  // Template palette — autocomplete for $ (shell env vars) and {{
+  // (claude-code template refs) in node command / prompt textareas.
+  // Triggered by typing the first char of either syntax; filters as the
+  // user types; Up/Down + Enter to insert; Esc to close.
+  (function () {
+    var palette = null;
+    var activeTextarea = null;
+    // { mode: 'shell' | 'claude', triggerStart: number, query: string, items: [...], selectedIndex: number }
+    var state = null;
+
+    function getSuggestions(textarea) {
+      var sourceId = textarea.getAttribute('data-palette-source');
+      if (!sourceId) return null;
+      var el = document.getElementById(sourceId);
+      if (!el) return null;
+      try { return JSON.parse(el.textContent); }
+      catch (e) { return null; }
+    }
+
+    function buildItems(mode, sugg) {
+      var items = [];
+      if (mode === 'shell') {
+        for (var i = 0; i < sugg.upstreams.length; i++) {
+          var id = sugg.upstreams[i];
+          var envName = 'UPSTREAM_' + id.toUpperCase().replace(/-/g, '_') + '_RESULT';
+          items.push({
+            insert: '$' + envName,
+            label: '$' + envName,
+            hint: 'stdout of upstream "' + id + '"',
+            group: 'upstream',
+          });
+        }
+        for (var j = 0; j < sugg.inputs.length; j++) {
+          items.push({
+            insert: '$' + sugg.inputs[j],
+            label: '$' + sugg.inputs[j],
+            hint: 'agent input',
+            group: 'input',
+          });
+        }
+        for (var k = 0; k < sugg.secrets.length; k++) {
+          items.push({
+            insert: '$' + sugg.secrets[k],
+            label: '$' + sugg.secrets[k],
+            hint: 'node secret',
+            group: 'secret',
+          });
+        }
+      } else {
+        for (var m = 0; m < sugg.upstreams.length; m++) {
+          var uid = sugg.upstreams[m];
+          items.push({
+            insert: '{{upstream.' + uid + '.result}}',
+            label: '{{upstream.' + uid + '.result}}',
+            hint: 'stdout of upstream "' + uid + '"',
+            group: 'upstream',
+          });
+        }
+        for (var n = 0; n < sugg.inputs.length; n++) {
+          items.push({
+            insert: '{{inputs.' + sugg.inputs[n] + '}}',
+            label: '{{inputs.' + sugg.inputs[n] + '}}',
+            hint: 'agent input',
+            group: 'input',
+          });
+        }
+      }
+      return items;
+    }
+
+    function detectTrigger(textarea) {
+      var v = textarea.value;
+      var pos = textarea.selectionStart;
+      // Walk backwards from the cursor looking for $ or {{. Bail out on
+      // whitespace or on another trigger char — keeps the palette scoped
+      // to the current "word" the user is typing.
+      for (var i = pos - 1; i >= 0 && i >= pos - 64; i--) {
+        var c = v.charAt(i);
+        if (c === '$') {
+          return { mode: 'shell', triggerStart: i, query: v.slice(i + 1, pos) };
+        }
+        if (c === '{' && i > 0 && v.charAt(i - 1) === '{') {
+          return { mode: 'claude', triggerStart: i - 1, query: v.slice(i + 1, pos) };
+        }
+        if (/\\s/.test(c)) return null;
+      }
+      return null;
+    }
+
+    function filterItems(items, query) {
+      if (!query) return items.slice(0, 10);
+      var q = query.toLowerCase();
+      var scored = [];
+      for (var i = 0; i < items.length; i++) {
+        var label = items[i].label.toLowerCase();
+        var idx = label.indexOf(q);
+        if (idx >= 0) scored.push({ item: items[i], score: idx });
+      }
+      scored.sort(function (a, b) { return a.score - b.score; });
+      return scored.slice(0, 10).map(function (s) { return s.item; });
+    }
+
+    function ensurePalette() {
+      if (palette) return palette;
+      palette = document.createElement('div');
+      palette.className = 'template-palette';
+      palette.setAttribute('role', 'listbox');
+      document.body.appendChild(palette);
+      return palette;
+    }
+
+    function closePalette() {
+      if (palette) palette.style.display = 'none';
+      activeTextarea = null;
+      state = null;
+    }
+
+    function positionPalette(textarea) {
+      var rect = textarea.getBoundingClientRect();
+      palette.style.left = Math.round(rect.left + window.scrollX) + 'px';
+      palette.style.top = Math.round(rect.bottom + window.scrollY + 4) + 'px';
+      palette.style.minWidth = Math.round(Math.min(rect.width, 420)) + 'px';
+    }
+
+    function renderPalette(items, selectedIndex) {
+      ensurePalette();
+      palette.innerHTML = '';
+      if (items.length === 0) {
+        var empty = document.createElement('div');
+        empty.className = 'template-palette__empty';
+        empty.textContent = 'No matches';
+        palette.appendChild(empty);
+      } else {
+        for (var i = 0; i < items.length; i++) {
+          var row = document.createElement('div');
+          row.className = 'template-palette__item' + (i === selectedIndex ? ' is-selected' : '');
+          row.setAttribute('data-index', String(i));
+          row.setAttribute('role', 'option');
+
+          var label = document.createElement('span');
+          label.className = 'template-palette__label mono';
+          label.textContent = items[i].label;
+          row.appendChild(label);
+
+          var hint = document.createElement('span');
+          hint.className = 'template-palette__hint';
+          hint.textContent = items[i].hint;
+          row.appendChild(hint);
+
+          palette.appendChild(row);
+        }
+      }
+      palette.style.display = 'block';
+    }
+
+    function insertChoice(item) {
+      if (!activeTextarea || !state) return;
+      var t = activeTextarea;
+      var before = t.value.slice(0, state.triggerStart);
+      var after = t.value.slice(t.selectionStart);
+      t.value = before + item.insert + after;
+      var newPos = (before + item.insert).length;
+      t.selectionStart = t.selectionEnd = newPos;
+      closePalette();
+      t.focus();
+      // Dispatch an input event so any listeners (form validation, etc.)
+      // see the synthetic insertion.
+      t.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+
+    function updateFromTextarea(textarea) {
+      var trig = detectTrigger(textarea);
+      if (!trig) { closePalette(); return; }
+      var sugg = getSuggestions(textarea);
+      if (!sugg) { closePalette(); return; }
+      var mode = textarea.getAttribute('data-template-palette');
+      // $ inside a claude-prompt textarea is just a literal $, not a trigger.
+      if (mode === 'claude' && trig.mode === 'shell') { closePalette(); return; }
+      if (mode === 'shell' && trig.mode === 'claude') { closePalette(); return; }
+
+      var all = buildItems(trig.mode, sugg);
+      var filtered = filterItems(all, trig.query);
+
+      activeTextarea = textarea;
+      state = {
+        mode: trig.mode,
+        triggerStart: trig.triggerStart,
+        query: trig.query,
+        items: filtered,
+        selectedIndex: 0,
+      };
+      positionPalette(textarea);
+      renderPalette(filtered, 0);
+    }
+
+    document.addEventListener('input', function (e) {
+      var t = e.target;
+      if (t && t.matches && t.matches('textarea[data-template-palette]')) {
+        updateFromTextarea(t);
+      }
+    });
+
+    document.addEventListener('keydown', function (e) {
+      if (!state || !activeTextarea) return;
+      if (e.target !== activeTextarea) return;
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        closePalette();
+        return;
+      }
+      if (state.items.length === 0) return;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        state.selectedIndex = (state.selectedIndex + 1) % state.items.length;
+        renderPalette(state.items, state.selectedIndex);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        state.selectedIndex = (state.selectedIndex - 1 + state.items.length) % state.items.length;
+        renderPalette(state.items, state.selectedIndex);
+      } else if (e.key === 'Enter' || e.key === 'Tab') {
+        // Swallow Enter/Tab only when the palette has a concrete pick —
+        // otherwise let the textarea behave normally.
+        e.preventDefault();
+        insertChoice(state.items[state.selectedIndex]);
+      }
+    });
+
+    document.addEventListener('click', function (e) {
+      if (!palette) return;
+      var row = e.target && e.target.closest && e.target.closest('.template-palette__item');
+      if (row && state) {
+        var idx = parseInt(row.getAttribute('data-index'), 10);
+        if (!isNaN(idx) && state.items[idx]) {
+          insertChoice(state.items[idx]);
+          return;
+        }
+      }
+      // Click outside the palette closes it.
+      if (activeTextarea && e.target !== activeTextarea && !(palette && palette.contains(e.target))) {
+        closePalette();
+      }
+    });
+
+    document.addEventListener('blur', function (e) {
+      if (e.target === activeTextarea) {
+        // Delay close so a click on a palette row is still registered.
+        setTimeout(closePalette, 120);
+      }
+    }, true);
+  })();
+
   // Auto-poll for in-progress runs
   var runDetail = document.querySelector('[data-run-in-progress]');
   if (runDetail) {

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -15,10 +15,12 @@ export interface RunDetailOptions {
   agent?: Agent;
   /** Contextual back link derived from the request's Referer header. */
   back?: PageHeaderBack;
+  /** Success/error banner surfaced on the detail page. */
+  flash?: { kind: 'error' | 'info' | 'ok'; message: string };
 }
 
 export function renderRunDetail(opts: RunDetailOptions): string {
-  const { run, partial, nodeExecutions, agent, back } = opts;
+  const { run, partial, nodeExecutions, agent, back, flash } = opts;
   const inProgress = run.status === 'running' || run.status === 'pending';
 
   // Run id is a UUID — safe to inline in an attribute without re-escaping.
@@ -34,9 +36,23 @@ export function renderRunDetail(opts: RunDetailOptions): string {
     </dd>
   ` : html``;
 
+  // Terminal v2 runs get clickable DAG nodes that offer "Replay from
+  // here". Running / pending runs intentionally don't — the executor
+  // hasn't finalised upstream outputs yet.
+  const canReplay = !!agent && (run.status === 'completed' || run.status === 'failed' || run.status === 'cancelled');
   const dagSection = isDagRun ? html`
     ${renderDagFallback(agent)}
-    ${renderDagView({ agent, nodeExecs: nodeExecutions, navBase: `/runs/${run.id}` })}
+    ${renderDagView({
+      agent,
+      nodeExecs: nodeExecutions,
+      navBase: `/runs/${run.id}`,
+      replay: canReplay
+        ? {
+            priorRunId: run.id,
+            requiresCommunityConfirm: agent.source === 'community' && agent.nodes.some((n) => n.type === 'shell'),
+          }
+        : undefined,
+    })}
   ` : html``;
 
   // Per-node execution as click-expandable cards (one <details> per node).
@@ -79,6 +95,7 @@ export function renderRunDetail(opts: RunDetailOptions): string {
 
       ${dagSection}
       ${nodeCards}
+      ${isDagRun && canReplay ? renderReplayFallback(run, agent!) : html``}
 
       ${isDagRun ? html`` : html`
         <h2>Output</h2>
@@ -91,7 +108,48 @@ export function renderRunDetail(opts: RunDetailOptions): string {
     return render(html`<!DOCTYPE html><html><body>${fragment}</body></html>`);
   }
 
-  return render(layout({ title: `Run ${run.id.slice(0, 8)}`, activeNav: 'runs' }, fragment));
+  return render(layout({ title: `Run ${run.id.slice(0, 8)}`, activeNav: 'runs', flash }, fragment));
+}
+
+/**
+ * No-JS fallback replay form wrapped in a <noscript>. When the DAG viz
+ * renders, the per-node dialog is the primary replay surface — this
+ * block only becomes visible if JS is disabled / the Cytoscape bootstrap
+ * fails to load. Keeps the feature reachable without JavaScript without
+ * cluttering the main flow.
+ */
+function renderReplayFallback(run: Run, agent: Agent): SafeHtml {
+  if (agent.nodes.length === 0) return html``;
+  const options = agent.nodes.map((n) => html`<option value="${n.id}">${n.id}</option>`);
+  const needsConfirm = agent.source === 'community' && agent.nodes.some((n) => n.type === 'shell');
+  const confirmInput = needsConfirm
+    ? html`
+      <label class="replay-form__confirm">
+        <input type="checkbox" name="confirm_community_shell" value="yes" required>
+        I've audited this community shell agent and accept the risk.
+      </label>`
+    : unsafeHtml('');
+  return html`
+    <noscript>
+      <section class="replay-form-section">
+        <h2>Replay</h2>
+        <p class="dim">
+          JavaScript is disabled, so the clickable DAG isn't available.
+          Pick a node below to replay from; upstream outputs from this run
+          will be reused.
+        </p>
+        <form action="/runs/${run.id}/replay" method="post" class="replay-form">
+          <label for="replay-from">Start from</label>
+          <select id="replay-from" name="fromNodeId" required>
+            <option value="">Select a node…</option>
+            ${options as unknown as SafeHtml[]}
+          </select>
+          ${confirmInput}
+          <button type="submit" class="btn btn--primary">Replay</button>
+        </form>
+      </section>
+    </noscript>
+  `;
 }
 
 /**

--- a/packages/dashboard/src/views/runs-list.ts
+++ b/packages/dashboard/src/views/runs-list.ts
@@ -20,12 +20,14 @@ export interface RunsListOptions {
     statuses: string[];
     triggeredBy: string[];
   };
+  /** Banner shown above the filter bar (redirected errors from mutation routes). */
+  flash?: { kind: 'error' | 'info' | 'ok'; message: string };
 }
 
 const ALL_STATUSES: RunStatus[] = ['pending', 'running', 'completed', 'failed', 'cancelled'];
 
 export function renderRunsList(opts: RunsListOptions): string {
-  const { rows, total, limit, offset, filter, distinct } = opts;
+  const { rows, total, limit, offset, filter, distinct, flash } = opts;
 
   const showingStart = total === 0 ? 0 : offset + 1;
   const showingEnd = Math.min(offset + rows.length, total);
@@ -89,8 +91,23 @@ export function renderRunsList(opts: RunsListOptions): string {
     </form>
   `;
 
+  const hasAnyFilter = filter.agent !== undefined
+    || filter.triggeredBy !== undefined
+    || (filter.q !== undefined && filter.q.length > 0)
+    || filter.statuses.length > 0;
+
   const table = rows.length === 0
-    ? html`<p class="dim">No runs match the current filters.</p>`
+    ? hasAnyFilter
+      ? html`
+        <div class="settings-empty" style="margin-top: 0;">
+          <h3 style="margin-top: 0;">No runs match</h3>
+          <p class="dim">No runs match the current filters. <a href="/runs">Reset filters</a> to see everything.</p>
+        </div>`
+      : html`
+        <div class="settings-empty" style="margin-top: 0;">
+          <h3 style="margin-top: 0;">No runs yet</h3>
+          <p class="dim">Trigger your first run from the <a href="/agents">Agents</a> page or <code>sua workflow run &lt;id&gt;</code>.</p>
+        </div>`
     : html`
       <table class="table">
         <thead>
@@ -121,7 +138,7 @@ export function renderRunsList(opts: RunsListOptions): string {
     ${pager}
   `;
 
-  return render(layout({ title: 'Runs', activeNav: 'runs' }, body));
+  return render(layout({ title: 'Runs', activeNav: 'runs', flash }, body));
 }
 
 function buildUrl(filter: RunsListOptions['filter'], limit: number, offset: number): string {

--- a/packages/dashboard/src/views/template-palette.ts
+++ b/packages/dashboard/src/views/template-palette.ts
@@ -1,0 +1,54 @@
+import type { Agent } from '@some-useful-agents/core';
+import { html, unsafeHtml, type SafeHtml } from './html.js';
+
+export interface PaletteSuggestions {
+  /** Upstream node ids available to this node. */
+  upstreams: string[];
+  /** Agent-level declared input names. */
+  inputs: string[];
+  /** Secret names this node declares (per-node injection). */
+  secrets: string[];
+}
+
+/**
+ * Compute the set of template + env-var suggestions surfaced by the
+ * command-palette on node edit/add forms. Sources:
+ *   - `upstreams`: all other nodes in the agent. The author may pick
+ *     a subset via `dependsOn:` — the palette offers the full list so
+ *     users don't have to toggle checkboxes before typing. Save-time
+ *     Zod re-validation catches references to undeclared upstreams.
+ *   - `inputs`: `agent.inputs` names (agent-level runtime inputs).
+ *   - `secrets`: the declared secrets on the node under edit (or
+ *     empty for new nodes — the add-node form doesn't yet edit
+ *     `secrets:`). Secrets are per-node, not agent-level, so this
+ *     list is empty on add-node today; edit-node uses the current
+ *     node's declared list.
+ */
+export function computePaletteSuggestions(
+  agent: Agent,
+  opts: { excludeNodeId?: string; nodeSecrets?: string[] } = {},
+): PaletteSuggestions {
+  const upstreams = agent.nodes
+    .map((n) => n.id)
+    .filter((id) => id !== opts.excludeNodeId)
+    .sort();
+  const inputs = Object.keys(agent.inputs ?? {}).sort();
+  const secrets = (opts.nodeSecrets ?? []).slice().sort();
+  return { upstreams, inputs, secrets };
+}
+
+/**
+ * Render the palette's data blob as a `<script type="application/json">`
+ * tag. Content is read by the client palette on input events; keeping
+ * it in a JSON payload avoids hand-rolled HTML attribute escaping on
+ * per-field data blobs.
+ */
+export function renderPalettePayload(
+  id: string,
+  suggestions: PaletteSuggestions,
+): SafeHtml {
+  // Ids in our schema are lowercase-alphanumeric-hyphens; escape the
+  // </script end-tag sequence to keep the payload inert.
+  const json = JSON.stringify(suggestions).replace(/<\/script/gi, '<\\/script');
+  return html`<script id="${id}" type="application/json">${unsafeHtml(json)}</script>`;
+}


### PR DESCRIPTION
## Summary

- **Click any DAG node** on `/runs/:id` or `/agents/:id` to open a native `<dialog>` with node metadata + actions. Run detail shows "Replay from here" + "Jump to details"; agent detail shows "Edit node" + "Replay from here" (wired to the latest completed run).
- **Template palette autocomplete** on Command + Prompt textareas: `$` opens a floating list of `$UPSTREAM_<ID>_RESULT` / `$<INPUT>` / `$<SECRET>`; `{{` opens `{{upstream.<id>.result}}` / `{{inputs.<NAME>}}`. Up/Down + Enter to insert, Esc to close, substring filter.
- **`POST /runs/:id/replay`** — validates prior run + agent + pivot node; dispatches via `executeAgentDag` with `replayFrom`; 303s to the new run on success, flashes back on failure.
- **Empty/error polish**: `/runs` splits into "No runs yet" (fresh install) vs "No runs match" (filters set); `/runs/<missing>` flashes back to `/runs`; kills the misleading "Click a node to inspect it" hint on agent detail.

## Design notes

- Dialog uses the browser-native `<dialog>` element — ESC + backdrop + focus-return come free.
- Palette suggestions computed server-side and embedded as a JSON payload (`<script type="application/json">`), same pattern as Cytoscape's element payload.
- Origin check in `requireAuth` is the CSRF defence on every POST under `/runs` and `/agents`.
- Replay always redirects to a new run (even on validation failure the executor writes a failed run row for the audit trail).

## Test plan

- [x] 87/87 dashboard tests pass (75 → 87, +12 new covering DAG replay wiring, node-dialog shell, replay route validation + success + cross-origin refusal, missing-run redirect, empty states, palette payload shape on add-node + edit-node).
- [x] 484/484 workspace tests pass.
- [x] `npm run lint` clean.
- [x] `npm run build` clean.
- [x] Smoked in a scratch project: seeded a two-node DAG, ran it twice, opened `/runs/<id>`, clicked a node → dialog → replay → new run rendered. Also confirmed palette fires on both `$` and `{{` in the edit-node form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)