### PR TITLE
feat(dashboard): /settings/variables CRUD surface (Variables PR 5/6)

### DIFF
--- a/packages/dashboard/src/routes/settings.ts
+++ b/packages/dashboard/src/routes/settings.ts
@@ -1,7 +1,9 @@
 import { Router, type Request, type Response } from 'express';
+import { looksLikeSensitive } from '@some-useful-agents/core';
 import { html } from '../views/html.js';
 import { renderSettingsShell } from '../views/settings-shell.js';
 import { renderSettingsSecrets } from '../views/settings-secrets.js';
+import { renderSettingsVariables } from '../views/settings-variables.js';
 import { renderSettingsGeneral } from '../views/settings-general.js';
 import { getContext, type DashboardContext } from '../context.js';
 import { SESSION_COOKIE } from '../auth-middleware.js';
@@ -9,6 +11,7 @@ import { SESSION_COOKIE } from '../auth-middleware.js';
 export const settingsRouter: Router = Router();
 
 const SECRET_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
+const VAR_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
 
 settingsRouter.get('/settings', (_req: Request, res: Response) => {
   res.redirect(303, '/settings/secrets');
@@ -113,6 +116,107 @@ settingsRouter.post('/settings/secrets/delete', async (req: Request, res: Respon
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     redirectWith(res, '/settings/secrets', 'setError', `Delete failed: ${msg}`);
+  }
+});
+
+// ── Variables ─────────────────────────────────────────────────────────────
+
+settingsRouter.get('/settings/variables', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const { flash, setError } = readQueryBanners(req);
+
+  if (!ctx.variablesStore) {
+    const body = html`
+      <div class="settings-empty">
+        <h3 style="margin-top: 0;">Variables</h3>
+        <p>No variables store configured.</p>
+        <p class="dim">Start the dashboard with a <code>variablesPath</code> to enable global variables.</p>
+      </div>
+    `;
+    res.type('html').send(renderSettingsShell({ active: 'variables', body, flash }));
+    return;
+  }
+
+  const all = ctx.variablesStore.list();
+  const variables = Object.entries(all).sort(([a], [b]) => a.localeCompare(b));
+
+  const body = renderSettingsVariables({
+    variables,
+    setError,
+    setNameValue: typeof req.query.name === 'string' ? req.query.name : undefined,
+    setValueValue: typeof req.query.value === 'string' ? req.query.value : undefined,
+    setDescriptionValue: typeof req.query.description === 'string' ? req.query.description : undefined,
+  });
+  res.type('html').send(renderSettingsShell({ active: 'variables', body, flash }));
+});
+
+settingsRouter.post('/settings/variables/set', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  const value = typeof body.value === 'string' ? body.value : '';
+  const description = typeof body.description === 'string' ? body.description.trim() : '';
+
+  if (!ctx.variablesStore) {
+    redirectWith(res, '/settings/variables', 'setError', 'Variables store not configured.');
+    return;
+  }
+
+  if (!VAR_NAME_RE.test(name)) {
+    redirectWith(
+      res,
+      '/settings/variables',
+      'setError',
+      `Invalid name "${name}". Must be uppercase letters, digits, or underscores (e.g. API_BASE_URL).`,
+      { name, value, description },
+    );
+    return;
+  }
+  if (value.length === 0) {
+    redirectWith(res, '/settings/variables', 'setError', 'Value is required.', { name, description });
+    return;
+  }
+
+  // Warn (but don't refuse) if the name looks like it should be a secret.
+  let flashMsg = `Saved ${name}.`;
+  if (looksLikeSensitive(name)) {
+    flashMsg += ` Note: "${name}" looks like it might be sensitive. Consider using Secrets instead.`;
+  }
+
+  try {
+    ctx.variablesStore.set(name, value, description || undefined);
+    redirectWith(res, '/settings/variables', 'flash', flashMsg);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    redirectWith(res, '/settings/variables', 'setError', `Save failed: ${msg}`, { name, value, description });
+  }
+});
+
+settingsRouter.post('/settings/variables/delete', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+
+  if (!ctx.variablesStore) {
+    redirectWith(res, '/settings/variables', 'setError', 'Variables store not configured.');
+    return;
+  }
+
+  if (!VAR_NAME_RE.test(name)) {
+    redirectWith(res, '/settings/variables', 'setError', `Invalid name "${name}".`);
+    return;
+  }
+
+  try {
+    const deleted = ctx.variablesStore.delete(name);
+    if (deleted) {
+      redirectWith(res, '/settings/variables', 'flash', `Deleted ${name}.`);
+    } else {
+      redirectWith(res, '/settings/variables', 'setError', `Variable "${name}" not found.`);
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    redirectWith(res, '/settings/variables', 'setError', `Delete failed: ${msg}`);
   }
 });
 

--- a/packages/dashboard/src/views/settings-shell.ts
+++ b/packages/dashboard/src/views/settings-shell.ts
@@ -2,7 +2,7 @@ import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
 
-export type SettingsTab = 'secrets' | 'integrations' | 'general';
+export type SettingsTab = 'secrets' | 'variables' | 'integrations' | 'general';
 
 export interface SettingsShellArgs {
   active: SettingsTab;
@@ -24,6 +24,7 @@ export function renderSettingsShell(args: SettingsShellArgs): string {
     ${pageHeader({ title: 'Settings' })}
     <nav class="tab-strip">
       ${tab('secrets', 'Secrets')}
+      ${tab('variables', 'Variables')}
       ${tab('integrations', 'Integrations')}
       ${tab('general', 'General')}
     </nav>

--- a/packages/dashboard/src/views/settings-variables.ts
+++ b/packages/dashboard/src/views/settings-variables.ts
@@ -1,0 +1,105 @@
+import type { Variable } from '@some-useful-agents/core';
+import { html, unsafeHtml, type SafeHtml } from './html.js';
+
+export interface SettingsVariablesArgs {
+  /** All variables, sorted by name. */
+  variables: Array<[string, Variable]>;
+  /** Inline error from a failed set/delete. */
+  setError?: string;
+  /** Preserve form values on round-trip. */
+  setNameValue?: string;
+  setValueValue?: string;
+  setDescriptionValue?: string;
+}
+
+/**
+ * Render the `/settings/variables` body. Variables are plain-text,
+ * non-sensitive values visible to every agent at run time. Unlike
+ * secrets, values ARE shown (they're not sensitive). CRUD parallels
+ * the secrets tab but without the unlock/lock ceremony.
+ */
+export function renderSettingsVariables(args: SettingsVariablesArgs): SafeHtml {
+  return html`
+    <div class="card">
+      <p class="card__title">Global variables</p>
+      <p class="dim">
+        Plain-text values available to every agent. Reference as
+        <code>$NAME</code> in shell commands or <code>{{vars.NAME}}</code>
+        in claude-code prompts. For sensitive values, use
+        <a href="/settings/secrets">Secrets</a> instead.
+      </p>
+      ${renderVariablesTable(args.variables)}
+    </div>
+
+    <div class="card">
+      <p class="card__title">Set a variable</p>
+      <p class="dim">
+        Names must be uppercase letters, digits, or underscores and start
+        with a letter or underscore (e.g. <code>API_BASE_URL</code>).
+        Setting an existing name overwrites its value.
+      </p>
+      ${setErrorBlock(args.setError)}
+      <form action="/settings/variables/set" method="post" class="settings-form">
+        <label class="settings-form__label" for="var-name">Name</label>
+        <input id="var-name" name="name" type="text" required
+          pattern="[A-Z_][A-Z0-9_]*"
+          placeholder="API_BASE_URL"
+          value="${args.setNameValue ?? ''}"
+          autocapitalize="off" autocorrect="off" spellcheck="false">
+
+        <label class="settings-form__label" for="var-value">Value</label>
+        <input id="var-value" name="value" type="text" required
+          placeholder="https://api.example.com"
+          value="${args.setValueValue ?? ''}"
+          autocomplete="off">
+
+        <label class="settings-form__label" for="var-description">Description (optional)</label>
+        <input id="var-description" name="description" type="text"
+          placeholder="Shared API base URL"
+          value="${args.setDescriptionValue ?? ''}">
+
+        <div class="settings-form__actions">
+          <button type="submit" class="btn btn--primary">Save variable</button>
+        </div>
+      </form>
+    </div>
+  `;
+}
+
+function renderVariablesTable(variables: Array<[string, Variable]>): SafeHtml {
+  if (variables.length === 0) {
+    return html`<p class="settings-empty" style="margin-top: var(--space-3);">No variables set yet. Add one below.</p>`;
+  }
+  const rows = variables.map(([name, v]) => html`
+    <tr>
+      <td class="mono">${name}</td>
+      <td class="mono">${v.value}</td>
+      <td class="dim">${v.description ?? ''}</td>
+      <td style="text-align: right;">
+        <form action="/settings/variables/delete" method="post"
+          data-confirm="Delete variable ${name}? Agents that reference it will get an empty value.">
+          <input type="hidden" name="name" value="${name}">
+          <button type="submit" class="btn btn--sm btn--ghost">Delete</button>
+        </form>
+      </td>
+    </tr>
+  `);
+  return html`
+    <table class="table" style="margin-top: var(--space-3);">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Value</th>
+          <th>Description</th>
+          <th style="text-align: right;">Action</th>
+        </tr>
+      </thead>
+      <tbody>${rows as unknown as SafeHtml[]}</tbody>
+    </table>
+  `;
+}
+
+function setErrorBlock(err: string | undefined): SafeHtml {
+  if (!err) return unsafeHtml('');
+  return html`<div class="flash flash--error" style="margin-bottom: var(--space-3);">${err}</div>`;
+}


### PR DESCRIPTION
## Summary
- Adds a **Variables** tab to the Settings shell (between Secrets and Integrations)
- Full CRUD: list all variables with values + descriptions, set/overwrite, delete with confirmation
- Names that look sensitive (TOKEN, KEY, PASS) trigger a flash warning suggesting Secrets instead

## Changes
- `SettingsTab` union gains `'variables'`
- New `settings-variables.ts` view: table of name/value/description + set form + delete buttons
- New routes in `settings.ts`: GET `/settings/variables`, POST `/set`, POST `/delete`
- Imports `looksLikeSensitive` from core for the warning

## Depends on
- PR #89 (Variables PR 4/6) — adds `variablesStore` to dashboard context

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (559 tests)
- [ ] Manual: navigate to /settings/variables — see Variables tab active
- [ ] Manual: set a variable → appears in the table with value shown
- [ ] Manual: delete a variable → confirmation dialog, variable removed
- [ ] Manual: set a variable named `API_TOKEN` → flash warning about sensitive name

🤖 Generated with [Claude Code](https://claude.com/claude-code)