### PR TITLE
feat(dashboard): palette extension with global variables + group separators (Variables PR 4/6)

### DIFF
--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { startDashboardServer } from '@some-useful-agents/dashboard';
-import { loadConfig, getAgentDirs, getDbPath, getSecretsPath, getRetentionDays } from '../config.js';
+import { loadConfig, getAgentDirs, getDbPath, getSecretsPath, getVariablesPath, getRetentionDays } from '../config.js';
 import * as ui from '../ui.js';
 
 function collectName(value: string, previous: string[]): string[] {
@@ -55,6 +55,7 @@ of scope for this release — wrap in launchd / systemd if you need it.
         agentDirs: dirs.all,
         dbPath: getDbPath(config),
         secretsPath: getSecretsPath(config),
+        variablesPath: getVariablesPath(config),
         retentionDays: getRetentionDays(config),
         allowUntrustedShell: new Set(options.allowUntrustedShell),
       });

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -82,6 +82,10 @@ export function getSecretsPath(config: SuaConfig): string {
   return join(resolve(config.dataDir), 'secrets.enc');
 }
 
+export function getVariablesPath(config: SuaConfig): string {
+  return join(resolve(config.dataDir), '.sua', 'variables.json');
+}
+
 export function getRetentionDays(config: SuaConfig): number {
   return config.runRetentionDays ?? 30;
 }

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -592,6 +592,19 @@ main.main--wide {
   text-overflow: ellipsis;
 }
 
+.template-palette__group {
+  padding: var(--space-1) var(--space-3);
+  font-size: 10px;
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-top: 1px solid var(--color-border);
+}
+.template-palette__group:first-child {
+  border-top: none;
+}
+
 .template-palette__empty {
   padding: var(--space-3);
   color: var(--color-text-muted);

--- a/packages/dashboard/src/context.ts
+++ b/packages/dashboard/src/context.ts
@@ -1,4 +1,4 @@
-import type { LocalProvider, RunStore, SecretsStore, AgentDefinition, AgentStore, ToolStore } from '@some-useful-agents/core';
+import type { LocalProvider, RunStore, SecretsStore, AgentDefinition, AgentStore, ToolStore, VariablesStore } from '@some-useful-agents/core';
 import type { SecretsSession } from './secrets-session.js';
 
 /**
@@ -67,7 +67,12 @@ export interface DashboardContext {
   toolStore?: ToolStore;
   /** When true, the dashboard allows POSTs that would execute community shell. */
   allowUntrustedShell: Set<string>;
-  /** Called to validate agent-supplied inputs at run-now time. Defaults built into LocalProvider. */
+  /**
+   * v0.17+: global variables store. Plain-text, non-sensitive values that
+   * are available to every agent at run time. Surfaces in the palette
+   * autocomplete and the /settings/variables tab.
+   */
+  variablesStore?: VariablesStore;
 }
 
 /**

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -5,6 +5,7 @@ import {
   RunStore,
   AgentStore,
   ToolStore,
+  VariablesStore,
   EncryptedFileStore,
   loadAgents,
   readMcpToken,
@@ -38,6 +39,8 @@ export interface StartDashboardOptions {
   dbPath: string;
   /** Path to the encrypted secrets file. */
   secretsPath: string;
+  /** Path to the plain-text global variables file (.sua/variables.json). */
+  variablesPath?: string;
   /** Path to the bearer token file. Defaults to `~/.sua/mcp-token`. */
   tokenPath?: string;
   /** Community shell agents the operator has pre-allowed. */
@@ -136,6 +139,12 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     // Non-fatal: tools surface degrades to built-ins only.
   }
 
+  // Global variables store (plain-text, non-sensitive).
+  let variablesStore: VariablesStore | undefined;
+  if (opts.variablesPath) {
+    variablesStore = new VariablesStore(opts.variablesPath);
+  }
+
   const ctx: DashboardContext = {
     token,
     allowlist: buildLoopbackAllowlist(opts.port),
@@ -152,6 +161,7 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     secretsPath: opts.secretsPath,
     rotateToken: () => rotateMcpToken(tokenPath),
     toolStore,
+    variablesStore,
     allowUntrustedShell: opts.allowUntrustedShell ?? new Set(),
   };
 

--- a/packages/dashboard/src/routes/agents.ts
+++ b/packages/dashboard/src/routes/agents.ts
@@ -138,7 +138,7 @@ agentsRouter.get('/agents/:name/add-node', (req: Request, res: Response) => {
   }
   const fromCreate = req.query.fromCreate === '1';
   const flashParam = typeof req.query.flash === 'string' ? req.query.flash : undefined;
-  res.type('html').send(renderAgentAddNode({ agent, fromCreate, flash: flashParam, toolStore: ctx.toolStore }));
+  res.type('html').send(renderAgentAddNode({ agent, fromCreate, flash: flashParam, toolStore: ctx.toolStore, variablesStore: ctx.variablesStore }));
 });
 
 agentsRouter.post('/agents/:name/add-node', (req: Request, res: Response) => {
@@ -167,13 +167,13 @@ agentsRouter.post('/agents/:name/add-node', (req: Request, res: Response) => {
   // Validate.
   if (!values.id || !NODE_ID_RE.test(values.id)) {
     res.status(400).type('html').send(renderAgentAddNode({
-      agent, values, error: 'Node id must be lowercase letters, digits, hyphens, or underscores.',
+      agent, values, variablesStore: ctx.variablesStore, error: 'Node id must be lowercase letters, digits, hyphens, or underscores.',
     }));
     return;
   }
   if (agent.nodes.some((n) => n.id === values.id)) {
     res.status(400).type('html').send(renderAgentAddNode({
-      agent, values, error: `A node with id "${values.id}" already exists in this agent.`,
+      agent, values, variablesStore: ctx.variablesStore, error: `A node with id "${values.id}" already exists in this agent.`,
     }));
     return;
   }
@@ -182,19 +182,19 @@ agentsRouter.post('/agents/:name/add-node', (req: Request, res: Response) => {
   const badDep = dependsOn.find((d) => !existingIds.has(d));
   if (badDep) {
     res.status(400).type('html').send(renderAgentAddNode({
-      agent, values, error: `Unknown upstream node: "${badDep}".`,
+      agent, values, variablesStore: ctx.variablesStore, error: `Unknown upstream node: "${badDep}".`,
     }));
     return;
   }
   if (values.type === 'shell' && (!values.command || values.command.trim() === '')) {
     res.status(400).type('html').send(renderAgentAddNode({
-      agent, values, error: 'Shell nodes need a command.',
+      agent, values, variablesStore: ctx.variablesStore, error: 'Shell nodes need a command.',
     }));
     return;
   }
   if (values.type === 'claude-code' && (!values.prompt || values.prompt.trim() === '')) {
     res.status(400).type('html').send(renderAgentAddNode({
-      agent, values, error: 'Claude-Code nodes need a prompt.',
+      agent, values, variablesStore: ctx.variablesStore, error: 'Claude-Code nodes need a prompt.',
     }));
     return;
   }
@@ -222,7 +222,7 @@ agentsRouter.post('/agents/:name/add-node', (req: Request, res: Response) => {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     res.status(400).type('html').send(renderAgentAddNode({
-      agent, values, error: `Save failed: ${msg}`,
+      agent, values, variablesStore: ctx.variablesStore, error: `Save failed: ${msg}`,
     }));
   }
 });
@@ -252,7 +252,7 @@ agentsRouter.get('/agents/:name/nodes/:nodeId/edit', (req: Request, res: Respons
     res.status(404).redirect(303, `/agents/${encodeURIComponent(agent.id)}?flash=${encodeURIComponent(`Node "${nodeId}" not found.`)}`);
     return;
   }
-  res.type('html').send(renderAgentEditNode({ agent, node, toolStore: ctx.toolStore }));
+  res.type('html').send(renderAgentEditNode({ agent, node, toolStore: ctx.toolStore, variablesStore: ctx.variablesStore }));
 });
 
 agentsRouter.post('/agents/:name/nodes/:nodeId/edit', (req: Request, res: Response) => {
@@ -288,14 +288,14 @@ agentsRouter.post('/agents/:name/nodes/:nodeId/edit', (req: Request, res: Respon
   const existingIds = new Set(agent.nodes.map((n) => n.id));
   if (dependsOn.includes(nodeId)) {
     res.status(400).type('html').send(renderAgentEditNode({
-      agent, node, values, error: 'A node cannot depend on itself.',
+      agent, node, values, variablesStore: ctx.variablesStore, error: 'A node cannot depend on itself.',
     }));
     return;
   }
   const badDep = dependsOn.find((d) => !existingIds.has(d));
   if (badDep) {
     res.status(400).type('html').send(renderAgentEditNode({
-      agent, node, values, error: `Unknown upstream node: "${badDep}".`,
+      agent, node, values, variablesStore: ctx.variablesStore, error: `Unknown upstream node: "${badDep}".`,
     }));
     return;
   }
@@ -303,19 +303,19 @@ agentsRouter.post('/agents/:name/nodes/:nodeId/edit', (req: Request, res: Respon
   // but a hand-crafted POST could bypass it. Re-check.
   if (hasCycleAfterEdit(agent, nodeId, dependsOn)) {
     res.status(400).type('html').send(renderAgentEditNode({
-      agent, node, values, error: 'Those dependencies would create a cycle in the DAG.',
+      agent, node, values, variablesStore: ctx.variablesStore, error: 'Those dependencies would create a cycle in the DAG.',
     }));
     return;
   }
   if (values.type === 'shell' && (!values.command || values.command.trim() === '')) {
     res.status(400).type('html').send(renderAgentEditNode({
-      agent, node, values, error: 'Shell nodes need a command.',
+      agent, node, values, variablesStore: ctx.variablesStore, error: 'Shell nodes need a command.',
     }));
     return;
   }
   if (values.type === 'claude-code' && (!values.prompt || values.prompt.trim() === '')) {
     res.status(400).type('html').send(renderAgentEditNode({
-      agent, node, values, error: 'Claude-Code nodes need a prompt.',
+      agent, node, values, variablesStore: ctx.variablesStore, error: 'Claude-Code nodes need a prompt.',
     }));
     return;
   }
@@ -353,7 +353,7 @@ agentsRouter.post('/agents/:name/nodes/:nodeId/edit', (req: Request, res: Respon
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     res.status(400).type('html').send(renderAgentEditNode({
-      agent, node, values, error: `Save failed: ${msg}`,
+      agent, node, values, variablesStore: ctx.variablesStore, error: `Save failed: ${msg}`,
     }));
   }
 });

--- a/packages/dashboard/src/template-palette.test.ts
+++ b/packages/dashboard/src/template-palette.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { VariablesStore } from '@some-useful-agents/core';
+import type { Agent } from '@some-useful-agents/core';
+import { computePaletteSuggestions } from './views/template-palette.js';
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: 'test-agent',
+    name: 'Test Agent',
+    status: 'active',
+    source: 'local',
+    version: 1,
+    nodes: [
+      { id: 'step-a', type: 'shell', command: 'echo a' },
+      { id: 'step-b', type: 'claude-code', prompt: 'hello', dependsOn: ['step-a'] },
+    ],
+    ...overrides,
+  };
+}
+
+describe('computePaletteSuggestions', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'palette-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns upstreams, inputs, secrets, and empty vars when no store', () => {
+    const agent = makeAgent({
+      inputs: { ZIP: { type: 'number', required: true } },
+    });
+    const result = computePaletteSuggestions(agent, { nodeSecrets: ['MY_KEY'] });
+    expect(result.upstreams).toEqual(['step-a', 'step-b']);
+    expect(result.inputs).toEqual(['ZIP']);
+    expect(result.secrets).toEqual(['MY_KEY']);
+    expect(result.vars).toEqual([]);
+  });
+
+  it('includes global variable names when variablesStore is provided', () => {
+    const store = new VariablesStore(join(dir, 'variables.json'));
+    store.set('API_URL', 'https://api.example.com', 'Shared API URL');
+    store.set('REGION', 'us-east-1');
+
+    const agent = makeAgent();
+    const result = computePaletteSuggestions(agent, { variablesStore: store });
+    expect(result.vars).toEqual(['API_URL', 'REGION']);
+  });
+
+  it('excludes the current node from upstreams', () => {
+    const agent = makeAgent();
+    const result = computePaletteSuggestions(agent, { excludeNodeId: 'step-a' });
+    expect(result.upstreams).toEqual(['step-b']);
+  });
+});

--- a/packages/dashboard/src/views/agent-add-node.ts
+++ b/packages/dashboard/src/views/agent-add-node.ts
@@ -1,10 +1,9 @@
-import type { Agent } from '@some-useful-agents/core';
+import type { Agent, ToolStore, VariablesStore } from '@some-useful-agents/core';
 import { html, render, unsafeHtml, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
 import { computePaletteSuggestions, renderPalettePayload } from './template-palette.js';
 import { renderToolPicker, renderToolInputsSection, getAvailableTools } from './tool-picker.js';
-import type { ToolStore } from '@some-useful-agents/core';
 
 /**
  * Render a reference card listing everything the author can inject into
@@ -88,8 +87,9 @@ export function renderAgentAddNode(args: {
   fromCreate?: boolean;
   /** v0.16+: tool store for the tool picker dropdown. */
   toolStore?: ToolStore;
+  variablesStore?: VariablesStore;
 }): string {
-  const { agent, values: v = {}, error, flash, fromCreate, toolStore } = args;
+  const { agent, values: v = {}, error, flash, fromCreate, toolStore, variablesStore } = args;
   const allTools = getAvailableTools(toolStore);
   const selectedTool = v.type === 'claude-code' ? 'claude-code' : 'shell-exec';
   const type = v.type ?? 'shell';
@@ -198,7 +198,7 @@ export function renderAgentAddNode(args: {
         </div>
       </fieldset>
 
-      ${renderPalettePayload('palette-add-node', computePaletteSuggestions(agent))}
+      ${renderPalettePayload('palette-add-node', computePaletteSuggestions(agent, { variablesStore }))}
 
       <div style="display: flex; gap: var(--space-2); justify-content: flex-end; align-items: center;">
         <a class="btn btn--ghost" href="/agents/${agent.id}">Cancel</a>

--- a/packages/dashboard/src/views/agent-edit-node.ts
+++ b/packages/dashboard/src/views/agent-edit-node.ts
@@ -1,4 +1,4 @@
-import type { Agent, AgentNode, ToolStore } from '@some-useful-agents/core';
+import type { Agent, AgentNode, ToolStore, VariablesStore } from '@some-useful-agents/core';
 import { html, render, unsafeHtml, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
@@ -27,8 +27,9 @@ export function renderAgentEditNode(args: {
   values?: EditNodeFormValues;
   error?: string;
   toolStore?: ToolStore;
+  variablesStore?: VariablesStore;
 }): string {
-  const { agent, node, values: submitted, error, toolStore } = args;
+  const { agent, node, values: submitted, error, toolStore, variablesStore } = args;
   const allTools = getAvailableTools(toolStore);
 
   // Fall back to the node's current values if nothing's been submitted.
@@ -98,7 +99,7 @@ export function renderAgentEditNode(args: {
           : html`<div>${depToggles as unknown as SafeHtml[]}</div>`}
       </fieldset>
 
-      ${renderAvailableVars(agent, node)}
+      ${renderAvailableVars(agent, node, variablesStore)}
 
       <fieldset style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--space-3); margin-bottom: var(--space-4);">
         <legend style="padding: 0 var(--space-2); font-size: var(--font-size-xs); font-weight: var(--weight-semibold); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em;">Implementation</legend>
@@ -131,6 +132,7 @@ export function renderAgentEditNode(args: {
         computePaletteSuggestions(agent, {
           excludeNodeId: node.id,
           nodeSecrets: node.secrets,
+          variablesStore,
         }),
       )}
 
@@ -170,12 +172,13 @@ function collectDownstream(agent: Agent, startId: string): Set<string> {
  * so the user knows what they can reference in the command/prompt without
  * having to type $ to discover them.
  */
-function renderAvailableVars(agent: Agent, node: AgentNode): SafeHtml {
+function renderAvailableVars(agent: Agent, node: AgentNode, variablesStore?: VariablesStore): SafeHtml {
   const inputs = Object.entries(agent.inputs ?? {});
   const upstreams = (node.dependsOn ?? []).filter((id) => agent.nodes.some((n) => n.id === id));
   const secrets = node.secrets ?? [];
+  const globalVars = variablesStore ? Object.entries(variablesStore.list()) : [];
 
-  if (inputs.length === 0 && upstreams.length === 0 && secrets.length === 0) {
+  if (inputs.length === 0 && upstreams.length === 0 && secrets.length === 0 && globalVars.length === 0) {
     return html``;
   }
 
@@ -192,6 +195,21 @@ function renderAvailableVars(agent: Agent, node: AgentNode): SafeHtml {
       <tr>
         <td class="mono" style="color: var(--color-primary);">$${name}</td>
         <td>agent input</td>
+        <td class="dim">${info}</td>
+      </tr>
+    `);
+  }
+
+  for (const [name, variable] of globalVars) {
+    const desc = variable.description ?? '';
+    const info = [
+      `value: ${variable.value}`,
+      desc,
+    ].filter(Boolean).join(' \u2014 ');
+    rows.push(html`
+      <tr>
+        <td class="mono" style="color: var(--color-primary);">$${name}</td>
+        <td>global variable</td>
         <td class="dim">${info}</td>
       </tr>
     `);

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -215,10 +215,18 @@ export const DASHBOARD_JS = `
             group: 'input',
           });
         }
-        for (var k = 0; k < sugg.secrets.length; k++) {
+        for (var k = 0; k < (sugg.vars || []).length; k++) {
           items.push({
-            insert: '$' + sugg.secrets[k],
-            label: '$' + sugg.secrets[k],
+            insert: '$' + sugg.vars[k],
+            label: '$' + sugg.vars[k],
+            hint: 'global variable',
+            group: 'var',
+          });
+        }
+        for (var l = 0; l < sugg.secrets.length; l++) {
+          items.push({
+            insert: '$' + sugg.secrets[l],
+            label: '$' + sugg.secrets[l],
             hint: 'node secret',
             group: 'secret',
           });
@@ -239,6 +247,14 @@ export const DASHBOARD_JS = `
             label: '{{inputs.' + sugg.inputs[n] + '}}',
             hint: 'agent input',
             group: 'input',
+          });
+        }
+        for (var p = 0; p < (sugg.vars || []).length; p++) {
+          items.push({
+            insert: '{{vars.' + sugg.vars[p] + '}}',
+            label: '{{vars.' + sugg.vars[p] + '}}',
+            hint: 'global variable',
+            group: 'var',
           });
         }
       }
@@ -300,6 +316,13 @@ export const DASHBOARD_JS = `
       palette.style.minWidth = Math.round(Math.min(rect.width, 420)) + 'px';
     }
 
+    var GROUP_LABELS = {
+      upstream: 'Upstream outputs',
+      input: 'Agent inputs',
+      var: 'Global variables',
+      secret: 'Secrets',
+    };
+
     function renderPalette(items, selectedIndex) {
       ensurePalette();
       palette.innerHTML = '';
@@ -309,7 +332,16 @@ export const DASHBOARD_JS = `
         empty.textContent = 'No matches';
         palette.appendChild(empty);
       } else {
+        var lastGroup = null;
         for (var i = 0; i < items.length; i++) {
+          if (items[i].group !== lastGroup) {
+            lastGroup = items[i].group;
+            var sep = document.createElement('div');
+            sep.className = 'template-palette__group';
+            sep.textContent = GROUP_LABELS[lastGroup] || lastGroup;
+            palette.appendChild(sep);
+          }
+
           var row = document.createElement('div');
           row.className = 'template-palette__item' + (i === selectedIndex ? ' is-selected' : '');
           row.setAttribute('data-index', String(i));

--- a/packages/dashboard/src/views/template-palette.ts
+++ b/packages/dashboard/src/views/template-palette.ts
@@ -1,4 +1,4 @@
-import type { Agent } from '@some-useful-agents/core';
+import type { Agent, VariablesStore } from '@some-useful-agents/core';
 import { html, unsafeHtml, type SafeHtml } from './html.js';
 
 export interface PaletteSuggestions {
@@ -8,6 +8,8 @@ export interface PaletteSuggestions {
   inputs: string[];
   /** Secret names this node declares (per-node injection). */
   secrets: string[];
+  /** Global variable names from /settings/variables. */
+  vars: string[];
 }
 
 /**
@@ -26,7 +28,7 @@ export interface PaletteSuggestions {
  */
 export function computePaletteSuggestions(
   agent: Agent,
-  opts: { excludeNodeId?: string; nodeSecrets?: string[] } = {},
+  opts: { excludeNodeId?: string; nodeSecrets?: string[]; variablesStore?: VariablesStore } = {},
 ): PaletteSuggestions {
   const upstreams = agent.nodes
     .map((n) => n.id)
@@ -34,7 +36,8 @@ export function computePaletteSuggestions(
     .sort();
   const inputs = Object.keys(agent.inputs ?? {}).sort();
   const secrets = (opts.nodeSecrets ?? []).slice().sort();
-  return { upstreams, inputs, secrets };
+  const vars = opts.variablesStore ? opts.variablesStore.listNames() : [];
+  return { upstreams, inputs, secrets, vars };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extends the template palette autocomplete to suggest global variables from `/settings/variables` alongside upstream outputs, agent inputs, and secrets
- Adds group separator headers (Upstream outputs, Agent inputs, Global variables, Secrets) to the palette dropdown for visual clarity
- Wires `VariablesStore` into the dashboard context and passes it through the CLI dashboard startup

## Changes
- `PaletteSuggestions` interface gains a `vars` field
- `computePaletteSuggestions` accepts optional `VariablesStore`
- Client-side JS renders `$VAR` (shell) and `{{vars.VAR}}` (claude-code) palette items
- Group separator rows with CSS styling in the palette dropdown
- `DashboardContext` gains optional `variablesStore`
- CLI dashboard command passes `variablesPath`
- Edit-node "Available variables" panel shows global variables with values + descriptions
- Tests for palette suggestions with vars

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (559 tests)
- [ ] Manual: open edit-node form, type `$` in command → see "Global variables" group if any exist
- [ ] Manual: type `{{` in prompt → see `{{vars.NAME}}` suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)