### PR TITLE
feat(core): executor tool dispatch + output framing (v0.16 PR 2/6)

### DIFF
--- a/.changeset/tools-v016-pr2.md
+++ b/.changeset/tools-v016-pr2.md
@@ -1,0 +1,27 @@
+---
+"@some-useful-agents/core": minor
+---
+
+**feat: executor tool dispatch + output framing (PR 2 of 6 for v0.16).**
+
+Wires the tool abstraction from PR 1 into the DAG executor so nodes with `tool:` actually run. Adds an output framing protocol for extracting structured JSON from shell tool stdout.
+
+### What ships
+
+- **Executor tool dispatch** — when a node has `tool:` set, the executor resolves it from the built-in registry (or the `ToolStore` for user-defined tools) and calls the tool's `execute()` function directly. Built-in tools run in-process; user tools with shell/claude-code implementations go through the existing `spawnProcess` path with a synthetic node shape derived from the tool's definition.
+- **Output framing** (`output-framing.ts`) — extracts the last JSON-parseable line from stdout as structured output. Shell tools that `printf '{"status":200}'` on their last line get automatic structured output capture. Plain-text stdout (v0.15 style) falls back to `{ result: stdout }`.
+- **`outputsJson` stored** — every completed node now writes its structured output to `node_executions.outputsJson` (the column PR 1 added). Both tool-dispatched and legacy-spawned nodes populate it.
+- **`ToolStore` on `DagExecutorDeps`** — optional; when present, the executor resolves user-defined tools from it. When absent, only built-in tools are available.
+- **v0.15 nodes unchanged** — nodes without `tool:` go through the existing spawn path. No backcompat desugaring at exec time; opt-in only.
+
+### Design notes
+
+- Built-in tool `exit_code` is extracted from the `ToolOutput` object (tools return it as a field). Legacy spawns use the process exit code as before.
+- The executor tries framed-output extraction even on legacy nodes — if a v0.15 shell script happens to emit a JSON last line, it'll be captured. No harm if it doesn't.
+- Template resolver v2 (path-based `{{upstream.X.body.items[0]}}`) is deferred to PR 3 — this PR gets tools running; the next PR makes their outputs addressable.
+
+### Tests
+
+517 total (508 → 517; +9 new):
+- `output-framing.test.ts` — 9 tests: JSON object/array extraction, trailing empty lines, non-JSON fallback, empty stdout, single-line JSON, `buildToolOutput` framed vs plain.
+- All 508 existing tests pass unchanged.

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -22,10 +22,14 @@
 import { randomUUID } from 'node:crypto';
 import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
-import type { Agent, AgentNode, NodeErrorCategory, NodeOutput } from './agent-v2-types.js';
+import type { Agent, AgentNode, NodeErrorCategory, NodeOutput, NodeStructuredOutput } from './agent-v2-types.js';
 import type { Run, RunStatus } from './types.js';
 import type { RunStore } from './run-store.js';
 import type { SecretsStore } from './secrets-store.js';
+import type { ToolStore } from './tool-store.js';
+import type { ToolOutput, BuiltinToolContext } from './tool-types.js';
+import { getBuiltinTool } from './builtin-tools.js';
+import { buildToolOutput } from './output-framing.js';
 import {
   UntrustedCommunityShellError,
   type ExecutionResult,
@@ -41,6 +45,12 @@ export interface DagExecutorDeps {
    * fails with category `setup`.
    */
   secretsStore?: SecretsStore;
+  /**
+   * v0.16+: tool store for user-defined tools. Built-in tools are resolved
+   * from the in-memory registry; user tools come from this store. Optional
+   * — if absent, only built-in tools are available.
+   */
+  toolStore?: ToolStore;
   /**
    * Agent ids the operator has pre-audited for community shell execution.
    * Propagated into each node's spawn; a shell node inside a `source:
@@ -263,18 +273,68 @@ export async function executeAgentDag(
       upstreamInputsJson: JSON.stringify(upstreamSnapshot),
     });
 
-    const spawnFn = deps.spawnNode ?? spawnNodeReal;
+    // v0.16 tool dispatch: if the node references a tool, resolve it and
+    // call its execute() function. Built-in tools run in-process; user
+    // tools that use shell/claude-code implementation types go through the
+    // same spawn path as v0.15 nodes. Nodes without a tool field fall
+    // through to the legacy spawn path directly (backcompat).
+    const toolId = resolveToolId(node);
+    const builtinEntry = toolId ? getBuiltinTool(toolId) : undefined;
+
     let result: SpawnResult;
+    let structuredOutput: ToolOutput | undefined;
+
     try {
-      result = await spawnFn(node, env, {
-        agentId: agent.id,
-        agentSource: agent.source,
-        allowUntrustedShell: deps.allowUntrustedShell,
-      });
+      if (builtinEntry) {
+        // Built-in tool: call execute() directly, no child process.
+        const toolInputs = resolveToolInputs(node, upstreamSnapshot);
+        const ctx: BuiltinToolContext = {
+          workingDirectory: node.workingDirectory,
+          env,
+          timeout: node.timeout,
+        };
+        structuredOutput = await builtinEntry.execute(toolInputs, ctx);
+        const stdout = structuredOutput.result ?? '';
+        result = { result: stdout, exitCode: (structuredOutput as Record<string, unknown>).exit_code as number ?? 0 };
+      } else if (toolId && deps.toolStore) {
+        // User-defined tool from the store — resolve its implementation and
+        // spawn via the same shell/claude-code path the v0.15 nodes use.
+        // The tool's implementation.command/prompt becomes the spawned body.
+        const userTool = deps.toolStore.getTool(toolId);
+        if (!userTool) {
+          throw new Error(`Tool "${toolId}" not found in registry or store.`);
+        }
+        const spawnFn = deps.spawnNode ?? spawnNodeReal;
+        // Build a synthetic node shape matching the tool's implementation
+        // so the existing spawner doesn't need to change.
+        const synthNode: AgentNode = {
+          ...node,
+          type: userTool.implementation.type === 'claude-code' ? 'claude-code' : 'shell',
+          command: userTool.implementation.command,
+          prompt: userTool.implementation.prompt,
+        };
+        const spawnResult = await spawnFn(synthNode, env, {
+          agentId: agent.id,
+          agentSource: agent.source,
+          allowUntrustedShell: deps.allowUntrustedShell,
+        });
+        result = spawnResult;
+        structuredOutput = buildToolOutput(spawnResult.result);
+      } else {
+        // v0.15 legacy path: no tool field, dispatch by type directly.
+        const spawnFn = deps.spawnNode ?? spawnNodeReal;
+        const spawnResult = await spawnFn(node, env, {
+          agentId: agent.id,
+          agentSource: agent.source,
+          allowUntrustedShell: deps.allowUntrustedShell,
+        });
+        result = spawnResult;
+        // Try to extract framed output from stdout even for legacy nodes,
+        // so users who upgrade their shell scripts to emit framed JSON get
+        // structured outputs without changing the node YAML.
+        structuredOutput = buildToolOutput(spawnResult.result);
+      }
     } catch (err) {
-      // Only `setup`-time surprises should reach here; the spawner catches
-      // spawn/exit/timeout internally and returns them as SpawnResults.
-      // Anything truly unexpected bubbles up tagged as setup.
       const message = (err as Error).message;
       deps.runStore.updateNodeExecution(runId, node.id, {
         status: 'failed',
@@ -287,13 +347,21 @@ export async function executeAgentDag(
     }
 
     const completedAt = new Date().toISOString();
+    const outputsJson = structuredOutput ? JSON.stringify(structuredOutput) : undefined;
+
     if (result.exitCode === 0) {
-      outputs.set(node.id, { result: result.result, exitCode: 0, source: agent.source });
+      outputs.set(node.id, {
+        result: result.result,
+        exitCode: 0,
+        source: agent.source,
+        outputs: structuredOutput as NodeStructuredOutput | undefined,
+      });
       deps.runStore.updateNodeExecution(runId, node.id, {
         status: 'completed',
         completedAt,
         result: result.result,
         exitCode: 0,
+        outputsJson,
       });
     } else {
       const category: NodeErrorCategory =
@@ -308,6 +376,7 @@ export async function executeAgentDag(
         result: result.result,
         exitCode: result.exitCode,
         error: result.error ?? `Process exited with code ${result.exitCode}`,
+        outputsJson,
       });
       firstFailure = { nodeId: node.id, category };
     }
@@ -653,3 +722,41 @@ async function spawnProcess(
 const MINIMAL_ALLOWLIST = ['PATH', 'HOME', 'LANG', 'TERM', 'TMPDIR'];
 const LOCAL_ALLOWLIST = [...MINIMAL_ALLOWLIST, 'USER', 'SHELL', 'NODE_ENV', 'TZ'];
 const LOCAL_PATTERNS = [/^LC_/];
+
+// -- Tool dispatch helpers --
+
+/**
+ * Derive the tool id for a node. Only nodes that explicitly set `tool:`
+ * go through the tool dispatch path. v0.15 nodes without `tool:` use
+ * the existing spawn path directly — desugaring to `shell-exec` /
+ * `claude-code` built-ins happens at a higher layer (YAML parser /
+ * import) when the user opts in, not silently at exec time.
+ */
+function resolveToolId(node: AgentNode): string | undefined {
+  return node.tool;
+}
+
+/**
+ * Build the inputs map for a tool invocation. For v0.16 nodes with
+ * `toolInputs:`, use those directly. For v0.15 nodes, fold the inline
+ * `command` / `prompt` into the shape the built-in tool expects.
+ */
+function resolveToolInputs(
+  node: AgentNode,
+  upstreamSnapshot: Record<string, string>,
+): Record<string, unknown> {
+  if (node.toolInputs) return { ...node.toolInputs };
+  // Backcompat: v0.15 inline fields → built-in tool input shape.
+  if (node.type === 'shell' && node.command) {
+    return { command: node.command };
+  }
+  if (node.type === 'claude-code' && node.prompt) {
+    return {
+      prompt: node.prompt,
+      model: node.model,
+      maxTurns: node.maxTurns,
+      allowedTools: node.allowedTools,
+    };
+  }
+  return {};
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,6 +38,7 @@ export {
   listBuiltinTools,
   isBuiltinTool,
 } from './builtin-tools.js';
+export { extractFramedOutput, buildToolOutput } from './output-framing.js';
 
 export {
   executeAgentDag,

--- a/packages/core/src/output-framing.test.ts
+++ b/packages/core/src/output-framing.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { extractFramedOutput, buildToolOutput } from './output-framing.js';
+
+describe('extractFramedOutput', () => {
+  it('extracts a JSON object from the last line', () => {
+    const stdout = 'some debug output\n{"status": 200, "body": {"ok": true}}\n';
+    const result = extractFramedOutput(stdout);
+    expect(result).toEqual({ status: 200, body: { ok: true } });
+  });
+
+  it('skips trailing empty lines', () => {
+    const stdout = '{"count": 3}\n\n\n';
+    const result = extractFramedOutput(stdout);
+    expect(result).toEqual({ count: 3 });
+  });
+
+  it('returns undefined when last line is not JSON', () => {
+    const stdout = 'just plain text\n';
+    expect(extractFramedOutput(stdout)).toBeUndefined();
+  });
+
+  it('returns undefined for empty stdout', () => {
+    expect(extractFramedOutput('')).toBeUndefined();
+  });
+
+  it('extracts a JSON array from the last line', () => {
+    const stdout = 'header\n[1, 2, 3]\n';
+    const result = extractFramedOutput(stdout);
+    expect(result).toEqual([1, 2, 3]);
+  });
+
+  it('returns undefined when the last line starts with a non-JSON char', () => {
+    const stdout = 'hello world\n';
+    expect(extractFramedOutput(stdout)).toBeUndefined();
+  });
+
+  it('handles a single JSON line with no prefix', () => {
+    const stdout = '{"result": "done"}';
+    const result = extractFramedOutput(stdout);
+    expect(result).toEqual({ result: 'done' });
+  });
+});
+
+describe('buildToolOutput', () => {
+  it('uses framed output when present', () => {
+    const stdout = 'debug\n{"status": 200}\n';
+    const output = buildToolOutput(stdout);
+    expect(output.status).toBe(200);
+    expect(output.result).toBe(stdout);
+  });
+
+  it('wraps plain stdout when no framed output is found', () => {
+    const stdout = 'just text\n';
+    const output = buildToolOutput(stdout);
+    expect(output.result).toBe(stdout);
+    expect(output.status).toBeUndefined();
+  });
+});

--- a/packages/core/src/output-framing.ts
+++ b/packages/core/src/output-framing.ts
@@ -1,0 +1,58 @@
+/**
+ * Output framing protocol. Shell tools emit structured output as a single
+ * JSON line at the end of stdout. The executor scans bottom-up for the last
+ * JSON-parseable line; that's the framed output. Everything before it stays
+ * in `result` as the human-readable stdout.
+ *
+ * Design choice: bottom-up scan of the last non-empty line is simpler than
+ * a sidecar FIFO or a magic delimiter. Tool authors use `jq` and `printf`
+ * — tools they already know. See the plan (tools-and-outputs-v0.16.md,
+ * "Output framing") for the full rationale.
+ */
+
+import type { ToolOutput } from './tool-types.js';
+
+/**
+ * Attempt to extract a framed JSON output from stdout. Returns the parsed
+ * object if the last non-empty line is valid JSON, or `undefined` if not.
+ *
+ * When framed output is found:
+ * - `output` = the parsed JSON object (tool's declared outputs)
+ * - `result` = the full stdout (for v0.15 compat / debugging)
+ *
+ * When no framed output is found, the caller should treat `result` = full
+ * stdout as the only output (v0.15 behaviour).
+ */
+export function extractFramedOutput(stdout: string): ToolOutput | undefined {
+  const lines = stdout.split('\n');
+  // Walk bottom-up past empty lines and trailing whitespace.
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (line.length === 0) continue;
+    // Quick guard: JSON objects start with { or [; skip obvious non-JSON.
+    if (line[0] !== '{' && line[0] !== '[') return undefined;
+    try {
+      const parsed = JSON.parse(line);
+      if (typeof parsed === 'object' && parsed !== null) {
+        return parsed as ToolOutput;
+      }
+    } catch {
+      return undefined;
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Build a ToolOutput from a raw execution result. Tries framed output
+ * first; falls back to wrapping the result string. Always sets `result`
+ * for v0.15 compat.
+ */
+export function buildToolOutput(stdout: string): ToolOutput {
+  const framed = extractFramedOutput(stdout);
+  if (framed) {
+    return { ...framed, result: stdout };
+  }
+  return { result: stdout };
+}


### PR DESCRIPTION
## Summary

- **Executor tool dispatch**: nodes with `tool:` resolve from the built-in registry or `ToolStore`, call `execute()` in-process for builtins, or spawn for user-defined tools.
- **Output framing** (`output-framing.ts`): extracts the last JSON line from stdout as structured output. Falls back to `{ result: stdout }` for plain text.
- **`outputsJson` stored** on every completed `node_execution` row.
- **`ToolStore` on `DagExecutorDeps`**: optional, resolves user-defined tools.
- **v0.15 nodes unchanged**: no `tool:` field = existing spawn path, no surprises.

## Test plan

- [x] 517/517 tests pass (508 → 517; +9 output-framing tests).
- [x] `npm run lint` clean.
- [x] All existing dag-executor tests pass unchanged (v0.15 spawn path untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)