### PR TITLE
feat(core): flow control foundation — onlyIf conditional edges + types (Flow PR A)

### DIFF
--- a/.changeset/flow-control-pr-a.md
+++ b/.changeset/flow-control-pr-a.md
@@ -1,0 +1,27 @@
+---
+"@some-useful-agents/core": minor
+---
+
+**feat: flow control foundation — node types, onlyIf conditional edges, nested run support (Flow PR A).**
+
+Lays the type + schema + executor foundation for control-flow primitives in agent flows. No new node type dispatch yet (conditional, switch, loop, etc. come in PRs B–E); this PR establishes the data layer and ships the `onlyIf` conditional edge feature end-to-end.
+
+### What ships
+
+- **Extended `NodeType` union**: `conditional`, `switch`, `loop`, `agent-invoke`, `branch`, `end`, `break` join `shell` + `claude-code`. Control-flow types are first-class — the executor will dispatch to dedicated logic per type.
+- **`onlyIf` on `AgentNode`**: edge-level conditional execution. Evaluates a predicate (`equals`, `notEquals`, `exists`) against an upstream node's structured output field before spawning. Skipped nodes get `condition_not_met` (not `upstream_failed`), which cascades to downstream nodes without triggering fail-fast.
+- **Control-flow config interfaces**: `ConditionalConfig`, `SwitchConfig`, `LoopConfig`, `AgentInvokeConfig`, `endMessage` on AgentNode. Ready for PRs B–E to implement.
+- **`condition_not_met` + `flow_ended`** error categories.
+- **`parent_run_id` + `parent_node_id`** on runs table (idempotent migration). Ready for nested agent-invoke runs in PR C.
+- **Zod schema** updated: accepts all new node types + `onlyIf` field. Control-flow nodes skip the command/prompt requirement.
+- **If/else branching** works today: two downstream nodes with complementary `onlyIf` predicates — one runs, the other skips.
+
+### Tests
+
+527 total (521 → 527; +6 new):
+- onlyIf.equals skips when no match / runs when match
+- Cascading condition_not_met to downstream nodes
+- onlyIf.notEquals
+- onlyIf.exists (null = absent)
+- If/else branching pattern (complementary predicates)
+- All 521 existing tests pass unchanged (full backcompat)

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -38,16 +38,52 @@ export function extractUpstreamReferences(text: string): Set<string> {
   return out;
 }
 
+const CONTROL_FLOW_TYPES = new Set([
+  'conditional', 'switch', 'loop', 'agent-invoke', 'branch', 'end', 'break',
+]);
+
+const onlyIfSchema = z.object({
+  upstream: z.string(),
+  field: z.string(),
+  equals: z.unknown().optional(),
+  notEquals: z.unknown().optional(),
+  exists: z.boolean().optional(),
+});
+
+const conditionalConfigSchema = z.object({
+  predicate: z.object({
+    field: z.string(),
+    equals: z.unknown().optional(),
+    notEquals: z.unknown().optional(),
+    exists: z.boolean().optional(),
+  }),
+});
+
+const switchConfigSchema = z.object({
+  field: z.string(),
+  cases: z.record(z.unknown()),
+});
+
+const loopConfigSchema = z.object({
+  over: z.string(),
+  agentId: z.string(),
+  maxIterations: z.number().int().positive().optional(),
+});
+
+const agentInvokeConfigSchema = z.object({
+  agentId: z.string(),
+  inputMapping: z.record(z.string()).optional(),
+});
+
 export const agentNodeSchema = z.object({
   id: z.string().regex(NODE_ID_RE, 'Node ids must be lowercase with hyphens/underscores only'),
-  type: z.enum(['shell', 'claude-code']),
+  type: z.enum([
+    'shell', 'claude-code',
+    'conditional', 'switch', 'loop', 'agent-invoke', 'branch', 'end', 'break',
+  ]),
 
-  /**
-   * v0.16+: named tool this node invokes. When set, `type` + `command` /
-   * `prompt` are not required — the tool's implementation provides them.
-   * When absent, `type` is required and v0.15 rules apply.
-   */
   tool: z.string().optional(),
+  action: z.string().optional(),
   toolInputs: z.record(z.unknown()).optional(),
 
   command: z.string().optional(),
@@ -64,19 +100,28 @@ export const agentNodeSchema = z.object({
   workingDirectory: z.string().optional(),
 
   dependsOn: z.array(z.string()).optional(),
+
+  // Flow control
+  onlyIf: onlyIfSchema.optional(),
+  conditionalConfig: conditionalConfigSchema.optional(),
+  switchConfig: switchConfigSchema.optional(),
+  loopConfig: loopConfigSchema.optional(),
+  agentInvokeConfig: agentInvokeConfigSchema.optional(),
+  endMessage: z.string().optional(),
+
   position: z.object({ x: z.number(), y: z.number() }).optional(),
 }).refine(
   (data) => {
-    // When a named tool is set, the tool provides the implementation —
-    // command/prompt are not required (they live in toolInputs or on the
-    // tool definition). `type` is still required: the YAML parser sets
-    // it from the tool's implementation type at load time.
+    // Control-flow node types don't need command/prompt/tool.
+    if (CONTROL_FLOW_TYPES.has(data.type)) return true;
+    // When a named tool is set, the tool provides the implementation.
     if (data.tool) return true;
+    // v0.15 compat: shell needs command, claude-code needs prompt.
     if (data.type === 'shell') return !!data.command;
     if (data.type === 'claude-code') return !!data.prompt;
     return false;
   },
-  { message: 'Nodes without a tool require command (shell) or prompt (claude-code)' },
+  { message: 'Execution nodes without a tool require command (shell) or prompt (claude-code)' },
 );
 
 export const agentV2Schema = z.object({

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -17,7 +17,24 @@ import type { AgentInputSpec } from './types.js';
 import type { AgentSource } from './agent-loader.js';
 
 export type AgentStatus = 'active' | 'paused' | 'archived' | 'draft';
-export type NodeType = 'shell' | 'claude-code';
+
+/**
+ * Node types. `shell` and `claude-code` are the original v0.15 execution
+ * types. Control-flow types (conditional, switch, loop, etc.) are first-class
+ * node types added in the flow-control PR series — they dispatch to dedicated
+ * executor logic rather than spawning a child process.
+ */
+export type NodeType =
+  | 'shell'
+  | 'claude-code'
+  | 'conditional'
+  | 'switch'
+  | 'loop'
+  | 'agent-invoke'
+  | 'branch'
+  | 'end'
+  | 'break';
+
 export type NodeExecutionStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled' | 'skipped';
 
 /**
@@ -45,7 +62,9 @@ export type NodeErrorCategory =
   | 'exit_nonzero'
   | 'timeout'
   | 'cancelled'
-  | 'upstream_failed';
+  | 'upstream_failed'
+  | 'condition_not_met'
+  | 'flow_ended';
 
 // Re-export so consumers of v2 types can import from one place without
 // reaching back into the v1 loader module.
@@ -56,6 +75,46 @@ export type { AgentSource };
  * a v1 `AgentDefinition` described, minus the cross-file chaining fields
  * (`dependsOn`/`input`/`source`) which now live at the agent or edge level.
  */
+// -- Flow control types --
+
+/**
+ * Edge-level conditional execution. When set on a node, the executor
+ * evaluates the predicate before spawning. If the condition fails, the
+ * node is skipped with `condition_not_met` — no failure cascade.
+ * `upstream` must also appear in the node's `dependsOn`.
+ */
+export interface OnlyIfCondition {
+  upstream: string;
+  field: string;
+  equals?: unknown;
+  notEquals?: unknown;
+  exists?: boolean;
+}
+
+export interface ConditionalConfig {
+  predicate: { field: string; equals?: unknown; notEquals?: unknown; exists?: boolean };
+}
+
+export interface SwitchConfig {
+  field: string;
+  cases: Record<string, unknown>;
+}
+
+export interface LoopConfig {
+  /** Field name in upstream's structured output to iterate over. */
+  over: string;
+  /** Agent id to invoke per item. */
+  agentId: string;
+  maxIterations?: number;
+}
+
+export interface AgentInvokeConfig {
+  agentId: string;
+  inputMapping?: Record<string, string>;
+}
+
+// -- Node definition --
+
 export interface AgentNode {
   id: string;
   type: NodeType;
@@ -106,6 +165,26 @@ export interface AgentNode {
    * topologically sorts on this field and rejects cycles.
    */
   dependsOn?: string[];
+
+  // -- Flow control (first-class node types) --
+
+  /**
+   * Edge-level conditional execution. If set, the executor evaluates the
+   * predicate before spawning this node. On failure → skipped with
+   * `condition_not_met`, no failure cascade to downstream.
+   */
+  onlyIf?: OnlyIfCondition;
+
+  /** Config for `type: 'conditional'` nodes. */
+  conditionalConfig?: ConditionalConfig;
+  /** Config for `type: 'switch'` nodes. */
+  switchConfig?: SwitchConfig;
+  /** Config for `type: 'loop'` nodes. */
+  loopConfig?: LoopConfig;
+  /** Config for `type: 'agent-invoke'` nodes. */
+  agentInvokeConfig?: AgentInvokeConfig;
+  /** Message for `type: 'end'` or `type: 'break'` nodes. */
+  endMessage?: string;
 
   /**
    * Optional layout hint for the v0.14 drag/drop editor. Ignored by the

--- a/packages/core/src/dag-executor.test.ts
+++ b/packages/core/src/dag-executor.test.ts
@@ -591,3 +591,174 @@ describe('executeAgentDag — env allowlist by trust level', () => {
     expect(env!.NODE_ENV).toBe('test');
   });
 });
+
+describe('executeAgentDag — onlyIf conditional edges', () => {
+  it('skips a node when onlyIf.equals does not match', async () => {
+    const agent = makeAgent({
+      nodes: [
+        { id: 'check', type: 'shell', command: 'echo check' },
+        {
+          id: 'process',
+          type: 'shell',
+          command: 'echo process',
+          dependsOn: ['check'],
+          onlyIf: { upstream: 'check', field: 'status', equals: 200 },
+        },
+      ],
+    });
+    const spawner = cannedSpawner({
+      check: { exitCode: 0, result: '{"status": 404}' },
+    });
+    const deps: DagExecutorDeps = { runStore, spawnNode: spawner };
+    const run = await executeAgentDag(agent, { triggeredBy: 'cli' }, deps);
+
+    // Run should complete (condition_not_met is not a failure).
+    expect(run.status).toBe('completed');
+
+    const execs = runStore.listNodeExecutions(run.id);
+    const processExec = execs.find((e) => e.nodeId === 'process');
+    expect(processExec!.status).toBe('skipped');
+    expect(processExec!.errorCategory).toBe('condition_not_met');
+  });
+
+  it('runs a node when onlyIf.equals matches', async () => {
+    const agent = makeAgent({
+      nodes: [
+        { id: 'check', type: 'shell', command: 'echo check' },
+        {
+          id: 'process',
+          type: 'shell',
+          command: 'echo process',
+          dependsOn: ['check'],
+          onlyIf: { upstream: 'check', field: 'status', equals: 200 },
+        },
+      ],
+    });
+    const spawner = cannedSpawner({
+      check: { exitCode: 0, result: '{"status": 200}' },
+      process: { exitCode: 0, result: 'done' },
+    });
+    const deps: DagExecutorDeps = { runStore, spawnNode: spawner };
+    const run = await executeAgentDag(agent, { triggeredBy: 'cli' }, deps);
+
+    expect(run.status).toBe('completed');
+    const execs = runStore.listNodeExecutions(run.id);
+    const processExec = execs.find((e) => e.nodeId === 'process');
+    expect(processExec!.status).toBe('completed');
+  });
+
+  it('cascades condition_not_met to downstream nodes without their own onlyIf', async () => {
+    const agent = makeAgent({
+      nodes: [
+        { id: 'check', type: 'shell', command: 'echo check' },
+        {
+          id: 'gated',
+          type: 'shell',
+          command: 'echo gated',
+          dependsOn: ['check'],
+          onlyIf: { upstream: 'check', field: 'ok', equals: true },
+        },
+        {
+          id: 'after-gated',
+          type: 'shell',
+          command: 'echo after',
+          dependsOn: ['gated'],
+        },
+      ],
+    });
+    const spawner = cannedSpawner({
+      check: { exitCode: 0, result: '{"ok": false}' },
+    });
+    const deps: DagExecutorDeps = { runStore, spawnNode: spawner };
+    const run = await executeAgentDag(agent, { triggeredBy: 'cli' }, deps);
+
+    expect(run.status).toBe('completed');
+    const execs = runStore.listNodeExecutions(run.id);
+    expect(execs.find((e) => e.nodeId === 'gated')!.errorCategory).toBe('condition_not_met');
+    expect(execs.find((e) => e.nodeId === 'after-gated')!.errorCategory).toBe('condition_not_met');
+  });
+
+  it('supports onlyIf.notEquals', async () => {
+    const agent = makeAgent({
+      nodes: [
+        { id: 'check', type: 'shell', command: 'echo check' },
+        {
+          id: 'fallback',
+          type: 'shell',
+          command: 'echo fallback',
+          dependsOn: ['check'],
+          onlyIf: { upstream: 'check', field: 'status', notEquals: 200 },
+        },
+      ],
+    });
+    const spawner = cannedSpawner({
+      check: { exitCode: 0, result: '{"status": 500}' },
+      fallback: { exitCode: 0, result: 'ran fallback' },
+    });
+    const deps: DagExecutorDeps = { runStore, spawnNode: spawner };
+    const run = await executeAgentDag(agent, { triggeredBy: 'cli' }, deps);
+
+    expect(run.status).toBe('completed');
+    const execs = runStore.listNodeExecutions(run.id);
+    expect(execs.find((e) => e.nodeId === 'fallback')!.status).toBe('completed');
+  });
+
+  it('supports onlyIf.exists', async () => {
+    const agent = makeAgent({
+      nodes: [
+        { id: 'check', type: 'shell', command: 'echo check' },
+        {
+          id: 'if-present',
+          type: 'shell',
+          command: 'echo exists',
+          dependsOn: ['check'],
+          onlyIf: { upstream: 'check', field: 'data', exists: true },
+        },
+      ],
+    });
+    const spawner = cannedSpawner({
+      check: { exitCode: 0, result: '{"data": null}' },
+    });
+    const deps: DagExecutorDeps = { runStore, spawnNode: spawner };
+    const run = await executeAgentDag(agent, { triggeredBy: 'cli' }, deps);
+
+    // data is null → exists: true fails → skipped
+    const execs = runStore.listNodeExecutions(run.id);
+    expect(execs.find((e) => e.nodeId === 'if-present')!.errorCategory).toBe('condition_not_met');
+  });
+
+  it('if/else branching: one branch runs, the other skips', async () => {
+    const agent = makeAgent({
+      nodes: [
+        { id: 'check', type: 'shell', command: 'echo check' },
+        {
+          id: 'on-success',
+          type: 'shell',
+          command: 'echo success',
+          dependsOn: ['check'],
+          onlyIf: { upstream: 'check', field: 'ok', equals: true },
+        },
+        {
+          id: 'on-failure',
+          type: 'shell',
+          command: 'echo failure',
+          dependsOn: ['check'],
+          onlyIf: { upstream: 'check', field: 'ok', notEquals: true },
+        },
+      ],
+    });
+    const spawner = cannedSpawner({
+      check: { exitCode: 0, result: '{"ok": true}' },
+      'on-success': { exitCode: 0, result: 'ran success' },
+      'on-failure': { exitCode: 0, result: 'ran failure' },
+    });
+    const deps: DagExecutorDeps = { runStore, spawnNode: spawner };
+    const run = await executeAgentDag(agent, { triggeredBy: 'cli' }, deps);
+
+    expect(run.status).toBe('completed');
+    const execs = runStore.listNodeExecutions(run.id);
+    expect(execs.find((e) => e.nodeId === 'on-success')!.status).toBe('completed');
+    expect(execs.find((e) => e.nodeId === 'on-failure')!.status).toBe('skipped');
+    expect(execs.find((e) => e.nodeId === 'on-failure')!.errorCategory).toBe('condition_not_met');
+  });
+});

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -22,7 +22,7 @@
 import { randomUUID } from 'node:crypto';
 import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
-import type { Agent, AgentNode, NodeErrorCategory, NodeOutput, NodeStructuredOutput } from './agent-v2-types.js';
+import type { Agent, AgentNode, NodeErrorCategory, NodeOutput, NodeStructuredOutput, OnlyIfCondition } from './agent-v2-types.js';
 import type { Run, RunStatus } from './types.js';
 import type { RunStore } from './run-store.js';
 import type { SecretsStore } from './secrets-store.js';
@@ -143,6 +143,7 @@ export async function executeAgentDag(
   const outputs = new Map<string, NodeOutput>();
   const order = topologicalSort(agent.nodes);
   let firstFailure: { nodeId: string; category: NodeErrorCategory } | undefined;
+  const skippedNodes = new Set<string>();
 
   // Replay pre-load: copy prior node_executions for nodes before the pivot.
   // Their stored `result` feeds downstream outputs so re-execution starts
@@ -202,6 +203,53 @@ export async function executeAgentDag(
   for (const node of order) {
     if (replaySkipIds.has(node.id)) continue;
     const nodeStartedAt = new Date().toISOString();
+
+    // onlyIf: conditional edge evaluation. If the predicate fails, skip
+    // with condition_not_met — NOT upstream_failed. Downstream nodes that
+    // depend on a condition-skipped node also get condition_not_met (cascading
+    // skip, not cascading failure).
+    if (node.onlyIf) {
+      const upOutput = outputs.get(node.onlyIf.upstream);
+      if (!evaluateOnlyIf(node.onlyIf, upOutput)) {
+        deps.runStore.createNodeExecution({
+          runId,
+          nodeId: node.id,
+          workflowVersion: agent.version,
+          status: 'skipped',
+          errorCategory: 'condition_not_met',
+          startedAt: nodeStartedAt,
+          completedAt: nodeStartedAt,
+          error: `Condition not met: ${node.onlyIf.field} on upstream "${node.onlyIf.upstream}"`,
+        });
+        // Mark as skipped in outputs so downstream nodes that depend on
+        // this node can detect the skip. We set a sentinel — downstream
+        // nodes with their own onlyIf evaluate independently; those
+        // without onlyIf cascade to condition_not_met.
+        skippedNodes.add(node.id);
+        continue;
+      }
+    }
+
+    // Check if any required upstream was condition-skipped. If a node
+    // depends on a condition-skipped node and doesn't have its own onlyIf
+    // (which would let it evaluate independently), it cascades.
+    if (!node.onlyIf) {
+      const skippedDep = (node.dependsOn ?? []).find((d) => skippedNodes.has(d));
+      if (skippedDep) {
+        deps.runStore.createNodeExecution({
+          runId,
+          nodeId: node.id,
+          workflowVersion: agent.version,
+          status: 'skipped',
+          errorCategory: 'condition_not_met',
+          startedAt: nodeStartedAt,
+          completedAt: nodeStartedAt,
+          error: `Skipped: upstream "${skippedDep}" was condition-skipped`,
+        });
+        skippedNodes.add(node.id);
+        continue;
+      }
+    }
 
     // Short-circuit: an earlier node already failed. Write a skipped row
     // whose error field names the failing upstream — keeps the run log
@@ -718,6 +766,66 @@ async function spawnProcess(
 // -- Env allowlists (duplicate of env-builder constants; keeping here lets
 //    the DAG executor build env without the v1 AgentDefinition intermediary.
 //    Extract to a shared module in a follow-up if this duplicates further.) --
+
+// -- onlyIf evaluation --
+
+/**
+ * Evaluate an `onlyIf` predicate against an upstream node's output.
+ * Returns true if the condition is met (node should execute), false
+ * if not (node should be skipped with condition_not_met).
+ *
+ * The `field` is a dot-separated path into the upstream's structured
+ * output (or the flat `result` string for v0.15 nodes).
+ */
+function evaluateOnlyIf(condition: OnlyIfCondition, upOutput: NodeOutput | undefined): boolean {
+  if (!upOutput) return false;
+
+  // Walk the field path into the structured output if available,
+  // falling back to the flat result string.
+  let value: unknown;
+  if (upOutput.outputs) {
+    value = walkPath(upOutput.outputs, condition.field);
+  } else {
+    // v0.15 node — only "result" is available as a field.
+    if (condition.field === 'result') {
+      value = upOutput.result;
+    } else {
+      // Try parsing result as JSON and walking the path.
+      try {
+        const parsed = JSON.parse(upOutput.result);
+        value = walkPath(parsed, condition.field);
+      } catch {
+        return false;
+      }
+    }
+  }
+
+  if (condition.exists !== undefined) {
+    return condition.exists ? value !== undefined && value !== null : value === undefined || value === null;
+  }
+  if (condition.equals !== undefined) {
+    return value == condition.equals; // loose equality for string/number coercion
+  }
+  if (condition.notEquals !== undefined) {
+    return value != condition.notEquals;
+  }
+  // No predicate specified — just check the field exists.
+  return value !== undefined && value !== null;
+}
+
+/** Walk a dot-separated path into a nested object. */
+function walkPath(obj: unknown, path: string): unknown {
+  let current: unknown = obj;
+  for (const segment of path.split('.')) {
+    if (current === null || current === undefined) return undefined;
+    if (typeof current === 'object') {
+      current = (current as Record<string, unknown>)[segment];
+    } else {
+      return undefined;
+    }
+  }
+  return current;
+}
 
 const MINIMAL_ALLOWLIST = ['PATH', 'HOME', 'LANG', 'TERM', 'TMPDIR'];
 const LOCAL_ALLOWLIST = [...MINIMAL_ALLOWLIST, 'USER', 'SHELL', 'NODE_ENV', 'TZ'];

--- a/packages/core/src/run-store.ts
+++ b/packages/core/src/run-store.ts
@@ -162,6 +162,14 @@ export class RunStore {
         ON node_executions(errorCategory) WHERE errorCategory IS NOT NULL;
     `);
 
+    // Flow control: nested runs link back to parent via parent_run_id + parent_node_id.
+    if (!runCols.has('parent_run_id')) {
+      this.db.exec(`ALTER TABLE runs ADD COLUMN parent_run_id TEXT`);
+    }
+    if (!runCols.has('parent_node_id')) {
+      this.db.exec(`ALTER TABLE runs ADD COLUMN parent_node_id TEXT`);
+    }
+
     // v0.16: structured tool outputs stored alongside the flat result.
     const execCols = columnNames(this.db, 'node_executions');
     if (!execCols.has('outputsjson')) {
@@ -182,11 +190,12 @@ export class RunStore {
     return Number(result.changes ?? 0);
   }
 
-  createRun(run: Run & { workflowId?: string; workflowVersion?: number; replayedFromRunId?: string; replayedFromNodeId?: string }): void {
+  createRun(run: Run & { workflowId?: string; workflowVersion?: number; replayedFromRunId?: string; replayedFromNodeId?: string; parentRunId?: string; parentNodeId?: string }): void {
     const stmt = this.db.prepare(`
       INSERT INTO runs (id, agentName, status, startedAt, completedAt, result, exitCode, error, triggeredBy,
-                        workflow_id, workflow_version, replayed_from_run_id, replayed_from_node_id)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        workflow_id, workflow_version, replayed_from_run_id, replayed_from_node_id,
+                        parent_run_id, parent_node_id)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     stmt.run(
       run.id, run.agentName, run.status, run.startedAt,
@@ -194,6 +203,7 @@ export class RunStore {
       run.error ?? null, run.triggeredBy,
       run.workflowId ?? null, run.workflowVersion ?? null,
       run.replayedFromRunId ?? null, run.replayedFromNodeId ?? null,
+      run.parentRunId ?? null, run.parentNodeId ?? null,
     );
   }
 
@@ -426,6 +436,8 @@ export class RunStore {
       workflowVersion: (row.workflow_version as number | null) ?? undefined,
       replayedFromRunId: (row.replayed_from_run_id as string | null) ?? undefined,
       replayedFromNodeId: (row.replayed_from_node_id as string | null) ?? undefined,
+      parentRunId: (row.parent_run_id as string | null) ?? undefined,
+      parentNodeId: (row.parent_node_id as string | null) ?? undefined,
     };
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -89,6 +89,14 @@ export interface Run {
    */
   replayedFromRunId?: string;
   replayedFromNodeId?: string;
+  /**
+   * Flow control: when this run is a nested sub-flow (invoked by an
+   * `agent-invoke` or `loop` node in another agent), these point at the
+   * parent run + the node that triggered the invocation. Used by the
+   * dashboard to render "Sub-flow of run-abc / node delegate".
+   */
+  parentRunId?: string;
+  parentNodeId?: string;
 }
 
 export interface RunRequest {

--- a/packages/dashboard/src/views/agent-edit-node.ts
+++ b/packages/dashboard/src/views/agent-edit-node.ts
@@ -5,7 +5,7 @@ import { pageHeader } from './page-header.js';
 import { computePaletteSuggestions, renderPalettePayload } from './template-palette.js';
 
 export interface EditNodeFormValues {
-  type?: 'shell' | 'claude-code';
+  type?: string;
   command?: string;
   prompt?: string;
   dependsOn?: string[];

--- a/packages/dashboard/src/views/tool-picker.ts
+++ b/packages/dashboard/src/views/tool-picker.ts
@@ -24,7 +24,7 @@ export function renderToolPicker(args: {
   tools: ToolDefinition[];
   selectedTool?: string;
   /** For edit-node: the current node's type, used to pre-select the right tool. */
-  currentType?: 'shell' | 'claude-code';
+  currentType?: string;
 }): SafeHtml {
   const { tools, selectedTool, currentType } = args;
 


### PR DESCRIPTION
## Summary

Foundation for control-flow primitives in agent flows. Ships `onlyIf` conditional edges end-to-end; the remaining node types (conditional, switch, loop, agent-invoke, branch, end, break) are typed + schema-validated but dispatch logic comes in PRs B–E.

- **7 new node types** in `NodeType` union (conditional, switch, loop, agent-invoke, branch, end, break)
- **`onlyIf` conditional edges** — predicate evaluation against upstream structured output before spawn. Skips with `condition_not_met` (no fail-fast cascade). Supports `equals`, `notEquals`, `exists`.
- **If/else branching** works now: two downstream nodes with complementary `onlyIf` predicates.
- **`parent_run_id` + `parent_node_id`** on runs table for nested runs (PR C).
- **Config interfaces** for all control-flow types on AgentNode.

## Test plan

- [x] 527/527 tests (521 → 527; +6 onlyIf tests). Zero regressions.
- [x] Lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)