### PR TITLE
feat: expand tutorial to 7 steps — inputs + flow control (docs sweep PR 3)

### DIFF
--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -439,7 +439,7 @@ describe('Dashboard help + tutorial', () => {
     expect(res.text).toMatch(/You have a project[\s\S]*?badge--ok[\s\S]*?done/);
     // Step 2: "Run your first agent" — not done yet, should show to-do badge
     // The progress card should reflect: 1 of 5 complete
-    expect(res.text).toContain('of 5 steps complete');
+    expect(res.text).toContain('of 7 steps complete');
   });
 
   it('GET /help/tutorial references the first agent by id for the Run CTA', async () => {

--- a/packages/dashboard/src/routes/help.ts
+++ b/packages/dashboard/src/routes/help.ts
@@ -105,6 +105,74 @@ helpRouter.post('/help/tutorial/scaffold-demo-dag', (req: Request, res: Response
   }
 });
 
+helpRouter.post('/help/tutorial/scaffold-parameterised-greet', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (ctx.agentStore.getAgent('parameterised-greet')) {
+    res.redirect(303, `/help/tutorial?flash=${encodeURIComponent('Agent "parameterised-greet" already exists.')}`);
+    return;
+  }
+  try {
+    ctx.agentStore.createAgent(
+      {
+        id: 'parameterised-greet',
+        name: 'Parameterised greeting',
+        description: 'Configurable greeting using agent inputs with defaults.',
+        status: 'active',
+        source: 'local',
+        mcp: false,
+        inputs: {
+          NAME: { type: 'string', default: 'World', description: 'Who to greet' },
+          STYLE: { type: 'enum', values: ['formal', 'casual'], default: 'casual' },
+        },
+        nodes: [{
+          id: 'greet',
+          type: 'shell',
+          command: 'if [ "$STYLE" = "formal" ]; then\n  echo "Good day, $NAME. I trust you are well."\nelse\n  echo "Hey $NAME! What\'s up?"\nfi',
+        }],
+      },
+      'dashboard',
+      'Scaffolded from /help/tutorial',
+    );
+    res.redirect(303, `/agents/parameterised-greet?from=tutorial&flash=${encodeURIComponent('Created! Try: Run now, or run from CLI with --input NAME=Greg --input STYLE=formal')}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/help/tutorial?flash=${encodeURIComponent(`Scaffold failed: ${msg}`)}`);
+  }
+});
+
+helpRouter.post('/help/tutorial/scaffold-conditional-router', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (ctx.agentStore.getAgent('conditional-router')) {
+    res.redirect(303, `/help/tutorial?flash=${encodeURIComponent('Agent "conditional-router" already exists.')}`);
+    return;
+  }
+  try {
+    ctx.agentStore.createAgent(
+      {
+        id: 'conditional-router',
+        name: 'Conditional router',
+        description: 'Routes data through different paths based on content. Teaches flow control.',
+        status: 'active',
+        source: 'local',
+        mcp: false,
+        nodes: [
+          { id: 'classify', type: 'shell', command: 'echo \'{"category":"tech","title":"New AI model released"}\'' },
+          { id: 'check', type: 'conditional' as 'shell', dependsOn: ['classify'], conditionalConfig: { predicate: { field: 'category', equals: 'tech' } } },
+          { id: 'tech-path', type: 'shell', command: 'echo "TECH ALERT: $UPSTREAM_CLASSIFY_RESULT"', dependsOn: ['check'], onlyIf: { upstream: 'check', field: 'matched', equals: true } },
+          { id: 'general-path', type: 'shell', command: 'echo "General news: $UPSTREAM_CLASSIFY_RESULT"', dependsOn: ['check'], onlyIf: { upstream: 'check', field: 'matched', notEquals: true } },
+          { id: 'merge', type: 'branch' as 'shell', dependsOn: ['tech-path', 'general-path'] },
+        ],
+      },
+      'dashboard',
+      'Scaffolded from /help/tutorial',
+    );
+    res.redirect(303, `/agents/conditional-router?from=tutorial&flash=${encodeURIComponent('Created! Run it to see conditional routing in action.')}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/help/tutorial?flash=${encodeURIComponent(`Scaffold failed: ${msg}`)}`);
+  }
+});
+
 function collectTutorialState(req: Request): TutorialState & { flash?: string } {
   const ctx = getContext(req.app.locals);
 
@@ -129,6 +197,9 @@ function collectTutorialState(req: Request): TutorialState & { flash?: string } 
 
   const hasHelloAgent = !!ctx.agentStore.getAgent('hello');
   const hasDemoDag = !!ctx.agentStore.getAgent('demo-digest');
+  const hasParameterisedGreet = !!ctx.agentStore.getAgent('parameterised-greet');
+  const hasConditionalRouter = !!ctx.agentStore.getAgent('conditional-router');
+  const hasResearchDigest = !!ctx.agentStore.getAgent('research-digest');
 
   // Pick the friendliest starting agent: prefer single-node v2, then any v2, then v1.
   const firstAgentId = v2Agents.find((a) => a.nodes.length === 1)?.id
@@ -146,6 +217,9 @@ function collectTutorialState(req: Request): TutorialState & { flash?: string } 
     latestRunId: latestRun?.id,
     hasHelloAgent,
     hasDemoDag,
+    hasParameterisedGreet,
+    hasConditionalRouter,
+    hasResearchDigest,
     flash,
   };
 }

--- a/packages/dashboard/src/views/tutorial.ts
+++ b/packages/dashboard/src/views/tutorial.ts
@@ -27,6 +27,12 @@ export interface TutorialState {
   hasHelloAgent: boolean;
   /** Whether the tutorial's scaffolded `demo-digest` 2-node DAG is in the DB. */
   hasDemoDag: boolean;
+  /** Whether the parameterised-greet example is in the DB. */
+  hasParameterisedGreet: boolean;
+  /** Whether the conditional-router example is in the DB. */
+  hasConditionalRouter: boolean;
+  /** Whether the research-digest example is in the DB. */
+  hasResearchDigest: boolean;
   /** Optional flash message from a scaffold action (success or error). */
   flash?: string;
 }
@@ -90,7 +96,9 @@ function buildSteps(s: TutorialState): Step[] {
     step2RunAnAgent(s),
     step3InspectOutput(s),
     step4MultiNodeDag(s),
-    step5WireUpSecret(s),
+    step5ConfigurableInputs(s),
+    step6FlowControl(s),
+    step7WireUpSecret(s),
   ];
 }
 
@@ -217,10 +225,65 @@ function step4MultiNodeDag(s: TutorialState): Step {
 }
 
 // ─── Step 5 ──────────────────────────────────────────────────────────
-// "Wire up a secret" — done when any agent declares a secret. Real CRUD
-// form lands in v0.15 PR 4; for now the action links to the placeholder
-// and the CLI command stays as the fallback.
-function step5WireUpSecret(s: TutorialState): Step {
+// "Make it configurable" — done when parameterised-greet exists.
+function step5ConfigurableInputs(s: TutorialState): Step {
+  const done = s.hasParameterisedGreet;
+
+  let summary: SafeHtml;
+  let action: SafeHtml | undefined;
+
+  if (done) {
+    summary = html`<span class="dim">The <code>parameterised-greet</code> agent is ready. Try running it with different inputs.</span>`;
+    action = html`<a class="btn btn--sm" href="/agents/parameterised-greet">View agent \u2192</a>`;
+  } else {
+    summary = html`
+      <div class="dim" style="margin-bottom: var(--space-3);">
+        Agents can declare inputs with defaults. Users supply values at run time via <code>--input NAME=Greg</code>.
+        This agent greets someone by name in a chosen style.
+      </div>
+    `;
+    action = html`
+      <form method="POST" action="/help/tutorial/scaffold-parameterised-greet" style="margin: 0; display: inline;">
+        <button type="submit" class="btn btn--primary btn--sm">Create parameterised-greet</button>
+      </form>
+    `;
+  }
+
+  return { n: 5, title: 'Make it configurable (inputs)', done, summary, action };
+}
+
+// ─── Step 6 ──────────────────────────────────────────────────────────
+// "Route with flow control" — done when conditional-router exists.
+function step6FlowControl(s: TutorialState): Step {
+  const done = s.hasConditionalRouter;
+
+  let summary: SafeHtml;
+  let action: SafeHtml | undefined;
+
+  if (done) {
+    summary = html`<span class="dim">The <code>conditional-router</code> agent is ready. Run it to see how data routes through different paths.</span>`;
+    action = html`<a class="btn btn--sm" href="/agents/conditional-router">View agent \u2192</a>`;
+  } else {
+    summary = html`
+      <div class="dim" style="margin-bottom: var(--space-3);">
+        Flow control nodes let agents make decisions. A <code>conditional</code> node evaluates a predicate;
+        downstream nodes use <code>onlyIf</code> to run only when the condition matches. A <code>branch</code>
+        node merges the results.
+      </div>
+    `;
+    action = html`
+      <form method="POST" action="/help/tutorial/scaffold-conditional-router" style="margin: 0; display: inline;">
+        <button type="submit" class="btn btn--primary btn--sm">Create conditional-router</button>
+      </form>
+    `;
+  }
+
+  return { n: 6, title: 'Route with flow control', done, summary, action };
+}
+
+// ─── Step 7 ──────────────────────────────────────────────────────────
+// "Wire up a secret" — done when any agent declares a secret.
+function step7WireUpSecret(s: TutorialState): Step {
   const done = s.usesSecrets;
   const summary = done
     ? html`<span class="dim">At least one agent declares a secret. Verify it's set on the Settings page.</span>`


### PR DESCRIPTION
## Summary

Tutorial narrative grows from 5 to 7 steps matching the example agents:

| Step | Title | Scaffold |
|---|---|---|
| 1 | Your first agent | hello (existing) |
| 2 | Run it | (existing) |
| 3 | Inspect the output | (existing) |
| 4 | Multi-node DAG | demo-digest (existing) |
| **5** | **Make it configurable** | **parameterised-greet (NEW)** |
| **6** | **Route with flow control** | **conditional-router (NEW)** |
| 7 | Wire up a secret | (renumbered from 5) |

- Two new scaffold POST routes
- TutorialState extended with `hasParameterisedGreet`, `hasConditionalRouter`, `hasResearchDigest`

## Test plan

- [x] 543/543 tests. Lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)