### PR TITLE
feat: sua examples command + README rewrite + per-package READMEs (docs sweep PR 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,266 +1,166 @@
 # some-useful-agents
 
-A local-first agent playground. Author agents in YAML, run them from the CLI or MCP, schedule them on cron, chain them into pipelines, and share them with the community.
+A local-first agent playground. Author agents as composable flows, run them from the CLI or MCP, schedule them on cron, chain them into multi-step pipelines with branching and loops, and manage everything from a web dashboard.
 
-MIT-licensed. Published to npm at `@some-useful-agents/*`. Designed to feel like `cron + shell scripts` except each "script" can also be a Claude Code prompt and the whole thing is observable, durable, and composable.
+MIT-licensed. Published to npm at `@some-useful-agents/*`.
 
-> **Threat model in 30 seconds.** sua is a local-first tool for a single user on a
-> machine they control. The MCP server binds `127.0.0.1` with a bearer token; only
-> agents marked `mcp: true` are callable from MCP clients. Community shell agents
-> refuse to run without explicit opt-in (`sua agent audit` + `--allow-untrusted-shell`);
-> community output flowing into a claude-code prompt is wrapped in UNTRUSTED
-> delimiters. The secrets store encrypts under a passphrase-derived key (scrypt
-> N=2^17); an empty passphrase explicitly opts into the legacy hostname-derived
-> fallback with a loud warning. Run `sua doctor --security` to verify your
-> install. Full model: [docs/SECURITY.md](docs/SECURITY.md).
+## What you get
 
-## Quick start (no clone needed)
+- **Agents as flows** — each agent is a DAG of nodes. Nodes execute shell commands, Claude Code prompts, or named tools. Flow control (conditional, switch, loop, agent-invoke, branch, end, break) lets agents make decisions and orchestrate sub-agents.
+- **9 built-in tools** — `shell-exec`, `claude-code`, `http-get`, `http-post`, `file-read`, `file-write`, `json-parse`, `json-path`, `template`. User-authored tools sit alongside in `tools/`.
+- **Dashboard** — web UI for managing agents, tools, runs, secrets, and settings. Visual DAG editor, click-to-replay, template palette autocomplete, per-node action dialogs.
+- **MCP server** — expose agents to Claude Desktop and other MCP clients over HTTP/SSE.
+- **Secrets store** — passphrase-encrypted at rest (scrypt N=2^17). Dashboard CRUD with session-cached passphrase.
+- **Scheduling** — cron expressions on any agent. Temporal provider available for durable workflows.
+- **8 bundled examples** — from "hello world" to conditional routing to agent orchestration. Auto-installed on `sua init`.
+
+## Quick start
 
 ```bash
 npm install -g @some-useful-agents/cli
 mkdir my-agents && cd my-agents
-sua init           # creates sua.config.json and agents/local/hello.yaml
-sua tutorial       # 5-stage walkthrough ending with a scheduled dad joke
+sua init                    # creates project + installs example agents
+sua workflow run hello      # run your first agent
+sua dashboard start         # open the web dashboard
 ```
 
-Prefer `npx`? `npx @some-useful-agents/cli <command>` works without installing globally.
+Prefer `npx`? `npx @some-useful-agents/cli@latest init` works without installing globally.
 
-The tutorial walks you through what sua is, builds a real agent that fetches a dad joke from icanhazdadjoke.com, and optionally schedules it daily at 9am. At any stage you can type `explain` to get a Claude or Codex deep-dive on that concept.
+## Example agents
 
-## Commands at a glance
+Installed automatically by `sua init`. Manage with `sua examples install/remove/list`.
 
-**Agents**
+| Agent | What it teaches |
+|---|---|
+| `hello` | Your first agent — single shell node |
+| `two-step-digest` | Chain nodes with `dependsOn` + upstream output passing |
+| `daily-greeting` | Cron scheduling (`schedule: "0 8 * * *"`) |
+| `parameterised-greet` | Agent inputs with defaults (`--input NAME=Greg`) |
+| `conditional-router` | Flow control: conditional + onlyIf + branch merge |
+| `research-digest` | Agent-invoke + loop (nested sub-flows) |
+| `daily-joke` | HTTP tool fetching from icanhazdadjoke.com |
+| `parameterised-greet-claude` | Claude Code companion (requires API key) |
+
+## CLI commands
+
+### Agents
 
 ```bash
-sua agent list                          # runnable agents (examples + local)
-sua agent list --catalog                # browse the community catalog
-sua agent new                           # interactive scaffold → agents/local/<name>.yaml
-sua agent run <name>                    # run an agent once
-sua agent run <name> --input K=V        # supply a declared input (repeatable)
-sua agent status [runId]                # recent runs, or one specific run
-sua agent logs <runId>                  # stdout/stderr of a past run
-sua agent cancel <runId>                # kill a running agent
-sua agent audit <name>                  # print resolved YAML (use before --allow-untrusted-shell)
+sua agent list                          # all agents (examples + local)
+sua agent new                           # interactive scaffold
+sua agent run <name>                    # run once
+sua agent run <name> --input K=V        # supply inputs
 ```
 
-**Scheduling**
+### Workflows (DAG agents)
 
 ```bash
-sua schedule list             # agents with a schedule field + next fire time
-sua schedule validate <name>  # validate the cron expression
-sua schedule start            # foreground cron daemon
+sua workflow list                       # DAG agents in the store
+sua workflow run <id>                   # execute a flow
+sua workflow replay <runId> --from <nodeId>  # replay from a node
+sua workflow import-yaml <file>         # import a v2 YAML into the store
 ```
 
-**Secrets** (passphrase-encrypted at rest, scoped per-agent)
+### Tools
 
 ```bash
-sua secrets set <NAME>        # prompts for passphrase (first time) + value
-sua secrets get <NAME>
-sua secrets list
-sua secrets delete <NAME>
-sua secrets migrate           # re-encrypt v1 or obfuscated store under a new passphrase
-sua secrets check <agent>     # which secrets an agent needs + whether set
+sua tool list                           # built-in + user tools
+sua tool show <id>                      # inspect inputs/outputs
+sua tool validate <file>                # schema-check a tool YAML
 ```
 
-In CI or any non-TTY context, set `SUA_SECRETS_PASSPHRASE` in the environment.
-Set it to the empty string to explicitly opt into the legacy hostname-derived
-key (labeled as `obfuscatedFallback` in the payload and flagged by
-`sua doctor --security`).
-
-**Services**
+### Examples
 
 ```bash
-sua mcp start                 # HTTP/SSE MCP server (port 3003)
-sua worker start              # Temporal worker (requires docker compose up)
+sua examples install                    # import all bundled examples
+sua examples remove                     # remove example agents from DB
+sua examples list                       # show install status
 ```
 
-**Utilities**
+### Secrets
 
 ```bash
-sua init                      # scaffold a new sua directory
-sua doctor                    # check Node, Docker, Claude CLI, scheduler, etc.
-sua tutorial                  # guided walkthrough
+sua secrets set <NAME>                  # store an encrypted secret
+sua secrets list                        # list names (values hidden)
+sua secrets delete <NAME>               # remove a secret
 ```
 
-## Agent YAML
+### Infrastructure
 
-A full-fat example showing most of the available fields:
+```bash
+sua init                                # initialize a project
+sua doctor                              # check prerequisites
+sua mcp start                           # start the MCP server
+sua dashboard start                     # start the web dashboard
+sua schedule list                       # show scheduled agents
+```
+
+## Dashboard
+
+Start with `sua dashboard start`. Features:
+
+- **Agents** — card grid, DAG visualization, click nodes for actions (edit, replay), per-node status
+- **Tools** — browse all 9 built-in tools + user tools, inspect inputs/outputs
+- **Runs** — filter by agent/status, replay from any node, nested run linking
+- **Settings** — secrets CRUD with passphrase unlock, MCP token rotation, retention policy
+- **Tutorial** — 7-step guided walkthrough that scaffolds agents from the dashboard
+
+## Flow control
+
+Agents support first-class flow control nodes:
 
 ```yaml
-name: daily-summary
-description: Summarize today's git activity with Claude
-type: claude-code
-prompt: |
-  Summarize the recent commits for {{inputs.REPO}}. Keep it under
-  {{inputs.MAX_BULLETS}} bullets.
-model: claude-sonnet-4-20250514
-inputs:                                  # typed runtime parameters
-  REPO:
-    type: string
-    default: gregmeyer/some-useful-agents
-  MAX_BULLETS:
-    type: number
-    default: 5
-dependsOn: [fetch-commits]               # chain: fetch-commits runs first
-input: "{{outputs.fetch-commits.result}}"  # upstream output flows in here
-schedule: "0 18 * * *"                   # daily at 6pm
-timeout: 120
-secrets:                                 # resolved from the secrets store
-  - GITHUB_TOKEN
-envAllowlist:                            # extra process.env to inherit
-  - HTTP_PROXY
-author: your-github-handle
-version: "1.0.0"
-tags: [git, summary, daily]
+nodes:
+  - id: fetch
+    type: shell
+    command: echo '{"status": 200, "data": "ok"}'
+
+  - id: check
+    type: conditional
+    dependsOn: [fetch]
+    conditionalConfig:
+      predicate: { field: status, equals: 200 }
+
+  - id: process
+    type: shell
+    command: echo "Processing..."
+    dependsOn: [check]
+    onlyIf: { upstream: check, field: matched, equals: true }
+
+  - id: fallback
+    type: shell
+    command: echo "Fetch failed"
+    dependsOn: [check]
+    onlyIf: { upstream: check, field: matched, notEquals: true }
 ```
 
-Required fields: `name`, `type` (`shell` or `claude-code`). Shell agents need `command`; claude-code agents need `prompt`. Everything else is optional.
+Available node types: `conditional`, `switch`, `loop`, `agent-invoke`, `branch`, `end`, `break`.
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full schema and security review checklist.
+## Security
 
-### Templates: `{{inputs.X}}` and `{{outputs.X.result}}`
+- **Secrets encrypted at rest** — scrypt N=2^17, passphrase-derived key
+- **MCP binds localhost** — bearer token auth, loopback-only by default
+- **Community shell gate** — community agents require explicit `--allow-untrusted-shell`
+- **Dashboard CSRF defense** — Origin header check on all mutations
+- **Example agents vetted** — CI security check + execution test on every PR
 
-Two template namespaces live in agent YAML. They look similar but do different things.
-
-#### `{{inputs.X}}` — caller-supplied values
-
-Declare typed parameters in the agent YAML and supply values at runtime with `--input K=V`:
-
-```yaml
-name: weather
-type: claude-code
-prompt: "Describe weather for zip {{inputs.ZIP}} as a {{inputs.STYLE}}."
-inputs:
-  ZIP:
-    type: number
-    required: true
-  STYLE:
-    type: enum
-    values: [haiku, verse, limerick]
-    default: haiku
-```
-
-```bash
-sua agent run weather --input ZIP=94110 --input STYLE=verse
-```
-
-Validated against the declared type (`string`, `number`, `boolean`, `enum`). Precedence: `--input` flag → `default:` in YAML → else fail. Works in `prompt:` and any `env:` value.
-
-**Shell agents read inputs as env vars**, not templates — bash's `$VAR` is the native idiom, and sua rejects `{{inputs.X}}` inside a shell `command:` at load time:
-
-```yaml
-type: shell
-command: 'curl -s "https://api.example.com/weather/$ZIP"'
-inputs:
-  ZIP: { type: number, required: true }
-```
-
-Supply via `sua agent run` (per invocation), `sua schedule start --input K=V` (daemon-wide override for every scheduled fire), or bake defaults into the YAML.
-
-#### `{{outputs.X.result}}` — chain handoff
-
-Pipe one agent's output into the next. Lives in the `input:` field of a dependent agent:
-
-```yaml
-name: fetch
-type: shell
-command: "curl -s https://icanhazdadjoke.com/ -H 'Accept: text/plain'"
-
-# ---
-
-name: summarize-joke
-type: claude-code
-prompt: "Summarize this joke in one sentence of formal English."
-dependsOn: [fetch]
-input: "{{outputs.fetch.result}}"    # appended to the prompt at run time
-```
-
-```bash
-sua agent run summarize-joke    # fetch runs first; its output flows into summarize-joke
-```
-
-You can reference `{{outputs.X.exitCode}}` the same way. For claude-code downstreams, the resolved value is appended to the prompt. For shell downstreams, it arrives as `$SUA_CHAIN_INPUT`. When the upstream is sourced from `agents/community/`, values are wrapped in `BEGIN/END UNTRUSTED INPUT` delimiters — see [docs/SECURITY.md](docs/SECURITY.md).
-
-`{{outputs.X.*}}` only resolves inside the `input:` field. Inside a `prompt:` or `command:` the literal text is sent through unchanged.
-
-## Running on Temporal
-
-Use Temporal instead of the local child-process provider when you want durable, observable execution.
-
-```bash
-docker compose up -d                                # Temporal dev server
-sua worker start                                     # worker runs on your host
-sua agent run hello --provider temporal              # or set SUA_PROVIDER=temporal
-open http://localhost:8233                           # Temporal Web UI
-```
-
-The worker runs on the host (not in Docker) because agents need your shell and your Claude CLI install. Temporal itself is the only thing running in Docker.
-
-## Architecture
-
-```
-HOST MACHINE
-+---------------------------------------------------------------+
-|                                                               |
-|  sua (CLI)    MCP server (HTTP)    Temporal worker            |
-|      \             |                     /                    |
-|       \            v                    /                     |
-|        ----> packages/core <-----------                       |
-|              AgentLoader                                      |
-|              Provider (Local | Temporal)                      |
-|              RunStore (node:sqlite, WAL)                      |
-|              Scheduler (node-cron)                            |
-|              SecretsStore (AES-256-GCM, passphrase-KEK v2)    |
-|                                                               |
-|  Agent execution                                              |
-|   - shell agents: child_process.spawn (on host)               |
-|   - claude-code agents: spawn('claude', ['--print', prompt])  |
-+-------------------------------+-------------------------------+
-                                | localhost:7233 (gRPC)
-                       +--------v--------+
-                       |    DOCKER       |
-                       |  Temporal       |
-                       |  (SQLite, :8233)|
-                       +-----------------+
-```
-
-All infrastructure except Temporal runs on the host. See [ADR-0004](docs/adr/0004-temporal-worker-on-host.md) for why.
+Full model: [docs/SECURITY.md](docs/SECURITY.md)
 
 ## Packages
 
-| Package | Install | Purpose |
-|---------|---------|---------|
-| `@some-useful-agents/cli` | `npm i -g @some-useful-agents/cli` | the `sua` binary |
-| `@some-useful-agents/core` | `npm i @some-useful-agents/core` | types, schemas, run store, scheduler — build on top |
-| `@some-useful-agents/mcp-server` | auto via CLI | MCP server (HTTP/SSE) |
-| `@some-useful-agents/temporal-provider` | auto via CLI | Temporal workflows + worker |
-| `@some-useful-agents/dashboard` | not yet | (roadmap: Phase 3 web UI) |
+| Package | Description |
+|---|---|
+| `@some-useful-agents/core` | Types, schemas, stores, executor, tools, secrets |
+| `@some-useful-agents/cli` | CLI commands, tutorial, scaffolding |
+| `@some-useful-agents/dashboard` | Web dashboard (Express, server-rendered HTML) |
+| `@some-useful-agents/mcp-server` | MCP server (HTTP/SSE transport) |
+| `@some-useful-agents/temporal-provider` | Temporal worker for durable workflows |
 
-All packages are published via OIDC with provenance attestations — verify with `npm view @some-useful-agents/cli attestations`.
+## Requirements
 
-## Security notes
-
-See [docs/SECURITY.md](docs/SECURITY.md) for the full threat model. One-liners:
-
-- **Env filtering by trust level** — community agents receive a minimal env (`PATH`, `HOME`, `LANG`, `TERM`, `TMPDIR` + allowlist). Dangerous vars like `AWS_SECRET_ACCESS_KEY` do not leak. See [ADR-0006](docs/adr/0006-env-filtering-by-trust-level.md).
-- **MCP bearer token + loopback bind** — v0.4.0 closed a critical gap. `sua init` writes a 32-byte token to `~/.sua/mcp-token` (chmod 0600); the server binds `127.0.0.1`, requires `Authorization: Bearer <token>`, and rejects non-loopback Host/Origin headers.
-- **MCP agents opt in** — only agents with `mcp: true` in their YAML are exposed via MCP's `list-agents` and `run-agent` tools (v0.5.0). The rest are invisible to MCP clients.
-- **Chain trust propagation** — community agent output flowing into a downstream local agent is wrapped in UNTRUSTED delimiters (claude-code) or blocked outright (shell), unless the shell downstream is explicitly allow-listed (v0.5.0).
-- **Community shell agent gate** — shell agents sourced from `agents/community/` refuse to run without `--allow-untrusted-shell <name>` on the CLI. Use `sua agent audit <name>` to print the resolved YAML before opting in (v0.6.0, wired end-to-end in v0.6.1).
-- **Run-store hygiene** — `data/runs.db` is chmod 0o600 at create. Rows older than `runRetentionDays` (default 30) are swept on startup. Opt-in `redactSecrets: true` on an agent scrubs known-prefix secrets (AWS, GitHub PAT, OpenAI / Anthropic, Slack) from its stdout/stderr before they land in the DB (v0.6.0).
-- **Cron frequency cap** — schedules fire no more than once per minute by default. 6-field sub-minute expressions require `allowHighFrequency: true` and emit a loud warning on every fire (v0.4.0).
-- **Secrets store** — passphrase-derived AES-256-GCM at `data/secrets.enc`, permissions `0600`. Key = `scrypt(passphrase, random-salt, N=2^17)` with KDF params stored in the payload for forward-tunability. Empty passphrase falls back to a labeled `obfuscatedFallback` mode (hostname-derived key, every load warns; `sua doctor --security` flags it). CI/non-TTY contexts read `SUA_SECRETS_PASSPHRASE`. Shipped in v0.10.0 — see [ADR-0014](docs/adr/0014-passphrase-kek-secrets-store.md); the v1 hostname-derived design is in [ADR-0007](docs/adr/0007-encrypted-file-secrets-store.md) (superseded).
-- **Self-check** — run `sua doctor --security` for a one-shot audit of file perms, MCP token presence, and community shell posture.
-- **Known-weak (still)** — the shell-agent Docker sandbox documented in [ADR-0005](docs/adr/0005-shell-sandbox-claude-on-host.md) remains aspirational; once you opt in past the community-shell gate, the agent runs with your full ambient authority. Don't install community agents you haven't audited.
-
-## Where is this going?
-
-- [ROADMAP.md](ROADMAP.md) — direction at three horizons (now / next / maybe) and what we've rejected
-- [docs/adr/](docs/adr/) — 13 architecture decision records explaining the "why" behind big calls
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md). TL;DR: fork, branch, add a `changeset` describing your change (`npx changeset`), open a PR against `main`. Agent contributions go in `agents/community/` and need a security review checklist.
+- Node.js >= 22.5.0
+- macOS or Linux (Windows untested)
+- Docker (optional, for Temporal)
 
 ## License
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,37 @@
+# @some-useful-agents/cli
+
+Command-line interface for some-useful-agents. Author, run, schedule, and manage agents from the terminal.
+
+## Install
+
+```bash
+npm install -g @some-useful-agents/cli
+```
+
+## Quick start
+
+```bash
+sua init                         # initialize a project
+sua workflow run hello           # run an agent
+sua tool list                    # see available tools
+sua examples install             # install bundled examples
+sua dashboard start              # open the web dashboard
+```
+
+## Commands
+
+- `sua agent` — list, new, run, status, logs, cancel, audit, edit, disable/enable
+- `sua workflow` — list, run, replay, import, export, status, logs
+- `sua tool` — list, show, validate
+- `sua examples` — install, remove, list
+- `sua secrets` — set, get, list, delete, migrate, check
+- `sua mcp` — start, rotate-token, token
+- `sua schedule` — list, validate
+- `sua dashboard` — start
+- `sua init`, `sua doctor`, `sua tutorial`
+
+See the [main repo README](https://github.com/gregmeyer/some-useful-agents) for full documentation.
+
+## License
+
+MIT

--- a/packages/cli/src/commands/examples.ts
+++ b/packages/cli/src/commands/examples.ts
@@ -1,0 +1,350 @@
+import { Command } from 'commander';
+import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  AgentStore,
+  parseAgent,
+  type Agent,
+} from '@some-useful-agents/core';
+import { loadConfig, getDbPath, getAgentDirs } from '../config.js';
+import * as ui from '../ui.js';
+
+const EXAMPLE_IDS = [
+  'hello', 'two-step-digest', 'daily-greeting', 'parameterised-greet',
+  'parameterised-greet-claude', 'conditional-router', 'research-digest', 'daily-joke',
+];
+
+export const examplesCommand = new Command('examples')
+  .description('Install or remove the bundled example agents');
+
+examplesCommand
+  .command('install')
+  .description('Import all bundled example agents into the agent store')
+  .option('--skip-existing', 'Skip agents that already exist instead of updating them')
+  .action((options: { skipExisting?: boolean }) => {
+    const config = loadConfig();
+    const dbPath = getDbPath(config);
+    const store = new AgentStore(dbPath);
+
+    // Write data files that examples reference.
+    const dataDir = join(config.agentsDir, 'examples', 'data');
+    ensureDataFiles(dataDir);
+
+    let installed = 0;
+    let skipped = 0;
+
+    for (const [id, yaml] of Object.entries(EXAMPLE_YAMLS)) {
+      if (options.skipExisting && store.getAgent(id)) {
+        skipped++;
+        continue;
+      }
+      try {
+        const agent = parseAgent(yaml);
+        const { version: _v, ...agentNoVersion } = agent;
+        void _v;
+        store.upsertAgent(agentNoVersion, 'import', `Installed from bundled examples`);
+        installed++;
+        ui.ok(`${ui.agent(id)}`);
+      } catch (err) {
+        ui.fail(`${id}: ${(err as Error).message}`);
+      }
+    }
+
+    store.close();
+    console.log('');
+    ui.info(`${installed} installed, ${skipped} skipped.`);
+  });
+
+examplesCommand
+  .command('remove')
+  .description('Remove all bundled example agents from the agent store')
+  .action(() => {
+    const config = loadConfig();
+    const dbPath = getDbPath(config);
+    const store = new AgentStore(dbPath);
+
+    let removed = 0;
+    for (const id of EXAMPLE_IDS) {
+      const existing = store.getAgent(id);
+      if (existing && existing.source === 'examples') {
+        store.deleteAgent(id);
+        removed++;
+        ui.ok(`Removed ${ui.agent(id)}`);
+      }
+    }
+
+    store.close();
+    if (removed === 0) {
+      ui.info('No example agents found to remove.');
+    } else {
+      console.log('');
+      ui.info(`${removed} example agent(s) removed.`);
+    }
+  });
+
+examplesCommand
+  .command('list')
+  .description('List the bundled example agents and whether each is installed')
+  .action(() => {
+    const config = loadConfig();
+    const dbPath = getDbPath(config);
+    const store = new AgentStore(dbPath);
+
+    for (const id of EXAMPLE_IDS) {
+      const exists = !!store.getAgent(id);
+      const status = exists ? '✓ installed' : '  not installed';
+      console.log(`  ${status}  ${ui.agent(id)}`);
+    }
+
+    store.close();
+  });
+
+/**
+ * Programmatic entry point for `sua init` auto-import. Imports all
+ * bundled examples, skipping any that already exist.
+ */
+export function examplesInstall(dbPath: string, agentsDir: string): void {
+  const store = new AgentStore(dbPath);
+  const dataDir = join(agentsDir, 'examples', 'data');
+  ensureDataFiles(dataDir);
+  let installed = 0;
+  for (const [id, yaml] of Object.entries(EXAMPLE_YAMLS)) {
+    if (store.getAgent(id)) continue;
+    try {
+      const agent = parseAgent(yaml);
+      const { version: _v, ...agentNoVersion } = agent;
+      void _v;
+      store.upsertAgent(agentNoVersion, 'import', 'Installed from bundled examples');
+      installed++;
+    } catch { /* skip broken during init */ }
+  }
+  store.close();
+  if (installed > 0) {
+    ui.ok(`${installed} example agent(s) installed. Run \`sua examples list\` to see them.`);
+  }
+}
+
+function ensureDataFiles(dataDir: string): void {
+  if (!existsSync(dataDir)) mkdirSync(dataDir, { recursive: true });
+
+  const headlinesPath = join(dataDir, 'sample-headlines.json');
+  if (!existsSync(headlinesPath)) {
+    writeFileSync(headlinesPath, SAMPLE_HEADLINES_JSON);
+  }
+
+  const topicsPath = join(dataDir, 'research-topics.json');
+  if (!existsSync(topicsPath)) {
+    writeFileSync(topicsPath, RESEARCH_TOPICS_JSON);
+  }
+}
+
+// -- Embedded example YAMLs (match agents/examples/*.yaml) --
+
+const EXAMPLE_YAMLS: Record<string, string> = {
+  'hello': `id: hello
+name: Hello
+description: Your first sua agent — prints a greeting.
+status: active
+source: examples
+signal:
+  title: Hello
+  icon: "\\U0001F44B"
+  format: text
+nodes:
+  - id: greet
+    type: shell
+    command: echo "Hello from sua! You just ran your first agent."
+`,
+
+  'two-step-digest': `id: two-step-digest
+name: Two-step digest
+description: Reads local headlines and formats a summary. Teaches dependsOn + upstream passing.
+status: active
+source: examples
+signal:
+  title: Daily Digest
+  icon: "\\U0001F4F0"
+  format: text
+  size: 2x1
+nodes:
+  - id: fetch
+    type: shell
+    tool: file-read
+    toolInputs:
+      path: agents/examples/data/sample-headlines.json
+  - id: summarise
+    type: shell
+    command: |
+      echo "=== Daily Digest ==="
+      echo "$UPSTREAM_FETCH_RESULT" | head -5
+      echo "---"
+      TOTAL=$(echo "$UPSTREAM_FETCH_RESULT" | grep -c '"title"' || echo 0)
+      echo "$TOTAL headlines loaded."
+    dependsOn: [fetch]
+`,
+
+  'daily-greeting': `id: daily-greeting
+name: Daily greeting
+description: Scheduled agent — greets you every morning at 8am.
+status: active
+source: examples
+schedule: "0 8 * * *"
+signal:
+  title: Morning Greeting
+  icon: "\\u2600\\uFE0F"
+  format: text
+  refresh: 24h
+nodes:
+  - id: greet
+    type: shell
+    command: echo "Good morning! Today is $(date +%A), $(date +%B\\ %d)."
+`,
+
+  'parameterised-greet': `id: parameterised-greet
+name: Parameterised greeting
+description: Configurable greeting using agent inputs with defaults.
+status: active
+source: examples
+signal:
+  title: Greeting
+  icon: "\\U0001F4AC"
+  format: text
+inputs:
+  NAME: { type: string, default: "World", description: "Who to greet" }
+  STYLE: { type: enum, values: [formal, casual], default: casual }
+nodes:
+  - id: greet
+    type: shell
+    command: |
+      if [ "$STYLE" = "formal" ]; then
+        echo "Good day, $NAME. I trust you are well."
+      else
+        echo "Hey $NAME! What's up?"
+      fi
+`,
+
+  'parameterised-greet-claude': `id: parameterised-greet-claude
+name: Parameterised greeting (Claude)
+description: Same concept as parameterised-greet, using Claude Code.
+status: active
+source: examples
+inputs:
+  NAME: { type: string, default: "World" }
+  STYLE: { type: enum, values: [formal, casual], default: casual }
+nodes:
+  - id: greet
+    type: claude-code
+    prompt: "Greet {{inputs.NAME}} in a {{inputs.STYLE}} style. One sentence only."
+`,
+
+  'conditional-router': `id: conditional-router
+name: Conditional router
+description: Routes data through different paths based on content. Teaches flow control.
+status: active
+source: examples
+signal:
+  title: Router
+  icon: "\\U0001F500"
+  format: json
+  field: merged
+nodes:
+  - id: classify
+    type: shell
+    command: echo '{"category":"tech","title":"New AI model released"}'
+  - id: check
+    type: conditional
+    dependsOn: [classify]
+    conditionalConfig:
+      predicate: { field: category, equals: tech }
+  - id: tech-path
+    type: shell
+    command: echo "TECH ALERT - $UPSTREAM_CLASSIFY_RESULT"
+    dependsOn: [check]
+    onlyIf: { upstream: check, field: matched, equals: true }
+  - id: general-path
+    type: shell
+    command: echo "General news - $UPSTREAM_CLASSIFY_RESULT"
+    dependsOn: [check]
+    onlyIf: { upstream: check, field: matched, notEquals: true }
+  - id: merge
+    type: branch
+    dependsOn: [tech-path, general-path]
+`,
+
+  'research-digest': `id: research-digest
+name: Research digest
+description: Boss agent that invokes sub-agents and loops over results.
+status: active
+source: examples
+signal:
+  title: Research
+  icon: "\\U0001F50D"
+  format: table
+  field: items
+  size: 2x1
+nodes:
+  - id: source
+    type: shell
+    tool: file-read
+    toolInputs:
+      path: agents/examples/data/research-topics.json
+  - id: research
+    type: loop
+    dependsOn: [source]
+    loopConfig:
+      over: topics
+      agentId: two-step-digest
+      maxIterations: 3
+  - id: compile
+    type: shell
+    command: |
+      echo "=== Research Complete ==="
+      echo "$UPSTREAM_RESEARCH_RESULT"
+    dependsOn: [research]
+`,
+
+  'daily-joke': `id: daily-joke
+name: Daily joke
+description: Fetches a real joke from the internet using the http-get tool.
+status: active
+source: examples
+signal:
+  title: Joke of the Day
+  icon: "\\U0001F3AD"
+  format: text
+  refresh: 24h
+nodes:
+  - id: fetch
+    type: shell
+    tool: http-get
+    toolInputs:
+      url: "https://icanhazdadjoke.com/"
+  - id: format
+    type: shell
+    command: |
+      echo "=== Joke of the Day ==="
+      JOKE=$(echo "$UPSTREAM_FETCH_RESULT" | grep -o '"joke":"[^"]*"' | sed 's/"joke":"//;s/"$//' 2>/dev/null)
+      if [ -n "$JOKE" ]; then
+        echo "$JOKE"
+      else
+        echo "$UPSTREAM_FETCH_RESULT"
+      fi
+    dependsOn: [fetch]
+`,
+};
+
+const SAMPLE_HEADLINES_JSON = `{
+  "headlines": [
+    { "title": "New AI safety framework published", "category": "tech" },
+    { "title": "Global temperatures hit record high", "category": "science" },
+    { "title": "Open source agent toolkit reaches 1.0", "category": "tech" },
+    { "title": "Quantum computing milestone achieved", "category": "science" },
+    { "title": "Developer productivity study shows 40% gains with AI", "category": "tech" }
+  ]
+}
+`;
+
+const RESEARCH_TOPICS_JSON = `{
+  "topics": ["AI safety", "quantum computing", "climate tech"]
+}
+`;

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,13 +1,13 @@
 import { Command } from 'commander';
 import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { ensureMcpToken, getMcpTokenPath } from '@some-useful-agents/core';
+import { ensureMcpToken, getMcpTokenPath, AgentStore, parseAgent } from '@some-useful-agents/core';
 import { HELLO_AGENT_YAML } from '../scaffolds.js';
 import * as ui from '../ui.js';
 
 export const initCommand = new Command('init')
   .description('Initialize some-useful-agents in the current directory')
-  .action(() => {
+  .action(async () => {
     const configPath = join(process.cwd(), 'sua.config.json');
 
     if (existsSync(configPath)) {
@@ -53,9 +53,21 @@ export const initCommand = new Command('init')
       ui.ok(`Created ${tokenPath} (mode 0600) — MCP bearer token`);
     }
 
+    // Auto-install bundled example agents so the dashboard + agent list
+    // aren't empty on first visit. Users can remove them later with
+    // `sua examples remove`.
+    ui.section('Installing example agents');
+    try {
+      const { examplesInstall } = await import('./examples.js');
+      examplesInstall(join(config.dataDir, 'runs.db'), config.agentsDir);
+    } catch {
+      ui.info('Run `sua examples install` to add the bundled examples.');
+    }
+
     ui.section('Next steps');
     ui.step('sua tutorial', 'guided walkthrough (recommended)');
     ui.step('sua agent run hello', 'run your first agent');
+    ui.step('sua examples list', 'see installed example agents');
     ui.step('sua doctor', 'check prerequisites');
     ui.step('sua mcp start', 'start the local MCP server on 127.0.0.1:3003');
   });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -26,6 +26,7 @@ import { tutorialCommand } from './commands/tutorial.js';
 import { dashboardCommand } from './commands/dashboard.js';
 import { workflowCommand } from './commands/workflow.js';
 import { toolCommand } from './commands/tool.js';
+import { examplesCommand } from './commands/examples.js';
 
 // Read version from our own package.json so `sua --version` always matches
 // the installed package version (no hardcoded drift).
@@ -87,5 +88,6 @@ program.addCommand(tutorialCommand);
 program.addCommand(dashboardCommand);
 program.addCommand(workflowCommand);
 program.addCommand(toolCommand);
+program.addCommand(examplesCommand);
 
 program.parse();

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,30 @@
+# @some-useful-agents/core
+
+Core library for some-useful-agents. Provides types, schemas, stores, the DAG executor, tool registry, secrets management, and template resolution.
+
+## What's inside
+
+- **Agent types + Zod schemas** — `Agent`, `AgentNode`, `NodeType` (shell, claude-code, conditional, switch, loop, agent-invoke, branch, end, break)
+- **DAG executor** — topological walk with flow control, onlyIf conditional edges, nested agent-invoke, loop iteration
+- **Tool system** — 9 built-in tools + `ToolStore` for user-defined tools
+- **Stores** — `AgentStore`, `RunStore`, `ToolStore` (SQLite via `node:sqlite`)
+- **Secrets** — `EncryptedFileStore` with scrypt-derived key, passphrase + legacy-fallback modes
+- **Template resolution** — `{{upstream.X.result}}`, `{{inputs.NAME}}`, `$UPSTREAM_X_RESULT`
+
+## Install
+
+```bash
+npm install @some-useful-agents/core
+```
+
+## Usage
+
+```typescript
+import { AgentStore, RunStore, executeAgentDag, listBuiltinTools } from '@some-useful-agents/core';
+```
+
+See the [main repo README](https://github.com/gregmeyer/some-useful-agents) for full documentation.
+
+## License
+
+MIT

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -1,0 +1,26 @@
+# @some-useful-agents/dashboard
+
+Web dashboard for some-useful-agents. Server-rendered HTML, no bundler, no framework.
+
+## Features
+
+- **Agents** — card grid, DAG visualization, click-to-replay, per-node action dialogs
+- **Tools** — browse built-in + user tools, inspect inputs/outputs
+- **Runs** — filter, paginate, nested run linking, replay from any node
+- **Settings** — secrets CRUD with passphrase unlock, MCP token rotation
+- **Tutorial** — 7-step guided walkthrough with inline scaffold actions
+- **Template palette** — autocomplete for `$` and `{{` in node command/prompt editors
+
+## Start
+
+```bash
+sua dashboard start --port 3000
+```
+
+The dashboard shares the MCP bearer token (`~/.sua/mcp-token`) for auth. A one-time sign-in URL is printed on startup.
+
+See the [main repo README](https://github.com/gregmeyer/some-useful-agents) for full documentation.
+
+## License
+
+MIT

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,0 +1,32 @@
+# @some-useful-agents/mcp-server
+
+MCP server for some-useful-agents. Exposes agents marked `mcp: true` to Claude Desktop and other MCP clients over HTTP/SSE transport.
+
+## Start
+
+```bash
+sua mcp start
+```
+
+Binds `127.0.0.1:3003` by default. Bearer token auth via `~/.sua/mcp-token`.
+
+## MCP client config
+
+```json
+{
+  "mcpServers": {
+    "some-useful-agents": {
+      "url": "http://127.0.0.1:3003/mcp",
+      "headers": {
+        "Authorization": "Bearer <token from ~/.sua/mcp-token>"
+      }
+    }
+  }
+}
+```
+
+See the [main repo README](https://github.com/gregmeyer/some-useful-agents) for full documentation.
+
+## License
+
+MIT

--- a/packages/temporal-provider/README.md
+++ b/packages/temporal-provider/README.md
@@ -1,0 +1,34 @@
+# @some-useful-agents/temporal-provider
+
+Temporal worker for some-useful-agents. Provides durable workflow execution as an alternative to the default local provider.
+
+## When to use
+
+- **Local provider** (default) — runs agents in-process. Good for development, single-machine deployments, and most use cases.
+- **Temporal provider** — runs agents as Temporal workflows. Use when you need durable execution, retries, visibility, and multi-machine orchestration.
+
+## Setup
+
+Requires a running Temporal server (Docker recommended):
+
+```bash
+docker compose up -d  # starts Temporal server
+sua worker start      # starts the Temporal worker
+```
+
+Configure in `sua.config.json`:
+
+```json
+{
+  "provider": "temporal",
+  "temporalAddress": "localhost:7233",
+  "temporalNamespace": "default",
+  "temporalTaskQueue": "sua-agents"
+}
+```
+
+See the [main repo README](https://github.com/gregmeyer/some-useful-agents) for full documentation.
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

- **\`sua examples install/remove/list\`** — manage bundled example agents. Install imports all 8 into the AgentStore + writes mock data files. Remove deletes them. List shows status.
- **\`sua init\` auto-imports examples** — new projects have agents in the dashboard from the start.
- **README.md rewrite** — covers agents as flows, 9 tools, flow control, dashboard, examples, all CLI commands.
- **5 per-package READMEs** — core, cli, dashboard, mcp-server, temporal-provider. Ship with npm tarballs so \`npm info\` + npmjs.com show useful content.

## Test plan

- [x] 543/543 tests. Lint + build clean.
- [ ] \`sua examples install\` on a fresh project → 8 agents visible in dashboard
- [ ] \`sua examples remove\` → agents gone
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)