### PR TITLE
feat(core): conditional + switch node dispatch (Flow PR B)

### DIFF
--- a/.changeset/flow-control-pr-b.md
+++ b/.changeset/flow-control-pr-b.md
@@ -1,0 +1,11 @@
+---
+"@some-useful-agents/core": minor
+---
+
+**feat: conditional + switch node dispatch in executor (Flow PR B).**
+
+First-class `conditional` and `switch` nodes now execute in the DAG. Both run in-process (no child process, no env resolution) and produce structured outputs that downstream nodes consume via `onlyIf` predicates.
+
+- **`conditional`**: evaluates a predicate (`equals`, `notEquals`, `exists`) against the first upstream's output field. Outputs `{ matched: boolean, value: unknown }`. Downstream nodes gate on `onlyIf: { upstream: check, field: matched, equals: true }`.
+- **`switch`**: matches an upstream field against named cases. Outputs `{ case: string, value: unknown }`. Unmatched values default to `"default"`. Downstream nodes gate on `onlyIf: { upstream: route, field: case, equals: "pro" }`.
+- Both compose with the `onlyIf` conditional edges from PR A for full if/else and multi-branch routing patterns.

--- a/packages/core/src/dag-executor.test.ts
+++ b/packages/core/src/dag-executor.test.ts
@@ -727,6 +727,147 @@ describe('executeAgentDag — onlyIf conditional edges', () => {
     expect(execs.find((e) => e.nodeId === 'if-present')!.errorCategory).toBe('condition_not_met');
   });
 
+  it('conditional node evaluates predicate and outputs matched boolean', async () => {
+    const agent = makeAgent({
+      nodes: [
+        { id: 'fetch', type: 'shell', command: 'echo hi' },
+        {
+          id: 'check',
+          type: 'conditional' as any,
+          dependsOn: ['fetch'],
+          conditionalConfig: {
+            predicate: { field: 'status', equals: 200 },
+          },
+        },
+        {
+          id: 'process',
+          type: 'shell',
+          command: 'echo ok',
+          dependsOn: ['check'],
+          onlyIf: { upstream: 'check', field: 'matched', equals: true },
+        },
+      ],
+    });
+    const spawner = cannedSpawner({
+      fetch: { exitCode: 0, result: '{"status": 200}' },
+      process: { exitCode: 0, result: 'processed' },
+    });
+    const deps: DagExecutorDeps = { runStore, spawnNode: spawner };
+    const run = await executeAgentDag(agent, { triggeredBy: 'cli' }, deps);
+
+    expect(run.status).toBe('completed');
+    const execs = runStore.listNodeExecutions(run.id);
+    const checkExec = execs.find((e) => e.nodeId === 'check');
+    expect(checkExec!.status).toBe('completed');
+    const checkOutput = JSON.parse(checkExec!.result!);
+    expect(checkOutput.matched).toBe(true);
+
+    const processExec = execs.find((e) => e.nodeId === 'process');
+    expect(processExec!.status).toBe('completed');
+  });
+
+  it('conditional node: unmatched predicate → downstream onlyIf skips', async () => {
+    const agent = makeAgent({
+      nodes: [
+        { id: 'fetch', type: 'shell', command: 'echo hi' },
+        {
+          id: 'check',
+          type: 'conditional' as any,
+          dependsOn: ['fetch'],
+          conditionalConfig: {
+            predicate: { field: 'status', equals: 200 },
+          },
+        },
+        {
+          id: 'process',
+          type: 'shell',
+          command: 'echo ok',
+          dependsOn: ['check'],
+          onlyIf: { upstream: 'check', field: 'matched', equals: true },
+        },
+      ],
+    });
+    const spawner = cannedSpawner({
+      fetch: { exitCode: 0, result: '{"status": 500}' },
+    });
+    const deps: DagExecutorDeps = { runStore, spawnNode: spawner };
+    const run = await executeAgentDag(agent, { triggeredBy: 'cli' }, deps);
+
+    expect(run.status).toBe('completed');
+    const execs = runStore.listNodeExecutions(run.id);
+    const checkOutput = JSON.parse(execs.find((e) => e.nodeId === 'check')!.result!);
+    expect(checkOutput.matched).toBe(false);
+    expect(execs.find((e) => e.nodeId === 'process')!.errorCategory).toBe('condition_not_met');
+  });
+
+  it('switch node routes to the matching case', async () => {
+    const agent = makeAgent({
+      nodes: [
+        { id: 'fetch', type: 'shell', command: 'echo hi' },
+        {
+          id: 'route',
+          type: 'switch' as any,
+          dependsOn: ['fetch'],
+          switchConfig: {
+            field: 'tier',
+            cases: { free: 'free', pro: 'pro', enterprise: 'enterprise' },
+          },
+        },
+        {
+          id: 'handle-free',
+          type: 'shell',
+          command: 'echo free',
+          dependsOn: ['route'],
+          onlyIf: { upstream: 'route', field: 'case', equals: 'free' },
+        },
+        {
+          id: 'handle-pro',
+          type: 'shell',
+          command: 'echo pro',
+          dependsOn: ['route'],
+          onlyIf: { upstream: 'route', field: 'case', equals: 'pro' },
+        },
+      ],
+    });
+    const spawner = cannedSpawner({
+      fetch: { exitCode: 0, result: '{"tier": "pro"}' },
+      'handle-pro': { exitCode: 0, result: 'handled pro' },
+    });
+    const deps: DagExecutorDeps = { runStore, spawnNode: spawner };
+    const run = await executeAgentDag(agent, { triggeredBy: 'cli' }, deps);
+
+    expect(run.status).toBe('completed');
+    const execs = runStore.listNodeExecutions(run.id);
+    expect(execs.find((e) => e.nodeId === 'handle-free')!.errorCategory).toBe('condition_not_met');
+    expect(execs.find((e) => e.nodeId === 'handle-pro')!.status).toBe('completed');
+    const routeOutput = JSON.parse(execs.find((e) => e.nodeId === 'route')!.result!);
+    expect(routeOutput.case).toBe('pro');
+  });
+
+  it('switch node defaults to "default" when no case matches', async () => {
+    const agent = makeAgent({
+      nodes: [
+        { id: 'fetch', type: 'shell', command: 'echo hi' },
+        {
+          id: 'route',
+          type: 'switch' as any,
+          dependsOn: ['fetch'],
+          switchConfig: { field: 'tier', cases: { free: 'free', pro: 'pro' } },
+        },
+      ],
+    });
+    const spawner = cannedSpawner({
+      fetch: { exitCode: 0, result: '{"tier": "unknown"}' },
+    });
+    const deps: DagExecutorDeps = { runStore, spawnNode: spawner };
+    const run = await executeAgentDag(agent, { triggeredBy: 'cli' }, deps);
+
+    const routeOutput = JSON.parse(
+      runStore.listNodeExecutions(run.id).find((e) => e.nodeId === 'route')!.result!,
+    );
+    expect(routeOutput.case).toBe('default');
+  });
+
   it('if/else branching: one branch runs, the other skips', async () => {
     const agent = makeAgent({
       nodes: [

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -268,6 +268,47 @@ export async function executeAgentDag(
       continue;
     }
 
+    // Control-flow node dispatch. These run in-process (no spawn, no env
+    // resolution needed) and produce structured outputs that downstream
+    // nodes consume via onlyIf predicates or template refs.
+    if (node.type === 'conditional' || node.type === 'switch') {
+      const cfResult = executeControlFlowNode(node, outputs);
+      const completedAt = new Date().toISOString();
+      const outputsJson = JSON.stringify(cfResult.output);
+      if (cfResult.ok) {
+        outputs.set(node.id, {
+          result: JSON.stringify(cfResult.output),
+          exitCode: 0,
+          source: agent.source,
+          outputs: cfResult.output,
+        });
+        deps.runStore.createNodeExecution({
+          runId,
+          nodeId: node.id,
+          workflowVersion: agent.version,
+          status: 'completed',
+          startedAt: nodeStartedAt,
+          completedAt,
+          result: JSON.stringify(cfResult.output),
+          exitCode: 0,
+          outputsJson,
+        });
+      } else {
+        deps.runStore.createNodeExecution({
+          runId,
+          nodeId: node.id,
+          workflowVersion: agent.version,
+          status: 'failed',
+          errorCategory: 'setup',
+          startedAt: nodeStartedAt,
+          completedAt,
+          error: cfResult.error,
+        });
+        firstFailure = { nodeId: node.id, category: 'setup' };
+      }
+      continue;
+    }
+
     // Resolve inputs + upstream snapshot before spawning. Input-resolution
     // failures (e.g. secrets store locked, missing required input) count
     // as 'setup' category, not 'exit_nonzero'.
@@ -772,6 +813,122 @@ async function spawnProcess(
 // -- Env allowlists (duplicate of env-builder constants; keeping here lets
 //    the DAG executor build env without the v1 AgentDefinition intermediary.
 //    Extract to a shared module in a follow-up if this duplicates further.) --
+
+// -- Control-flow node dispatch --
+
+interface ControlFlowResult {
+  ok: boolean;
+  output: Record<string, unknown>;
+  error?: string;
+}
+
+/**
+ * Execute a `conditional` or `switch` node. Pure in-process evaluation —
+ * no child process, no env, no secrets. Reads the upstream structured
+ * output and produces a result downstream nodes consume.
+ */
+function executeControlFlowNode(
+  node: AgentNode,
+  outputs: Map<string, NodeOutput>,
+): ControlFlowResult {
+  if (node.type === 'conditional') {
+    return executeConditionalNode(node, outputs);
+  }
+  if (node.type === 'switch') {
+    return executeSwitchNode(node, outputs);
+  }
+  return { ok: false, output: {}, error: `Unknown control-flow type: ${node.type}` };
+}
+
+function executeConditionalNode(
+  node: AgentNode,
+  outputs: Map<string, NodeOutput>,
+): ControlFlowResult {
+  const config = node.conditionalConfig;
+  if (!config) {
+    return { ok: false, output: {}, error: 'Conditional node missing conditionalConfig' };
+  }
+  // The conditional evaluates against its first upstream's output.
+  const upstreamId = (node.dependsOn ?? [])[0];
+  if (!upstreamId) {
+    return { ok: false, output: {}, error: 'Conditional node has no dependsOn' };
+  }
+  const upOutput = outputs.get(upstreamId);
+  if (!upOutput) {
+    return { ok: false, output: {}, error: `Upstream "${upstreamId}" has no output` };
+  }
+
+  // Resolve the field value from structured output or parsed JSON result.
+  let value: unknown;
+  if (upOutput.outputs) {
+    value = walkPath(upOutput.outputs, config.predicate.field);
+  } else {
+    try {
+      const parsed = JSON.parse(upOutput.result);
+      value = walkPath(parsed, config.predicate.field);
+    } catch {
+      value = config.predicate.field === 'result' ? upOutput.result : undefined;
+    }
+  }
+
+  let matched = false;
+  if (config.predicate.exists !== undefined) {
+    matched = config.predicate.exists
+      ? (value !== undefined && value !== null)
+      : (value === undefined || value === null);
+  } else if (config.predicate.equals !== undefined) {
+    matched = value == config.predicate.equals;
+  } else if (config.predicate.notEquals !== undefined) {
+    matched = value != config.predicate.notEquals;
+  } else {
+    matched = value !== undefined && value !== null;
+  }
+
+  return { ok: true, output: { matched, value } };
+}
+
+function executeSwitchNode(
+  node: AgentNode,
+  outputs: Map<string, NodeOutput>,
+): ControlFlowResult {
+  const config = node.switchConfig;
+  if (!config) {
+    return { ok: false, output: {}, error: 'Switch node missing switchConfig' };
+  }
+  const upstreamId = (node.dependsOn ?? [])[0];
+  if (!upstreamId) {
+    return { ok: false, output: {}, error: 'Switch node has no dependsOn' };
+  }
+  const upOutput = outputs.get(upstreamId);
+  if (!upOutput) {
+    return { ok: false, output: {}, error: `Upstream "${upstreamId}" has no output` };
+  }
+
+  let value: unknown;
+  if (upOutput.outputs) {
+    value = walkPath(upOutput.outputs, config.field);
+  } else {
+    try {
+      const parsed = JSON.parse(upOutput.result);
+      value = walkPath(parsed, config.field);
+    } catch {
+      value = config.field === 'result' ? upOutput.result : undefined;
+    }
+  }
+
+  // Find matching case. Cases are keyed by name; the value stored is what
+  // the field should match. If none match, case = 'default' (always present
+  // implicitly).
+  let matchedCase = 'default';
+  for (const [caseName, caseValue] of Object.entries(config.cases)) {
+    if (value == caseValue) {
+      matchedCase = caseName;
+      break;
+    }
+  }
+
+  return { ok: true, output: { case: matchedCase, value } };
+}
 
 // -- onlyIf evaluation --
 


### PR DESCRIPTION
## Summary

- **`conditional` node**: evaluates predicate against upstream output, produces `{ matched: boolean, value }`. Downstream gates via `onlyIf`.
- **`switch` node**: matches upstream field against named cases, produces `{ case: string, value }`. Unmatched → `"default"`.
- Both run in-process (no spawn, no env). Compose with PR A's `onlyIf` for full if/else and multi-branch routing.

## Test plan

- [x] 531/531 tests (527 → 531; +4 new). Lint + build clean.
- conditional matched → downstream runs; unmatched → downstream skipped
- switch routes to correct case; no match → default
- Full if/else pattern with conditional + complementary onlyIf edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)