### PR TITLE
feat: tool CLI + /tools dashboard + agent tool visibility (v0.16 PR 3/6)

### DIFF
--- a/.changeset/tools-v016-pr3.md
+++ b/.changeset/tools-v016-pr3.md
@@ -1,0 +1,26 @@
+---
+"@some-useful-agents/cli": minor
+"@some-useful-agents/dashboard": minor
+---
+
+**feat: tool CLI + /tools dashboard + tool visibility on agent detail (PR 3 of 6 for v0.16).**
+
+Surfaces the tool abstraction from PRs 1–2 so users can browse, inspect, and validate tools from both the CLI and the dashboard.
+
+### What ships
+
+- **`sua tool list`** — tabular listing of all built-in + user-defined tools with id, source, implementation type, description.
+- **`sua tool show <id>`** — detailed view of a tool's inputs (name, type, required, default, description) + outputs + implementation.
+- **`sua tool validate <file>`** — schema-check a tool YAML without storing it. Reports each Zod issue with path + message.
+- **`/tools`** dashboard page — card grid of all tools, split into "Built-in tools" and "User tools" sections. Reuses the agent-card component.
+- **`/tools/:id`** detail page — inputs table, outputs table, implementation card, back-link to /tools.
+- **Tool visibility on agent detail sidebar** — new "Tools" section between Secrets and action buttons. Lists the unique tool ids this agent's nodes reference, each as a clickable badge linking to `/tools/:id`. v0.15 nodes show their implicit tool (`shell-exec` / `claude-code`).
+- **"Tools" nav link** in the topbar — sits between Agents and Runs.
+
+### Tests
+
+521 total (517 → 521; +4 new):
+- `/tools` lists built-in tools
+- `/tools/http-get` renders detail with inputs/outputs
+- `/tools/nonexistent` redirects to /tools
+- Agent detail sidebar shows tool badge for implicit shell-exec

--- a/packages/cli/src/commands/tool.ts
+++ b/packages/cli/src/commands/tool.ts
@@ -1,0 +1,175 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import Table from 'cli-table3';
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { parse as parseYaml } from 'yaml';
+import {
+  listBuiltinTools,
+  getBuiltinTool,
+  toolDefinitionSchema,
+  ToolStore,
+  type ToolDefinition,
+} from '@some-useful-agents/core';
+import { loadConfig, getDbPath } from '../config.js';
+import * as ui from '../ui.js';
+
+export const toolCommand = new Command('tool')
+  .description('Manage tools used by agent nodes');
+
+toolCommand
+  .command('list')
+  .description('List all available tools (built-in + user-defined)')
+  .action(() => {
+    const builtins = listBuiltinTools();
+    const config = loadConfig();
+    const dbPath = getDbPath(config);
+
+    let userTools: ToolDefinition[] = [];
+    try {
+      const store = new ToolStore(dbPath);
+      userTools = store.listTools();
+      store.close();
+    } catch {
+      // DB may not exist yet — fine, just show builtins.
+    }
+
+    if (builtins.length === 0 && userTools.length === 0) {
+      ui.info('No tools available.');
+      return;
+    }
+
+    const table = new Table({
+      head: [
+        chalk.bold('Id'),
+        chalk.bold('Source'),
+        chalk.bold('Impl'),
+        chalk.bold('Description'),
+      ],
+    });
+
+    for (const t of builtins) {
+      table.push([
+        ui.agent(t.id),
+        chalk.dim('builtin'),
+        chalk.dim(t.implementation.type),
+        t.description ?? '',
+      ]);
+    }
+
+    for (const t of userTools) {
+      table.push([
+        ui.agent(t.id),
+        t.source,
+        t.implementation.type,
+        t.description ?? '',
+      ]);
+    }
+
+    console.log(table.toString());
+    console.log(ui.dim(`\n${builtins.length} built-in, ${userTools.length} user-defined`));
+  });
+
+toolCommand
+  .command('show')
+  .description('Show a tool\'s definition (inputs, outputs, implementation)')
+  .argument('<id>', 'Tool id')
+  .action((id: string) => {
+    // Check builtins first.
+    const builtin = getBuiltinTool(id);
+    if (builtin) {
+      printToolDetail(builtin.definition);
+      return;
+    }
+
+    // Check user store.
+    const config = loadConfig();
+    const dbPath = getDbPath(config);
+    try {
+      const store = new ToolStore(dbPath);
+      const tool = store.getTool(id);
+      store.close();
+      if (tool) {
+        printToolDetail(tool);
+        return;
+      }
+    } catch {
+      // DB not available.
+    }
+
+    ui.fail(`Tool "${id}" not found.`);
+    process.exit(1);
+  });
+
+toolCommand
+  .command('validate')
+  .description('Schema-check a tool YAML file without storing it')
+  .argument('<file>', 'Path to a tool YAML file')
+  .action((file: string) => {
+    if (!existsSync(file) || statSync(file).isDirectory()) {
+      ui.fail(`Not a file: ${file}`);
+      process.exit(1);
+    }
+
+    let raw: unknown;
+    try {
+      const text = readFileSync(file, 'utf-8');
+      raw = parseYaml(text);
+    } catch (err) {
+      ui.fail(`Cannot parse ${file}: ${(err as Error).message}`);
+      process.exit(1);
+    }
+
+    const result = toolDefinitionSchema.safeParse(raw);
+    if (result.success) {
+      ui.ok(`${file} is valid.`);
+      ui.kv('Id', result.data.id);
+      ui.kv('Name', result.data.name);
+      ui.kv('Inputs', Object.keys(result.data.inputs).join(', ') || 'none');
+      ui.kv('Outputs', Object.keys(result.data.outputs).join(', ') || 'none');
+      ui.kv('Implementation', result.data.implementation.type);
+    } else {
+      ui.fail(`${file} has validation errors:`);
+      for (const issue of result.error.issues) {
+        console.log(`  ${chalk.red('✖')} ${issue.path.join('.')}: ${issue.message}`);
+      }
+      process.exit(1);
+    }
+  });
+
+function printToolDetail(tool: ToolDefinition): void {
+  ui.section(tool.name);
+  ui.kv('Id', tool.id);
+  ui.kv('Source', tool.source);
+  ui.kv('Description', tool.description ?? ui.dim('none'));
+  ui.kv('Implementation', tool.implementation.type);
+
+  if (Object.keys(tool.inputs).length > 0) {
+    console.log('');
+    ui.section('Inputs');
+    const table = new Table({
+      head: [chalk.bold('Name'), chalk.bold('Type'), chalk.bold('Required'), chalk.bold('Default'), chalk.bold('Description')],
+    });
+    for (const [name, spec] of Object.entries(tool.inputs)) {
+      table.push([
+        chalk.cyan(name),
+        spec.type,
+        spec.required ? 'yes' : chalk.dim('no'),
+        spec.default !== undefined ? String(spec.default) : chalk.dim('—'),
+        spec.description ?? '',
+      ]);
+    }
+    console.log(table.toString());
+  }
+
+  if (Object.keys(tool.outputs).length > 0) {
+    console.log('');
+    ui.section('Outputs');
+    const table = new Table({
+      head: [chalk.bold('Name'), chalk.bold('Type'), chalk.bold('Description')],
+    });
+    for (const [name, spec] of Object.entries(tool.outputs)) {
+      table.push([chalk.cyan(name), spec.type, spec.description ?? '']);
+    }
+    console.log(table.toString());
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -25,6 +25,7 @@ import { scheduleCommand } from './commands/schedule.js';
 import { tutorialCommand } from './commands/tutorial.js';
 import { dashboardCommand } from './commands/dashboard.js';
 import { workflowCommand } from './commands/workflow.js';
+import { toolCommand } from './commands/tool.js';
 
 // Read version from our own package.json so `sua --version` always matches
 // the installed package version (no hardcoded drift).
@@ -85,5 +86,6 @@ program.addCommand(scheduleCommand);
 program.addCommand(tutorialCommand);
 program.addCommand(dashboardCommand);
 program.addCommand(workflowCommand);
+program.addCommand(toolCommand);
 
 program.parse();

--- a/packages/dashboard/src/context.ts
+++ b/packages/dashboard/src/context.ts
@@ -1,4 +1,4 @@
-import type { LocalProvider, RunStore, SecretsStore, AgentDefinition, AgentStore } from '@some-useful-agents/core';
+import type { LocalProvider, RunStore, SecretsStore, AgentDefinition, AgentStore, ToolStore } from '@some-useful-agents/core';
 import type { SecretsSession } from './secrets-session.js';
 
 /**
@@ -60,6 +60,11 @@ export interface DashboardContext {
    * middleware's constant-time compare sees the new value.
    */
   rotateToken: () => string;
+  /**
+   * v0.16+: tool store for user-defined tools. Built-in tools are resolved
+   * from the in-memory registry; user tools come from this store.
+   */
+  toolStore?: ToolStore;
   /** When true, the dashboard allows POSTs that would execute community shell. */
   allowUntrustedShell: Set<string>;
   /** Called to validate agent-supplied inputs at run-now time. Defaults built into LocalProvider. */

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -1372,6 +1372,58 @@ describe('Dashboard /runs/:id/replay (PR 5)', () => {
   });
 });
 
+describe('Dashboard /tools (v0.16 PR 3)', () => {
+  it('GET /tools lists built-in tools', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/tools')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('shell-exec');
+    expect(res.text).toContain('http-get');
+    expect(res.text).toContain('json-parse');
+    expect(res.text).toContain('Built-in tools');
+  });
+
+  it('GET /tools/:id renders a built-in tool detail page', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/tools/http-get')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('http-get');
+    expect(res.text).toContain('builtin');
+    expect(res.text).toContain('Inputs');
+    expect(res.text).toContain('url');
+    expect(res.text).toContain('Outputs');
+    expect(res.text).toContain('status');
+  });
+
+  it('GET /tools/:unknown redirects to /tools', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/tools/nonexistent')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toBe('/tools');
+  });
+
+  it('agent detail sidebar shows tool badges', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'tool-vis-test', name: 'Tool Vis', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'main', type: 'shell', command: 'echo hi' }],
+    }, 'cli', 'seed');
+    const res = await request(app).get('/agents/tool-vis-test')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    // v0.15 shell node → implicit tool badge "shell-exec" in the sidebar.
+    expect(res.text).toContain('shell-exec');
+    expect(res.text).toContain('/tools/shell-exec');
+  });
+});
+
 describe('Dashboard template palette (PR 5)', () => {
   async function seedTwoNodeAgent(id = 'palette-test') {
     agentStore.createAgent({

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -4,6 +4,7 @@ import {
   LocalProvider,
   RunStore,
   AgentStore,
+  ToolStore,
   EncryptedFileStore,
   loadAgents,
   readMcpToken,
@@ -21,6 +22,7 @@ import { agentsRouter } from './routes/agents.js';
 import { runsRouter } from './routes/runs.js';
 import { runNowRouter } from './routes/run-now.js';
 import { runMutationsRouter } from './routes/run-mutations.js';
+import { toolsRouter } from './routes/tools.js';
 import { assetsRouter } from './routes/assets.js';
 import { settingsRouter } from './routes/settings.js';
 import { helpRouter } from './routes/help.js';
@@ -92,6 +94,7 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   app.use(settingsRouter);
   app.use(helpRouter);
   app.use(versionsRouter);
+  app.use(toolsRouter);
 
   // Catch-all 404 for authenticated routes.
   app.use((_req, res) => {
@@ -125,6 +128,13 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
   await provider.initialize();
 
   const secretsSession = new EncryptedFileSecretsSession(opts.secretsPath);
+  // Tool store shares the same DB path. WAL mode makes concurrent handles safe.
+  let toolStore: ToolStore | undefined;
+  try {
+    toolStore = new ToolStore(opts.dbPath);
+  } catch {
+    // Non-fatal: tools surface degrades to built-ins only.
+  }
 
   const ctx: DashboardContext = {
     token,
@@ -141,6 +151,7 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     dbPath: opts.dbPath,
     secretsPath: opts.secretsPath,
     rotateToken: () => rotateMcpToken(tokenPath),
+    toolStore,
     allowUntrustedShell: opts.allowUntrustedShell ?? new Set(),
   };
 

--- a/packages/dashboard/src/routes/tools.ts
+++ b/packages/dashboard/src/routes/tools.ts
@@ -1,0 +1,49 @@
+import { Router, type Request, type Response } from 'express';
+import { listBuiltinTools, getBuiltinTool } from '@some-useful-agents/core';
+import { getContext } from '../context.js';
+import { renderToolsList } from '../views/tools-list.js';
+import { renderToolDetail } from '../views/tool-detail.js';
+import type { ToolDefinition } from '@some-useful-agents/core';
+
+export const toolsRouter: Router = Router();
+
+toolsRouter.get('/tools', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const builtins = listBuiltinTools();
+  let userTools: ToolDefinition[] = [];
+  try {
+    if (ctx.toolStore) {
+      userTools = ctx.toolStore.listTools();
+    }
+  } catch {
+    // Store not available — show builtins only.
+  }
+  res.type('html').send(renderToolsList({ builtins, userTools }));
+});
+
+toolsRouter.get('/tools/:id', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+
+  // Check builtins first.
+  const builtin = getBuiltinTool(id);
+  if (builtin) {
+    res.type('html').send(renderToolDetail({ tool: builtin.definition }));
+    return;
+  }
+
+  // Check user store.
+  try {
+    if (ctx.toolStore) {
+      const tool = ctx.toolStore.getTool(id);
+      if (tool) {
+        res.type('html').send(renderToolDetail({ tool }));
+        return;
+      }
+    }
+  } catch {
+    // Store unavailable.
+  }
+
+  res.status(404).redirect(303, '/tools');
+});

--- a/packages/dashboard/src/views/agent-detail-v2.ts
+++ b/packages/dashboard/src/views/agent-detail-v2.ts
@@ -179,6 +179,8 @@ export async function renderAgentDetailV2(args: {
         </div>
       </section>
 
+      ${renderToolsSection(agent)}
+
       <div class="inspector__actions" style="flex-wrap: wrap;">
         <a class="btn btn--primary btn--sm" href="/agents/${agent.id}/add-node">+ Add node</a>
         <a class="btn btn--sm" href="/agents/${agent.id}/versions">Versions</a>
@@ -252,6 +254,37 @@ export async function renderAgentDetailV2(args: {
   `;
 
   return render(layout({ title: agent.id, activeNav: 'agents', flash, wide: true }, body));
+}
+
+/**
+ * Collect the unique tools this agent's nodes reference and render them
+ * as a sidebar section. Derives from the DAG — no separate store query.
+ * Shows which tools the agent depends on at a glance.
+ */
+function renderToolsSection(agent: Agent): SafeHtml {
+  const toolIds = new Set<string>();
+  for (const node of agent.nodes) {
+    if (node.tool) {
+      toolIds.add(node.tool);
+    } else {
+      // v0.15 nodes without an explicit tool: show their implicit tool.
+      toolIds.add(node.type === 'shell' ? 'shell-exec' : 'claude-code');
+    }
+  }
+  if (toolIds.size === 0) return html``;
+
+  const badges = [...toolIds].sort().map((id) => html`
+    <a href="/tools/${id}" class="badge badge--muted" style="text-decoration: none;">${id}</a>
+  `);
+
+  return html`
+    <section class="inspector__section">
+      <h4>Tools</h4>
+      <div style="display:flex; gap:var(--space-2); flex-wrap:wrap;">
+        ${badges as unknown as SafeHtml[]}
+      </div>
+    </section>
+  `;
 }
 
 function vStatusBadge(status: string): SafeHtml {

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -4,8 +4,8 @@ import { footer } from './footer.js';
 
 export interface LayoutOptions {
   title: string;
-  /** Highlight in the nav (one of: agents, runs, settings, help). */
-  activeNav?: 'agents' | 'runs' | 'settings' | 'help';
+  /** Highlight in the nav (one of: agents, tools, runs, settings, help). */
+  activeNav?: 'agents' | 'tools' | 'runs' | 'settings' | 'help';
   /** Flash banner shown at the top of the body (errors from prior actions). */
   flash?: { kind: 'error' | 'info' | 'ok'; message: string };
   /** Widen the main column (for screens with 2-col layouts). */
@@ -35,6 +35,7 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
   <a class="topbar__brand" href="/">sua</a>
   <nav class="topbar__nav">
     <a href="/agents" class="${opts.activeNav === 'agents' ? 'is-active' : ''}">Agents</a>
+    <a href="/tools" class="${opts.activeNav === 'tools' ? 'is-active' : ''}">Tools</a>
     <a href="/runs" class="${opts.activeNav === 'runs' ? 'is-active' : ''}">Runs</a>
     <a href="/settings" class="${opts.activeNav === 'settings' ? 'is-active' : ''}">Settings</a>
     <a href="/help" class="${opts.activeNav === 'help' ? 'is-active' : ''}">Help</a>

--- a/packages/dashboard/src/views/tool-detail.ts
+++ b/packages/dashboard/src/views/tool-detail.ts
@@ -1,0 +1,87 @@
+import type { ToolDefinition } from '@some-useful-agents/core';
+import { html, render, unsafeHtml, type SafeHtml } from './html.js';
+import { layout } from './layout.js';
+import { pageHeader } from './page-header.js';
+
+export function renderToolDetail(args: {
+  tool: ToolDefinition;
+}): string {
+  const { tool } = args;
+
+  const sourceBadge = tool.source === 'builtin'
+    ? html`<span class="badge badge--muted">builtin</span>`
+    : html`<span class="badge badge--ok">${tool.source}</span>`;
+
+  const implBadge = tool.implementation.type === 'shell'
+    ? html`<span class="badge badge--ok">shell</span>`
+    : tool.implementation.type === 'claude-code'
+      ? html`<span class="badge badge--info">claude-code</span>`
+      : html`<span class="badge badge--muted">${tool.implementation.type}</span>`;
+
+  const inputRows = Object.entries(tool.inputs).map(([name, spec]) => html`
+    <tr>
+      <td class="mono">${name}</td>
+      <td>${spec.type}</td>
+      <td>${spec.required ? html`<span class="badge badge--warn">required</span>` : html`<span class="dim">optional</span>`}</td>
+      <td class="mono">${spec.default !== undefined ? String(spec.default) : html`<span class="dim">\u2014</span>`}</td>
+      <td class="dim">${spec.description ?? ''}</td>
+    </tr>
+  `);
+
+  const outputRows = Object.entries(tool.outputs).map(([name, spec]) => html`
+    <tr>
+      <td class="mono">${name}</td>
+      <td>${spec.type}</td>
+      <td class="dim">${spec.description ?? ''}</td>
+    </tr>
+  `);
+
+  const body = html`
+    ${pageHeader({
+      title: tool.id,
+      meta: [sourceBadge, implBadge],
+      description: tool.description ?? undefined,
+      back: { href: '/tools', label: 'Back to tools' },
+    })}
+
+    ${Object.keys(tool.inputs).length > 0 ? html`
+      <section>
+        <h2>Inputs</h2>
+        <table class="table">
+          <thead><tr><th>Name</th><th>Type</th><th>Required</th><th>Default</th><th>Description</th></tr></thead>
+          <tbody>${inputRows as unknown as SafeHtml[]}</tbody>
+        </table>
+      </section>
+    ` : html`<p class="dim">No inputs declared.</p>`}
+
+    ${Object.keys(tool.outputs).length > 0 ? html`
+      <section style="margin-top: var(--space-6);">
+        <h2>Outputs</h2>
+        <table class="table">
+          <thead><tr><th>Name</th><th>Type</th><th>Description</th></tr></thead>
+          <tbody>${outputRows as unknown as SafeHtml[]}</tbody>
+        </table>
+      </section>
+    ` : html`<p class="dim">No outputs declared.</p>`}
+
+    <section style="margin-top: var(--space-6);">
+      <h2>Implementation</h2>
+      <div class="card">
+        <dl class="kv">
+          <dt>Type</dt><dd>${tool.implementation.type}</dd>
+          ${tool.implementation.command
+            ? html`<dt>Command</dt><dd class="mono" style="white-space: pre-wrap;">${tool.implementation.command}</dd>`
+            : unsafeHtml('')}
+          ${tool.implementation.prompt
+            ? html`<dt>Prompt</dt><dd style="white-space: pre-wrap;">${tool.implementation.prompt}</dd>`
+            : unsafeHtml('')}
+          ${tool.implementation.builtinName
+            ? html`<dt>Builtin</dt><dd class="mono">${tool.implementation.builtinName}</dd>`
+            : unsafeHtml('')}
+        </dl>
+      </div>
+    </section>
+  `;
+
+  return render(layout({ title: `Tool: ${tool.id}`, activeNav: 'tools' }, body));
+}

--- a/packages/dashboard/src/views/tools-list.ts
+++ b/packages/dashboard/src/views/tools-list.ts
@@ -1,0 +1,80 @@
+import type { ToolDefinition } from '@some-useful-agents/core';
+import { html, render, type SafeHtml } from './html.js';
+import { layout } from './layout.js';
+import { pageHeader } from './page-header.js';
+
+export function renderToolsList(args: {
+  builtins: ToolDefinition[];
+  userTools: ToolDefinition[];
+}): string {
+  const { builtins, userTools } = args;
+  const total = builtins.length + userTools.length;
+
+  const body = html`
+    ${pageHeader({ title: 'Tools' })}
+
+    ${total === 0 ? html`
+      <div class="settings-empty">
+        <h3 style="margin-top: 0;">No tools yet</h3>
+        <p class="dim">Tools are named, reusable units of work that agent nodes invoke.<br>
+          9 built-in tools ship with sua. Create your own in <code>tools/</code>.</p>
+      </div>
+    ` : html``}
+
+    ${builtins.length > 0 ? html`
+      <section>
+        <h2>Built-in tools</h2>
+        <div class="agent-grid">
+          ${builtins.map((t) => renderToolCard(t)) as unknown as SafeHtml[]}
+        </div>
+      </section>
+    ` : html``}
+
+    ${userTools.length > 0 ? html`
+      <section style="margin-top: var(--space-6);">
+        <h2>User tools</h2>
+        <div class="agent-grid">
+          ${userTools.map((t) => renderToolCard(t)) as unknown as SafeHtml[]}
+        </div>
+      </section>
+    ` : html``}
+
+    <footer style="margin-top: var(--space-8); text-align: center;">
+      <p class="dim">${String(total)} tool${total === 1 ? '' : 's'} available</p>
+    </footer>
+  `;
+
+  return render(layout({ title: 'Tools', activeNav: 'tools' }, body));
+}
+
+function renderToolCard(t: ToolDefinition): SafeHtml {
+  const sourceBadge = t.source === 'builtin'
+    ? html`<span class="badge badge--muted">builtin</span>`
+    : t.source === 'community'
+      ? html`<span class="badge badge--err">community</span>`
+      : html`<span class="badge badge--ok">${t.source}</span>`;
+
+  const implBadge = t.implementation.type === 'shell'
+    ? html`<span class="badge badge--ok">shell</span>`
+    : t.implementation.type === 'claude-code'
+      ? html`<span class="badge badge--info">claude-code</span>`
+      : html`<span class="badge badge--muted">${t.implementation.type}</span>`;
+
+  const inputCount = Object.keys(t.inputs).length;
+  const outputCount = Object.keys(t.outputs).length;
+
+  return html`
+    <article class="agent-card">
+      <div class="agent-card__header">
+        <h3 class="agent-card__title"><a href="/tools/${t.id}">${t.id}</a></h3>
+        ${sourceBadge}
+        ${implBadge}
+      </div>
+      <p class="agent-card__desc">${t.description ?? 'No description.'}</p>
+      <div class="agent-card__meta">
+        <span>${String(inputCount)} input${inputCount === 1 ? '' : 's'}</span>
+        <span>${String(outputCount)} output${outputCount === 1 ? '' : 's'}</span>
+      </div>
+    </article>
+  `;
+}


### PR DESCRIPTION
## Summary

- **`sua tool list/show/validate`** CLI commands for browsing + inspecting + schema-checking tools.
- **`/tools`** dashboard page with card grid (built-in + user tools), **`/tools/:id`** detail with inputs/outputs/implementation tables.
- **Tool visibility on agent detail sidebar** — "Tools" section shows which tools each agent uses, linking to `/tools/:id`.
- **"Tools" nav link** in the topbar between Agents and Runs.
- **`ToolStore`** wired into dashboard context for user-defined tool resolution.

## Test plan

- [x] 521/521 tests pass (517 → 521; +4 dashboard tests).
- [x] `npm run lint` clean.
- [x] `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)