### PR TITLE
feat: tool picker on node forms + config/actions types (v0.16 PR 4/6)

### DIFF
--- a/.changeset/tools-v016-pr4.md
+++ b/.changeset/tools-v016-pr4.md
@@ -1,0 +1,8 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/dashboard": minor
+---
+
+**feat: tool picker on node forms + tool config/actions types (PR 4 of 6 for v0.16).**
+
+Replaces the Shell/Claude Code type radio on add-node and edit-node forms with a tool dropdown listing all 9 built-in tools + user tools. Selecting a tool dynamically renders its declared input fields with palette autocomplete (both `$` and `{{` triggers). Extends the tool model with `config` (project-level defaults) and `actions` (multi-action tools).

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -48,6 +48,7 @@ export const agentNodeSchema = z.object({
    * When absent, `type` is required and v0.15 rules apply.
    */
   tool: z.string().optional(),
+  action: z.string().optional(),
   toolInputs: z.record(z.unknown()).optional(),
 
   command: z.string().optional(),

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -74,6 +74,13 @@ export interface AgentNode {
   tool?: string;
 
   /**
+   * For multi-action tools: which action to invoke. When the tool has
+   * `actions:` declared, this selects the operation (e.g. `action: "query"`
+   * on a postgres tool). Single-action tools ignore this field.
+   */
+  action?: string;
+
+  /**
    * Tool-specific inputs. When `tool:` is set, these are passed to the
    * tool's execute function. For backwards compat, `command` and `prompt`
    * continue to work as top-level fields and are folded into `toolInputs`

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -287,7 +287,13 @@ export async function executeAgentDag(
     try {
       if (builtinEntry) {
         // Built-in tool: call execute() directly, no child process.
-        const toolInputs = resolveToolInputs(node, upstreamSnapshot);
+        // Merge tool-level config (project defaults) with per-invocation
+        // inputs so the user doesn't repeat common values every node.
+        const toolInputs = {
+          ...(builtinEntry.definition.config ?? {}),
+          ...resolveToolInputs(node, upstreamSnapshot),
+          ...(node.action ? { _action: node.action } : {}),
+        };
         const ctx: BuiltinToolContext = {
           workingDirectory: node.workingDirectory,
           env,

--- a/packages/core/src/tool-schema.ts
+++ b/packages/core/src/tool-schema.ts
@@ -33,14 +33,22 @@ const toolImplementationSchema = z.object({
   { message: 'Shell tools need command, claude-code need prompt, builtin need builtinName' },
 );
 
+const toolActionSchema = z.object({
+  description: z.string().optional(),
+  inputs: z.record(z.string(), toolInputFieldSchema).default({}),
+  outputs: z.record(z.string(), toolOutputFieldSchema).default({}),
+});
+
 export const toolDefinitionSchema = z.object({
   id: z.string().regex(TOOL_ID_RE, 'Tool id must be lowercase with hyphens only'),
   name: z.string().min(1),
   description: z.string().optional(),
   source: z.enum(['local', 'examples', 'community', 'builtin']).default('local'),
 
+  config: z.record(z.unknown()).optional(),
   inputs: z.record(z.string(), toolInputFieldSchema).default({}),
   outputs: z.record(z.string(), toolOutputFieldSchema).default({}),
+  actions: z.record(z.string(), toolActionSchema).optional(),
 
   implementation: toolImplementationSchema,
 });

--- a/packages/core/src/tool-types.ts
+++ b/packages/core/src/tool-types.ts
@@ -41,6 +41,32 @@ export interface ToolImplementation {
 }
 
 /**
+ * Tool-level configuration. Set once per project (or per tool install),
+ * persists across invocations. Merged with per-invocation `inputs` at
+ * dispatch time — config values act as defaults that inputs can override.
+ *
+ * Example: an `http-get` tool with `config.baseUrl` set means nodes
+ * only need to pass `inputs.path` instead of a full URL every time.
+ * Config values can reference secrets via `{{secrets.NAME}}` and
+ * global variables via `{{vars.NAME}}`.
+ */
+export interface ToolConfig {
+  [key: string]: unknown;
+}
+
+/**
+ * A named operation within a multi-action tool. Single-action tools
+ * (the common case) omit `actions` and use top-level `inputs`/`outputs`
+ * directly. Multi-action tools declare each operation with its own
+ * typed I/O; the node specifies `action: "query"` alongside `tool:`.
+ */
+export interface ToolAction {
+  description?: string;
+  inputs: Record<string, ToolInputField>;
+  outputs: Record<string, ToolOutputField>;
+}
+
+/**
  * The full definition of a tool as stored in `tools/` YAML or the DB.
  * Analogous to `Agent` for agents.
  */
@@ -50,8 +76,25 @@ export interface ToolDefinition {
   description?: string;
   source: ToolSource;
 
+  /**
+   * Project-level configuration. Merged with per-invocation inputs at
+   * dispatch time. Stored in `.sua/tool-config/<id>.json` or inline in
+   * the tool YAML for bundled defaults.
+   */
+  config?: ToolConfig;
+
+  /** Per-invocation inputs for single-action tools. */
   inputs: Record<string, ToolInputField>;
+  /** Declared outputs for single-action tools. */
   outputs: Record<string, ToolOutputField>;
+
+  /**
+   * Multi-action tools declare named operations here. When `actions` is
+   * set, the top-level `inputs`/`outputs` serve as shared defaults that
+   * every action inherits (actions can override per-field). Nodes
+   * reference a specific action via `action: "query"` on the node YAML.
+   */
+  actions?: Record<string, ToolAction>;
 
   implementation: ToolImplementation;
 

--- a/packages/dashboard/src/routes/agents.ts
+++ b/packages/dashboard/src/routes/agents.ts
@@ -138,7 +138,7 @@ agentsRouter.get('/agents/:name/add-node', (req: Request, res: Response) => {
   }
   const fromCreate = req.query.fromCreate === '1';
   const flashParam = typeof req.query.flash === 'string' ? req.query.flash : undefined;
-  res.type('html').send(renderAgentAddNode({ agent, fromCreate, flash: flashParam }));
+  res.type('html').send(renderAgentAddNode({ agent, fromCreate, flash: flashParam, toolStore: ctx.toolStore }));
 });
 
 agentsRouter.post('/agents/:name/add-node', (req: Request, res: Response) => {
@@ -252,7 +252,7 @@ agentsRouter.get('/agents/:name/nodes/:nodeId/edit', (req: Request, res: Respons
     res.status(404).redirect(303, `/agents/${encodeURIComponent(agent.id)}?flash=${encodeURIComponent(`Node "${nodeId}" not found.`)}`);
     return;
   }
-  res.type('html').send(renderAgentEditNode({ agent, node }));
+  res.type('html').send(renderAgentEditNode({ agent, node, toolStore: ctx.toolStore }));
 });
 
 agentsRouter.post('/agents/:name/nodes/:nodeId/edit', (req: Request, res: Response) => {

--- a/packages/dashboard/src/views/agent-add-node.ts
+++ b/packages/dashboard/src/views/agent-add-node.ts
@@ -3,6 +3,8 @@ import { html, render, unsafeHtml, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
 import { computePaletteSuggestions, renderPalettePayload } from './template-palette.js';
+import { renderToolPicker, renderToolInputsSection, getAvailableTools } from './tool-picker.js';
+import type { ToolStore } from '@some-useful-agents/core';
 
 /**
  * Render a reference card listing everything the author can inject into
@@ -84,8 +86,12 @@ export function renderAgentAddNode(args: {
   flash?: string;
   /** True if the user just landed here from /agents/new — surface a "Done" hint. */
   fromCreate?: boolean;
+  /** v0.16+: tool store for the tool picker dropdown. */
+  toolStore?: ToolStore;
 }): string {
-  const { agent, values: v = {}, error, flash, fromCreate } = args;
+  const { agent, values: v = {}, error, flash, fromCreate, toolStore } = args;
+  const allTools = getAvailableTools(toolStore);
+  const selectedTool = v.type === 'claude-code' ? 'claude-code' : 'shell-exec';
   const type = v.type ?? 'shell';
   const isShell = type === 'shell';
   const isClaude = type === 'claude-code';
@@ -155,17 +161,8 @@ export function renderAgentAddNode(args: {
         <span class="dim" style="font-size: var(--font-size-xs);">Lowercase, hyphens or underscores. Must be unique within this agent.</span>
       </label>
 
-      <fieldset style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--space-3); margin-bottom: var(--space-4);">
-        <legend style="padding: 0 var(--space-2); font-size: var(--font-size-xs); font-weight: var(--weight-semibold); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em;">Type</legend>
-        <label style="display: flex; align-items: center; gap: var(--space-2); margin-bottom: var(--space-2);">
-          <input type="radio" name="type" value="shell" ${isShell ? 'checked' : ''}>
-          <span><strong>Shell</strong> <span class="dim">\u2014 runs a command. Upstream outputs come in as <code>$UPSTREAM_&lt;NODEID&gt;_RESULT</code> env vars.</span></span>
-        </label>
-        <label style="display: flex; align-items: center; gap: var(--space-2);">
-          <input type="radio" name="type" value="claude-code" ${isClaude ? 'checked' : ''}>
-          <span><strong>Claude Code</strong> <span class="dim">\u2014 runs a prompt. Upstream outputs interpolate via <code>{{upstream.&lt;nodeId&gt;.result}}</code>.</span></span>
-        </label>
-      </fieldset>
+      ${renderToolPicker({ tools: allTools, selectedTool, currentType: v.type })}
+      ${renderToolInputsSection(selectedTool, allTools)}
 
       <fieldset style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--space-3); margin-bottom: var(--space-4);">
         <legend style="padding: 0 var(--space-2); font-size: var(--font-size-xs); font-weight: var(--weight-semibold); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em;">Depends on</legend>
@@ -175,23 +172,31 @@ export function renderAgentAddNode(args: {
 
       ${availableVariablesPanel(agent)}
 
-      <label class="node-field" data-node-field="shell" style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-4);">
-        <strong>Command <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-xs);">(shell only)</span></strong>
-        <textarea name="command" rows="4" placeholder='echo "$UPSTREAM_FETCH_RESULT" | wc -w'
-          style="${TEXTAREA_STYLE}"
-          data-template-palette="shell"
-          data-palette-source="palette-add-node">${v.command ?? ''}</textarea>
-        <span class="dim" style="font-size: var(--font-size-xs);">Type <code>$</code> for available env vars.</span>
-      </label>
+      <fieldset style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--space-3); margin-bottom: var(--space-4);">
+        <legend style="padding: 0 var(--space-2); font-size: var(--font-size-xs); font-weight: var(--weight-semibold); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em;">Implementation</legend>
 
-      <label class="node-field" data-node-field="claude-code" style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-6);">
-        <strong>Prompt <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-xs);">(claude-code only)</span></strong>
-        <textarea name="prompt" rows="4" placeholder='Summarise: {{upstream.fetch.result}}'
-          style="${TEXTAREA_STYLE}"
-          data-template-palette="claude"
-          data-palette-source="palette-add-node">${v.prompt ?? ''}</textarea>
-        <span class="dim" style="font-size: var(--font-size-xs);">Type <code>{{</code> for available template refs.</span>
-      </label>
+        <div class="node-field" data-node-field="shell">
+          <label style="display: flex; flex-direction: column; gap: var(--space-1);">
+            <strong>Command</strong>
+            <textarea name="command" rows="4" placeholder='echo "$UPSTREAM_FETCH_RESULT" | wc -w'
+              style="${TEXTAREA_STYLE}"
+              data-template-palette="shell"
+              data-palette-source="palette-add-node">${v.command ?? ''}</textarea>
+            <span class="dim" style="font-size: var(--font-size-xs);">Type <code>$</code> for available env vars.</span>
+          </label>
+        </div>
+
+        <div class="node-field" data-node-field="claude-code">
+          <label style="display: flex; flex-direction: column; gap: var(--space-1);">
+            <strong>Prompt</strong>
+            <textarea name="prompt" rows="4" placeholder='Summarise: {{upstream.fetch.result}}'
+              style="${TEXTAREA_STYLE}"
+              data-template-palette="claude"
+              data-palette-source="palette-add-node">${v.prompt ?? ''}</textarea>
+            <span class="dim" style="font-size: var(--font-size-xs);">Type <code>{{</code> for available template refs.</span>
+          </label>
+        </div>
+      </fieldset>
 
       ${renderPalettePayload('palette-add-node', computePaletteSuggestions(agent))}
 

--- a/packages/dashboard/src/views/agent-edit-node.ts
+++ b/packages/dashboard/src/views/agent-edit-node.ts
@@ -1,8 +1,9 @@
-import type { Agent, AgentNode } from '@some-useful-agents/core';
+import type { Agent, AgentNode, ToolStore } from '@some-useful-agents/core';
 import { html, render, unsafeHtml, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
 import { computePaletteSuggestions, renderPalettePayload } from './template-palette.js';
+import { renderToolPicker, renderToolInputsSection, getAvailableTools } from './tool-picker.js';
 
 export interface EditNodeFormValues {
   type?: 'shell' | 'claude-code';
@@ -24,8 +25,10 @@ export function renderAgentEditNode(args: {
   node: AgentNode;
   values?: EditNodeFormValues;
   error?: string;
+  toolStore?: ToolStore;
 }): string {
-  const { agent, node, values: submitted, error } = args;
+  const { agent, node, values: submitted, error, toolStore } = args;
+  const allTools = getAvailableTools(toolStore);
 
   // Fall back to the node's current values if nothing's been submitted.
   const v: EditNodeFormValues = {
@@ -81,17 +84,8 @@ export function renderAgentEditNode(args: {
         <span class="dim" style="font-size: var(--font-size-xs);">Immutable. Renaming would break every <code>{{upstream.${node.id}.result}}</code> reference in this agent. Delete + re-create if you need a different id.</span>
       </label>
 
-      <fieldset style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--space-3); margin-bottom: var(--space-4);">
-        <legend style="padding: 0 var(--space-2); font-size: var(--font-size-xs); font-weight: var(--weight-semibold); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em;">Type</legend>
-        <label style="display: flex; align-items: center; gap: var(--space-2); margin-bottom: var(--space-2);">
-          <input type="radio" name="type" value="shell" ${isShell ? 'checked' : ''}>
-          <span><strong>Shell</strong> <span class="dim">\u2014 uses <code>$UPSTREAM_&lt;ID&gt;_RESULT</code> env vars.</span></span>
-        </label>
-        <label style="display: flex; align-items: center; gap: var(--space-2);">
-          <input type="radio" name="type" value="claude-code" ${isClaude ? 'checked' : ''}>
-          <span><strong>Claude Code</strong> <span class="dim">\u2014 uses <code>{{upstream.&lt;id&gt;.result}}</code> templates.</span></span>
-        </label>
-      </fieldset>
+      ${renderToolPicker({ tools: allTools, selectedTool: node.tool, currentType: v.type })}
+      ${renderToolInputsSection(node.tool ?? (v.type === 'claude-code' ? 'claude-code' : 'shell-exec'), allTools, node.toolInputs as Record<string, unknown> | undefined)}
 
       <fieldset style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--space-3); margin-bottom: var(--space-4);">
         <legend style="padding: 0 var(--space-2); font-size: var(--font-size-xs); font-weight: var(--weight-semibold); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em;">Depends on</legend>
@@ -101,23 +95,31 @@ export function renderAgentEditNode(args: {
           : html`<div>${depToggles as unknown as SafeHtml[]}</div>`}
       </fieldset>
 
-      <label class="node-field" data-node-field="shell" style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-4);">
-        <strong>Command <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-xs);">(shell only)</span></strong>
-        <textarea name="command" rows="4"
-          style="${TEXTAREA_STYLE}"
-          data-template-palette="shell"
-          data-palette-source="palette-edit-node">${v.command ?? ''}</textarea>
-        <span class="dim" style="font-size: var(--font-size-xs);">Type <code>$</code> for available env vars.</span>
-      </label>
+      <fieldset style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--space-3); margin-bottom: var(--space-4);">
+        <legend style="padding: 0 var(--space-2); font-size: var(--font-size-xs); font-weight: var(--weight-semibold); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em;">Implementation</legend>
 
-      <label class="node-field" data-node-field="claude-code" style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-6);">
-        <strong>Prompt <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-xs);">(claude-code only)</span></strong>
-        <textarea name="prompt" rows="4"
-          style="${TEXTAREA_STYLE}"
-          data-template-palette="claude"
-          data-palette-source="palette-edit-node">${v.prompt ?? ''}</textarea>
-        <span class="dim" style="font-size: var(--font-size-xs);">Type <code>{{</code> for available template refs.</span>
-      </label>
+        <div class="node-field" data-node-field="shell">
+          <label style="display: flex; flex-direction: column; gap: var(--space-1);">
+            <strong>Command</strong>
+            <textarea name="command" rows="4"
+              style="${TEXTAREA_STYLE}"
+              data-template-palette="shell"
+              data-palette-source="palette-edit-node">${v.command ?? ''}</textarea>
+            <span class="dim" style="font-size: var(--font-size-xs);">Type <code>$</code> for available env vars.</span>
+          </label>
+        </div>
+
+        <div class="node-field" data-node-field="claude-code">
+          <label style="display: flex; flex-direction: column; gap: var(--space-1);">
+            <strong>Prompt</strong>
+            <textarea name="prompt" rows="4"
+              style="${TEXTAREA_STYLE}"
+              data-template-palette="claude"
+              data-palette-source="palette-edit-node">${v.prompt ?? ''}</textarea>
+            <span class="dim" style="font-size: var(--font-size-xs);">Type <code>{{</code> for available template refs.</span>
+          </label>
+        </div>
+      </fieldset>
 
       ${renderPalettePayload(
         'palette-edit-node',

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -29,6 +29,93 @@ export const DASHBOARD_JS = `
     }
   });
 
+  // Tool-picker dropdown: swap visible input fields when the tool changes.
+  // shell-exec → Command textarea, claude-code → Prompt textarea, other →
+  // dynamically generated fields from the tool's declared inputs schema.
+  (function () {
+    var select = document.getElementById('node-tool-select');
+    var schemasEl = document.getElementById('tool-schemas');
+    var typeHidden = document.getElementById('node-type-hidden');
+    var descEl = document.getElementById('tool-description');
+    var inputsSection = document.getElementById('tool-inputs-section');
+    if (!select || !schemasEl) return;
+
+    var schemas;
+    try { schemas = JSON.parse(schemasEl.textContent || '{}'); } catch (e) { return; }
+
+    function updateDescription(toolId) {
+      if (!descEl || !schemas[toolId]) return;
+      descEl.textContent = schemas[toolId].description || '';
+    }
+
+    function updateType(toolId) {
+      if (!typeHidden || !schemas[toolId]) return;
+      var implType = schemas[toolId].implType;
+      typeHidden.value = implType === 'claude-code' ? 'claude-code' : 'shell';
+    }
+
+    function updateFields(toolId) {
+      // Show/hide the built-in command/prompt textareas.
+      var shellField = document.querySelector('[data-node-field="shell"]');
+      var claudeField = document.querySelector('[data-node-field="claude-code"]');
+      if (shellField) shellField.style.display = (toolId === 'shell-exec') ? '' : 'none';
+      if (claudeField) claudeField.style.display = (toolId === 'claude-code') ? '' : 'none';
+
+      // For non-builtin tools, generate inputs from the schema.
+      if (!inputsSection) return;
+      if (toolId === 'shell-exec' || toolId === 'claude-code') {
+        inputsSection.innerHTML = '';
+        return;
+      }
+      var schema = schemas[toolId];
+      if (!schema || !schema.inputs) { inputsSection.innerHTML = ''; return; }
+
+      // Determine palette mode from tool's implementation type.
+      var paletteMode = schema.implType === 'claude-code' ? 'claude' : 'shell';
+      // Find the palette-source id (reuse whichever one is on the page).
+      var existingPalette = document.querySelector('[data-palette-source]');
+      var paletteSource = existingPalette ? existingPalette.getAttribute('data-palette-source') : '';
+
+      var html = '';
+      for (var name in schema.inputs) {
+        var spec = schema.inputs[name];
+        var req = spec.required ? ' required' : '';
+        var defVal = spec['default'] !== undefined ? String(spec['default']) : '';
+        var isTextLike = spec.type === 'string' || spec.type === 'json';
+        html += '<label style="display:flex;flex-direction:column;gap:var(--space-1);margin-bottom:var(--space-3);">';
+        html += '<strong>' + name + ' <span class="dim" style="font-weight:var(--weight-regular);font-size:var(--font-size-xs);">(' + spec.type + (spec.required ? ', required' : '') + ')</span></strong>';
+        if (isTextLike) {
+          // Use a textarea for string/json fields so the palette can trigger.
+          html += '<textarea name="toolInput_' + name + '" rows="2"' + req;
+          html += ' data-template-palette="both"';
+          html += ' data-palette-source="' + paletteSource + '"';
+          html += ' style="padding:var(--space-2) var(--space-3);border:1px solid var(--color-border-strong);border-radius:var(--radius-sm);font-size:var(--font-size-sm);font-family:var(--font-mono);resize:vertical;">';
+          html += defVal.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+          html += '</textarea>';
+          html += '<span class="dim" style="font-size:var(--font-size-xs);">Type <code>$</code> or <code>{{</code> for available refs.</span>';
+        } else {
+          html += '<input type="text" name="toolInput_' + name + '" value="' + defVal.replace(/"/g, '&quot;') + '"' + req;
+          html += ' style="padding:var(--space-2) var(--space-3);border:1px solid var(--color-border-strong);border-radius:var(--radius-sm);font-size:var(--font-size-sm);font-family:var(--font-mono);">';
+        }
+        if (spec.description) html += '<span class="dim" style="font-size:var(--font-size-xs);">' + spec.description + '</span>';
+        html += '</label>';
+      }
+      inputsSection.innerHTML = html;
+    }
+
+    // Initial render.
+    var initial = select.value;
+    updateDescription(initial);
+    updateFields(initial);
+
+    select.addEventListener('change', function () {
+      var toolId = select.value;
+      updateDescription(toolId);
+      updateType(toolId);
+      updateFields(toolId);
+    });
+  })();
+
   // Grey-out the inactive node-type field (Command vs Prompt) based on
   // which <input type="radio" name="type"> is selected. The form still
   // submits both fields — the server validates against the selected
@@ -265,9 +352,14 @@ export const DASHBOARD_JS = `
       var sugg = getSuggestions(textarea);
       if (!sugg) { closePalette(); return; }
       var mode = textarea.getAttribute('data-template-palette');
-      // $ inside a claude-prompt textarea is just a literal $, not a trigger.
-      if (mode === 'claude' && trig.mode === 'shell') { closePalette(); return; }
-      if (mode === 'shell' && trig.mode === 'claude') { closePalette(); return; }
+      // For tool-input fields (mode="both"), show whichever syntax the
+      // user is typing. For dedicated Command/Prompt textareas, enforce
+      // the single syntax. "both" is set on dynamically generated tool
+      // input fields where the user may use either syntax.
+      if (mode !== 'both') {
+        if (mode === 'claude' && trig.mode === 'shell') { closePalette(); return; }
+        if (mode === 'shell' && trig.mode === 'claude') { closePalette(); return; }
+      }
 
       var all = buildItems(trig.mode, sugg);
       var filtered = filterItems(all, trig.query);

--- a/packages/dashboard/src/views/tool-picker.ts
+++ b/packages/dashboard/src/views/tool-picker.ts
@@ -1,0 +1,107 @@
+import { listBuiltinTools, type ToolDefinition, type ToolStore } from '@some-useful-agents/core';
+import { html, unsafeHtml, type SafeHtml } from './html.js';
+
+/**
+ * All available tools for the node-form dropdown. Built-ins first, then
+ * user tools. The two backcompat tools (shell-exec, claude-code) are
+ * listed at the top since they're the most common.
+ */
+export function getAvailableTools(toolStore?: ToolStore): ToolDefinition[] {
+  const builtins = listBuiltinTools();
+  let userTools: ToolDefinition[] = [];
+  try {
+    if (toolStore) userTools = toolStore.listTools();
+  } catch { /* store not available */ }
+  return [...builtins, ...userTools];
+}
+
+/**
+ * Render the tool picker: a `<select name="tool">` dropdown plus a
+ * JSON payload of all tool schemas so client JS can swap input fields
+ * dynamically when the selection changes.
+ */
+export function renderToolPicker(args: {
+  tools: ToolDefinition[];
+  selectedTool?: string;
+  /** For edit-node: the current node's type, used to pre-select the right tool. */
+  currentType?: 'shell' | 'claude-code';
+}): SafeHtml {
+  const { tools, selectedTool, currentType } = args;
+
+  // Derive the effective selection. When editing a v0.15 node that
+  // has no explicit `tool:`, default to its implicit tool.
+  const effective = selectedTool
+    ?? (currentType === 'shell' ? 'shell-exec' : currentType === 'claude-code' ? 'claude-code' : 'shell-exec');
+
+  const options = tools.map((t) => {
+    const selected = t.id === effective ? ' selected' : '';
+    const label = t.id === 'shell-exec' ? 'Shell (shell-exec)'
+      : t.id === 'claude-code' ? 'Claude Code (claude-code)'
+      : `${t.id} — ${t.name}`;
+    return html`<option value="${t.id}"${unsafeHtml(selected)}>${label}</option>`;
+  });
+
+  // Embed tool schemas so JS can render dynamic input fields.
+  const schemasPayload = JSON.stringify(
+    Object.fromEntries(tools.map((t) => [t.id, {
+      inputs: t.inputs,
+      outputs: t.outputs,
+      implType: t.implementation.type,
+      description: t.description,
+    }])),
+  ).replace(/<\/script/gi, '<\\/script');
+
+  return html`
+    <fieldset style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--space-3); margin-bottom: var(--space-4);">
+      <legend style="padding: 0 var(--space-2); font-size: var(--font-size-xs); font-weight: var(--weight-semibold); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em;">Tool</legend>
+      <select name="tool" id="node-tool-select" style="padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm); font-family: var(--font-mono); min-width: 16rem;">
+        ${options as unknown as SafeHtml[]}
+      </select>
+      <p class="dim" style="margin: var(--space-2) 0 0; font-size: var(--font-size-xs);" id="tool-description"></p>
+    </fieldset>
+    <input type="hidden" name="type" id="node-type-hidden" value="${effective === 'claude-code' ? 'claude-code' : 'shell'}">
+    <script id="tool-schemas" type="application/json">${unsafeHtml(schemasPayload)}</script>
+  `;
+}
+
+/**
+ * Render the dynamic tool-inputs section. For shell-exec/claude-code,
+ * this is empty (those tools use the existing command/prompt textareas).
+ * For other tools, generate one field per declared input.
+ *
+ * The section is server-rendered for the initially-selected tool; JS
+ * swaps it when the dropdown changes. The `id="tool-inputs-section"`
+ * container is the JS target.
+ */
+export function renderToolInputsSection(
+  selectedTool: string,
+  tools: ToolDefinition[],
+  existingInputs?: Record<string, unknown>,
+): SafeHtml {
+  // shell-exec and claude-code use the existing command/prompt fields.
+  if (selectedTool === 'shell-exec' || selectedTool === 'claude-code') {
+    return html`<div id="tool-inputs-section"></div>`;
+  }
+
+  const tool = tools.find((t) => t.id === selectedTool);
+  if (!tool) return html`<div id="tool-inputs-section"></div>`;
+
+  const fields = Object.entries(tool.inputs).map(([name, spec]) => {
+    const value = existingInputs?.[name] ?? spec.default ?? '';
+    const required = spec.required ? 'required' : '';
+    return html`
+      <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-3);">
+        <strong>${name} <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-xs);">(${spec.type}${spec.required ? ', required' : ''})</span></strong>
+        <input type="text" name="toolInput_${name}" value="${String(value)}" ${unsafeHtml(required)}
+          style="padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm); font-family: var(--font-mono);">
+        ${spec.description ? html`<span class="dim" style="font-size: var(--font-size-xs);">${spec.description}</span>` : html``}
+      </label>
+    `;
+  });
+
+  return html`
+    <div id="tool-inputs-section">
+      ${fields as unknown as SafeHtml[]}
+    </div>
+  `;
+}


### PR DESCRIPTION
## Summary

- **Tool dropdown** replaces type radio on add-node + edit-node forms. Lists all 9 built-ins + user tools.
- **Dynamic input fields**: selecting a tool renders its declared inputs as textareas with `$` / `{{` palette autocomplete.
- **Implementation fieldset**: Command/Prompt wrapped in a proper card matching the Tool and Depends-on sections.
- **Tool config** type: project-level defaults merged with per-invocation inputs.
- **Tool actions** type: multi-action tools with named operations.

## Test plan

- [x] 521/521 tests pass. Lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)