### PR TITLE
feat: suggest improvements modal + agent-analyzer + template fix

### DIFF
--- a/agents/examples/agent-analyzer.yaml
+++ b/agents/examples/agent-analyzer.yaml
@@ -53,8 +53,11 @@ nodes:
           inputs:
             - name: MY_VAR
               type: string
-      - Node ids must be lowercase with hyphens/underscores only.
+      - Input names MUST be UPPERCASE_WITH_UNDERSCORES (e.g. TOPIC, API_URL, MAX_RETRIES).
+        Never use lowercase input names.
+      - Node ids must be lowercase with hyphens/underscores only (e.g. fetch-data, step-1).
       - Keep the same agent `id` as the original.
+      - `type` for inputs must be one of: string, number, boolean, enum.
 
       Respond in EXACTLY this format (keep the XML tags):
       <classification>NO_IMPROVEMENTS | SUGGESTIONS | REWRITE</classification>

--- a/agents/examples/agent-analyzer.yaml
+++ b/agents/examples/agent-analyzer.yaml
@@ -43,6 +43,19 @@ nodes:
       - SUGGESTIONS: Specific improvements that would make the agent better.
       - REWRITE: The fundamental approach or logic should be rethought.
 
+      CRITICAL YAML RULES for the <yaml> section:
+      - `inputs` must be an OBJECT (map), not an array. Example:
+          inputs:
+            MY_VAR:
+              type: string
+              default: "value"
+        NOT:
+          inputs:
+            - name: MY_VAR
+              type: string
+      - Node ids must be lowercase with hyphens/underscores only.
+      - Keep the same agent `id` as the original.
+
       Respond in EXACTLY this format (keep the XML tags):
       <classification>NO_IMPROVEMENTS | SUGGESTIONS | REWRITE</classification>
       <summary>One sentence summarizing your assessment</summary>

--- a/agents/examples/agent-analyzer.yaml
+++ b/agents/examples/agent-analyzer.yaml
@@ -1,0 +1,62 @@
+id: agent-analyzer
+name: Agent Analyzer
+description: >
+  AI-powered agent review. Analyzes an agent's YAML holistically and suggests
+  improvements — missing variables, hardcoded values, prompt quality, cross-node
+  data flow. Run via "Suggest improvements" on any agent's detail page.
+status: active
+source: examples
+
+inputs:
+  AGENT_YAML:
+    type: string
+    required: true
+    description: The full YAML definition of the agent to analyze.
+  FOCUS:
+    type: string
+    required: false
+    default: ""
+    description: Optional focus area, e.g. "what variables am I missing to count loop iterations?"
+
+nodes:
+  - id: analyze
+    type: claude-code
+    prompt: |
+      You are an expert agent architect reviewing a sua DAG agent.
+
+      Analyze the FULL agent holistically — cross-node data flow, dependency
+      ordering, input/variable usage, prompt quality, error handling, and
+      whether the design achieves its purpose efficiently.
+
+      Look for:
+      - Missing variables or inputs that would improve configurability
+      - Hardcoded values that should be agent inputs or global variables
+      - Missing error handling, timeouts, or retry logic
+      - Opportunities to split or merge nodes for clarity
+      - Unused or redundant dependencies between nodes
+      - Prompt improvements for claude-code nodes
+
+      {{inputs.FOCUS}}
+
+      Classify your assessment as exactly one of:
+      - NO_IMPROVEMENTS: The agent is well-designed, no changes needed.
+      - SUGGESTIONS: Specific improvements that would make the agent better.
+      - REWRITE: The fundamental approach or logic should be rethought.
+
+      Respond in EXACTLY this format (keep the XML tags):
+      <classification>NO_IMPROVEMENTS | SUGGESTIONS | REWRITE</classification>
+      <summary>One sentence summarizing your assessment</summary>
+      <details>
+      Your detailed analysis. Be specific: name nodes, variables, prompts.
+      For multi-node agents, analyze how data flows between nodes.
+      </details>
+      <yaml>
+      If SUGGESTIONS or REWRITE, provide the complete improved YAML.
+      Must be valid, keep the same agent id. If NO_IMPROVEMENTS, leave empty.
+      </yaml>
+
+      Here is the agent YAML to review:
+
+      {{inputs.AGENT_YAML}}
+    maxTurns: 1
+    timeout: 120

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -988,11 +988,22 @@ async function spawnNodeReal(
     });
   }
 
-  // claude-code
+  // claude-code — resolve {{inputs.X}}, {{upstream.X.result}}, {{vars.X}}
+  // in the prompt before passing to the CLI.
   if (!node.prompt) {
     return { result: '', exitCode: 1, error: `Claude-code node "${node.id}" has no prompt`, category: 'setup' };
   }
-  const args = ['--print', node.prompt];
+  let resolvedPrompt = node.prompt;
+  // Build upstream map from env's UPSTREAM_*_RESULT keys
+  const upstreamMap: Record<string, string> = {};
+  for (const [k, v] of Object.entries(env)) {
+    const m = k.match(/^UPSTREAM_(.+)_RESULT$/);
+    if (m) upstreamMap[m[1].toLowerCase().replace(/_/g, '-')] = v;
+  }
+  resolvedPrompt = resolveUpstreamTemplate(resolvedPrompt, upstreamMap);
+  resolvedPrompt = resolveVarsTemplate(resolvedPrompt, env);
+  resolvedPrompt = substituteInputs(resolvedPrompt, env);
+  const args = ['--print', resolvedPrompt];
   if (node.model) { args.push('--model', node.model); }
   if (node.maxTurns) { args.push('--max-turns', String(node.maxTurns)); }
   if (node.allowedTools?.length) { args.push('--allowedTools', node.allowedTools.join(',')); }

--- a/packages/dashboard/src/routes/agents.ts
+++ b/packages/dashboard/src/routes/agents.ts
@@ -465,6 +465,32 @@ agentsRouter.post('/agents/:name/yaml', (req: Request, res: Response) => {
   }
 
   const body = (req.body ?? {}) as Record<string, unknown>;
+
+  // "Edit suggested YAML first" / "Review + apply" — render the editor
+  // pre-filled with the suggested YAML instead of saving.
+  if (typeof body.prefillYaml === 'string' && !body.yaml) {
+    const prefilled = body.prefillYaml as string;
+    const editorBody = h`
+      ${pageHeader({
+        title: `Edit YAML \u2014 ${agent.id}`,
+        back: { href: `/agents/${agent.id}`, label: `Back to ${agent.id}` },
+        description: `Editing AI-suggested YAML. Review and save to create a new version.`,
+      })}
+      <form method="POST" action="/agents/${agent.id}/yaml" class="card" style="max-width: 800px;">
+        <label style="display: flex; flex-direction: column; gap: var(--space-2);">
+          <textarea name="yaml" rows="30" required
+            style="padding: var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-family: var(--font-mono); font-size: var(--font-size-xs); resize: vertical; line-height: 1.5; tab-size: 2;">${prefilled}</textarea>
+        </label>
+        <div style="margin-top: var(--space-3); display: flex; gap: var(--space-2); justify-content: flex-end;">
+          <a class="btn btn--ghost" href="/agents/${agent.id}">Cancel</a>
+          <button type="submit" class="btn btn--primary">Save YAML</button>
+        </div>
+      </form>
+    `;
+    res.type('html').send(renderHtml(layout({ title: `Edit YAML \u2014 ${agent.id}`, activeNav: 'agents' }, editorBody)));
+    return;
+  }
+
   const yamlText = typeof body.yaml === 'string' ? body.yaml : '';
 
   let parsed: Agent;

--- a/packages/dashboard/src/routes/run-now.ts
+++ b/packages/dashboard/src/routes/run-now.ts
@@ -1,5 +1,5 @@
 import { Router, type Request, type Response } from 'express';
-import { executeAgentDag, exportAgent, parseAgent } from '@some-useful-agents/core';
+import { executeAgentDag, exportAgent, parseAgent, type RunStatus } from '@some-useful-agents/core';
 import { readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { getContext } from '../context.js';
@@ -43,17 +43,49 @@ runNowRouter.post('/agents/:name/run', async (req: Request, res: Response) => {
       res.redirect(303, `/agents/${encodeURIComponent(v2Agent.id)}?flash=${encodeURIComponent(flash)}`);
       return;
     }
+    // Fire-and-forget: start the DAG executor but don't await it.
+    // The executor creates the run row in 'running' state synchronously
+    // before spawning nodes, so the redirect to /runs/:id lands on a
+    // valid page that polls for progress.
+    const runPromise = executeAgentDag(
+      v2Agent,
+      { triggeredBy: 'dashboard', inputs: {} },
+      {
+        runStore: ctx.runStore,
+        secretsStore: ctx.secretsStore,
+        allowUntrustedShell: ctx.allowUntrustedShell,
+      },
+    );
+
+    // Give the executor a moment to create the run row, then redirect.
+    // The run row is created synchronously at the top of executeAgentDag
+    // before any async node work starts.
     try {
-      const run = await executeAgentDag(
-        v2Agent,
-        { triggeredBy: 'dashboard', inputs: {} },
-        {
-          runStore: ctx.runStore,
-          secretsStore: ctx.secretsStore,
-          allowUntrustedShell: ctx.allowUntrustedShell,
-        },
-      );
-      res.redirect(303, `/runs/${encodeURIComponent(run.id)}${fromSuffix}`);
+      // Wait just long enough for the run row to exist (near-instant).
+      const run = await Promise.race([
+        runPromise,
+        new Promise<null>((resolve) => setTimeout(() => resolve(null), 200)),
+      ]);
+
+      if (run) {
+        // Fast agent: already finished.
+        res.redirect(303, `/runs/${encodeURIComponent(run.id)}${fromSuffix}`);
+      } else {
+        // Still running: find the most recent run for this agent.
+        const { rows } = ctx.runStore.queryRuns({
+          agentName: v2Agent.id,
+          statuses: ['running'] as RunStatus[],
+          limit: 1,
+          offset: 0,
+        });
+        if (rows.length > 0) {
+          res.redirect(303, `/runs/${encodeURIComponent(rows[0].id)}${fromSuffix}`);
+        } else {
+          // Fallback: wait for the full run.
+          const fullRun = await runPromise;
+          res.redirect(303, `/runs/${encodeURIComponent(fullRun.id)}${fromSuffix}`);
+        }
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       res.redirect(303, `/agents/${encodeURIComponent(v2Agent.id)}?flash=${encodeURIComponent(message)}`);

--- a/packages/dashboard/src/routes/run-now.ts
+++ b/packages/dashboard/src/routes/run-now.ts
@@ -43,13 +43,21 @@ runNowRouter.post('/agents/:name/run', async (req: Request, res: Response) => {
       res.redirect(303, `/agents/${encodeURIComponent(v2Agent.id)}?flash=${encodeURIComponent(flash)}`);
       return;
     }
+    // Extract input_NAME fields from the form body.
+    const inputs: Record<string, string> = {};
+    for (const [k, v] of Object.entries(body)) {
+      if (k.startsWith('input_') && typeof v === 'string' && v.trim() !== '') {
+        inputs[k.slice(6)] = v.trim();
+      }
+    }
+
     // Fire-and-forget: start the DAG executor but don't await it.
     // The executor creates the run row in 'running' state synchronously
     // before spawning nodes, so the redirect to /runs/:id lands on a
     // valid page that polls for progress.
     const runPromise = executeAgentDag(
       v2Agent,
-      { triggeredBy: 'dashboard', inputs: {} },
+      { triggeredBy: 'dashboard', inputs },
       {
         runStore: ctx.runStore,
         secretsStore: ctx.secretsStore,

--- a/packages/dashboard/src/routes/run-now.ts
+++ b/packages/dashboard/src/routes/run-now.ts
@@ -1,8 +1,12 @@
 import { Router, type Request, type Response } from 'express';
-import { executeAgentDag } from '@some-useful-agents/core';
+import { executeAgentDag, exportAgent, parseAgent } from '@some-useful-agents/core';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 import { getContext } from '../context.js';
 
 export const runNowRouter: Router = Router();
+
+const ANALYZER_AGENT_ID = 'agent-analyzer';
 
 /**
  * POST /agents/:name/run — trigger an agent with YAML defaults.
@@ -83,5 +87,83 @@ runNowRouter.post('/agents/:name/run', async (req: Request, res: Response) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     res.redirect(303, `/agents/${encodeURIComponent(agent.name)}?flash=${encodeURIComponent(message)}`);
+  }
+});
+
+/**
+ * POST /agents/:name/analyze — run the agent-analyzer with the target
+ * agent's YAML as input. Returns JSON so the client can render results
+ * in a modal without navigating away.
+ */
+runNowRouter.post('/agents/:name/analyze', async (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
+
+  const target = ctx.agentStore.getAgent(name);
+  if (!target) {
+    res.json({ ok: false, error: 'Agent not found.' });
+    return;
+  }
+
+  // Auto-import the analyzer agent from examples if not in the store.
+  let analyzer = ctx.agentStore.getAgent(ANALYZER_AGENT_ID);
+  if (!analyzer) {
+    try {
+      const yamlPath = join(resolve('agents/examples'), `${ANALYZER_AGENT_ID}.yaml`);
+      const yamlText = readFileSync(yamlPath, 'utf-8');
+      const parsed = parseAgent(yamlText);
+      ctx.agentStore.createAgent(parsed, 'import', 'Auto-imported for suggest improvements');
+      analyzer = ctx.agentStore.getAgent(ANALYZER_AGENT_ID);
+    } catch { /* fall through */ }
+    if (!analyzer) {
+      res.json({ ok: false, error: 'Analyzer agent not found. Ensure agent-analyzer.yaml exists in agents/examples/.' });
+      return;
+    }
+  }
+
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const focus = typeof body.focus === 'string' ? body.focus.trim() : '';
+  const targetYaml = exportAgent(target);
+
+  try {
+    const run = await executeAgentDag(
+      analyzer,
+      {
+        triggeredBy: 'dashboard',
+        inputs: {
+          AGENT_YAML: targetYaml,
+          ...(focus ? { FOCUS: `Focus your analysis on: ${focus}` } : {}),
+        },
+      },
+      {
+        runStore: ctx.runStore,
+        secretsStore: ctx.secretsStore,
+        variablesStore: ctx.variablesStore,
+      },
+    );
+
+    if (run.status !== 'completed' || !run.result) {
+      res.json({ ok: false, error: run.error ?? `Analysis failed (status: ${run.status}).`, runId: run.id });
+      return;
+    }
+
+    const extract = (tag: string): string | undefined => {
+      const m = run.result!.match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`, 'i'));
+      return m ? m[1].trim() : undefined;
+    };
+    const classRaw = extract('classification')?.toUpperCase().trim() ?? 'SUGGESTIONS';
+    const classification = ['NO_IMPROVEMENTS', 'SUGGESTIONS', 'REWRITE'].includes(classRaw) ? classRaw : 'SUGGESTIONS';
+
+    res.json({
+      ok: true,
+      runId: run.id,
+      classification,
+      summary: extract('summary') ?? '',
+      details: extract('details') ?? run.result,
+      yaml: extract('yaml') || undefined,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    res.json({ ok: false, error: message });
   }
 });

--- a/packages/dashboard/src/routes/run-now.ts
+++ b/packages/dashboard/src/routes/run-now.ts
@@ -161,6 +161,7 @@ runNowRouter.post('/agents/:name/analyze', async (req: Request, res: Response) =
       summary: extract('summary') ?? '',
       details: extract('details') ?? run.result,
       yaml: extract('yaml') || undefined,
+      currentYaml: targetYaml,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/packages/dashboard/src/routes/run-now.ts
+++ b/packages/dashboard/src/routes/run-now.ts
@@ -154,13 +154,24 @@ runNowRouter.post('/agents/:name/analyze', async (req: Request, res: Response) =
     const classRaw = extract('classification')?.toUpperCase().trim() ?? 'SUGGESTIONS';
     const classification = ['NO_IMPROVEMENTS', 'SUGGESTIONS', 'REWRITE'].includes(classRaw) ? classRaw : 'SUGGESTIONS';
 
+    const suggestedYaml = extract('yaml') || undefined;
+    let yamlError: string | undefined;
+    if (suggestedYaml && suggestedYaml.length > 10) {
+      try {
+        parseAgent(suggestedYaml);
+      } catch (e) {
+        yamlError = e instanceof Error ? e.message : String(e);
+      }
+    }
+
     res.json({
       ok: true,
       runId: run.id,
       classification,
       summary: extract('summary') ?? '',
       details: extract('details') ?? run.result,
-      yaml: extract('yaml') || undefined,
+      yaml: suggestedYaml,
+      yamlError,
       currentYaml: targetYaml,
     });
   } catch (err) {

--- a/packages/dashboard/src/views/agent-detail-v2.ts
+++ b/packages/dashboard/src/views/agent-detail-v2.ts
@@ -73,6 +73,10 @@ export async function renderAgentDetailV2(args: {
           </button>
         </form>
       `
+    : Object.keys(agent.inputs ?? {}).length > 0
+    ? html`
+        <button type="button" class="btn btn--primary" id="run-with-inputs-btn">Run now</button>
+      `
     : html`
         <form method="POST" action="/agents/${agent.id}/run" style="display: inline;" data-run-form="${agent.id}">
           ${fromHidden}
@@ -265,17 +269,75 @@ export async function renderAgentDetailV2(args: {
     </div>
 
     <div id="run-modal" class="modal-backdrop">
-      <div class="modal" style="max-width: 400px;">
-        <div style="text-align: center; padding: var(--space-6);">
-          <div class="spinner" style="margin: 0 auto var(--space-3);"></div>
-          <p style="font-weight: var(--weight-medium); margin: 0 0 var(--space-2);">Running ${agent.id}...</p>
-          <p class="dim" style="font-size: var(--font-size-xs); margin: 0;">Starting execution. You'll be redirected to the run detail page.</p>
+      <div class="modal" style="max-width: 500px;">
+        <div id="run-modal-content">
+          ${renderRunInputsForm(agent, from)}
         </div>
       </div>
     </div>
   `;
 
   return render(layout({ title: agent.id, activeNav: 'agents', flash, wide: true }, body));
+}
+
+/**
+ * Render the Run Now inputs form for the run modal. Shows each declared
+ * input with its type, default value pre-filled, description, and whether
+ * it's required. Submits to POST /agents/:id/run with input_NAME fields.
+ */
+function renderRunInputsForm(agent: Agent, from?: string): SafeHtml {
+  const inputs = Object.entries(agent.inputs ?? {});
+  const FIELD = 'padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm); font-family: var(--font-mono); width: 100%;';
+
+  if (inputs.length === 0) {
+    // No inputs — just a spinner (form submits immediately via JS).
+    return html`
+      <div style="text-align: center; padding: var(--space-6);">
+        <div class="spinner" style="margin: 0 auto var(--space-3);"></div>
+        <p style="font-weight: var(--weight-medium); margin: 0 0 var(--space-2);">Running ${agent.id}...</p>
+        <p class="dim" style="font-size: var(--font-size-xs); margin: 0;">Starting execution.</p>
+      </div>
+    `;
+  }
+
+  const fields = inputs.map(([name, spec]) => {
+    const defVal = spec.default !== undefined ? String(spec.default) : '';
+    const reqLabel = spec.required !== false && spec.default === undefined
+      ? html`<span style="color: var(--color-err); font-size: var(--font-size-xs);">required</span>`
+      : html`<span class="dim" style="font-size: var(--font-size-xs);">optional</span>`;
+    const desc = spec.description
+      ? html`<span class="dim" style="font-size: var(--font-size-xs);">${spec.description}</span>`
+      : html``;
+    return html`
+      <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-3);">
+        <div style="display: flex; align-items: baseline; gap: var(--space-2);">
+          <strong style="font-size: var(--font-size-sm);">${name}</strong>
+          <span class="badge badge--muted" style="font-size: 9px;">${spec.type}</span>
+          ${reqLabel}
+        </div>
+        <input type="text" name="input_${name}" value="${defVal}"
+          placeholder="${defVal || '(empty)'}"
+          style="${FIELD}"
+          ${spec.required !== false && spec.default === undefined ? 'required' : ''}>
+        ${desc}
+      </label>
+    `;
+  });
+
+  return html`
+    <form method="POST" action="/agents/${agent.id}/run" data-run-form="${agent.id}">
+      ${from ? html`<input type="hidden" name="from" value="${from}">` : html``}
+      <h3 style="margin: 0 0 var(--space-3);">Run ${agent.id}</h3>
+      <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-4);">
+        Set input values for this run. Defaults are pre-filled.
+      </p>
+      ${fields as unknown as SafeHtml[]}
+      <div style="display: flex; gap: var(--space-2); justify-content: flex-end; margin-top: var(--space-3);">
+        <button type="button" class="btn btn--ghost btn--sm" data-close-modal="1">Cancel</button>
+        <button type="submit" class="btn btn--primary btn--sm">Run</button>
+      </div>
+    </form>
+  `;
 }
 
 /**

--- a/packages/dashboard/src/views/agent-detail-v2.ts
+++ b/packages/dashboard/src/views/agent-detail-v2.ts
@@ -186,6 +186,7 @@ export async function renderAgentDetailV2(args: {
       <div class="inspector__actions" style="flex-wrap: wrap;">
         <a class="btn btn--primary btn--sm" href="/agents/${agent.id}/add-node">+ Add node</a>
         <a class="btn btn--sm" href="/agents/${agent.id}/yaml">Edit YAML</a>
+        <button type="button" class="btn btn--sm" id="suggest-btn" data-agent-id="${agent.id}">Suggest improvements</button>
         <a class="btn btn--sm" href="/agents/${agent.id}/versions">Versions</a>
         <a class="btn btn--sm" href="#runs">Recent runs</a>
       </div>
@@ -254,6 +255,12 @@ export async function renderAgentDetailV2(args: {
 
       <div class="agent-detail__aside">
         ${inspector}
+      </div>
+    </div>
+
+    <div id="suggest-modal" class="modal-backdrop">
+      <div class="modal" style="max-width: 720px; max-height: 85vh; overflow-y: auto;">
+        <div id="suggest-modal-content"></div>
       </div>
     </div>
   `;

--- a/packages/dashboard/src/views/agent-detail-v2.ts
+++ b/packages/dashboard/src/views/agent-detail-v2.ts
@@ -74,7 +74,7 @@ export async function renderAgentDetailV2(args: {
         </form>
       `
     : html`
-        <form method="POST" action="/agents/${agent.id}/run" style="display: inline;">
+        <form method="POST" action="/agents/${agent.id}/run" style="display: inline;" data-run-form="${agent.id}">
           ${fromHidden}
           <button type="submit" class="btn btn--primary">Run now</button>
         </form>
@@ -261,6 +261,16 @@ export async function renderAgentDetailV2(args: {
     <div id="suggest-modal" class="modal-backdrop">
       <div class="modal" style="max-width: 720px; max-height: 85vh; overflow-y: auto;">
         <div id="suggest-modal-content"></div>
+      </div>
+    </div>
+
+    <div id="run-modal" class="modal-backdrop">
+      <div class="modal" style="max-width: 400px;">
+        <div style="text-align: center; padding: var(--space-6);">
+          <div class="spinner" style="margin: 0 auto var(--space-3);"></div>
+          <p style="font-weight: var(--weight-medium); margin: 0 0 var(--space-2);">Running ${agent.id}...</p>
+          <p class="dim" style="font-size: var(--font-size-xs); margin: 0;">Starting execution. You'll be redirected to the run detail page.</p>
+        </div>
       </div>
     </div>
   `;

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -613,8 +613,16 @@ export const DASHBOARD_JS = `
         } else if (data.yaml) {
           h += '<pre style="font-size:var(--font-size-xs);background:var(--color-surface-raised);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-3);margin-bottom:var(--space-3);max-height:300px;overflow-y:auto;white-space:pre-wrap;">' + esc(data.yaml) + '</pre>';
         }
+        if (data.yamlError) {
+          h += '<div class="flash flash--error" style="margin-bottom:var(--space-3);font-size:var(--font-size-xs);">' +
+            '<strong>Suggested YAML has validation errors:</strong> ' + esc(data.yamlError) +
+            '<br>Click "Edit YAML" to fix manually.</div>';
+        }
         h += '<div style="display:flex;gap:var(--space-2);justify-content:flex-end;flex-wrap:wrap;">';
-        if (data.yaml) h += '<button type="button" class="btn btn--primary btn--sm" id="sg-apply">Review + apply</button>';
+        if (data.yaml) {
+          var applyLabel = data.yamlError ? 'Edit YAML to fix' : 'Review + apply';
+          h += '<button type="button" class="btn btn--primary btn--sm" id="sg-apply">' + esc(applyLabel) + '</button>';
+        }
         h += '<button type="button" class="btn btn--ghost btn--sm" id="sg-dismiss">Dismiss</button></div>';
         content.innerHTML = h;
         var ab = document.getElementById('sg-apply');

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -523,126 +523,122 @@ export const DASHBOARD_JS = `
     setTimeout(poll, 2000);
   }
 
-  // Suggest improvements — modal that stays on the agent page, fetches
-  // analysis from the analyzer agent, renders results inline.
+  // Suggest improvements — modal with progress feedback, cancel, colored diff.
   (function () {
     var btn = document.getElementById('suggest-btn');
     var modal = document.getElementById('suggest-modal');
     var content = document.getElementById('suggest-modal-content');
     if (!btn || !modal || !content) return;
-
     var agentId = btn.getAttribute('data-agent-id');
+    var PHASES = [
+      [0,'Sending YAML to Claude...'],[5,'Reading the DAG structure...'],
+      [15,'Analyzing cross-node data flow...'],[30,'Generating suggestions...'],
+      [60,'Still working (complex agent)...'],[90,'Almost there...']
+    ];
 
-    function esc(s) {
-      var d = document.createElement('div');
-      d.textContent = s;
-      return d.innerHTML;
-    }
-
+    function esc(s) { var d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
     function closeModal() { modal.classList.remove('is-open'); }
+
+    function coloredDiff(oldT, newT) {
+      var oL = oldT.split('\\n'), nL = newT.split('\\n');
+      var oS = {}, nS = {};
+      for (var i = 0; i < oL.length; i++) oS[oL[i].trim()] = true;
+      for (var j = 0; j < nL.length; j++) nS[nL[j].trim()] = true;
+      var DEL = 'background:rgba(255,0,0,0.08);color:#cf222e;';
+      var ADD = 'background:rgba(0,180,0,0.08);color:#1a7f37;';
+      var P = 'font-size:var(--font-size-xs);background:var(--color-surface-raised);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-3);max-height:280px;overflow-y:auto;white-space:pre-wrap;word-break:break-all;margin:0;';
+      var h = '<div style="display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3);margin-bottom:var(--space-3);">';
+      h += '<div><p class="dim" style="font-size:var(--font-size-xs);margin:0 0 var(--space-1);">Current</p><pre style="' + P + '">';
+      for (var a = 0; a < oL.length; a++) h += '<span style="display:block;' + (nS[oL[a].trim()] ? '' : DEL) + '">' + esc(oL[a]) + '</span>';
+      h += '</pre></div><div><p class="dim" style="font-size:var(--font-size-xs);margin:0 0 var(--space-1);">Suggested</p><pre style="' + P + '">';
+      for (var b = 0; b < nL.length; b++) h += '<span style="display:block;' + (oS[nL[b].trim()] ? '' : ADD) + '">' + esc(nL[b]) + '</span>';
+      h += '</pre></div></div>';
+      return h;
+    }
 
     btn.addEventListener('click', function () {
       modal.classList.add('is-open');
+      var t0 = Date.now();
       content.innerHTML =
-        '<div style="text-align:center;padding:var(--space-6);">' +
-        '<div class="spinner" style="margin:0 auto var(--space-3);"></div>' +
-        '<p style="font-weight:var(--weight-medium);margin:0 0 var(--space-2);">Analyzing ' + esc(agentId) + '...</p>' +
-        '<p class="dim" style="font-size:var(--font-size-xs);margin:0;">This usually takes 10\u201330 seconds.</p>' +
+        '<div style="padding:var(--space-4);">' +
+        '<div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-4);">' +
+          '<div class="spinner"></div>' +
+          '<div style="flex:1;"><div style="font-weight:var(--weight-medium);">Analyzing ' + esc(agentId) + '</div>' +
+          '<div class="dim" style="font-size:var(--font-size-xs);" id="sg-phase">' + PHASES[0][1] + '</div></div>' +
+          '<div style="font-family:var(--font-mono);font-size:var(--font-size-lg);color:var(--color-text-muted);min-width:3rem;text-align:right;" id="sg-timer">0s</div>' +
+        '</div>' +
+        '<div style="height:4px;background:var(--color-border);border-radius:2px;overflow:hidden;margin-bottom:var(--space-3);">' +
+          '<div id="sg-bar" style="height:100%;background:var(--color-primary);border-radius:2px;width:0%;transition:width 1s linear;"></div>' +
+        '</div>' +
+        '<div style="text-align:right;"><button type="button" class="btn btn--ghost btn--sm" id="sg-cancel">Cancel</button></div>' +
         '</div>';
 
+      var tick = setInterval(function () {
+        var s = Math.round((Date.now() - t0) / 1000);
+        var te = document.getElementById('sg-timer'); if (te) te.textContent = s + 's';
+        var be = document.getElementById('sg-bar'); if (be) be.style.width = Math.min(s/120*100, 98) + '%';
+        var pe = document.getElementById('sg-phase'); if (pe) {
+          var m = PHASES[0][1]; for (var i = 0; i < PHASES.length; i++) { if (s >= PHASES[i][0]) m = PHASES[i][1]; }
+          pe.textContent = m;
+        }
+      }, 1000);
+
+      var ctrl = new AbortController();
+      var ce = document.getElementById('sg-cancel');
+      if (ce) ce.addEventListener('click', function () { ctrl.abort(); clearInterval(tick); closeModal(); });
+
       fetch('/agents/' + encodeURIComponent(agentId) + '/analyze', {
-        method: 'POST',
-        credentials: 'same-origin',
+        method: 'POST', credentials: 'same-origin',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: '',
+        body: '', signal: ctrl.signal,
       })
-        .then(function (r) { return r.json(); })
-        .then(function (data) {
-          if (!data.ok) {
-            content.innerHTML =
-              '<h3 style="margin:0 0 var(--space-3);">Analysis failed</h3>' +
-              '<div class="flash flash--error">' + esc(data.error || 'Unknown error') + '</div>' +
-              (data.runId ? '<p class="dim" style="font-size:var(--font-size-xs);margin:var(--space-2) 0 0;">Run: <a href="/runs/' + esc(data.runId) + '">' + esc(data.runId.slice(0, 8)) + '</a></p>' : '') +
-              '<div style="margin-top:var(--space-3);text-align:right;">' +
-              '<button type="button" class="btn btn--ghost btn--sm" data-close-modal="1">Close</button>' +
-              '</div>';
-            return;
-          }
-
-          var bc = data.classification === 'NO_IMPROVEMENTS' ? 'badge--ok'
-            : data.classification === 'REWRITE' ? 'badge--err' : 'badge--warn';
-          var bl = data.classification === 'NO_IMPROVEMENTS' ? 'No improvements needed'
-            : data.classification === 'REWRITE' ? 'Recommend rewrite' : 'Suggested improvements';
-
-          var h = '<div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3);">' +
-            '<span class="badge ' + bc + '">' + esc(bl) + '</span>' +
-            '</div>';
-          if (data.summary) h += '<p style="font-weight:var(--weight-medium);margin:0 0 var(--space-3);">' + esc(data.summary) + '</p>';
-          if (data.details) h += '<pre style="white-space:pre-wrap;font-family:inherit;font-size:var(--font-size-sm);line-height:1.6;margin:0 0 var(--space-3);color:var(--color-text-muted);max-height:300px;overflow-y:auto;">' + esc(data.details) + '</pre>';
-
-          if (data.yaml && data.currentYaml) {
-            var PRE = 'font-size:var(--font-size-xs);background:var(--color-surface-raised);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-3);max-height:280px;overflow-y:auto;white-space:pre-wrap;word-break:break-all;margin:0;';
-            h += '<div style="display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3);margin-bottom:var(--space-3);">' +
-              '<div><p class="dim" style="font-size:var(--font-size-xs);margin:0 0 var(--space-1);">Current</p>' +
-              '<pre style="' + PRE + '">' + esc(data.currentYaml) + '</pre></div>' +
-              '<div><p class="dim" style="font-size:var(--font-size-xs);margin:0 0 var(--space-1);">Suggested</p>' +
-              '<pre style="' + PRE + '">' + esc(data.yaml) + '</pre></div>' +
-              '</div>';
-          } else if (data.yaml) {
-            h += '<details style="margin-bottom:var(--space-3);">' +
-              '<summary style="cursor:pointer;font-size:var(--font-size-xs);font-weight:var(--weight-semibold);color:var(--color-primary);">View suggested YAML</summary>' +
-              '<pre style="font-size:var(--font-size-xs);background:var(--color-surface-raised);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-3);margin-top:var(--space-2);max-height:300px;overflow-y:auto;white-space:pre-wrap;word-break:break-all;">' + esc(data.yaml) + '</pre>' +
-              '</details>';
-          }
-
-          h += '<div style="display:flex;gap:var(--space-2);justify-content:flex-end;flex-wrap:wrap;">';
-          if (data.yaml) {
-            h += '<button type="button" class="btn btn--primary btn--sm" id="suggest-apply-btn">Review + apply</button>';
-          }
-          h += '<button type="button" class="btn btn--ghost btn--sm" id="suggest-dismiss-btn">Dismiss</button>';
-          h += '</div>';
-
-          // Wire up buttons after innerHTML is set.
-          setTimeout(function () {
-            var applyBtn = document.getElementById('suggest-apply-btn');
-            if (applyBtn && data.yaml) {
-              applyBtn.addEventListener('click', function () {
-                // Submit via a dynamic form with a textarea to preserve newlines/quotes.
-                var form = document.createElement('form');
-                form.method = 'POST';
-                form.action = '/agents/' + encodeURIComponent(agentId) + '/yaml';
-                var ta = document.createElement('textarea');
-                ta.name = 'prefillYaml';
-                ta.value = data.yaml;
-                ta.style.display = 'none';
-                form.appendChild(ta);
-                document.body.appendChild(form);
-                form.submit();
-              });
-            }
-            var dismissBtn = document.getElementById('suggest-dismiss-btn');
-            if (dismissBtn) {
-              dismissBtn.addEventListener('click', function () {
-                modal.classList.remove('is-open');
-              });
-            }
-          }, 0);
-
-          content.innerHTML = h;
-        })
-        .catch(function (err) {
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        clearInterval(tick);
+        if (!data.ok) {
           content.innerHTML =
-            '<h3 style="margin:0 0 var(--space-3);">Error</h3>' +
-            '<div class="flash flash--error">' + esc(String(err)) + '</div>' +
-            '<div style="margin-top:var(--space-3);text-align:right;">' +
-            '<button type="button" class="btn btn--ghost btn--sm" data-close-modal="1">Close</button>' +
-            '</div>';
+            '<h3 style="margin:0 0 var(--space-3);">Analysis failed</h3>' +
+            '<div class="flash flash--error">' + esc(data.error || 'Unknown error') + '</div>' +
+            (data.runId ? '<p class="dim" style="font-size:var(--font-size-xs);margin:var(--space-2) 0 0;">Run: <a href="/runs/' + esc(data.runId) + '">' + esc(data.runId.slice(0,8)) + '</a></p>' : '') +
+            '<div style="margin-top:var(--space-3);text-align:right;"><button type="button" class="btn btn--ghost btn--sm" data-close-modal="1">Close</button></div>';
+          return;
+        }
+        var bc = data.classification === 'NO_IMPROVEMENTS' ? 'badge--ok' : data.classification === 'REWRITE' ? 'badge--err' : 'badge--warn';
+        var bl = data.classification === 'NO_IMPROVEMENTS' ? 'No improvements needed' : data.classification === 'REWRITE' ? 'Recommend rewrite' : 'Suggested improvements';
+        var h = '<div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3);"><span class="badge ' + bc + '">' + esc(bl) + '</span></div>';
+        if (data.summary) h += '<p style="font-weight:var(--weight-medium);margin:0 0 var(--space-3);">' + esc(data.summary) + '</p>';
+        if (data.details) h += '<pre style="white-space:pre-wrap;font-family:inherit;font-size:var(--font-size-sm);line-height:1.6;margin:0 0 var(--space-3);color:var(--color-text-muted);max-height:250px;overflow-y:auto;">' + esc(data.details) + '</pre>';
+        if (data.yaml && data.currentYaml) {
+          h += coloredDiff(data.currentYaml, data.yaml);
+        } else if (data.yaml) {
+          h += '<pre style="font-size:var(--font-size-xs);background:var(--color-surface-raised);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-3);margin-bottom:var(--space-3);max-height:300px;overflow-y:auto;white-space:pre-wrap;">' + esc(data.yaml) + '</pre>';
+        }
+        h += '<div style="display:flex;gap:var(--space-2);justify-content:flex-end;flex-wrap:wrap;">';
+        if (data.yaml) h += '<button type="button" class="btn btn--primary btn--sm" id="sg-apply">Review + apply</button>';
+        h += '<button type="button" class="btn btn--ghost btn--sm" id="sg-dismiss">Dismiss</button></div>';
+        content.innerHTML = h;
+        var ab = document.getElementById('sg-apply');
+        if (ab && data.yaml) ab.addEventListener('click', function () {
+          var f = document.createElement('form'); f.method = 'POST';
+          f.action = '/agents/' + encodeURIComponent(agentId) + '/yaml';
+          var t = document.createElement('textarea'); t.name = 'prefillYaml'; t.value = data.yaml; t.style.display = 'none';
+          f.appendChild(t); document.body.appendChild(f); f.submit();
         });
+        var db = document.getElementById('sg-dismiss');
+        if (db) db.addEventListener('click', closeModal);
+      })
+      .catch(function (err) {
+        clearInterval(tick);
+        if (err.name === 'AbortError') return;
+        content.innerHTML =
+          '<h3 style="margin:0 0 var(--space-3);">Error</h3>' +
+          '<div class="flash flash--error">' + esc(String(err)) + '</div>' +
+          '<div style="margin-top:var(--space-3);text-align:right;"><button type="button" class="btn btn--ghost btn--sm" data-close-modal="1">Close</button></div>';
+      });
     });
 
     modal.addEventListener('click', function (e) {
       if (e.target === modal) closeModal();
-      // Delegated close for dynamically created buttons.
       if (e.target && e.target.getAttribute && e.target.getAttribute('data-close-modal')) closeModal();
     });
   })();

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -523,6 +523,98 @@ export const DASHBOARD_JS = `
     setTimeout(poll, 2000);
   }
 
+  // Suggest improvements — modal that stays on the agent page, fetches
+  // analysis from the analyzer agent, renders results inline.
+  (function () {
+    var btn = document.getElementById('suggest-btn');
+    var modal = document.getElementById('suggest-modal');
+    var content = document.getElementById('suggest-modal-content');
+    if (!btn || !modal || !content) return;
+
+    var agentId = btn.getAttribute('data-agent-id');
+
+    function esc(s) {
+      var d = document.createElement('div');
+      d.textContent = s;
+      return d.innerHTML;
+    }
+
+    function closeModal() { modal.classList.remove('is-open'); }
+
+    btn.addEventListener('click', function () {
+      modal.classList.add('is-open');
+      content.innerHTML =
+        '<div style="text-align:center;padding:var(--space-6);">' +
+        '<div class="spinner" style="margin:0 auto var(--space-3);"></div>' +
+        '<p style="font-weight:var(--weight-medium);margin:0 0 var(--space-2);">Analyzing ' + esc(agentId) + '...</p>' +
+        '<p class="dim" style="font-size:var(--font-size-xs);margin:0;">This usually takes 10\u201330 seconds.</p>' +
+        '</div>';
+
+      fetch('/agents/' + encodeURIComponent(agentId) + '/analyze', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: '',
+      })
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
+          if (!data.ok) {
+            content.innerHTML =
+              '<h3 style="margin:0 0 var(--space-3);">Analysis failed</h3>' +
+              '<div class="flash flash--error">' + esc(data.error || 'Unknown error') + '</div>' +
+              (data.runId ? '<p class="dim" style="font-size:var(--font-size-xs);margin:var(--space-2) 0 0;">Run: <a href="/runs/' + esc(data.runId) + '">' + esc(data.runId.slice(0, 8)) + '</a></p>' : '') +
+              '<div style="margin-top:var(--space-3);text-align:right;">' +
+              '<button type="button" class="btn btn--ghost btn--sm" onclick="document.getElementById(&quot;suggest-modal&quot;).classList.remove(&quot;is-open&quot;)">Close</button>' +
+              '</div>';
+            return;
+          }
+
+          var bc = data.classification === 'NO_IMPROVEMENTS' ? 'badge--ok'
+            : data.classification === 'REWRITE' ? 'badge--err' : 'badge--warn';
+          var bl = data.classification === 'NO_IMPROVEMENTS' ? 'No improvements needed'
+            : data.classification === 'REWRITE' ? 'Recommend rewrite' : 'Suggested improvements';
+
+          var h = '<div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3);">' +
+            '<span class="badge ' + bc + '">' + esc(bl) + '</span>' +
+            '</div>';
+          if (data.summary) h += '<p style="font-weight:var(--weight-medium);margin:0 0 var(--space-3);">' + esc(data.summary) + '</p>';
+          if (data.details) h += '<pre style="white-space:pre-wrap;font-family:inherit;font-size:var(--font-size-sm);line-height:1.6;margin:0 0 var(--space-3);color:var(--color-text-muted);max-height:300px;overflow-y:auto;">' + esc(data.details) + '</pre>';
+
+          if (data.yaml) {
+            h += '<details style="margin-bottom:var(--space-3);">' +
+              '<summary style="cursor:pointer;font-size:var(--font-size-xs);font-weight:var(--weight-semibold);color:var(--color-primary);">View suggested YAML</summary>' +
+              '<pre style="font-size:var(--font-size-xs);background:var(--color-surface-raised);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-3);margin-top:var(--space-2);max-height:300px;overflow-y:auto;white-space:pre-wrap;word-break:break-all;">' + esc(data.yaml) + '</pre>' +
+              '</details>';
+          }
+
+          h += '<div style="display:flex;gap:var(--space-2);justify-content:flex-end;flex-wrap:wrap;">';
+          if (data.yaml) {
+            // "Review + apply" opens the YAML editor pre-filled with the suggestion.
+            h += '<form method="POST" action="/agents/' + encodeURIComponent(agentId) + '/yaml" style="margin:0;">' +
+              '<input type="hidden" name="prefillYaml" value="' + esc(data.yaml).replace(/"/g, '&quot;') + '">' +
+              '<button type="submit" class="btn btn--primary btn--sm">Review + apply</button>' +
+              '</form>';
+          }
+          h += '<button type="button" class="btn btn--ghost btn--sm" onclick="document.getElementById(&quot;suggest-modal&quot;).classList.remove(&quot;is-open&quot;)">Dismiss</button>';
+          h += '</div>';
+
+          content.innerHTML = h;
+        })
+        .catch(function (err) {
+          content.innerHTML =
+            '<h3 style="margin:0 0 var(--space-3);">Error</h3>' +
+            '<div class="flash flash--error">' + esc(String(err)) + '</div>' +
+            '<div style="margin-top:var(--space-3);text-align:right;">' +
+            '<button type="button" class="btn btn--ghost btn--sm" onclick="document.getElementById(&quot;suggest-modal&quot;).classList.remove(&quot;is-open&quot;)">Close</button>' +
+            '</div>';
+        });
+    });
+
+    modal.addEventListener('click', function (e) {
+      if (e.target === modal) closeModal();
+    });
+  })();
+
   // Secret save confirmation modal — shows the value one last time with
   // a copy button before the encrypted write. Value is never shown again.
   (function () {

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -564,7 +564,7 @@ export const DASHBOARD_JS = `
               '<div class="flash flash--error">' + esc(data.error || 'Unknown error') + '</div>' +
               (data.runId ? '<p class="dim" style="font-size:var(--font-size-xs);margin:var(--space-2) 0 0;">Run: <a href="/runs/' + esc(data.runId) + '">' + esc(data.runId.slice(0, 8)) + '</a></p>' : '') +
               '<div style="margin-top:var(--space-3);text-align:right;">' +
-              '<button type="button" class="btn btn--ghost btn--sm" onclick="document.getElementById(&quot;suggest-modal&quot;).classList.remove(&quot;is-open&quot;)">Close</button>' +
+              '<button type="button" class="btn btn--ghost btn--sm" data-close-modal="1">Close</button>' +
               '</div>';
             return;
           }
@@ -580,7 +580,15 @@ export const DASHBOARD_JS = `
           if (data.summary) h += '<p style="font-weight:var(--weight-medium);margin:0 0 var(--space-3);">' + esc(data.summary) + '</p>';
           if (data.details) h += '<pre style="white-space:pre-wrap;font-family:inherit;font-size:var(--font-size-sm);line-height:1.6;margin:0 0 var(--space-3);color:var(--color-text-muted);max-height:300px;overflow-y:auto;">' + esc(data.details) + '</pre>';
 
-          if (data.yaml) {
+          if (data.yaml && data.currentYaml) {
+            var PRE = 'font-size:var(--font-size-xs);background:var(--color-surface-raised);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-3);max-height:280px;overflow-y:auto;white-space:pre-wrap;word-break:break-all;margin:0;';
+            h += '<div style="display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3);margin-bottom:var(--space-3);">' +
+              '<div><p class="dim" style="font-size:var(--font-size-xs);margin:0 0 var(--space-1);">Current</p>' +
+              '<pre style="' + PRE + '">' + esc(data.currentYaml) + '</pre></div>' +
+              '<div><p class="dim" style="font-size:var(--font-size-xs);margin:0 0 var(--space-1);">Suggested</p>' +
+              '<pre style="' + PRE + '">' + esc(data.yaml) + '</pre></div>' +
+              '</div>';
+          } else if (data.yaml) {
             h += '<details style="margin-bottom:var(--space-3);">' +
               '<summary style="cursor:pointer;font-size:var(--font-size-xs);font-weight:var(--weight-semibold);color:var(--color-primary);">View suggested YAML</summary>' +
               '<pre style="font-size:var(--font-size-xs);background:var(--color-surface-raised);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-3);margin-top:var(--space-2);max-height:300px;overflow-y:auto;white-space:pre-wrap;word-break:break-all;">' + esc(data.yaml) + '</pre>' +
@@ -589,14 +597,36 @@ export const DASHBOARD_JS = `
 
           h += '<div style="display:flex;gap:var(--space-2);justify-content:flex-end;flex-wrap:wrap;">';
           if (data.yaml) {
-            // "Review + apply" opens the YAML editor pre-filled with the suggestion.
-            h += '<form method="POST" action="/agents/' + encodeURIComponent(agentId) + '/yaml" style="margin:0;">' +
-              '<input type="hidden" name="prefillYaml" value="' + esc(data.yaml).replace(/"/g, '&quot;') + '">' +
-              '<button type="submit" class="btn btn--primary btn--sm">Review + apply</button>' +
-              '</form>';
+            h += '<button type="button" class="btn btn--primary btn--sm" id="suggest-apply-btn">Review + apply</button>';
           }
-          h += '<button type="button" class="btn btn--ghost btn--sm" onclick="document.getElementById(&quot;suggest-modal&quot;).classList.remove(&quot;is-open&quot;)">Dismiss</button>';
+          h += '<button type="button" class="btn btn--ghost btn--sm" id="suggest-dismiss-btn">Dismiss</button>';
           h += '</div>';
+
+          // Wire up buttons after innerHTML is set.
+          setTimeout(function () {
+            var applyBtn = document.getElementById('suggest-apply-btn');
+            if (applyBtn && data.yaml) {
+              applyBtn.addEventListener('click', function () {
+                // Submit via a dynamic form with a textarea to preserve newlines/quotes.
+                var form = document.createElement('form');
+                form.method = 'POST';
+                form.action = '/agents/' + encodeURIComponent(agentId) + '/yaml';
+                var ta = document.createElement('textarea');
+                ta.name = 'prefillYaml';
+                ta.value = data.yaml;
+                ta.style.display = 'none';
+                form.appendChild(ta);
+                document.body.appendChild(form);
+                form.submit();
+              });
+            }
+            var dismissBtn = document.getElementById('suggest-dismiss-btn');
+            if (dismissBtn) {
+              dismissBtn.addEventListener('click', function () {
+                modal.classList.remove('is-open');
+              });
+            }
+          }, 0);
 
           content.innerHTML = h;
         })
@@ -605,13 +635,15 @@ export const DASHBOARD_JS = `
             '<h3 style="margin:0 0 var(--space-3);">Error</h3>' +
             '<div class="flash flash--error">' + esc(String(err)) + '</div>' +
             '<div style="margin-top:var(--space-3);text-align:right;">' +
-            '<button type="button" class="btn btn--ghost btn--sm" onclick="document.getElementById(&quot;suggest-modal&quot;).classList.remove(&quot;is-open&quot;)">Close</button>' +
+            '<button type="button" class="btn btn--ghost btn--sm" data-close-modal="1">Close</button>' +
             '</div>';
         });
     });
 
     modal.addEventListener('click', function (e) {
       if (e.target === modal) closeModal();
+      // Delegated close for dynamically created buttons.
+      if (e.target && e.target.getAttribute && e.target.getAttribute('data-close-modal')) closeModal();
     });
   })();
 

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -523,6 +523,16 @@ export const DASHBOARD_JS = `
     setTimeout(poll, 2000);
   }
 
+  // Run-now modal — show spinner while the POST submits.
+  (function () {
+    var runForm = document.querySelector('[data-run-form]');
+    var runModal = document.getElementById('run-modal');
+    if (!runForm || !runModal) return;
+    runForm.addEventListener('submit', function () {
+      runModal.classList.add('is-open');
+    });
+  })();
+
   // Suggest improvements — modal with progress feedback, cancel, colored diff.
   (function () {
     var btn = document.getElementById('suggest-btn');

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -536,30 +536,34 @@ export const DASHBOARD_JS = `
       });
     }
 
-    // When the form inside the modal submits, swap content to a spinner.
+    var SPINNER_HTML =
+      '<div style="text-align:center;padding:var(--space-6);">' +
+      '<div class="spinner" style="margin:0 auto var(--space-3);"></div>' +
+      '<p style="font-weight:var(--weight-medium);margin:0 0 var(--space-2);">Running...</p>' +
+      '<p class="dim" style="font-size:var(--font-size-xs);margin:0;">Starting execution.</p></div>';
+
+    // When the form inside the modal submits, swap to spinner AFTER the
+    // browser has processed the submit (setTimeout avoids disconnecting
+    // the form before the POST fires).
     var runForm = runModal.querySelector('[data-run-form]');
     if (runForm) {
       runForm.addEventListener('submit', function () {
-        var mc = document.getElementById('run-modal-content');
-        if (mc) mc.innerHTML =
-          '<div style="text-align:center;padding:var(--space-6);">' +
-          '<div class="spinner" style="margin:0 auto var(--space-3);"></div>' +
-          '<p style="font-weight:var(--weight-medium);margin:0 0 var(--space-2);">Running...</p>' +
-          '<p class="dim" style="font-size:var(--font-size-xs);margin:0;">Starting execution.</p></div>';
+        setTimeout(function () {
+          var mc = document.getElementById('run-modal-content');
+          if (mc) mc.innerHTML = SPINNER_HTML;
+        }, 0);
       });
     }
 
-    // Also handle no-inputs agents (form outside modal with data-run-form).
+    // No-inputs agents: form is outside the modal. Show modal with spinner.
     var externalForm = document.querySelector('form[data-run-form]:not(#run-modal form)');
     if (externalForm) {
       externalForm.addEventListener('submit', function () {
         runModal.classList.add('is-open');
-        var mc = document.getElementById('run-modal-content');
-        if (mc) mc.innerHTML =
-          '<div style="text-align:center;padding:var(--space-6);">' +
-          '<div class="spinner" style="margin:0 auto var(--space-3);"></div>' +
-          '<p style="font-weight:var(--weight-medium);margin:0 0 var(--space-2);">Running...</p>' +
-          '<p class="dim" style="font-size:var(--font-size-xs);margin:0;">Starting execution.</p></div>';
+        setTimeout(function () {
+          var mc = document.getElementById('run-modal-content');
+          if (mc) mc.innerHTML = SPINNER_HTML;
+        }, 0);
       });
     }
 

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -523,13 +523,50 @@ export const DASHBOARD_JS = `
     setTimeout(poll, 2000);
   }
 
-  // Run-now modal — show spinner while the POST submits.
+  // Run-now modal — open inputs form or show spinner while POST submits.
   (function () {
-    var runForm = document.querySelector('[data-run-form]');
     var runModal = document.getElementById('run-modal');
-    if (!runForm || !runModal) return;
-    runForm.addEventListener('submit', function () {
-      runModal.classList.add('is-open');
+    if (!runModal) return;
+
+    // "Run now" button for agents with inputs — opens the modal form.
+    var inputsBtn = document.getElementById('run-with-inputs-btn');
+    if (inputsBtn) {
+      inputsBtn.addEventListener('click', function () {
+        runModal.classList.add('is-open');
+      });
+    }
+
+    // When the form inside the modal submits, swap content to a spinner.
+    var runForm = runModal.querySelector('[data-run-form]');
+    if (runForm) {
+      runForm.addEventListener('submit', function () {
+        var mc = document.getElementById('run-modal-content');
+        if (mc) mc.innerHTML =
+          '<div style="text-align:center;padding:var(--space-6);">' +
+          '<div class="spinner" style="margin:0 auto var(--space-3);"></div>' +
+          '<p style="font-weight:var(--weight-medium);margin:0 0 var(--space-2);">Running...</p>' +
+          '<p class="dim" style="font-size:var(--font-size-xs);margin:0;">Starting execution.</p></div>';
+      });
+    }
+
+    // Also handle no-inputs agents (form outside modal with data-run-form).
+    var externalForm = document.querySelector('form[data-run-form]:not(#run-modal form)');
+    if (externalForm) {
+      externalForm.addEventListener('submit', function () {
+        runModal.classList.add('is-open');
+        var mc = document.getElementById('run-modal-content');
+        if (mc) mc.innerHTML =
+          '<div style="text-align:center;padding:var(--space-6);">' +
+          '<div class="spinner" style="margin:0 auto var(--space-3);"></div>' +
+          '<p style="font-weight:var(--weight-medium);margin:0 0 var(--space-2);">Running...</p>' +
+          '<p class="dim" style="font-size:var(--font-size-xs);margin:0;">Starting execution.</p></div>';
+      });
+    }
+
+    // Close modal on backdrop click or data-close-modal buttons.
+    runModal.addEventListener('click', function (e) {
+      if (e.target === runModal) runModal.classList.remove('is-open');
+      if (e.target && e.target.getAttribute && e.target.getAttribute('data-close-modal')) runModal.classList.remove('is-open');
     });
   })();
 


### PR DESCRIPTION
## Summary
- **Suggest improvements** button on agent detail page opens an inline modal
- Modal shows spinner while Claude analyzes, then renders classified results (no page navigation)
- Agent-analyzer is an example agent that receives YAML as input and outputs structured suggestions
- Fixes a bug where `{{inputs.X}}` templates in claude-code node prompts were never resolved

## Flow
1. Click "Suggest improvements" in agent sidebar
2. Modal opens with spinner ("Analyzing agent-name... 10-30 seconds")
3. POST `/agents/:name/analyze` runs agent-analyzer, returns JSON
4. Modal renders: classification badge, summary, details, collapsible suggested YAML
5. "Review + apply" opens YAML editor pre-filled with suggestion
6. "Dismiss" closes modal, stays on page

## Bug fix
`spawnNodeReal` was passing `node.prompt` raw to `claude --print` without substituting `{{inputs.X}}`, `{{upstream.X.result}}`, or `{{vars.X}}` templates. Now resolves all three before spawning.

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 561 tests pass
- [ ] Manual: click Suggest improvements → modal with spinner → results with badge
- [ ] Manual: "Review + apply" → YAML editor pre-filled
- [ ] Manual: test with a claude-code agent that uses `{{inputs.X}}` in its prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)