### PR TITLE
feat(core): tool abstraction — types, schema, store, 9 built-ins (v0.16 PR 1/6)

### DIFF
--- a/.changeset/tools-v016-pr1.md
+++ b/.changeset/tools-v016-pr1.md
@@ -1,0 +1,25 @@
+---
+"@some-useful-agents/core": minor
+---
+
+**feat: tool abstraction foundation — types, schema, store, 9 built-in tools (PR 1 of 6 for v0.16).**
+
+Introduces the **tool** as a named, reusable unit of work a node invokes by reference. Nodes gain `tool` + `toolInputs` fields; the executor will resolve tool refs and dispatch via the built-in registry or user-defined tools (wired in PR 2). This PR lays the data layer only — no runtime dispatch yet.
+
+### What ships
+
+- **`tool-types.ts`** — `ToolDefinition`, `ToolOutput`, `BuiltinToolEntry`, `BuiltinToolContext`, `ToolSource`, `ToolFieldType`, `ToolInputField`, `ToolOutputField`, `ToolImplementation`.
+- **`tool-schema.ts`** — Zod validation for tool YAML (id, name, source, inputs/outputs with typed fields, implementation with type-specific requirements).
+- **`tool-store.ts`** — SQLite `tools` table with CRUD (create, get, list, update, upsert, delete). Mirrors agent-store's `DatabaseSync` + `ensureSchema()` pattern.
+- **`builtin-tools.ts`** — registry of 9 built-in tools: `shell-exec`, `claude-code`, `http-get`, `http-post`, `file-read`, `file-write`, `json-parse`, `json-path`, `template`. Each has a `ToolDefinition` (schema) + a Node-native `execute()` function.
+- **`AgentNode.tool`** + **`AgentNode.toolInputs`** — optional fields on the v2 node type. When `tool` is set, the node schema doesn't require inline `command`/`prompt` (the tool provides them). `type` stays required for backwards compat — the YAML parser derives it from the tool's implementation at load time.
+- **`NodeExecutionRecord.outputsJson`** — new column on `node_executions` for structured tool outputs. Idempotent `ALTER TABLE ADD COLUMN` migration on first open.
+- **`NodeStructuredOutput`** type + `NodeOutput.outputs` field for in-memory structured output passing between nodes.
+- **Variable defaults confirmed** — `AgentInputSpec.default` + `description` already exist in types, Zod schema, and executor resolve. The UI surface (agent detail sidebar) is the remaining task.
+
+### Tests
+
+508 total (484 → 508; +24 new):
+- `tool-schema.test.ts` — 7 tests: valid shell/claude-code/builtin tools, invalid id, missing required fields, typed inputs/outputs round-trip.
+- `tool-store.test.ts` — 7 tests: create, get, list (sorted), update, upsert, delete, nonexistent lookups.
+- `builtin-tools.test.ts` — 10 tests: registry lists all 9 tools, retrieval by id, isBuiltinTool checks, shell-exec executes a command, json-parse/json-path/template/file-read exercise the execute functions.

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -42,6 +42,14 @@ export const agentNodeSchema = z.object({
   id: z.string().regex(NODE_ID_RE, 'Node ids must be lowercase with hyphens/underscores only'),
   type: z.enum(['shell', 'claude-code']),
 
+  /**
+   * v0.16+: named tool this node invokes. When set, `type` + `command` /
+   * `prompt` are not required — the tool's implementation provides them.
+   * When absent, `type` is required and v0.15 rules apply.
+   */
+  tool: z.string().optional(),
+  toolInputs: z.record(z.unknown()).optional(),
+
   command: z.string().optional(),
   prompt: z.string().optional(),
   model: z.string().optional(),
@@ -59,11 +67,16 @@ export const agentNodeSchema = z.object({
   position: z.object({ x: z.number(), y: z.number() }).optional(),
 }).refine(
   (data) => {
+    // When a named tool is set, the tool provides the implementation —
+    // command/prompt are not required (they live in toolInputs or on the
+    // tool definition). `type` is still required: the YAML parser sets
+    // it from the tool's implementation type at load time.
+    if (data.tool) return true;
     if (data.type === 'shell') return !!data.command;
     if (data.type === 'claude-code') return !!data.prompt;
     return false;
   },
-  { message: 'Shell nodes require "command", claude-code nodes require "prompt"' },
+  { message: 'Nodes without a tool require command (shell) or prompt (claude-code)' },
 );
 
 export const agentV2Schema = z.object({

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -60,10 +60,31 @@ export interface AgentNode {
   id: string;
   type: NodeType;
 
-  // Shell
+  /**
+   * v0.16+: named tool this node invokes. When set, the executor resolves
+   * the tool by id from the tool registry and uses its implementation
+   * instead of the inline `type`-based dispatch. The tool's declared
+   * inputs/outputs drive template validation + structured output capture.
+   *
+   * Backwards compat: nodes without `tool` fall through to the v0.15
+   * `type`-based dispatch (shell-exec / claude-code built-in tools).
+   * At load time, `type: shell` desugars to `tool: 'shell-exec'` and
+   * `type: claude-code` desugars to `tool: 'claude-code'`.
+   */
+  tool?: string;
+
+  /**
+   * Tool-specific inputs. When `tool:` is set, these are passed to the
+   * tool's execute function. For backwards compat, `command` and `prompt`
+   * continue to work as top-level fields and are folded into `toolInputs`
+   * at load time.
+   */
+  toolInputs?: Record<string, unknown>;
+
+  // Shell (v0.15 compat — desugars to toolInputs.command)
   command?: string;
 
-  // Claude-code
+  // Claude-code (v0.15 compat — desugars to toolInputs.prompt)
   prompt?: string;
   model?: string;
   maxTurns?: number;
@@ -182,6 +203,22 @@ export interface NodeExecutionRecord {
   inputsJson?: string;
   /** Snapshot of upstream node results that fed into this node. */
   upstreamInputsJson?: string;
+  /**
+   * v0.16+: the full structured output object for this node execution,
+   * JSON-serialized. Keys match the tool's declared `outputs`. `result`
+   * stays as a convenience field but becomes derived from `outputsJson.result`
+   * for tools that declare it.
+   */
+  outputsJson?: string;
+}
+
+/**
+ * v0.16+: the parsed structured output. `result` is the v0.15-compat
+ * flat string; tool-declared fields sit alongside it.
+ */
+export interface NodeStructuredOutput {
+  [key: string]: unknown;
+  result?: string;
 }
 
 /**
@@ -192,6 +229,8 @@ export interface NodeExecutionRecord {
 export interface NodeOutput {
   result: string;
   exitCode: number;
+  /** v0.16+: structured output from the tool, if the node used one. */
+  outputs?: NodeStructuredOutput;
   /** Agent source at the time of execution; propagates for trust wrapping. */
   source: AgentSource;
 }

--- a/packages/core/src/builtin-tools.test.ts
+++ b/packages/core/src/builtin-tools.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { getBuiltinTool, listBuiltinTools, isBuiltinTool } from './builtin-tools.js';
+
+describe('Builtin tool registry', () => {
+  it('lists all 9 built-in tools', () => {
+    const tools = listBuiltinTools();
+    expect(tools.length).toBe(9);
+    const ids = tools.map((t) => t.id).sort();
+    expect(ids).toEqual([
+      'claude-code', 'file-read', 'file-write', 'http-get', 'http-post',
+      'json-parse', 'json-path', 'shell-exec', 'template',
+    ]);
+  });
+
+  it('retrieves shell-exec by id', () => {
+    const entry = getBuiltinTool('shell-exec');
+    expect(entry).toBeDefined();
+    expect(entry!.definition.source).toBe('builtin');
+    expect(entry!.definition.implementation.type).toBe('builtin');
+  });
+
+  it('isBuiltinTool returns true for known ids', () => {
+    expect(isBuiltinTool('shell-exec')).toBe(true);
+    expect(isBuiltinTool('claude-code')).toBe(true);
+    expect(isBuiltinTool('http-get')).toBe(true);
+  });
+
+  it('isBuiltinTool returns false for unknown ids', () => {
+    expect(isBuiltinTool('not-a-tool')).toBe(false);
+  });
+
+  it('shell-exec executes a simple command', async () => {
+    const entry = getBuiltinTool('shell-exec')!;
+    const result = await entry.execute({ command: 'echo hello-tools' }, {});
+    expect(result.stdout).toContain('hello-tools');
+    expect(result.exit_code).toBe(0);
+    expect(result.result).toContain('hello-tools');
+  });
+
+  it('json-parse parses valid JSON', async () => {
+    const entry = getBuiltinTool('json-parse')!;
+    const result = await entry.execute({ text: '{"a":1}' }, {});
+    expect(result.value).toEqual({ a: 1 });
+    expect(result.result).toBe('{"a":1}');
+  });
+
+  it('json-path extracts a nested value', async () => {
+    const entry = getBuiltinTool('json-path')!;
+    const result = await entry.execute({
+      data: { items: [{ title: 'hello' }] },
+      path: 'items.0.title',
+    }, {});
+    expect(result.value).toBe('hello');
+    expect(result.result).toBe('hello');
+  });
+
+  it('template returns the text as-is', async () => {
+    const entry = getBuiltinTool('template')!;
+    const result = await entry.execute({ text: 'Hello {{name}}' }, {});
+    expect(result.result).toBe('Hello {{name}}');
+  });
+
+  it('file-read reads a file', async () => {
+    const entry = getBuiltinTool('file-read')!;
+    const result = await entry.execute({ path: 'package.json' }, {});
+    expect(result.content).toContain('some-useful-agents');
+    expect(result.bytes).toBeGreaterThan(0);
+  });
+
+  it('http-get fetches a URL (skipped without network)', async () => {
+    // This test validates the function shape; real HTTP is tested in
+    // integration. We just check it doesn't throw on construction.
+    const entry = getBuiltinTool('http-get')!;
+    expect(entry.definition.inputs.url.required).toBe(true);
+    expect(entry.definition.outputs.status.type).toBe('number');
+  });
+});

--- a/packages/core/src/builtin-tools.ts
+++ b/packages/core/src/builtin-tools.ts
@@ -1,0 +1,321 @@
+import { execSync, type ExecSyncOptions } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type {
+  ToolDefinition,
+  ToolOutput,
+  BuiltinToolEntry,
+  BuiltinToolContext,
+} from './tool-types.js';
+
+/**
+ * Built-in tool registry. Each entry provides a ToolDefinition (schema)
+ * plus a Node-native execute function the executor calls directly —
+ * no child process spawn needed for the hot path.
+ *
+ * Built-ins are always trusted (source: 'builtin'); the community-shell
+ * gate doesn't apply.
+ */
+
+function def(
+  id: string,
+  name: string,
+  description: string,
+  inputs: ToolDefinition['inputs'],
+  outputs: ToolDefinition['outputs'],
+  execute: BuiltinToolEntry['execute'],
+): BuiltinToolEntry {
+  return {
+    definition: {
+      id,
+      name,
+      description,
+      source: 'builtin',
+      inputs,
+      outputs,
+      implementation: { type: 'builtin', builtinName: id },
+    },
+    execute,
+  };
+}
+
+const BUILTINS: BuiltinToolEntry[] = [
+  def(
+    'shell-exec',
+    'Shell exec',
+    'Run an arbitrary shell command. Backcompat tool for v0.15 type:shell nodes.',
+    {
+      command: { type: 'string', description: 'Shell command to execute.' },
+    },
+    {
+      stdout: { type: 'string', description: 'Full stdout.' },
+      stderr: { type: 'string', description: 'Full stderr.' },
+      exit_code: { type: 'number', description: 'Process exit code.' },
+      result: { type: 'string', description: 'Alias for stdout (v0.15 compat).' },
+    },
+    async (inputs, ctx) => {
+      const command = String(inputs.command ?? '');
+      const opts: ExecSyncOptions = {
+        cwd: ctx.workingDirectory,
+        env: { ...process.env, ...ctx.env },
+        timeout: (ctx.timeout ?? 300) * 1000,
+        maxBuffer: 10 * 1024 * 1024,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      };
+      try {
+        const stdout = execSync(command, opts) as unknown as string;
+        return { stdout, stderr: '', exit_code: 0, result: stdout };
+      } catch (err: unknown) {
+        const e = err as { stdout?: string; stderr?: string; status?: number };
+        const stdout = String(e.stdout ?? '');
+        const stderr = String(e.stderr ?? '');
+        return { stdout, stderr, exit_code: e.status ?? 1, result: stdout };
+      }
+    },
+  ),
+
+  def(
+    'claude-code',
+    'Claude Code',
+    'Run a Claude Code prompt. Backcompat tool for v0.15 type:claude-code nodes.',
+    {
+      prompt: { type: 'string', description: 'Prompt text.' },
+      model: { type: 'string', description: 'Model override.' },
+      maxTurns: { type: 'number', description: 'Max conversation turns.', default: 10 },
+      allowedTools: { type: 'json', description: 'Allowed tool names (JSON array).' },
+    },
+    {
+      text: { type: 'string', description: 'Assistant final text.' },
+      result: { type: 'string', description: 'Alias for text (v0.15 compat).' },
+    },
+    async (inputs, ctx) => {
+      const prompt = String(inputs.prompt ?? '');
+      const args = ['--print', prompt];
+      if (inputs.model) args.push('--model', String(inputs.model));
+      if (inputs.maxTurns) args.push('--max-turns', String(inputs.maxTurns));
+      const allowedTools = inputs.allowedTools;
+      if (Array.isArray(allowedTools)) {
+        for (const t of allowedTools) args.push('--allowedTools', String(t));
+      }
+      const opts: ExecSyncOptions = {
+        cwd: ctx.workingDirectory,
+        env: { ...process.env, ...ctx.env },
+        timeout: (ctx.timeout ?? 600) * 1000,
+        maxBuffer: 10 * 1024 * 1024,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      };
+      try {
+        const stdout = execSync(`claude ${args.map(a => `'${a.replace(/'/g, "'\\''")}'`).join(' ')}`, opts) as unknown as string;
+        return { text: stdout, result: stdout };
+      } catch (err: unknown) {
+        const e = err as { stdout?: string; status?: number };
+        const text = String(e.stdout ?? '');
+        return { text, result: text, exit_code: e.status ?? 1 };
+      }
+    },
+  ),
+
+  def(
+    'http-get',
+    'HTTP GET',
+    'Issue an HTTP GET and return the response. JSON bodies are auto-parsed.',
+    {
+      url: { type: 'string', description: 'Absolute URL to fetch.', required: true },
+      timeout: { type: 'number', description: 'Timeout in seconds.', default: 30 },
+    },
+    {
+      status: { type: 'number', description: 'HTTP status code.' },
+      body: { type: 'json', description: 'Response body (JSON-decoded if applicable, else string).' },
+      headers: { type: 'object', description: 'Response headers.' },
+      duration_ms: { type: 'number', description: 'Request duration in milliseconds.' },
+    },
+    async (inputs) => {
+      const url = String(inputs.url ?? '');
+      const timeout = Number(inputs.timeout ?? 30) * 1000;
+      const start = Date.now();
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeout);
+      try {
+        const res = await fetch(url, { signal: controller.signal });
+        const text = await res.text();
+        let body: unknown;
+        try { body = JSON.parse(text); } catch { body = text; }
+        return {
+          status: res.status,
+          body,
+          headers: Object.fromEntries(res.headers.entries()),
+          duration_ms: Date.now() - start,
+          result: typeof body === 'string' ? body : JSON.stringify(body),
+        };
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  ),
+
+  def(
+    'http-post',
+    'HTTP POST',
+    'Issue an HTTP POST with a JSON body.',
+    {
+      url: { type: 'string', description: 'Absolute URL.', required: true },
+      body: { type: 'json', description: 'Request body (JSON-encoded).' },
+      timeout: { type: 'number', description: 'Timeout in seconds.', default: 30 },
+    },
+    {
+      status: { type: 'number', description: 'HTTP status code.' },
+      body: { type: 'json', description: 'Response body.' },
+      headers: { type: 'object', description: 'Response headers.' },
+      duration_ms: { type: 'number', description: 'Request duration in milliseconds.' },
+    },
+    async (inputs) => {
+      const url = String(inputs.url ?? '');
+      const timeout = Number(inputs.timeout ?? 30) * 1000;
+      const reqBody = inputs.body !== undefined ? JSON.stringify(inputs.body) : undefined;
+      const start = Date.now();
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeout);
+      try {
+        const res = await fetch(url, {
+          method: 'POST',
+          headers: reqBody ? { 'Content-Type': 'application/json' } : {},
+          body: reqBody,
+          signal: controller.signal,
+        });
+        const text = await res.text();
+        let body: unknown;
+        try { body = JSON.parse(text); } catch { body = text; }
+        return {
+          status: res.status,
+          body,
+          headers: Object.fromEntries(res.headers.entries()),
+          duration_ms: Date.now() - start,
+          result: typeof body === 'string' ? body : JSON.stringify(body),
+        };
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  ),
+
+  def(
+    'file-read',
+    'File read',
+    'Read a file from the project directory.',
+    {
+      path: { type: 'string', description: 'Relative path within the project.', required: true },
+    },
+    {
+      content: { type: 'string', description: 'File content as UTF-8.' },
+      bytes: { type: 'number', description: 'File size in bytes.' },
+      result: { type: 'string', description: 'Alias for content.' },
+    },
+    async (inputs, ctx) => {
+      const filePath = resolve(ctx.workingDirectory ?? process.cwd(), String(inputs.path));
+      const content = readFileSync(filePath, 'utf-8');
+      return { content, bytes: Buffer.byteLength(content), result: content };
+    },
+  ),
+
+  def(
+    'file-write',
+    'File write',
+    'Write content to a file in the project directory.',
+    {
+      path: { type: 'string', description: 'Relative path within the project.', required: true },
+      content: { type: 'string', description: 'Content to write.', required: true },
+    },
+    {
+      bytes: { type: 'number', description: 'Bytes written.' },
+      path: { type: 'string', description: 'Resolved file path.' },
+      result: { type: 'string', description: 'Resolved file path.' },
+    },
+    async (inputs, ctx) => {
+      const filePath = resolve(ctx.workingDirectory ?? process.cwd(), String(inputs.path));
+      const content = String(inputs.content);
+      writeFileSync(filePath, content, 'utf-8');
+      return { bytes: Buffer.byteLength(content), path: filePath, result: filePath };
+    },
+  ),
+
+  def(
+    'json-parse',
+    'JSON parse',
+    'Parse a JSON string into a structured value.',
+    {
+      text: { type: 'string', description: 'JSON string to parse.', required: true },
+    },
+    {
+      value: { type: 'json', description: 'Parsed value.' },
+      result: { type: 'string', description: 'Re-serialized JSON.' },
+    },
+    async (inputs) => {
+      const text = String(inputs.text ?? '');
+      const value = JSON.parse(text);
+      return { value, result: JSON.stringify(value) };
+    },
+  ),
+
+  def(
+    'json-path',
+    'JSON path',
+    'Extract a value from a JSON object using a dot-separated path.',
+    {
+      data: { type: 'json', description: 'Input object/array.', required: true },
+      path: { type: 'string', description: 'Dot-separated path (e.g. "items.0.title").', required: true },
+    },
+    {
+      value: { type: 'json', description: 'Extracted value.' },
+      result: { type: 'string', description: 'Extracted value as string.' },
+    },
+    async (inputs) => {
+      const data = inputs.data;
+      const path = String(inputs.path ?? '');
+      let current: unknown = data;
+      for (const segment of path.split('.')) {
+        if (current === null || current === undefined) break;
+        if (typeof current === 'object') {
+          current = (current as Record<string, unknown>)[segment];
+        } else {
+          current = undefined;
+        }
+      }
+      const str = current === undefined ? '' : typeof current === 'string' ? current : JSON.stringify(current);
+      return { value: current, result: str };
+    },
+  ),
+
+  def(
+    'template',
+    'Template',
+    'Literal text with {{inputs.X}} interpolation. No side effects.',
+    {
+      text: { type: 'string', description: 'Template text.', required: true },
+    },
+    {
+      result: { type: 'string', description: 'Interpolated text.' },
+    },
+    async (inputs) => {
+      return { result: String(inputs.text ?? '') };
+    },
+  ),
+];
+
+const REGISTRY = new Map<string, BuiltinToolEntry>();
+for (const entry of BUILTINS) {
+  REGISTRY.set(entry.definition.id, entry);
+}
+
+export function getBuiltinTool(id: string): BuiltinToolEntry | undefined {
+  return REGISTRY.get(id);
+}
+
+export function listBuiltinTools(): ToolDefinition[] {
+  return BUILTINS.map((e) => e.definition);
+}
+
+export function isBuiltinTool(id: string): boolean {
+  return REGISTRY.has(id);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,19 @@ export {
 } from './agent-v2-schema.js';
 export { parseAgent, exportAgent, exportAgents, AgentYamlParseError } from './agent-yaml.js';
 export { AgentStore } from './agent-store.js';
+export * from './tool-types.js';
+export {
+  toolDefinitionSchema,
+  type ToolDefinitionInput,
+  type ToolDefinitionParsed,
+} from './tool-schema.js';
+export { ToolStore } from './tool-store.js';
+export {
+  getBuiltinTool,
+  listBuiltinTools,
+  isBuiltinTool,
+} from './builtin-tools.js';
+
 export {
   executeAgentDag,
   topologicalSort,

--- a/packages/core/src/run-store.ts
+++ b/packages/core/src/run-store.ts
@@ -161,6 +161,12 @@ export class RunStore {
       CREATE INDEX IF NOT EXISTS idx_node_executions_category
         ON node_executions(errorCategory) WHERE errorCategory IS NOT NULL;
     `);
+
+    // v0.16: structured tool outputs stored alongside the flat result.
+    const execCols = columnNames(this.db, 'node_executions');
+    if (!execCols.has('outputsjson')) {
+      this.db.exec(`ALTER TABLE node_executions ADD COLUMN outputsJson TEXT`);
+    }
   }
 
   /**
@@ -322,8 +328,8 @@ export class RunStore {
       INSERT INTO node_executions (
         runId, nodeId, workflowVersion, status, errorCategory,
         startedAt, completedAt, result, exitCode, error,
-        inputsJson, upstreamInputsJson
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        inputsJson, upstreamInputsJson, outputsJson
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     stmt.run(
       record.runId, record.nodeId, record.workflowVersion, record.status,
@@ -331,6 +337,7 @@ export class RunStore {
       record.startedAt, record.completedAt ?? null,
       record.result ?? null, record.exitCode ?? null, record.error ?? null,
       record.inputsJson ?? null, record.upstreamInputsJson ?? null,
+      record.outputsJson ?? null,
     );
   }
 
@@ -338,7 +345,7 @@ export class RunStore {
     runId: string,
     nodeId: string,
     updates: Partial<Pick<NodeExecutionRecord,
-      'status' | 'errorCategory' | 'completedAt' | 'result' | 'exitCode' | 'error' | 'inputsJson' | 'upstreamInputsJson'
+      'status' | 'errorCategory' | 'completedAt' | 'result' | 'exitCode' | 'error' | 'inputsJson' | 'upstreamInputsJson' | 'outputsJson'
     >>,
   ): void {
     const fields: string[] = [];
@@ -351,6 +358,7 @@ export class RunStore {
     if (updates.error !== undefined) { fields.push('error = ?'); values.push(updates.error); }
     if (updates.inputsJson !== undefined) { fields.push('inputsJson = ?'); values.push(updates.inputsJson); }
     if (updates.upstreamInputsJson !== undefined) { fields.push('upstreamInputsJson = ?'); values.push(updates.upstreamInputsJson); }
+    if (updates.outputsJson !== undefined) { fields.push('outputsJson = ?'); values.push(updates.outputsJson); }
     if (fields.length === 0) return;
 
     values.push(runId, nodeId);
@@ -435,6 +443,7 @@ export class RunStore {
       error: (row.error as string | null) ?? undefined,
       inputsJson: (row.inputsJson as string | null) ?? undefined,
       upstreamInputsJson: (row.upstreamInputsJson as string | null) ?? undefined,
+      outputsJson: (row.outputsJson as string | null) ?? undefined,
     };
   }
 }

--- a/packages/core/src/tool-schema.test.ts
+++ b/packages/core/src/tool-schema.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { toolDefinitionSchema } from './tool-schema.js';
+
+describe('toolDefinitionSchema', () => {
+  it('accepts a valid shell tool', () => {
+    const result = toolDefinitionSchema.safeParse({
+      id: 'my-tool',
+      name: 'My Tool',
+      implementation: { type: 'shell', command: 'echo hi' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a valid claude-code tool', () => {
+    const result = toolDefinitionSchema.safeParse({
+      id: 'ai-tool',
+      name: 'AI Tool',
+      implementation: { type: 'claude-code', prompt: 'Summarise.' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a valid builtin tool', () => {
+    const result = toolDefinitionSchema.safeParse({
+      id: 'http-get',
+      name: 'HTTP GET',
+      source: 'builtin',
+      implementation: { type: 'builtin', builtinName: 'http-get' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects tool with invalid id', () => {
+    const result = toolDefinitionSchema.safeParse({
+      id: 'BAD ID',
+      name: 'Bad',
+      implementation: { type: 'shell', command: 'echo' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects shell tool without command', () => {
+    const result = toolDefinitionSchema.safeParse({
+      id: 'bad-shell',
+      name: 'Bad Shell',
+      implementation: { type: 'shell' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects builtin without builtinName', () => {
+    const result = toolDefinitionSchema.safeParse({
+      id: 'bad-builtin',
+      name: 'Bad Builtin',
+      implementation: { type: 'builtin' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('parses inputs and outputs correctly', () => {
+    const result = toolDefinitionSchema.safeParse({
+      id: 'typed-tool',
+      name: 'Typed',
+      inputs: {
+        url: { type: 'string', required: true },
+        timeout: { type: 'number', default: 30 },
+      },
+      outputs: {
+        status: { type: 'number' },
+        body: { type: 'json', description: 'Response body.' },
+      },
+      implementation: { type: 'shell', command: 'curl' },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.inputs.url.required).toBe(true);
+      expect(result.data.inputs.timeout.default).toBe(30);
+      expect(result.data.outputs.body.description).toBe('Response body.');
+    }
+  });
+});

--- a/packages/core/src/tool-schema.ts
+++ b/packages/core/src/tool-schema.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+
+const TOOL_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+const toolFieldTypeSchema = z.enum([
+  'string', 'number', 'boolean', 'json', 'object', 'array',
+]);
+
+const toolInputFieldSchema = z.object({
+  type: toolFieldTypeSchema,
+  description: z.string().optional(),
+  default: z.union([z.string(), z.number(), z.boolean()]).optional(),
+  required: z.boolean().optional(),
+});
+
+const toolOutputFieldSchema = z.object({
+  type: toolFieldTypeSchema,
+  description: z.string().optional(),
+});
+
+const toolImplementationSchema = z.object({
+  type: z.enum(['shell', 'claude-code', 'builtin']),
+  command: z.string().optional(),
+  prompt: z.string().optional(),
+  builtinName: z.string().optional(),
+}).refine(
+  (data) => {
+    if (data.type === 'shell') return !!data.command;
+    if (data.type === 'claude-code') return !!data.prompt;
+    if (data.type === 'builtin') return !!data.builtinName;
+    return false;
+  },
+  { message: 'Shell tools need command, claude-code need prompt, builtin need builtinName' },
+);
+
+export const toolDefinitionSchema = z.object({
+  id: z.string().regex(TOOL_ID_RE, 'Tool id must be lowercase with hyphens only'),
+  name: z.string().min(1),
+  description: z.string().optional(),
+  source: z.enum(['local', 'examples', 'community', 'builtin']).default('local'),
+
+  inputs: z.record(z.string(), toolInputFieldSchema).default({}),
+  outputs: z.record(z.string(), toolOutputFieldSchema).default({}),
+
+  implementation: toolImplementationSchema,
+});
+
+export type ToolDefinitionInput = z.input<typeof toolDefinitionSchema>;
+export type ToolDefinitionParsed = z.output<typeof toolDefinitionSchema>;

--- a/packages/core/src/tool-store.test.ts
+++ b/packages/core/src/tool-store.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ToolStore } from './tool-store.js';
+import type { ToolDefinition } from './tool-types.js';
+
+let dir: string;
+let store: ToolStore;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'sua-tool-store-'));
+  store = new ToolStore(join(dir, 'runs.db'));
+});
+
+afterEach(() => {
+  try { store.close(); } catch {}
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+function sampleTool(id = 'http-get', overrides: Partial<ToolDefinition> = {}): ToolDefinition {
+  return {
+    id,
+    name: 'HTTP GET',
+    description: 'Fetch a URL.',
+    source: 'local',
+    inputs: { url: { type: 'string', required: true } },
+    outputs: { status: { type: 'number' }, body: { type: 'json' } },
+    implementation: { type: 'shell', command: 'curl -s "$url"' },
+    ...overrides,
+  };
+}
+
+describe('ToolStore', () => {
+  it('creates and retrieves a tool', () => {
+    const tool = store.createTool(sampleTool());
+    expect(tool.createdAt).toBeDefined();
+
+    const loaded = store.getTool('http-get');
+    expect(loaded).toBeDefined();
+    expect(loaded!.id).toBe('http-get');
+    expect(loaded!.name).toBe('HTTP GET');
+    expect(loaded!.inputs.url.type).toBe('string');
+    expect(loaded!.outputs.body.type).toBe('json');
+    expect(loaded!.implementation.command).toBe('curl -s "$url"');
+  });
+
+  it('lists tools sorted by id', () => {
+    store.createTool(sampleTool('b-tool'));
+    store.createTool(sampleTool('a-tool'));
+    const list = store.listTools();
+    expect(list.map((t) => t.id)).toEqual(['a-tool', 'b-tool']);
+  });
+
+  it('updates an existing tool', () => {
+    store.createTool(sampleTool());
+    store.updateTool({ ...sampleTool(), name: 'HTTP GET v2' });
+    const loaded = store.getTool('http-get');
+    expect(loaded!.name).toBe('HTTP GET v2');
+  });
+
+  it('upserts: inserts if absent, updates if present', () => {
+    store.upsertTool(sampleTool());
+    expect(store.getTool('http-get')).toBeDefined();
+
+    store.upsertTool({ ...sampleTool(), name: 'Updated' });
+    expect(store.getTool('http-get')!.name).toBe('Updated');
+  });
+
+  it('deletes a tool', () => {
+    store.createTool(sampleTool());
+    expect(store.deleteTool('http-get')).toBe(true);
+    expect(store.getTool('http-get')).toBeUndefined();
+  });
+
+  it('returns false when deleting a nonexistent tool', () => {
+    expect(store.deleteTool('ghost')).toBe(false);
+  });
+
+  it('returns undefined for nonexistent tool', () => {
+    expect(store.getTool('ghost')).toBeUndefined();
+  });
+});

--- a/packages/core/src/tool-store.ts
+++ b/packages/core/src/tool-store.ts
@@ -1,0 +1,137 @@
+import { DatabaseSync } from 'node:sqlite';
+import type { ToolDefinition, ToolSource } from './tool-types.js';
+
+/**
+ * Persistent store for tool definitions. Mirrors the agent-store pattern:
+ * single SQLite table, idempotent schema creation, simple CRUD.
+ *
+ * Tool versioning is deferred to v0.18 — editing a tool is destructive
+ * (overwrite). The CHANGELOG documents this so early adopters don't
+ * assume git-style history.
+ */
+export class ToolStore {
+  private readonly db: DatabaseSync;
+
+  constructor(dbPath: string) {
+    this.db = new DatabaseSync(dbPath);
+    this.db.exec('PRAGMA journal_mode = WAL');
+    this.ensureSchema();
+  }
+
+  static fromHandle(db: DatabaseSync): ToolStore {
+    const store = Object.create(ToolStore.prototype) as ToolStore;
+    (store as unknown as { db: DatabaseSync }).db = db;
+    store.ensureSchema();
+    return store;
+  }
+
+  private ensureSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS tools (
+        id               TEXT PRIMARY KEY,
+        name             TEXT NOT NULL,
+        description      TEXT,
+        source           TEXT NOT NULL DEFAULT 'local',
+        inputs_json      TEXT NOT NULL DEFAULT '{}',
+        outputs_json     TEXT NOT NULL DEFAULT '{}',
+        implementation_json TEXT NOT NULL,
+        yaml_text        TEXT,
+        created_at       TEXT NOT NULL,
+        updated_at       TEXT NOT NULL
+      )
+    `);
+  }
+
+  createTool(tool: ToolDefinition, yamlText?: string): ToolDefinition {
+    const now = new Date().toISOString();
+    this.db.prepare(`
+      INSERT INTO tools (id, name, description, source, inputs_json, outputs_json, implementation_json, yaml_text, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      tool.id,
+      tool.name,
+      tool.description ?? null,
+      tool.source,
+      JSON.stringify(tool.inputs),
+      JSON.stringify(tool.outputs),
+      JSON.stringify(tool.implementation),
+      yamlText ?? null,
+      now,
+      now,
+    );
+    return { ...tool, createdAt: now, updatedAt: now };
+  }
+
+  updateTool(tool: ToolDefinition, yamlText?: string): ToolDefinition {
+    const now = new Date().toISOString();
+    this.db.prepare(`
+      UPDATE tools SET name = ?, description = ?, source = ?, inputs_json = ?, outputs_json = ?,
+        implementation_json = ?, yaml_text = ?, updated_at = ?
+      WHERE id = ?
+    `).run(
+      tool.name,
+      tool.description ?? null,
+      tool.source,
+      JSON.stringify(tool.inputs),
+      JSON.stringify(tool.outputs),
+      JSON.stringify(tool.implementation),
+      yamlText ?? null,
+      now,
+      tool.id,
+    );
+    return { ...tool, updatedAt: now };
+  }
+
+  upsertTool(tool: ToolDefinition, yamlText?: string): ToolDefinition {
+    const existing = this.getTool(tool.id);
+    if (existing) return this.updateTool(tool, yamlText);
+    return this.createTool(tool, yamlText);
+  }
+
+  getTool(id: string): ToolDefinition | undefined {
+    const row = this.db.prepare('SELECT * FROM tools WHERE id = ?').get(id) as unknown as ToolRow | undefined;
+    if (!row) return undefined;
+    return rowToTool(row);
+  }
+
+  listTools(): ToolDefinition[] {
+    const rows = this.db.prepare('SELECT * FROM tools ORDER BY id').all() as unknown as ToolRow[];
+    return rows.map(rowToTool);
+  }
+
+  deleteTool(id: string): boolean {
+    const result = this.db.prepare('DELETE FROM tools WHERE id = ?').run(id);
+    return result.changes > 0;
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}
+
+interface ToolRow {
+  id: string;
+  name: string;
+  description: string | null;
+  source: string;
+  inputs_json: string;
+  outputs_json: string;
+  implementation_json: string;
+  yaml_text: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToTool(row: ToolRow): ToolDefinition {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description ?? undefined,
+    source: row.source as ToolSource,
+    inputs: JSON.parse(row.inputs_json),
+    outputs: JSON.parse(row.outputs_json),
+    implementation: JSON.parse(row.implementation_json),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}

--- a/packages/core/src/tool-types.ts
+++ b/packages/core/src/tool-types.ts
@@ -1,0 +1,92 @@
+/**
+ * Tool types. A tool is a named, reusable unit of work that a node invokes
+ * by reference. It declares typed inputs + structured outputs; the executor
+ * validates both at save time (template paths) and run time (output framing).
+ *
+ * v0.16 introduces the abstraction; v0.15's inline `type: shell` /
+ * `type: claude-code` desugar into `tool: shell-exec` / `tool: claude-code`
+ * at load time for backwards compatibility.
+ */
+
+export type ToolSource = 'local' | 'examples' | 'community' | 'builtin';
+
+export type ToolFieldType =
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'json'
+  | 'object'
+  | 'array';
+
+export interface ToolInputField {
+  type: ToolFieldType;
+  description?: string;
+  default?: string | number | boolean;
+  required?: boolean;
+}
+
+export interface ToolOutputField {
+  type: ToolFieldType;
+  description?: string;
+}
+
+export type ToolImplementationType = 'shell' | 'claude-code' | 'builtin';
+
+export interface ToolImplementation {
+  type: ToolImplementationType;
+  command?: string;
+  prompt?: string;
+  /** For builtin tools: the registered function name in the built-in registry. */
+  builtinName?: string;
+}
+
+/**
+ * The full definition of a tool as stored in `tools/` YAML or the DB.
+ * Analogous to `Agent` for agents.
+ */
+export interface ToolDefinition {
+  id: string;
+  name: string;
+  description?: string;
+  source: ToolSource;
+
+  inputs: Record<string, ToolInputField>;
+  outputs: Record<string, ToolOutputField>;
+
+  implementation: ToolImplementation;
+
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+/**
+ * The structured output a tool produces at run time. Keys match the
+ * tool's declared `outputs`. The executor validates the shape against
+ * the declaration; extra fields are dropped, missing required fields
+ * fail the node.
+ *
+ * Every tool also produces a synthetic `result` field (full stdout for
+ * shell, assistant text for claude-code) for v0.15 backcompat. User
+ * tools may declare `result` explicitly in their outputs if they want
+ * to control its value.
+ */
+export interface ToolOutput {
+  [key: string]: unknown;
+  result?: string;
+}
+
+/**
+ * A registered built-in tool. The executor calls `execute()` directly
+ * instead of spawning a child process. Built-in tools are always
+ * trusted (source: 'builtin') and don't go through the shell gate.
+ */
+export interface BuiltinToolEntry {
+  definition: ToolDefinition;
+  execute: (inputs: Record<string, unknown>, context: BuiltinToolContext) => Promise<ToolOutput>;
+}
+
+export interface BuiltinToolContext {
+  workingDirectory?: string;
+  env?: Record<string, string>;
+  timeout?: number;
+}


### PR DESCRIPTION
## Summary

- **Tool types** (`tool-types.ts`): `ToolDefinition`, `ToolOutput`, `BuiltinToolEntry` with typed inputs/outputs and three implementation types (shell, claude-code, builtin).
- **Tool Zod schema** (`tool-schema.ts`): validates tool YAML with type-specific refinements (shell needs command, builtin needs builtinName, etc).
- **Tool store** (`tool-store.ts`): SQLite `tools` table with full CRUD, mirrors the agent-store pattern.
- **9 built-in tools** (`builtin-tools.ts`): `shell-exec`, `claude-code`, `http-get`, `http-post`, `file-read`, `file-write`, `json-parse`, `json-path`, `template`. Each has a schema + a Node-native execute function.
- **AgentNode evolution**: `tool?` + `toolInputs?` fields. When `tool` is set, inline command/prompt aren't required. Schema refine softened accordingly.
- **`node_executions.outputsJson`**: new column for structured tool outputs. Idempotent ALTER TABLE migration.
- **Variable defaults**: confirmed `AgentInputSpec.default` already works end-to-end in types + Zod + executor. UI surface is the remaining piece.

## Design notes

- `type` stays required on AgentNode (not optional) to avoid cascading type changes across the codebase. Tool-based nodes set `type` from the tool's implementation type at parse/load time.
- No runtime dispatch yet — executor wiring is PR 2. This PR is purely the data layer + registry.
- Built-in tools use `execSync` for shell-exec and `fetch` for HTTP tools. Claude-code shells out to `claude` CLI (same as v0.15).
- Tool store has no versioning (destructive overwrite). Versioning deferred to v0.18.

## Test plan

- [x] 508/508 workspace tests pass (484 → 508; +24 new).
- [x] `npm run lint` clean.
- [x] `npm run build` clean.
- [x] Tool schema: valid/invalid tools, typed fields round-trip (7 tests)
- [x] Tool store: CRUD, sorted list, upsert, delete (7 tests)
- [x] Built-in registry: all 9 listed, retrieval, shell-exec/json-parse/json-path/template/file-read execute correctly (10 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)