### PR TITLE
feat(core): progressJson column + executor progress wiring

### DIFF
--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -320,6 +320,12 @@ export interface NodeExecutionRecord {
    * for tools that declare it.
    */
   outputsJson?: string;
+  /**
+   * v0.17+: real-time progress events captured during multi-turn LLM
+   * execution, JSON-serialized array of SpawnProgress events. Updated
+   * in-flight by the executor so the dashboard can poll for turn status.
+   */
+  progressJson?: string;
 }
 
 /**

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -32,7 +32,7 @@ import { getBuiltinTool } from './builtin-tools.js';
 import { buildToolOutput } from './output-framing.js';
 import { UntrustedCommunityShellError } from './agent-executor.js';
 import { buildNodeEnv, buildUpstreamSnapshot, filterEnvForLog } from './node-env.js';
-import { type SpawnResult, type SpawnNodeFn, spawnNodeReal } from './node-spawner.js';
+import { type SpawnResult, type SpawnNodeFn, type SpawnProgress, spawnNodeReal } from './node-spawner.js';
 import { resolveToolId, resolveToolInputs } from './tool-dispatch.js';
 import {
   executeControlFlowNode,
@@ -549,6 +549,17 @@ export async function executeAgentDag(
       upstreamInputsJson: JSON.stringify(upstreamSnapshot),
     });
 
+    // Progress collector: accumulates SpawnProgress events and writes
+    // them to the DB so the dashboard can poll for turn status.
+    const progressEvents: SpawnProgress[] = [];
+    const onProgress = (event: SpawnProgress) => {
+      progressEvents.push(event);
+      // Write to DB on each event so polling picks it up immediately.
+      deps.runStore.updateNodeExecution(runId, node.id, {
+        progressJson: JSON.stringify(progressEvents),
+      });
+    };
+
     // v0.16 tool dispatch: if the node references a tool, resolve it and
     // call its execute() function. Built-in tools run in-process; user
     // tools that use shell/claude-code implementation types go through the
@@ -595,21 +606,19 @@ export async function executeAgentDag(
           command: userTool.implementation.command,
           prompt: userTool.implementation.prompt,
         };
-        const spawnResult = await spawnFn(synthNode, env, {
-          agentId: agent.id,
-          agentSource: agent.source,
-          allowUntrustedShell: deps.allowUntrustedShell,
-        });
+        const spawnOpts = { agentId: agent.id, agentSource: agent.source, allowUntrustedShell: deps.allowUntrustedShell };
+        const spawnResult = spawnFn === spawnNodeReal
+          ? await spawnNodeReal(synthNode, env, spawnOpts, onProgress)
+          : await spawnFn(synthNode, env, spawnOpts);
         result = spawnResult;
         structuredOutput = buildToolOutput(spawnResult.result);
       } else {
         // v0.15 legacy path: no tool field, dispatch by type directly.
         const spawnFn = deps.spawnNode ?? spawnNodeReal;
-        const spawnResult = await spawnFn(node, env, {
-          agentId: agent.id,
-          agentSource: agent.source,
-          allowUntrustedShell: deps.allowUntrustedShell,
-        });
+        const spawnOpts = { agentId: agent.id, agentSource: agent.source, allowUntrustedShell: deps.allowUntrustedShell };
+        const spawnResult = spawnFn === spawnNodeReal
+          ? await spawnNodeReal(node, env, spawnOpts, onProgress)
+          : await spawnFn(node, env, spawnOpts);
         result = spawnResult;
         // Try to extract framed output from stdout even for legacy nodes,
         // so users who upgrade their shell scripts to emit framed JSON get

--- a/packages/core/src/run-store.ts
+++ b/packages/core/src/run-store.ts
@@ -175,6 +175,11 @@ export class RunStore {
     if (!execCols.has('outputsjson')) {
       this.db.exec(`ALTER TABLE node_executions ADD COLUMN outputsJson TEXT`);
     }
+
+    // v0.17: real-time progress events captured during multi-turn LLM execution.
+    if (!execCols.has('progressjson')) {
+      this.db.exec(`ALTER TABLE node_executions ADD COLUMN progressJson TEXT`);
+    }
   }
 
   /**
@@ -338,8 +343,8 @@ export class RunStore {
       INSERT INTO node_executions (
         runId, nodeId, workflowVersion, status, errorCategory,
         startedAt, completedAt, result, exitCode, error,
-        inputsJson, upstreamInputsJson, outputsJson
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        inputsJson, upstreamInputsJson, outputsJson, progressJson
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     stmt.run(
       record.runId, record.nodeId, record.workflowVersion, record.status,
@@ -347,7 +352,7 @@ export class RunStore {
       record.startedAt, record.completedAt ?? null,
       record.result ?? null, record.exitCode ?? null, record.error ?? null,
       record.inputsJson ?? null, record.upstreamInputsJson ?? null,
-      record.outputsJson ?? null,
+      record.outputsJson ?? null, record.progressJson ?? null,
     );
   }
 
@@ -355,7 +360,7 @@ export class RunStore {
     runId: string,
     nodeId: string,
     updates: Partial<Pick<NodeExecutionRecord,
-      'status' | 'errorCategory' | 'completedAt' | 'result' | 'exitCode' | 'error' | 'inputsJson' | 'upstreamInputsJson' | 'outputsJson'
+      'status' | 'errorCategory' | 'completedAt' | 'result' | 'exitCode' | 'error' | 'inputsJson' | 'upstreamInputsJson' | 'outputsJson' | 'progressJson'
     >>,
   ): void {
     const fields: string[] = [];
@@ -369,6 +374,7 @@ export class RunStore {
     if (updates.inputsJson !== undefined) { fields.push('inputsJson = ?'); values.push(updates.inputsJson); }
     if (updates.upstreamInputsJson !== undefined) { fields.push('upstreamInputsJson = ?'); values.push(updates.upstreamInputsJson); }
     if (updates.outputsJson !== undefined) { fields.push('outputsJson = ?'); values.push(updates.outputsJson); }
+    if (updates.progressJson !== undefined) { fields.push('progressJson = ?'); values.push(updates.progressJson); }
     if (fields.length === 0) return;
 
     values.push(runId, nodeId);
@@ -456,6 +462,7 @@ export class RunStore {
       inputsJson: (row.inputsJson as string | null) ?? undefined,
       upstreamInputsJson: (row.upstreamInputsJson as string | null) ?? undefined,
       outputsJson: (row.outputsJson as string | null) ?? undefined,
+      progressJson: (row.progressJson as string | null) ?? undefined,
     };
   }
 }


### PR DESCRIPTION
## Summary
PR 3 of the DAG executor refactor. Adds real-time progress tracking for multi-turn LLM node executions.

## Changes

### DB schema
- `ALTER TABLE node_executions ADD COLUMN progressJson TEXT`
- Stores a JSON array of `SpawnProgress` events, updated in-flight during execution

### NodeExecutionRecord type
- New optional `progressJson` field on the type in `agent-v2-types.ts`

### RunStore
- `createNodeExecution` and `updateNodeExecution` handle `progressJson`
- `rowToNodeExecution` maps the column from DB rows

### DAG executor
- Creates a progress collector per node execution
- Passes `onProgress` callback to `spawnNodeReal` (from PR 2's LlmSpawner)
- Each `SpawnProgress` event (turn_start, turn_complete, tool_use, etc.) writes to DB immediately
- Dashboard polling can read `progressJson` without waiting for the node to complete
- Test mock spawners (`SpawnNodeFn`) are unaffected — `onProgress` only passed to the real spawner

## Next
PR 4 (dashboard): run-detail polling reads `progressJson` and displays turn indicators. Suggest modal polls run status with real progress instead of time-based guesses.

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 561 tests pass (zero behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)