### PR TITLE
feat: branch (merge) node + dashboard viz shapes (Flow PR F — closes flow control)

### DIFF
--- a/.changeset/flow-control-pr-f.md
+++ b/.changeset/flow-control-pr-f.md
@@ -1,0 +1,23 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/dashboard": patch
+---
+
+**feat: branch (merge) node + dashboard viz shapes (Flow PR F — closes flow control).**
+
+Final flow-control PR. Adds the `branch` merge-point node and distinct Cytoscape shapes for all control-flow node types.
+
+- **`branch` node**: explicit fan-in merge point. Collects all upstream outputs into `{ merged: Record<string, unknown>, count: number }`. Condition-skipped upstreams are excluded gracefully (the branch always runs, even if some paths were skipped). Bypasses the condition_not_met cascade that would otherwise skip downstream nodes with a skipped dependency.
+- **Dashboard viz shapes**: conditional/switch = diamond, loop = round-octagon, agent-invoke = barrel, branch = round-pentagon, end/break = octagon. Each control-flow type also has a distinct color tint so the DAG at a glance shows where routing happens vs where execution happens.
+
+### Flow control is complete
+
+With PRs A–F, agent flows now support:
+- `conditional` — if/else predicate evaluation
+- `switch` — multi-case routing
+- `loop` — iterate over arrays with sub-agent invocation
+- `agent-invoke` — nested sub-flows with parent-child run linking
+- `branch` — explicit fan-in merge
+- `end` — clean early termination
+- `break` — exit current loop iteration
+- `onlyIf` — edge-level conditional execution on any node

--- a/packages/core/src/dag-executor.test.ts
+++ b/packages/core/src/dag-executor.test.ts
@@ -1178,6 +1178,85 @@ describe('executeAgentDag — loop (Flow PR D)', () => {
   });
 });
 
+describe('executeAgentDag — branch merge (Flow PR F)', () => {
+  it('branch node merges all upstream outputs', async () => {
+    const agent = makeAgent({
+      nodes: [
+        { id: 'a', type: 'shell', command: 'echo a' },
+        { id: 'b', type: 'shell', command: 'echo b' },
+        {
+          id: 'merge',
+          type: 'branch' as any,
+          dependsOn: ['a', 'b'],
+        },
+      ],
+    });
+    const spawner = cannedSpawner({
+      a: { exitCode: 0, result: '{"val":"from-a"}' },
+      b: { exitCode: 0, result: '{"val":"from-b"}' },
+    });
+    const deps: DagExecutorDeps = { runStore, spawnNode: spawner };
+    const run = await executeAgentDag(agent, { triggeredBy: 'cli' }, deps);
+
+    expect(run.status).toBe('completed');
+    const execs = runStore.listNodeExecutions(run.id);
+    const mergeExec = execs.find((e) => e.nodeId === 'merge');
+    expect(mergeExec!.status).toBe('completed');
+    const mergeOutput = JSON.parse(mergeExec!.result!);
+    expect(mergeOutput.count).toBe(2);
+    expect(mergeOutput.merged.a).toBeDefined();
+    expect(mergeOutput.merged.b).toBeDefined();
+  });
+
+  it('branch node excludes condition-skipped upstreams from merge', async () => {
+    const agent = makeAgent({
+      nodes: [
+        { id: 'gate', type: 'shell', command: 'echo gate' },
+        {
+          id: 'cond',
+          type: 'conditional' as any,
+          dependsOn: ['gate'],
+          conditionalConfig: { predicate: { field: 'go', equals: true } },
+        },
+        {
+          id: 'path-a',
+          type: 'shell',
+          command: 'echo a',
+          dependsOn: ['cond'],
+          onlyIf: { upstream: 'cond', field: 'matched', equals: true },
+        },
+        {
+          id: 'path-b',
+          type: 'shell',
+          command: 'echo b',
+          dependsOn: ['cond'],
+          onlyIf: { upstream: 'cond', field: 'matched', notEquals: true },
+        },
+        {
+          id: 'merge',
+          type: 'branch' as any,
+          dependsOn: ['path-a', 'path-b'],
+        },
+      ],
+    });
+    const spawner = cannedSpawner({
+      gate: { exitCode: 0, result: '{"go": true}' },
+      'path-a': { exitCode: 0, result: 'took-a' },
+    });
+    const deps: DagExecutorDeps = { runStore, spawnNode: spawner };
+    const run = await executeAgentDag(agent, { triggeredBy: 'cli' }, deps);
+
+    expect(run.status).toBe('completed');
+    const mergeOutput = JSON.parse(
+      runStore.listNodeExecutions(run.id).find((e) => e.nodeId === 'merge')!.result!,
+    );
+    // Only path-a is in the merge; path-b was condition-skipped.
+    expect(mergeOutput.count).toBe(1);
+    expect(mergeOutput.merged['path-a']).toBeDefined();
+    expect(mergeOutput.merged['path-b']).toBeUndefined();
+  });
+});
+
 describe('executeAgentDag — end + break (Flow PR E)', () => {
   it('end node terminates the flow and skips remaining nodes', async () => {
     const agent = makeAgent({

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -262,7 +262,9 @@ export async function executeAgentDag(
     // Check if any required upstream was condition-skipped. If a node
     // depends on a condition-skipped node and doesn't have its own onlyIf
     // (which would let it evaluate independently), it cascades.
-    if (!node.onlyIf) {
+    // Exception: branch (merge) nodes handle missing upstreams gracefully
+    // by excluding them from the merged result — they should always run.
+    if (!node.onlyIf && node.type !== 'branch') {
       const skippedDep = (node.dependsOn ?? []).find((d) => skippedNodes.has(d));
       if (skippedDep) {
         deps.runStore.createNodeExecution({
@@ -300,6 +302,43 @@ export async function executeAgentDag(
     // Control-flow node dispatch. These run in-process (no spawn, no env
     // resolution needed) and produce structured outputs that downstream
     // nodes consume via onlyIf predicates or template refs.
+    if (node.type === 'branch') {
+      // Branch (merge) node: collects all upstream outputs into a merged
+      // result. Acts as an explicit fan-in point — waits for all dependsOn
+      // to complete (the topo sort already guarantees this), then produces
+      // a { merged: Record<string, unknown> } where each key is an upstream
+      // node id and the value is its structured output or result string.
+      const merged: Record<string, unknown> = {};
+      for (const dep of node.dependsOn ?? []) {
+        const upOutput = outputs.get(dep);
+        if (upOutput) {
+          merged[dep] = upOutput.outputs ?? upOutput.result;
+        }
+        // Condition-skipped upstreams are absent from `outputs` — they
+        // simply don't appear in the merged result, which is correct.
+      }
+      const output = { merged, count: Object.keys(merged).length };
+      const outputsJson = JSON.stringify(output);
+      outputs.set(node.id, {
+        result: outputsJson,
+        exitCode: 0,
+        source: agent.source,
+        outputs: output,
+      });
+      deps.runStore.createNodeExecution({
+        runId,
+        nodeId: node.id,
+        workflowVersion: agent.version,
+        status: 'completed',
+        startedAt: nodeStartedAt,
+        completedAt: new Date().toISOString(),
+        result: outputsJson,
+        exitCode: 0,
+        outputsJson,
+      });
+      continue;
+    }
+
     if (node.type === 'end') {
       // End node: terminate the entire flow cleanly. All remaining nodes
       // are skipped with flow_ended. The run completes as 'completed'

--- a/packages/dashboard/src/routes/assets.ts
+++ b/packages/dashboard/src/routes/assets.ts
@@ -113,10 +113,29 @@ const GRAPH_RENDER_JS = `
   // and claude-code stay in the project's accent palette so the DAG
   // viz blends with the rest of the dashboard chrome.
   var typeStyle = {
-    shell:         { fill: '#dcfce7', border: '#15803d', text: '#166534' },
-    'claude-code': { fill: '#dbeafe', border: '#2563eb', text: '#1d4ed8' },
+    shell:           { fill: '#dcfce7', border: '#15803d', text: '#166534' },
+    'claude-code':   { fill: '#dbeafe', border: '#2563eb', text: '#1d4ed8' },
+    'conditional':   { fill: '#fef3c7', border: '#b45309', text: '#92400e' },
+    'switch':        { fill: '#fef3c7', border: '#b45309', text: '#92400e' },
+    'loop':          { fill: '#e0e7ff', border: '#4f46e5', text: '#3730a3' },
+    'agent-invoke':  { fill: '#ede9fe', border: '#7c3aed', text: '#5b21b6' },
+    'branch':        { fill: '#f0fdf4', border: '#16a34a', text: '#166534' },
+    'end':           { fill: '#fee2e2', border: '#dc2626', text: '#991b1b' },
+    'break':         { fill: '#fff7ed', border: '#ea580c', text: '#9a3412' },
   };
   var defaultStyle = { fill: '#f9fafb', border: '#d1d5db', text: '#374151' };
+
+  // Control-flow nodes get distinct shapes so the DAG viz visually
+  // distinguishes execution nodes from routing/control nodes.
+  var typeShape = {
+    'conditional': 'diamond',
+    'switch':      'diamond',
+    'loop':        'round-octagon',
+    'agent-invoke': 'barrel',
+    'branch':      'round-pentagon',
+    'end':         'octagon',
+    'break':       'octagon',
+  };
 
   function pick(n, key) {
     var s = n.data('status');
@@ -145,7 +164,10 @@ const GRAPH_RENDER_JS = `
           'width': 'label',
           'height': 26,
           'padding': '10px',
-          'shape': 'round-rectangle',
+          'shape': function (n) {
+            var t = n.data('type');
+            return (t && typeShape[t]) || 'round-rectangle';
+          },
           'border-width': 1,
           'corner-radius': '6px',
         },


### PR DESCRIPTION
## Summary

Final flow-control PR. Completes the entire A–F series.

- **`branch` node**: fan-in merge point. Collects upstream outputs into `{ merged, count }`. Condition-skipped upstreams excluded gracefully. Bypasses cascade-skip so it always runs.
- **Dashboard viz shapes**: distinct Cytoscape shapes per control-flow type (diamond, octagon, barrel, round-pentagon, round-octagon) with per-type color tints.

### Flow control complete

| Type | Shape | Color |
|---|---|---|
| conditional / switch | diamond | amber |
| loop | round-octagon | indigo |
| agent-invoke | barrel | violet |
| branch | round-pentagon | green |
| end / break | octagon | red / orange |
| shell / claude-code | round-rectangle | green / blue (unchanged) |

## Test plan

- [x] 543/543 tests (541 → 543; +2 branch tests). Lint + build clean.
- Branch merges 2 upstream outputs with correct count
- Branch excludes condition-skipped paths from merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)