### PR TITLE
feat(dashboard): agent-detail Variables section for editing input defaults (Variables PR 6/6)

### DIFF
--- a/packages/dashboard/src/routes/agents.ts
+++ b/packages/dashboard/src/routes/agents.ts
@@ -1,5 +1,5 @@
 import { Router, type Request, type Response } from 'express';
-import type { Agent, AgentDefinition, RunStatus } from '@some-useful-agents/core';
+import type { Agent, AgentDefinition, AgentInputSpec, RunStatus } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 import { renderAgentsList, type HomeStats } from '../views/agents-list.js';
 import { renderAgentDetail } from '../views/agent-detail.js';
@@ -412,6 +412,79 @@ agentsRouter.post('/agents/:name/nodes/:nodeId/delete', (req: Request, res: Resp
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     res.redirect(303, `/agents/${encodeURIComponent(agent.id)}?flash=${encodeURIComponent(`Delete failed: ${msg}`)}`);
+  }
+});
+
+/**
+ * POST /agents/:name/inputs/update — update defaults and descriptions on
+ * existing agent inputs, optionally add a new input. Creates a new version.
+ */
+agentsRouter.post('/agents/:name/inputs/update', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
+  const agent = ctx.agentStore.getAgent(name);
+  if (!agent) {
+    res.status(404).redirect(303, '/agents');
+    return;
+  }
+
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const updatedInputs: Record<string, AgentInputSpec> = {};
+
+  // Update defaults and descriptions on existing inputs.
+  for (const [inputName, spec] of Object.entries(agent.inputs ?? {})) {
+    const newDefault = typeof body[`default_${inputName}`] === 'string'
+      ? (body[`default_${inputName}`] as string).trim()
+      : undefined;
+    const newDescription = typeof body[`description_${inputName}`] === 'string'
+      ? (body[`description_${inputName}`] as string).trim()
+      : undefined;
+
+    const updated: AgentInputSpec = { ...spec };
+
+    if (newDefault !== undefined && newDefault !== '') {
+      if (spec.type === 'number') updated.default = Number(newDefault);
+      else if (spec.type === 'boolean') updated.default = newDefault === 'true';
+      else updated.default = newDefault;
+    } else if (newDefault === '') {
+      delete updated.default;
+    }
+
+    if (newDescription !== undefined && newDescription !== '') {
+      updated.description = newDescription;
+    } else if (newDescription === '') {
+      delete updated.description;
+    }
+
+    updatedInputs[inputName] = updated;
+  }
+
+  // Merge new input (if provided).
+  const merged = mergeNewInput(updatedInputs, body);
+
+  try {
+    ctx.agentStore.createNewVersion(
+      agent.id,
+      {
+        id: agent.id,
+        name: agent.name,
+        description: agent.description,
+        status: agent.status,
+        schedule: agent.schedule,
+        source: agent.source,
+        mcp: agent.mcp,
+        nodes: agent.nodes,
+        inputs: merged && Object.keys(merged).length > 0 ? merged : undefined,
+        author: agent.author,
+        tags: agent.tags,
+      },
+      'dashboard',
+      'Updated input defaults via dashboard',
+    );
+    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}?flash=${encodeURIComponent('Updated input defaults. New version created.')}#variables`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}?flash=${encodeURIComponent(`Save failed: ${msg}`)}#variables`);
   }
 });
 

--- a/packages/dashboard/src/views/agent-detail-v2.ts
+++ b/packages/dashboard/src/views/agent-detail-v2.ts
@@ -172,6 +172,8 @@ export async function renderAgentDetailV2(args: {
         </dl>
       </section>
 
+      ${renderInputsSection(agent)}
+
       <section class="inspector__section">
         <h4>Secrets</h4>
         <div style="display:flex; gap:var(--space-2); flex-wrap:wrap;">
@@ -236,6 +238,8 @@ export async function renderAgentDetailV2(args: {
           </section>
         ` : html``}
 
+        ${renderInputDefaultsSection(agent)}
+
         <section id="runs">
           <h2>Recent runs</h2>
           ${recentRuns.length === 0
@@ -254,6 +258,143 @@ export async function renderAgentDetailV2(args: {
   `;
 
   return render(layout({ title: agent.id, activeNav: 'agents', flash, wide: true }, body));
+}
+
+/**
+ * Render the full "Variables" section in the main content area.
+ * Shows existing agent inputs with defaults + descriptions in a table,
+ * plus an inline form for editing defaults on existing inputs and
+ * adding new ones. Editing POSTs to /agents/:id/inputs/update.
+ *
+ * Provisional: this section migrates into the dashboard revamp's
+ * tabbed agent detail layout as its own tab.
+ */
+function renderInputDefaultsSection(agent: Agent): SafeHtml {
+  const inputs = Object.entries(agent.inputs ?? {});
+
+  const inputRows = inputs.map(([name, spec]) => {
+    const defVal = spec.default !== undefined ? String(spec.default) : '';
+    const desc = spec.description ?? '';
+    return html`
+      <tr>
+        <td class="mono">${name}</td>
+        <td>
+          <span class="badge badge--muted" style="font-size: 9px;">${spec.type}</span>
+        </td>
+        <td>
+          <input type="text" name="default_${name}" value="${defVal}"
+            placeholder="(none)"
+            style="padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs); font-family: var(--font-mono); width: 10rem;">
+        </td>
+        <td>
+          <input type="text" name="description_${name}" value="${desc}"
+            placeholder="(none)"
+            style="padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs); width: 14rem;">
+        </td>
+        <td class="dim" style="font-size: var(--font-size-xs);">
+          ${spec.required !== false && spec.default === undefined ? 'required' : 'optional'}
+        </td>
+      </tr>
+    `;
+  });
+
+  return html`
+    <section id="variables">
+      <h2>Variables</h2>
+      <p class="dim" style="font-size: var(--font-size-xs); margin-bottom: var(--space-3);">
+        Agent-level inputs: values supplied via <code>--input NAME=value</code> at run time.
+        Defaults fill in when no value is supplied. Edit defaults below and save to create a new version.
+      </p>
+      <form method="POST" action="/agents/${agent.id}/inputs/update">
+        ${inputs.length > 0 ? html`
+          <table class="table" style="font-size: var(--font-size-xs); margin-bottom: var(--space-3);">
+            <thead>
+              <tr><th>Name</th><th>Type</th><th>Default</th><th>Description</th><th></th></tr>
+            </thead>
+            <tbody>${inputRows as unknown as SafeHtml[]}</tbody>
+          </table>
+        ` : html`
+          <p class="dim" style="margin-bottom: var(--space-3);">No inputs declared yet. Add one below.</p>
+        `}
+        <details>
+          <summary style="cursor: pointer; font-size: var(--font-size-xs); color: var(--color-primary); font-weight: var(--weight-medium);">+ Add a new input</summary>
+          <div style="margin-top: var(--space-2); display: flex; gap: var(--space-2); flex-wrap: wrap; align-items: flex-end;">
+            <label style="display: flex; flex-direction: column; gap: 2px; font-size: var(--font-size-xs);">
+              Name
+              <input type="text" name="newInputName" placeholder="API_URL" pattern="[A-Z_][A-Z0-9_]*"
+                style="padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs); font-family: var(--font-mono); width: 10rem;">
+            </label>
+            <label style="display: flex; flex-direction: column; gap: 2px; font-size: var(--font-size-xs);">
+              Type
+              <select name="newInputType" style="padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs);">
+                <option value="string">string</option>
+                <option value="number">number</option>
+                <option value="boolean">boolean</option>
+                <option value="enum">enum</option>
+              </select>
+            </label>
+            <label style="display: flex; flex-direction: column; gap: 2px; font-size: var(--font-size-xs);">
+              Default
+              <input type="text" name="newInputDefault" placeholder="optional"
+                style="padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs); font-family: var(--font-mono); width: 10rem;">
+            </label>
+            <label style="display: flex; flex-direction: column; gap: 2px; font-size: var(--font-size-xs);">
+              Description
+              <input type="text" name="newInputDescription" placeholder="optional"
+                style="padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs); width: 14rem;">
+            </label>
+          </div>
+        </details>
+        <div style="margin-top: var(--space-3); display: flex; gap: var(--space-2); justify-content: flex-end;">
+          <button type="submit" class="btn btn--primary btn--sm">Save variables</button>
+        </div>
+      </form>
+    </section>
+  `;
+}
+
+/**
+ * Render the agent-level inputs section in the inspector sidebar.
+ * Shows declared inputs with their type, default, and description.
+ * Links to #variables for full editing.
+ */
+function renderInputsSection(agent: Agent): SafeHtml {
+  const inputs = Object.entries(agent.inputs ?? {});
+  if (inputs.length === 0) {
+    return html`
+      <section class="inspector__section">
+        <h4>Variables</h4>
+        <span class="dim" style="font-size: var(--font-size-xs);">No agent inputs declared.</span>
+        <div style="margin-top: var(--space-2);">
+          <a class="dim" href="#variables" style="font-size: var(--font-size-xs);">+ Add input</a>
+        </div>
+      </section>
+    `;
+  }
+
+  const rows = inputs.map(([name, spec]) => {
+    const defVal = spec.default !== undefined ? String(spec.default) : '';
+    const typeBadge = html`<span class="badge badge--muted" style="font-size: 9px;">${spec.type}</span>`;
+    return html`
+      <div style="display: flex; align-items: baseline; gap: var(--space-2); font-size: var(--font-size-xs); padding: var(--space-1) 0; border-bottom: 1px solid var(--color-border);">
+        <code style="flex: 0 0 auto;">${name}</code>
+        ${typeBadge}
+        <span class="dim" style="margin-left: auto; text-align: right;">
+          ${defVal ? defVal : spec.required !== false ? 'required' : 'optional'}
+        </span>
+      </div>
+    `;
+  });
+
+  return html`
+    <section class="inspector__section">
+      <h4>Variables</h4>
+      <div>${rows as unknown as SafeHtml[]}</div>
+      <div style="margin-top: var(--space-2);">
+        <a class="dim" href="#variables" style="font-size: var(--font-size-xs);">Edit defaults</a>
+      </div>
+    </section>
+  `;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds a **Variables** section to the agent detail page for managing agent-level input defaults
- Inspector sidebar shows a compact summary of declared inputs (name, type, default/required)
- Main content area has an editable table with inline text fields for defaults and descriptions
- New POST route `/agents/:name/inputs/update` creates a new agent version with updated defaults

## Changes
- `renderInputsSection()` — inspector sidebar compact view
- `renderInputDefaultsSection()` — main content editable table + "Add new input" form
- `POST /agents/:name/inputs/update` route — merges updated defaults/descriptions, optionally adds new input, creates new version

## Depends on
- PR #90 (Variables PR 5/6)
- PR #89 (Variables PR 4/6)

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (559 tests)
- [ ] Manual: open agent detail → see Variables section in sidebar inspector
- [ ] Manual: edit a default value → save → new version created with updated default
- [ ] Manual: add a new input via the expandable form → appears in the table after save
- [ ] Manual: clear a default → save → input becomes required again

🤖 Generated with [Claude Code](https://claude.com/claude-code)