### PR TITLE
feat(core): agent-invoke + nested runs (Flow PR C)

### DIFF
--- a/.changeset/flow-control-pr-c.md
+++ b/.changeset/flow-control-pr-c.md
@@ -1,0 +1,12 @@
+---
+"@some-useful-agents/core": minor
+---
+
+**feat: agent-invoke node type + nested runs (Flow PR C).**
+
+An `agent-invoke` node runs another agent as a nested sub-flow. The sub-agent gets its own `runs` row linked to the parent via `parent_run_id` + `parent_node_id`. The parent node waits for the sub-run to complete and captures its result as structured output.
+
+- **Recursive `executeAgentDag`** — the executor calls itself with the sub-agent's definition, threading `parentRunId`/`parentNodeId` so the audit trail is complete.
+- **`AgentStore` on `DagExecutorDeps`** — required for resolving sub-agents by id. Fails cleanly when absent or when the sub-agent isn't found.
+- **Input mapping** — `agentInvokeConfig.inputMapping` maps upstream outputs to sub-agent inputs. Supports `upstream.<id>.<field>` path expressions.
+- **Parent node result** = sub-run's final result. Sub-run failure propagates as parent node failure with `setup` category.

--- a/packages/core/src/dag-executor.test.ts
+++ b/packages/core/src/dag-executor.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { RunStore } from './run-store.js';
+import { AgentStore } from './agent-store.js';
 import { MemorySecretsStore } from './secrets-store.js';
 import {
   executeAgentDag,
@@ -901,5 +902,143 @@ describe('executeAgentDag — onlyIf conditional edges', () => {
     expect(execs.find((e) => e.nodeId === 'on-success')!.status).toBe('completed');
     expect(execs.find((e) => e.nodeId === 'on-failure')!.status).toBe('skipped');
     expect(execs.find((e) => e.nodeId === 'on-failure')!.errorCategory).toBe('condition_not_met');
+  });
+});
+
+describe('executeAgentDag — agent-invoke (Flow PR C)', () => {
+  let agentStore: AgentStore;
+
+  beforeEach(() => {
+    agentStore = new AgentStore(join(dir, 'runs.db'));
+  });
+
+  afterEach(() => {
+    try { agentStore.close(); } catch { /* may share DB handle */ }
+  });
+
+  it('invokes a sub-agent and captures its result', async () => {
+    // Create the sub-agent in the store.
+    agentStore.createAgent(
+      {
+        id: 'sub-agent',
+        name: 'Sub',
+        status: 'active',
+        source: 'local',
+        mcp: false,
+        nodes: [{ id: 'main', type: 'shell', command: 'echo sub-result' }],
+      },
+      'cli',
+      'seed',
+    );
+
+    const parentAgent = makeAgent({
+      nodes: [
+        {
+          id: 'delegate',
+          type: 'agent-invoke' as any,
+          agentInvokeConfig: { agentId: 'sub-agent' },
+        },
+      ],
+    });
+
+    // The sub-agent's shell node runs via the real spawner (not mocked),
+    // so we don't pass spawnNode — this is a true integration test.
+    const deps: DagExecutorDeps = { runStore, agentStore };
+    const run = await executeAgentDag(parentAgent, { triggeredBy: 'cli' }, deps);
+
+    expect(run.status).toBe('completed');
+
+    // Parent node should have the sub-agent's result.
+    const execs = runStore.listNodeExecutions(run.id);
+    const delegateExec = execs.find((e) => e.nodeId === 'delegate');
+    expect(delegateExec!.status).toBe('completed');
+    expect(delegateExec!.result).toContain('sub-result');
+
+    // There should be a nested run with parent_run_id set.
+    const allRuns = runStore.queryRuns({ limit: 10, offset: 0, statuses: [] });
+    const subRun = allRuns.rows.find((r) => r.parentRunId === run.id);
+    expect(subRun).toBeDefined();
+    expect(subRun!.parentNodeId).toBe('delegate');
+    expect(subRun!.agentName).toBe('sub-agent');
+    expect(subRun!.status).toBe('completed');
+  });
+
+  it('fails the parent node when sub-agent is not found', async () => {
+    const parentAgent = makeAgent({
+      nodes: [
+        {
+          id: 'delegate',
+          type: 'agent-invoke' as any,
+          agentInvokeConfig: { agentId: 'nonexistent' },
+        },
+      ],
+    });
+    const deps: DagExecutorDeps = { runStore, agentStore };
+    const run = await executeAgentDag(parentAgent, { triggeredBy: 'cli' }, deps);
+
+    expect(run.status).toBe('failed');
+    const execs = runStore.listNodeExecutions(run.id);
+    expect(execs.find((e) => e.nodeId === 'delegate')!.errorCategory).toBe('setup');
+    expect(execs.find((e) => e.nodeId === 'delegate')!.error).toContain('not found');
+  });
+
+  it('fails when agentStore is not provided', async () => {
+    const parentAgent = makeAgent({
+      nodes: [
+        {
+          id: 'delegate',
+          type: 'agent-invoke' as any,
+          agentInvokeConfig: { agentId: 'any' },
+        },
+      ],
+    });
+    const deps: DagExecutorDeps = { runStore };
+    const run = await executeAgentDag(parentAgent, { triggeredBy: 'cli' }, deps);
+
+    expect(run.status).toBe('failed');
+    const execs = runStore.listNodeExecutions(run.id);
+    expect(execs.find((e) => e.nodeId === 'delegate')!.error).toContain('agentStore');
+  });
+
+  it('chains parent → sub-agent → downstream node', async () => {
+    agentStore.createAgent(
+      {
+        id: 'fetcher',
+        name: 'Fetcher',
+        status: 'active',
+        source: 'local',
+        mcp: false,
+        nodes: [{ id: 'fetch', type: 'shell', command: 'echo fetched-data' }],
+      },
+      'cli',
+      'seed',
+    );
+
+    const parentAgent = makeAgent({
+      nodes: [
+        {
+          id: 'invoke-fetcher',
+          type: 'agent-invoke' as any,
+          agentInvokeConfig: { agentId: 'fetcher' },
+        },
+        {
+          id: 'process',
+          type: 'shell',
+          command: 'echo processed',
+          dependsOn: ['invoke-fetcher'],
+        },
+      ],
+    });
+
+    const spawner = cannedSpawner({
+      process: { exitCode: 0, result: 'processed-output' },
+    });
+    const deps: DagExecutorDeps = { runStore, agentStore, spawnNode: spawner };
+    const run = await executeAgentDag(parentAgent, { triggeredBy: 'cli' }, deps);
+
+    expect(run.status).toBe('completed');
+    const execs = runStore.listNodeExecutions(run.id);
+    expect(execs.find((e) => e.nodeId === 'invoke-fetcher')!.status).toBe('completed');
+    expect(execs.find((e) => e.nodeId === 'process')!.status).toBe('completed');
   });
 });

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -25,6 +25,7 @@ import { spawn } from 'node:child_process';
 import type { Agent, AgentNode, NodeErrorCategory, NodeOutput, NodeStructuredOutput, OnlyIfCondition } from './agent-v2-types.js';
 import type { Run, RunStatus } from './types.js';
 import type { RunStore } from './run-store.js';
+import type { AgentStore } from './agent-store.js';
 import type { SecretsStore } from './secrets-store.js';
 import type { ToolStore } from './tool-store.js';
 import type { ToolOutput, BuiltinToolContext } from './tool-types.js';
@@ -51,6 +52,11 @@ export interface DagExecutorDeps {
    * — if absent, only built-in tools are available.
    */
   toolStore?: ToolStore;
+  /**
+   * v0.16+: agent store for resolving sub-agents in `agent-invoke` nodes.
+   * Required iff any node has `type: 'agent-invoke'`.
+   */
+  agentStore?: AgentStore;
   /**
    * Agent ids the operator has pre-audited for community shell execution.
    * Propagated into each node's spawn; a shell node inside a `source:
@@ -94,6 +100,10 @@ export interface DagExecuteOptions {
    *     the pivot with a missing upstream.
    */
   replayFrom?: { priorRunId: string; fromNodeId: string };
+  /** Flow control: set when this execution is a nested sub-flow invoked
+   *  by an `agent-invoke` or `loop` node in a parent run. */
+  parentRunId?: string;
+  parentNodeId?: string;
 }
 
 /**
@@ -138,6 +148,8 @@ export async function executeAgentDag(
     workflowVersion: agent.version,
     replayedFromRunId: options.replayFrom?.priorRunId,
     replayedFromNodeId: options.replayFrom?.fromNodeId,
+    parentRunId: options.parentRunId,
+    parentNodeId: options.parentNodeId,
   });
 
   const outputs = new Map<string, NodeOutput>();
@@ -271,6 +283,44 @@ export async function executeAgentDag(
     // Control-flow node dispatch. These run in-process (no spawn, no env
     // resolution needed) and produce structured outputs that downstream
     // nodes consume via onlyIf predicates or template refs.
+    if (node.type === 'agent-invoke') {
+      const invokeResult = await executeAgentInvokeNode(node, outputs, runId, options, deps, agent);
+      const completedAt = new Date().toISOString();
+      if (invokeResult.ok) {
+        const outputsJson = invokeResult.output ? JSON.stringify(invokeResult.output) : undefined;
+        outputs.set(node.id, {
+          result: invokeResult.result ?? '',
+          exitCode: 0,
+          source: agent.source,
+          outputs: invokeResult.output,
+        });
+        deps.runStore.createNodeExecution({
+          runId,
+          nodeId: node.id,
+          workflowVersion: agent.version,
+          status: 'completed',
+          startedAt: nodeStartedAt,
+          completedAt,
+          result: invokeResult.result,
+          exitCode: 0,
+          outputsJson,
+        });
+      } else {
+        deps.runStore.createNodeExecution({
+          runId,
+          nodeId: node.id,
+          workflowVersion: agent.version,
+          status: 'failed',
+          errorCategory: 'setup',
+          startedAt: nodeStartedAt,
+          completedAt,
+          error: invokeResult.error,
+        });
+        firstFailure = { nodeId: node.id, category: 'setup' };
+      }
+      continue;
+    }
+
     if (node.type === 'conditional' || node.type === 'switch') {
       const cfResult = executeControlFlowNode(node, outputs);
       const completedAt = new Date().toISOString();
@@ -928,6 +978,97 @@ function executeSwitchNode(
   }
 
   return { ok: true, output: { case: matchedCase, value } };
+}
+
+// -- agent-invoke dispatch --
+
+interface AgentInvokeResult {
+  ok: boolean;
+  result?: string;
+  output?: Record<string, unknown>;
+  error?: string;
+}
+
+/**
+ * Execute an `agent-invoke` node. Resolves the sub-agent from the
+ * AgentStore, maps inputs from upstream outputs, then recursively calls
+ * `executeAgentDag`. The sub-agent gets its own `runs` row linked to
+ * the parent via `parentRunId` + `parentNodeId`.
+ */
+async function executeAgentInvokeNode(
+  node: AgentNode,
+  outputs: Map<string, NodeOutput>,
+  parentRunId: string,
+  parentOptions: DagExecuteOptions,
+  deps: DagExecutorDeps,
+  parentAgent: Agent,
+): Promise<AgentInvokeResult> {
+  const config = node.agentInvokeConfig;
+  if (!config) {
+    return { ok: false, error: 'agent-invoke node missing agentInvokeConfig' };
+  }
+  if (!deps.agentStore) {
+    return { ok: false, error: 'agent-invoke requires agentStore on DagExecutorDeps' };
+  }
+
+  const subAgent = deps.agentStore.getAgent(config.agentId);
+  if (!subAgent) {
+    return { ok: false, error: `Sub-agent "${config.agentId}" not found in store` };
+  }
+
+  // Map inputs from upstream outputs or the parent's caller inputs.
+  const subInputs: Record<string, string> = {};
+  if (config.inputMapping) {
+    for (const [subKey, sourceExpr] of Object.entries(config.inputMapping)) {
+      // sourceExpr can be a literal or an upstream path like "upstream.fetch.result".
+      if (sourceExpr.startsWith('upstream.')) {
+        const parts = sourceExpr.split('.');
+        const upId = parts[1];
+        const field = parts.slice(2).join('.');
+        const upOutput = outputs.get(upId);
+        if (upOutput?.outputs) {
+          const val = walkPath(upOutput.outputs, field);
+          subInputs[subKey] = val !== undefined ? String(val) : '';
+        } else if (upOutput) {
+          subInputs[subKey] = upOutput.result;
+        }
+      } else {
+        // Literal value or parent input ref.
+        subInputs[subKey] = sourceExpr;
+      }
+    }
+  }
+
+  // Recursive execution with nested-run linking.
+  const subRun = await executeAgentDag(
+    subAgent,
+    {
+      triggeredBy: parentOptions.triggeredBy,
+      inputs: subInputs,
+      parentRunId,
+      parentNodeId: node.id,
+    },
+    deps,
+  );
+
+  if (subRun.status === 'completed') {
+    // Parse the sub-run's result as structured output if possible.
+    let output: Record<string, unknown> = { result: subRun.result ?? '' };
+    if (subRun.result) {
+      try {
+        const parsed = JSON.parse(subRun.result);
+        if (typeof parsed === 'object' && parsed !== null) {
+          output = { ...parsed, result: subRun.result };
+        }
+      } catch { /* plain string result */ }
+    }
+    return { ok: true, result: subRun.result ?? '', output };
+  }
+
+  return {
+    ok: false,
+    error: `Sub-agent "${config.agentId}" failed: ${subRun.error ?? subRun.status}`,
+  };
 }
 
 // -- onlyIf evaluation --


### PR DESCRIPTION
## Summary

- **`agent-invoke` node type**: runs another agent as a nested sub-flow via recursive `executeAgentDag`.
- **Nested runs**: sub-agent gets its own `runs` row with `parent_run_id` + `parent_node_id` linking to the parent.
- **`AgentStore` on `DagExecutorDeps`**: resolves sub-agents by id. Clean error when missing.
- **Input mapping**: `agentInvokeConfig.inputMapping` maps upstream outputs to sub-agent inputs via `upstream.<id>.<field>` path expressions.
- **Parent node result** = sub-run's final result. Sub-run failure propagates as parent failure.

## Test plan

- [x] 535/535 tests (531 → 535; +4 new). Lint + build clean.
- agent-invoke executes sub-agent + captures result + creates nested run with parent linkage
- Missing sub-agent → clean error on parent node
- Missing agentStore → clean error
- Parent → sub-agent → downstream node chain works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)