### PR TITLE
fix: increase agent-analyzer maxTurns from 1 to 3

### DIFF
--- a/agents/examples/agent-analyzer.yaml
+++ b/agents/examples/agent-analyzer.yaml
@@ -74,5 +74,5 @@ nodes:
       Here is the agent YAML to review:
 
       {{inputs.AGENT_YAML}}
-    maxTurns: 1
+    maxTurns: 3
     timeout: 120


### PR DESCRIPTION
## Summary
The analyzer agent was failing with "Reached max turns (1)" on every analysis because `maxTurns: 1` didn't give Claude enough room to produce the full structured response.

## Fix
Changed `maxTurns` from 1 to 3 in `agents/examples/agent-analyzer.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)