### PR TITLE
feat(core): loop node type — iterate + sub-agent per item (Flow PR D)

### DIFF
--- a/.changeset/flow-control-pr-d.md
+++ b/.changeset/flow-control-pr-d.md
@@ -1,0 +1,11 @@
+---
+"@some-useful-agents/core": minor
+---
+
+**feat: loop node type — iterate + invoke sub-agent per item (Flow PR D).**
+
+A `loop` node iterates over an array from upstream structured output, invoking a sub-agent per item. Each iteration is a nested run linked to the parent. Results are collected into `{ items: result[], count: number }`.
+
+- **Best-effort**: failed iterations record `null` in the items array; the loop itself only fails on invalid config or missing sub-agent.
+- **`maxIterations`**: caps the iteration count to prevent runaway loops.
+- **`ITEM` + `ITEM_INDEX` inputs**: each sub-agent invocation receives the current item as `$ITEM` and its zero-based index as `$ITEM_INDEX`.

--- a/packages/core/src/dag-executor.test.ts
+++ b/packages/core/src/dag-executor.test.ts
@@ -1042,3 +1042,138 @@ describe('executeAgentDag — agent-invoke (Flow PR C)', () => {
     expect(execs.find((e) => e.nodeId === 'process')!.status).toBe('completed');
   });
 });
+
+describe('executeAgentDag — loop (Flow PR D)', () => {
+  let agentStore: AgentStore;
+
+  beforeEach(() => {
+    agentStore = new AgentStore(join(dir, 'runs.db'));
+  });
+
+  afterEach(() => {
+    try { agentStore.close(); } catch {}
+  });
+
+  it('iterates over an array and invokes sub-agent per item', async () => {
+    agentStore.createAgent(
+      {
+        id: 'item-handler',
+        name: 'Item Handler',
+        status: 'active',
+        source: 'local',
+        mcp: false,
+        nodes: [{ id: 'handle', type: 'shell', command: 'echo "handled-$ITEM"' }],
+      },
+      'cli',
+      'seed',
+    );
+
+    const parentAgent = makeAgent({
+      nodes: [
+        { id: 'source', type: 'shell', command: 'echo source' },
+        {
+          id: 'each',
+          type: 'loop' as any,
+          dependsOn: ['source'],
+          loopConfig: { over: 'items', agentId: 'item-handler' },
+        },
+      ],
+    });
+
+    const spawner = cannedSpawner({
+      source: { exitCode: 0, result: '{"items": ["a", "b", "c"]}' },
+    });
+    // Don't mock the sub-agent spawns — let them run real shell.
+    const deps: DagExecutorDeps = { runStore, agentStore, spawnNode: spawner };
+    const run = await executeAgentDag(parentAgent, { triggeredBy: 'cli' }, deps);
+
+    expect(run.status).toBe('completed');
+    const execs = runStore.listNodeExecutions(run.id);
+    const loopExec = execs.find((e) => e.nodeId === 'each');
+    expect(loopExec!.status).toBe('completed');
+
+    const loopOutput = JSON.parse(loopExec!.result!);
+    expect(loopOutput.count).toBe(3);
+    expect(loopOutput.items).toHaveLength(3);
+
+    // Verify nested runs were created.
+    const allRuns = runStore.queryRuns({ limit: 20, offset: 0, statuses: [] });
+    const subRuns = allRuns.rows.filter((r) => r.parentRunId === run.id);
+    expect(subRuns).toHaveLength(3);
+  });
+
+  it('fails cleanly when loop field is not an array', async () => {
+    agentStore.createAgent(
+      {
+        id: 'dummy',
+        name: 'Dummy',
+        status: 'active',
+        source: 'local',
+        mcp: false,
+        nodes: [{ id: 'main', type: 'shell', command: 'echo ok' }],
+      },
+      'cli',
+      'seed',
+    );
+
+    const parentAgent = makeAgent({
+      nodes: [
+        { id: 'source', type: 'shell', command: 'echo source' },
+        {
+          id: 'each',
+          type: 'loop' as any,
+          dependsOn: ['source'],
+          loopConfig: { over: 'notAnArray', agentId: 'dummy' },
+        },
+      ],
+    });
+    const spawner = cannedSpawner({
+      source: { exitCode: 0, result: '{"notAnArray": "string"}' },
+    });
+    const deps: DagExecutorDeps = { runStore, agentStore, spawnNode: spawner };
+    const run = await executeAgentDag(parentAgent, { triggeredBy: 'cli' }, deps);
+
+    expect(run.status).toBe('failed');
+    const execs = runStore.listNodeExecutions(run.id);
+    expect(execs.find((e) => e.nodeId === 'each')!.error).toContain('not an array');
+  });
+
+  it('respects maxIterations', async () => {
+    agentStore.createAgent(
+      {
+        id: 'counter',
+        name: 'Counter',
+        status: 'active',
+        source: 'local',
+        mcp: false,
+        nodes: [{ id: 'count', type: 'shell', command: 'echo counted' }],
+      },
+      'cli',
+      'seed',
+    );
+
+    const parentAgent = makeAgent({
+      nodes: [
+        { id: 'source', type: 'shell', command: 'echo source' },
+        {
+          id: 'each',
+          type: 'loop' as any,
+          dependsOn: ['source'],
+          loopConfig: { over: 'items', agentId: 'counter', maxIterations: 2 },
+        },
+      ],
+    });
+    const spawner = cannedSpawner({
+      source: { exitCode: 0, result: '{"items": [1, 2, 3, 4, 5]}' },
+    });
+    const deps: DagExecutorDeps = { runStore, agentStore, spawnNode: spawner };
+    const run = await executeAgentDag(parentAgent, { triggeredBy: 'cli' }, deps);
+
+    expect(run.status).toBe('completed');
+    const loopOutput = JSON.parse(
+      runStore.listNodeExecutions(run.id).find((e) => e.nodeId === 'each')!.result!,
+    );
+    // Only 2 iterations despite 5 items.
+    expect(loopOutput.count).toBe(2);
+  });
+});

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -283,6 +283,44 @@ export async function executeAgentDag(
     // Control-flow node dispatch. These run in-process (no spawn, no env
     // resolution needed) and produce structured outputs that downstream
     // nodes consume via onlyIf predicates or template refs.
+    if (node.type === 'loop') {
+      const loopResult = await executeLoopNode(node, outputs, runId, options, deps, agent);
+      const completedAt = new Date().toISOString();
+      if (loopResult.ok) {
+        const outputsJson = JSON.stringify(loopResult.output);
+        outputs.set(node.id, {
+          result: JSON.stringify(loopResult.output),
+          exitCode: 0,
+          source: agent.source,
+          outputs: loopResult.output,
+        });
+        deps.runStore.createNodeExecution({
+          runId,
+          nodeId: node.id,
+          workflowVersion: agent.version,
+          status: 'completed',
+          startedAt: nodeStartedAt,
+          completedAt,
+          result: JSON.stringify(loopResult.output),
+          exitCode: 0,
+          outputsJson,
+        });
+      } else {
+        deps.runStore.createNodeExecution({
+          runId,
+          nodeId: node.id,
+          workflowVersion: agent.version,
+          status: 'failed',
+          errorCategory: 'setup',
+          startedAt: nodeStartedAt,
+          completedAt,
+          error: loopResult.error,
+        });
+        firstFailure = { nodeId: node.id, category: 'setup' };
+      }
+      continue;
+    }
+
     if (node.type === 'agent-invoke') {
       const invokeResult = await executeAgentInvokeNode(node, outputs, runId, options, deps, agent);
       const completedAt = new Date().toISOString();
@@ -1068,6 +1106,107 @@ async function executeAgentInvokeNode(
   return {
     ok: false,
     error: `Sub-agent "${config.agentId}" failed: ${subRun.error ?? subRun.status}`,
+  };
+}
+
+// -- loop dispatch --
+
+/**
+ * Execute a `loop` node. Iterates over an array extracted from upstream
+ * structured output, invoking a sub-agent per item. Each iteration is
+ * a nested run linked to the parent. Results are collected into an
+ * `{ items: result[], count: number }` output.
+ *
+ * If any iteration fails, the loop continues (best-effort) and the
+ * failed item is recorded as `null` in the items array. The loop node
+ * itself only fails if the config is invalid or the sub-agent can't
+ * be found.
+ */
+async function executeLoopNode(
+  node: AgentNode,
+  outputs: Map<string, NodeOutput>,
+  parentRunId: string,
+  parentOptions: DagExecuteOptions,
+  deps: DagExecutorDeps,
+  parentAgent: Agent,
+): Promise<AgentInvokeResult> {
+  const config = node.loopConfig;
+  if (!config) {
+    return { ok: false, error: 'Loop node missing loopConfig' };
+  }
+  if (!deps.agentStore) {
+    return { ok: false, error: 'Loop node requires agentStore on DagExecutorDeps' };
+  }
+
+  const subAgent = deps.agentStore.getAgent(config.agentId);
+  if (!subAgent) {
+    return { ok: false, error: `Loop sub-agent "${config.agentId}" not found in store` };
+  }
+
+  // Extract the array to iterate over from the first upstream's output.
+  const upstreamId = (node.dependsOn ?? [])[0];
+  if (!upstreamId) {
+    return { ok: false, error: 'Loop node has no dependsOn' };
+  }
+  const upOutput = outputs.get(upstreamId);
+  if (!upOutput) {
+    return { ok: false, error: `Upstream "${upstreamId}" has no output` };
+  }
+
+  let items: unknown[];
+  if (upOutput.outputs) {
+    const arr = walkPath(upOutput.outputs, config.over);
+    if (!Array.isArray(arr)) {
+      return { ok: false, error: `Loop field "${config.over}" on upstream "${upstreamId}" is not an array` };
+    }
+    items = arr;
+  } else {
+    try {
+      const parsed = JSON.parse(upOutput.result);
+      const arr = walkPath(parsed, config.over);
+      if (!Array.isArray(arr)) {
+        return { ok: false, error: `Loop field "${config.over}" on upstream "${upstreamId}" is not an array` };
+      }
+      items = arr;
+    } catch {
+      return { ok: false, error: `Cannot parse upstream "${upstreamId}" result as JSON for loop` };
+    }
+  }
+
+  const maxIter = config.maxIterations ?? 1000;
+  const limited = items.slice(0, maxIter);
+  const results: (string | null)[] = [];
+
+  for (let i = 0; i < limited.length; i++) {
+    const item = limited[i];
+    // Each iteration passes the current item as the ITEM input to the sub-agent.
+    const subInputs: Record<string, string> = {
+      ITEM: typeof item === 'string' ? item : JSON.stringify(item),
+      ITEM_INDEX: String(i),
+    };
+
+    const subRun = await executeAgentDag(
+      subAgent,
+      {
+        triggeredBy: parentOptions.triggeredBy,
+        inputs: subInputs,
+        parentRunId,
+        parentNodeId: node.id,
+      },
+      deps,
+    );
+
+    if (subRun.status === 'completed') {
+      results.push(subRun.result ?? null);
+    } else {
+      results.push(null);
+    }
+  }
+
+  return {
+    ok: true,
+    result: JSON.stringify({ items: results, count: results.length }),
+    output: { items: results, count: results.length },
   };
 }
 


### PR DESCRIPTION
## Summary

- **`loop` node type**: iterates over an array from upstream structured output, invoking a sub-agent per item as a nested run.
- **Collected output**: `{ items: result[], count: number }`. Failed iterations = `null` in the array (best-effort, no early abort).
- **`maxIterations`**: configurable cap (default 1000).
- **`ITEM` + `ITEM_INDEX`**: passed as inputs to each sub-agent invocation.

## Test plan

- [x] 538/538 tests (535 → 538; +3 new). Lint + build clean.
- Loop over 3 items → 3 nested runs + collected results
- Non-array field → clean error
- maxIterations: 2 caps a 5-item array to 2 iterations

🤖 Generated with [Claude Code](https://claude.com/claude-code)