### PR TITLE
feat: global variables store + sua vars CLI (Variables PR 1/6)

### DIFF
--- a/.changeset/variables-pr1.md
+++ b/.changeset/variables-pr1.md
@@ -1,0 +1,12 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+---
+
+**feat: global variables store + `sua vars` CLI (Variables PR 1 of 6).**
+
+Adds a plain-text global variables store at `.sua/variables.json` for non-sensitive project-wide values (API_BASE_URL, REGION, DEFAULT_TIMEOUT). Variables are visible to every agent at run time — executor wiring comes in PR 2.
+
+- **`VariablesStore`** in core — JSON-backed CRUD with `get/set/delete/list/getAll`. Creates the `.sua/` directory on first write.
+- **`sua vars list/get/set/delete`** CLI — mirrors the secrets CLI pattern. `set` warns when a name looks sensitive (TOKEN, KEY, PASS, SECRET) and suggests using `sua secrets set` instead.
+- **`looksLikeSensitive()`** helper — flags names that probably belong in the encrypted store.

--- a/packages/cli/src/commands/vars.ts
+++ b/packages/cli/src/commands/vars.ts
@@ -1,0 +1,105 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import Table from 'cli-table3';
+import { VariablesStore, looksLikeSensitive } from '@some-useful-agents/core';
+import { loadConfig } from '../config.js';
+import * as ui from '../ui.js';
+import { join } from 'node:path';
+
+function getVarsPath(): string {
+  const config = loadConfig();
+  return join(config.dataDir, '.sua', 'variables.json');
+}
+
+export const varsCommand = new Command('vars')
+  .description('Manage global variables (non-sensitive, project-wide values)');
+
+varsCommand
+  .command('list')
+  .description('List all global variables (names + values)')
+  .action(() => {
+    const store = new VariablesStore(getVarsPath());
+    const vars = store.list();
+    const names = Object.keys(vars).sort();
+
+    if (names.length === 0) {
+      ui.info('No global variables set. Run `sua vars set <NAME> <VALUE>` to add one.');
+      return;
+    }
+
+    const table = new Table({
+      head: [chalk.bold('Name'), chalk.bold('Value'), chalk.bold('Description')],
+    });
+
+    for (const name of names) {
+      const v = vars[name];
+      const warn = looksLikeSensitive(name) ? chalk.yellow(' ⚠') : '';
+      table.push([
+        ui.agent(name) + warn,
+        v.value,
+        v.description ?? '',
+      ]);
+    }
+    console.log(table.toString());
+    console.log(ui.dim(`\n${names.length} variable(s)`));
+
+    const sensitive = names.filter(looksLikeSensitive);
+    if (sensitive.length > 0) {
+      console.log('');
+      ui.warn(
+        `${sensitive.length} variable(s) have names that look sensitive: ${sensitive.join(', ')}. ` +
+        `If these are secrets, move them to \`sua secrets set\` for encrypted storage.`,
+      );
+    }
+  });
+
+varsCommand
+  .command('get')
+  .description('Print a variable\'s value')
+  .argument('<name>', 'Variable name')
+  .action((name: string) => {
+    const store = new VariablesStore(getVarsPath());
+    const v = store.getValue(name);
+    if (v === undefined) {
+      ui.fail(`Variable "${name}" not set.`);
+      process.exit(1);
+    }
+    console.log(v);
+  });
+
+varsCommand
+  .command('set')
+  .description('Set a global variable')
+  .argument('<name>', 'Variable name (e.g. API_BASE_URL)')
+  .argument('<value>', 'Value')
+  .option('-d, --description <desc>', 'Optional description')
+  .action((name: string, value: string, options: { description?: string }) => {
+    if (!/^[A-Z_][A-Z0-9_]*$/.test(name)) {
+      ui.fail(`Invalid variable name "${name}". Must be UPPERCASE_WITH_UNDERSCORES.`);
+      process.exit(1);
+    }
+
+    if (looksLikeSensitive(name)) {
+      ui.warn(
+        `"${name}" looks like it might be a secret. If this value is sensitive, ` +
+        `use \`sua secrets set ${name}\` instead (encrypted storage).`,
+      );
+    }
+
+    const store = new VariablesStore(getVarsPath());
+    store.set(name, value, options.description);
+    ui.ok(`Set ${ui.agent(name)} = ${value}`);
+  });
+
+varsCommand
+  .command('delete')
+  .description('Delete a global variable')
+  .argument('<name>', 'Variable name')
+  .action((name: string) => {
+    const store = new VariablesStore(getVarsPath());
+    if (!store.delete(name)) {
+      ui.warn(`Variable "${name}" not found.`);
+      process.exit(1);
+    }
+    ui.ok(`Deleted ${ui.agent(name)}`);
+  });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -27,6 +27,7 @@ import { dashboardCommand } from './commands/dashboard.js';
 import { workflowCommand } from './commands/workflow.js';
 import { toolCommand } from './commands/tool.js';
 import { examplesCommand } from './commands/examples.js';
+import { varsCommand } from './commands/vars.js';
 
 // Read version from our own package.json so `sua --version` always matches
 // the installed package version (no hardcoded drift).
@@ -89,5 +90,6 @@ program.addCommand(dashboardCommand);
 program.addCommand(workflowCommand);
 program.addCommand(toolCommand);
 program.addCommand(examplesCommand);
+program.addCommand(varsCommand);
 
 program.parse();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,7 @@ export {
   isBuiltinTool,
 } from './builtin-tools.js';
 export { extractFramedOutput, buildToolOutput } from './output-framing.js';
+export { VariablesStore, looksLikeSensitive, type Variable } from './variables-store.js';
 
 export {
   executeAgentDag,

--- a/packages/core/src/variables-store.test.ts
+++ b/packages/core/src/variables-store.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { VariablesStore, looksLikeSensitive } from './variables-store.js';
+
+let dir: string;
+let store: VariablesStore;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'sua-vars-'));
+  store = new VariablesStore(join(dir, '.sua', 'variables.json'));
+});
+
+afterEach(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('VariablesStore', () => {
+  it('starts empty', () => {
+    expect(store.listNames()).toEqual([]);
+    expect(store.getAll()).toEqual({});
+  });
+
+  it('sets and gets a variable', () => {
+    store.set('API_URL', 'https://api.example.com', 'Base URL');
+    expect(store.getValue('API_URL')).toBe('https://api.example.com');
+    expect(store.get('API_URL')).toEqual({ value: 'https://api.example.com', description: 'Base URL' });
+  });
+
+  it('lists variables sorted', () => {
+    store.set('B_VAR', 'b');
+    store.set('A_VAR', 'a');
+    expect(store.listNames()).toEqual(['A_VAR', 'B_VAR']);
+  });
+
+  it('overwrites existing value', () => {
+    store.set('X', 'old');
+    store.set('X', 'new');
+    expect(store.getValue('X')).toBe('new');
+  });
+
+  it('deletes a variable', () => {
+    store.set('DOOMED', 'value');
+    expect(store.delete('DOOMED')).toBe(true);
+    expect(store.has('DOOMED')).toBe(false);
+  });
+
+  it('returns false when deleting nonexistent', () => {
+    expect(store.delete('GHOST')).toBe(false);
+  });
+
+  it('persists across instances', () => {
+    store.set('PERSIST', 'yes');
+    const store2 = new VariablesStore(join(dir, '.sua', 'variables.json'));
+    expect(store2.getValue('PERSIST')).toBe('yes');
+  });
+
+  it('getAll returns flat name→value map', () => {
+    store.set('A', '1');
+    store.set('B', '2');
+    expect(store.getAll()).toEqual({ A: '1', B: '2' });
+  });
+});
+
+describe('looksLikeSensitive', () => {
+  it('flags TOKEN, KEY, PASS, SECRET', () => {
+    expect(looksLikeSensitive('API_TOKEN')).toBe(true);
+    expect(looksLikeSensitive('MY_KEY')).toBe(true);
+    expect(looksLikeSensitive('DB_PASSWORD')).toBe(true);
+    expect(looksLikeSensitive('SHARED_SECRET')).toBe(true);
+  });
+
+  it('does not flag normal names', () => {
+    expect(looksLikeSensitive('API_URL')).toBe(false);
+    expect(looksLikeSensitive('REGION')).toBe(false);
+    expect(looksLikeSensitive('DEFAULT_TIMEOUT')).toBe(false);
+  });
+});

--- a/packages/core/src/variables-store.ts
+++ b/packages/core/src/variables-store.ts
@@ -1,0 +1,104 @@
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+/**
+ * Global variables store. Plain-text JSON file at `.sua/variables.json`.
+ * Variables are non-sensitive project-wide values (API_BASE_URL, REGION,
+ * DEFAULT_TIMEOUT) available to every agent at run time.
+ *
+ * NOT encrypted — if a value is sensitive, it belongs in the secrets
+ * store. The `sua doctor` check flags names that look like secrets
+ * (TOKEN, KEY, PASS, SECRET) so users can move them.
+ */
+
+export interface Variable {
+  value: string;
+  description?: string;
+}
+
+interface VariablesFile {
+  version: 1;
+  variables: Record<string, Variable>;
+}
+
+export class VariablesStore {
+  private readonly path: string;
+
+  constructor(filePath: string) {
+    this.path = filePath;
+    const dir = dirname(filePath);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+
+  get(name: string): Variable | undefined {
+    return this.read().variables[name];
+  }
+
+  getValue(name: string): string | undefined {
+    return this.read().variables[name]?.value;
+  }
+
+  set(name: string, value: string, description?: string): void {
+    const data = this.read();
+    data.variables[name] = { value, ...(description ? { description } : {}) };
+    this.write(data);
+  }
+
+  delete(name: string): boolean {
+    const data = this.read();
+    if (!(name in data.variables)) return false;
+    delete data.variables[name];
+    this.write(data);
+    return true;
+  }
+
+  list(): Record<string, Variable> {
+    return { ...this.read().variables };
+  }
+
+  listNames(): string[] {
+    return Object.keys(this.read().variables).sort();
+  }
+
+  has(name: string): boolean {
+    return name in this.read().variables;
+  }
+
+  /** All values as a flat name→value map (for executor injection). */
+  getAll(): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(this.read().variables)) {
+      out[k] = v.value;
+    }
+    return out;
+  }
+
+  private read(): VariablesFile {
+    if (!existsSync(this.path)) {
+      return { version: 1, variables: {} };
+    }
+    try {
+      const raw = readFileSync(this.path, 'utf-8');
+      const parsed = JSON.parse(raw) as VariablesFile;
+      if (parsed.version !== 1) {
+        throw new Error(`Unsupported variables file version: ${parsed.version}`);
+      }
+      return parsed;
+    } catch (err) {
+      if ((err as Error).message.includes('version')) throw err;
+      return { version: 1, variables: {} };
+    }
+  }
+
+  private write(data: VariablesFile): void {
+    writeFileSync(this.path, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+  }
+}
+
+/** Names that look like they should be secrets, not plain variables. */
+const SENSITIVE_PATTERNS = [/TOKEN/i, /KEY/i, /PASS/i, /SECRET/i, /PASSWORD/i, /CREDENTIAL/i];
+
+/** Check if a variable name looks sensitive (for `sua doctor` warnings). */
+export function looksLikeSensitive(name: string): boolean {
+  return SENSITIVE_PATTERNS.some((re) => re.test(name));
+}


### PR DESCRIPTION
## Summary

- **`VariablesStore`** — plain-text JSON at `.sua/variables.json`. CRUD for non-sensitive project-wide values.
- **`sua vars list/get/set/delete`** — mirrors the secrets CLI. Warns when names look sensitive (TOKEN, KEY, PASS, SECRET).
- **`looksLikeSensitive()`** — flags names that should probably be in the encrypted store.

Executor wiring (`$NAME` / `{{vars.NAME}}`) comes in PR 2.

## Test plan

- [x] 553/553 tests (543 → 553; +10 new). Lint + build clean.
- Store: empty start, set/get, list sorted, overwrite, delete, persistence, getAll
- Sensitivity check: flags TOKEN/KEY/PASS/SECRET, ignores API_URL/REGION

🤖 Generated with [Claude Code](https://claude.com/claude-code)