### PR TITLE
fix: show available variables on edit form + simplify example syntax

### DIFF
--- a/agents/examples/parameterised-greet.yaml
+++ b/agents/examples/parameterised-greet.yaml
@@ -18,8 +18,7 @@ nodes:
   - id: greet
     type: shell
     command: |
-      if [ "$STYLE" = "formal" ]; then
-        echo "Good day, $NAME. I trust you are well."
-      else
-        echo "Hey $NAME! What's up?"
-      fi
+      case "$STYLE" in
+        formal) echo "Good day, $NAME. I trust you are well." ;;
+        *)      echo "Hey $NAME! What's up?" ;;
+      esac

--- a/packages/cli/src/commands/examples.ts
+++ b/packages/cli/src/commands/examples.ts
@@ -216,11 +216,10 @@ nodes:
   - id: greet
     type: shell
     command: |
-      if [ "$STYLE" = "formal" ]; then
-        echo "Good day, $NAME. I trust you are well."
-      else
-        echo "Hey $NAME! What's up?"
-      fi
+      case "$STYLE" in
+        formal) echo "Good day, $NAME. I trust you are well." ;;
+        *)      echo "Hey $NAME! What's up?" ;;
+      esac
 `,
 
   'parameterised-greet-claude': `id: parameterised-greet-claude

--- a/packages/dashboard/src/routes/help.ts
+++ b/packages/dashboard/src/routes/help.ts
@@ -127,7 +127,7 @@ helpRouter.post('/help/tutorial/scaffold-parameterised-greet', (req: Request, re
         nodes: [{
           id: 'greet',
           type: 'shell',
-          command: 'if [ "$STYLE" = "formal" ]; then\n  echo "Good day, $NAME. I trust you are well."\nelse\n  echo "Hey $NAME! What\'s up?"\nfi',
+          command: 'case "$STYLE" in\n  formal) echo "Good day, $NAME. I trust you are well." ;;\n  *)      echo "Hey $NAME! What\'s up?" ;;\nesac',
         }],
       },
       'dashboard',

--- a/packages/dashboard/src/views/agent-edit-node.ts
+++ b/packages/dashboard/src/views/agent-edit-node.ts
@@ -100,6 +100,8 @@ export function renderAgentEditNode(args: {
           : html`<div>${depToggles as unknown as SafeHtml[]}</div>`}
       </fieldset>
 
+      ${renderAvailableVars(agent, node)}
+
       <fieldset style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--space-3); margin-bottom: var(--space-4);">
         <legend style="padding: 0 var(--space-2); font-size: var(--font-size-xs); font-weight: var(--weight-semibold); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em;">Implementation</legend>
 
@@ -162,6 +164,66 @@ function collectDownstream(agent: Agent, startId: string): Set<string> {
     }
   }
   return down;
+}
+
+/**
+ * Visible summary of variables available to this node. Shows agent-level
+ * inputs (with defaults), upstream node outputs, and declared secrets
+ * so the user knows what they can reference in the command/prompt without
+ * having to type $ to discover them.
+ */
+function renderAvailableVars(agent: Agent, node: AgentNode): SafeHtml {
+  const inputs = Object.entries(agent.inputs ?? {});
+  const upstreams = (node.dependsOn ?? []).filter((id) => agent.nodes.some((n) => n.id === id));
+  const secrets = node.secrets ?? [];
+
+  if (inputs.length === 0 && upstreams.length === 0 && secrets.length === 0) {
+    return html``;
+  }
+
+  const rows: SafeHtml[] = [];
+
+  for (const [name, spec] of inputs) {
+    const defVal = spec.default !== undefined ? String(spec.default) : '';
+    rows.push(html`
+      <tr>
+        <td class="mono" style="color: var(--color-primary);">$${name}</td>
+        <td>agent input</td>
+        <td class="dim">${defVal ? `default: ${defVal}` : 'required'}</td>
+      </tr>
+    `);
+  }
+
+  for (const id of upstreams) {
+    const envName = `UPSTREAM_${id.toUpperCase().replace(/-/g, '_')}_RESULT`;
+    rows.push(html`
+      <tr>
+        <td class="mono" style="color: var(--color-primary);">$${envName}</td>
+        <td>upstream output</td>
+        <td class="dim">from node "${id}"</td>
+      </tr>
+    `);
+  }
+
+  for (const name of secrets) {
+    rows.push(html`
+      <tr>
+        <td class="mono" style="color: var(--color-warn);">$${name}</td>
+        <td>secret</td>
+        <td class="dim">injected at runtime</td>
+      </tr>
+    `);
+  }
+
+  return html`
+    <fieldset style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--space-3); margin-bottom: var(--space-4); background: var(--color-surface-raised);">
+      <legend style="padding: 0 var(--space-2); font-size: var(--font-size-xs); font-weight: var(--weight-semibold); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em;">Available variables</legend>
+      <table class="table" style="font-size: var(--font-size-xs);">
+        <thead><tr><th>Variable</th><th>Source</th><th>Info</th></tr></thead>
+        <tbody>${rows as unknown as SafeHtml[]}</tbody>
+      </table>
+    </fieldset>
+  `;
 }
 
 const INPUT_STYLE: SafeHtml = unsafeHtml(

--- a/packages/dashboard/src/views/tutorial.ts
+++ b/packages/dashboard/src/views/tutorial.ts
@@ -192,7 +192,7 @@ function step4MultiNodeDag(s: TutorialState): Step {
 
   if (done) {
     summary = html`<span class="dim">You've executed a multi-node agent. The DAG viz on each run shows node-level status.</span>`;
-    action = html`<a class="btn btn--sm" href="/agents">Browse DAG agents \u2192</a>`;
+    action = html`<a class="btn btn--sm" href="/agents/demo-digest">View demo-digest \u2192</a>`;
   } else if (s.hasDemoDag) {
     summary = html`<span class="dim">The <code>demo-digest</code> 2-node DAG is already scaffolded. <a href="/agents/demo-digest">View its DAG</a> or run it.</span>`;
     action = html`


### PR DESCRIPTION
## Summary

- **Available variables table** on node edit form — shows agent inputs (with defaults), upstream outputs, and secrets so users know what's in scope without typing `$`.
- **Simpler shell syntax** — `parameterised-greet` example uses `case/esac` instead of `if/fi`. Updated in YAML, embedded copy, and scaffold route.

## Test plan

- [x] 543/543 tests. Lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)