### PR TITLE
feat(dashboard): real-time progress UI for LLM node execution

### DIFF
--- a/agents/examples/agent-analyzer.yaml
+++ b/agents/examples/agent-analyzer.yaml
@@ -58,6 +58,11 @@ nodes:
       - Node ids must be lowercase with hyphens/underscores only (e.g. fetch-data, step-1).
       - Keep the same agent `id` as the original.
       - `type` for inputs must be one of: string, number, boolean, enum.
+      - Enum inputs MUST include a non-empty `values` array. Example:
+          STYLE:
+            type: enum
+            values: [haiku, limerick, prose]
+            default: haiku
 
       Respond in EXACTLY this format (keep the XML tags):
       <classification>NO_IMPROVEMENTS | SUGGESTIONS | REWRITE</classification>

--- a/packages/dashboard/src/routes/assets.ts
+++ b/packages/dashboard/src/routes/assets.ts
@@ -378,6 +378,72 @@ const GRAPH_RENDER_JS = `
         btn.textContent = 'Replay (community)';
       }
 
+      // Intercept submit: pre-check for missing upstream outputs,
+      // show spinner modal while replaying.
+      form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        // Close the node dialog first.
+        if (dialogSupported) dialog.close();
+
+        // Show a replay modal (reuse run-modal if it exists, or create one).
+        var replayModal = document.getElementById('run-modal');
+        var replayContent = document.getElementById('run-modal-content');
+        if (!replayModal || !replayContent) {
+          // No modal on page — fall back to form submit.
+          form.removeEventListener('submit', arguments.callee);
+          form.submit();
+          return;
+        }
+
+        replayModal.classList.add('is-open');
+        replayContent.innerHTML =
+          '<div style="text-align:center;padding:var(--space-6);">' +
+          '<div class="spinner" style="margin:0 auto var(--space-3);"></div>' +
+          '<p style="font-weight:var(--weight-medium);margin:0 0 var(--space-2);">Checking replay from ' + data.id + '...</p>' +
+          '</div>';
+
+        // Pre-check.
+        fetch('/runs/' + encodeURIComponent(replayRunId) + '/replay-check?fromNodeId=' + encodeURIComponent(data.id), { credentials: 'same-origin' })
+          .then(function (r) { return r.json(); })
+          .then(function (check) {
+            if (!check.ok) {
+              replayContent.innerHTML =
+                '<h3 style="margin:0 0 var(--space-3);">Cannot replay</h3>' +
+                '<div class="flash flash--error">' + check.error + '</div>' +
+                '<div style="margin-top:var(--space-3);text-align:right;"><button type="button" class="btn btn--ghost btn--sm" onclick="document.getElementById(\\x27run-modal\\x27).classList.remove(\\x27is-open\\x27)">Close</button></div>';
+              return;
+            }
+            if (check.missing && check.missing.length > 0) {
+              replayContent.innerHTML =
+                '<h3 style="margin:0 0 var(--space-3);">Missing upstream outputs</h3>' +
+                '<p class="dim" style="font-size:var(--font-size-xs);margin:0 0 var(--space-3);">The prior run is missing completed outputs for these upstream nodes. Replay cannot proceed.</p>' +
+                '<ul style="margin:0 0 var(--space-3);padding-left:var(--space-6);">' +
+                check.missing.map(function (n) { return '<li class="mono">' + n + '</li>'; }).join('') +
+                '</ul>' +
+                '<p class="dim" style="font-size:var(--font-size-xs);margin:0 0 var(--space-3);">Try running the full agent instead, or replay from an earlier node.</p>' +
+                '<div style="display:flex;gap:var(--space-2);justify-content:flex-end;">' +
+                '<button type="button" class="btn btn--ghost btn--sm" onclick="document.getElementById(\\x27run-modal\\x27).classList.remove(\\x27is-open\\x27)">Close</button>' +
+                '</div>';
+              return;
+            }
+            // All good — show spinner and submit.
+            replayContent.innerHTML =
+              '<div style="text-align:center;padding:var(--space-6);">' +
+              '<div class="spinner" style="margin:0 auto var(--space-3);"></div>' +
+              '<p style="font-weight:var(--weight-medium);margin:0 0 var(--space-2);">Replaying from ' + data.id + '...</p>' +
+              '<p class="dim" style="font-size:var(--font-size-xs);margin:0;">Reusing outputs from ' + check.available.length + ' upstream node(s).</p>' +
+              '</div>';
+            // Remove the interceptor and submit for real.
+            form.removeEventListener('submit', arguments.callee);
+            form.submit();
+          })
+          .catch(function () {
+            // Pre-check failed — submit anyway and let the server handle it.
+            form.removeEventListener('submit', arguments.callee);
+            form.submit();
+          });
+      });
+
       form.appendChild(btn);
       actionsEl.appendChild(form);
     }

--- a/packages/dashboard/src/routes/assets.ts
+++ b/packages/dashboard/src/routes/assets.ts
@@ -413,6 +413,18 @@ const GRAPH_RENDER_JS = `
                 '<div style="margin-top:var(--space-3);text-align:right;"><button type="button" class="btn btn--ghost btn--sm" onclick="document.getElementById(\\x27run-modal\\x27).classList.remove(\\x27is-open\\x27)">Close</button></div>';
               return;
             }
+            if (check.configErrors && check.configErrors.length > 0) {
+              replayContent.innerHTML =
+                '<h3 style="margin:0 0 var(--space-3);">Node configuration error</h3>' +
+                '<div class="flash flash--error" style="margin-bottom:var(--space-3);">' +
+                check.configErrors.map(function (e) { return '<div>' + e + '</div>'; }).join('') +
+                '</div>' +
+                '<p class="dim" style="font-size:var(--font-size-xs);margin:0 0 var(--space-3);">Fix the agent definition before replaying. The node is missing required configuration.</p>' +
+                '<div style="display:flex;gap:var(--space-2);justify-content:flex-end;">' +
+                '<button type="button" class="btn btn--ghost btn--sm" onclick="document.getElementById(\\x27run-modal\\x27).classList.remove(\\x27is-open\\x27)">Close</button>' +
+                '</div>';
+              return;
+            }
             if (check.missing && check.missing.length > 0) {
               replayContent.innerHTML =
                 '<h3 style="margin:0 0 var(--space-3);">Missing upstream outputs</h3>' +

--- a/packages/dashboard/src/routes/run-mutations.ts
+++ b/packages/dashboard/src/routes/run-mutations.ts
@@ -1,8 +1,72 @@
 import { Router, type Request, type Response } from 'express';
-import { executeAgentDag } from '@some-useful-agents/core';
+import { executeAgentDag, topologicalSort, type RunStatus } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 
 export const runMutationsRouter: Router = Router();
+
+/**
+ * GET /runs/:id/replay-check?fromNodeId=X — pre-flight check for replay.
+ * Returns JSON with whether upstream outputs are available and what
+ * agent inputs exist (so the UI can show input fields if needed).
+ */
+runMutationsRouter.get('/runs/:id/replay-check', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const fromNodeId = typeof req.query.fromNodeId === 'string' ? req.query.fromNodeId : '';
+
+  const priorRun = ctx.runStore.getRun(id);
+  if (!priorRun?.workflowId) {
+    res.json({ ok: false, error: 'Run not found or not a DAG run.' });
+    return;
+  }
+
+  const agent = ctx.agentStore.getAgent(priorRun.workflowId);
+  if (!agent) {
+    res.json({ ok: false, error: `Agent "${priorRun.workflowId}" not found.` });
+    return;
+  }
+
+  const order = topologicalSort(agent.nodes);
+  const pivotIndex = order.findIndex((n) => n.id === fromNodeId);
+  if (pivotIndex < 0) {
+    res.json({ ok: false, error: `Node "${fromNodeId}" not found in agent.` });
+    return;
+  }
+
+  // Check which upstream nodes have stored outputs in the prior run.
+  const priorExecs = ctx.runStore.listNodeExecutions(id);
+  const priorByNode = new Map(priorExecs.map((e) => [e.nodeId, e]));
+  const upstreamIds = order.slice(0, pivotIndex).map((n) => n.id);
+
+  const missing: string[] = [];
+  const available: string[] = [];
+  for (const nodeId of upstreamIds) {
+    const exec = priorByNode.get(nodeId);
+    if (exec?.status === 'completed' && exec.result !== undefined) {
+      available.push(nodeId);
+    } else {
+      missing.push(nodeId);
+    }
+  }
+
+  // Agent inputs for the input form.
+  const inputs = Object.entries(agent.inputs ?? {}).map(([name, spec]) => ({
+    name,
+    type: spec.type,
+    default: spec.default !== undefined ? String(spec.default) : undefined,
+    required: spec.required !== false && spec.default === undefined,
+    description: spec.description,
+  }));
+
+  res.json({
+    ok: true,
+    canReplay: missing.length === 0,
+    missing,
+    available,
+    inputs,
+    fromNodeId,
+  });
+});
 
 /**
  * POST /runs/:id/replay — re-execute an agent starting from a specific
@@ -60,21 +124,46 @@ runMutationsRouter.post('/runs/:id/replay', async (req: Request, res: Response) 
     return;
   }
 
+  // Fire-and-forget: start replay but redirect immediately.
+  const replayPromise = executeAgentDag(
+    agent,
+    {
+      triggeredBy: 'dashboard',
+      inputs: {},
+      replayFrom: { priorRunId: id, fromNodeId },
+    },
+    {
+      runStore: ctx.runStore,
+      secretsStore: ctx.secretsStore,
+      allowUntrustedShell: ctx.allowUntrustedShell,
+    },
+  );
+
   try {
-    const replay = await executeAgentDag(
-      agent,
-      {
-        triggeredBy: 'dashboard',
-        inputs: {},
-        replayFrom: { priorRunId: id, fromNodeId },
-      },
-      {
-        runStore: ctx.runStore,
-        secretsStore: ctx.secretsStore,
-        allowUntrustedShell: ctx.allowUntrustedShell,
-      },
-    );
-    res.redirect(303, `/runs/${encodeURIComponent(replay.id)}?flash=${encodeURIComponent(`Replayed from "${fromNodeId}".`)}`);
+    // Wait briefly for the run row to be created.
+    const result = await Promise.race([
+      replayPromise,
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), 500)),
+    ]);
+
+    if (result) {
+      // Fast replay — already done.
+      res.redirect(303, `/runs/${encodeURIComponent(result.id)}?flash=${encodeURIComponent(`Replayed from "${fromNodeId}".`)}`);
+    } else {
+      // Still running — find the new run.
+      const { rows } = ctx.runStore.queryRuns({
+        agentName: agent.id,
+        statuses: ['running'] as RunStatus[],
+        limit: 1,
+        offset: 0,
+      });
+      if (rows.length > 0) {
+        res.redirect(303, `/runs/${encodeURIComponent(rows[0].id)}?flash=${encodeURIComponent(`Replaying from "${fromNodeId}"...`)}`);
+      } else {
+        const fullResult = await replayPromise;
+        res.redirect(303, `/runs/${encodeURIComponent(fullResult.id)}?flash=${encodeURIComponent(`Replayed from "${fromNodeId}".`)}`);
+      }
+    }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     res.redirect(303, `/runs/${encodeURIComponent(id)}?flash=${encodeURIComponent(`Replay failed: ${message}`)}`);

--- a/packages/dashboard/src/routes/run-mutations.ts
+++ b/packages/dashboard/src/routes/run-mutations.ts
@@ -33,6 +33,29 @@ runMutationsRouter.get('/runs/:id/replay-check', (req: Request, res: Response) =
     return;
   }
 
+  // Validate the pivot node's config. Control-flow nodes need their
+  // respective config objects; missing config will fail at execution time.
+  const pivotNode = order[pivotIndex];
+  const configErrors: string[] = [];
+  if (pivotNode.type === 'conditional' && !pivotNode.conditionalConfig) {
+    configErrors.push(`Node "${fromNodeId}" is a conditional but missing conditionalConfig.`);
+  }
+  if (pivotNode.type === 'switch' && !pivotNode.switchConfig) {
+    configErrors.push(`Node "${fromNodeId}" is a switch but missing switchConfig.`);
+  }
+  if (pivotNode.type === 'loop' && !pivotNode.loopConfig) {
+    configErrors.push(`Node "${fromNodeId}" is a loop but missing loopConfig.`);
+  }
+  if (pivotNode.type === 'agent-invoke' && !pivotNode.agentInvokeConfig) {
+    configErrors.push(`Node "${fromNodeId}" is an agent-invoke but missing agentInvokeConfig.`);
+  }
+  if (pivotNode.type === 'shell' && !pivotNode.command) {
+    configErrors.push(`Node "${fromNodeId}" is a shell node but has no command.`);
+  }
+  if (pivotNode.type === 'claude-code' && !pivotNode.prompt) {
+    configErrors.push(`Node "${fromNodeId}" is a claude-code node but has no prompt.`);
+  }
+
   // Check which upstream nodes have stored outputs in the prior run.
   const priorExecs = ctx.runStore.listNodeExecutions(id);
   const priorByNode = new Map(priorExecs.map((e) => [e.nodeId, e]));
@@ -60,8 +83,9 @@ runMutationsRouter.get('/runs/:id/replay-check', (req: Request, res: Response) =
 
   res.json({
     ok: true,
-    canReplay: missing.length === 0,
+    canReplay: missing.length === 0 && configErrors.length === 0,
     missing,
+    configErrors,
     available,
     inputs,
     fromNodeId,

--- a/packages/dashboard/src/routes/run-now.ts
+++ b/packages/dashboard/src/routes/run-now.ts
@@ -165,57 +165,108 @@ runNowRouter.post('/agents/:name/analyze', async (req: Request, res: Response) =
   const focus = typeof body.focus === 'string' ? body.focus.trim() : '';
   const targetYaml = exportAgent(target);
 
-  try {
-    const run = await executeAgentDag(
-      analyzer,
-      {
-        triggeredBy: 'dashboard',
-        inputs: {
-          AGENT_YAML: targetYaml,
-          ...(focus ? { FOCUS: `Focus your analysis on: ${focus}` } : {}),
-        },
+  // Fire-and-forget: start the analyzer but don't await it.
+  // Return the runId immediately so the client can poll.
+  const runPromise = executeAgentDag(
+    analyzer,
+    {
+      triggeredBy: 'dashboard',
+      inputs: {
+        AGENT_YAML: targetYaml,
+        ...(focus ? { FOCUS: `Focus your analysis on: ${focus}` } : {}),
       },
-      {
-        runStore: ctx.runStore,
-        secretsStore: ctx.secretsStore,
-        variablesStore: ctx.variablesStore,
-      },
-    );
+    },
+    {
+      runStore: ctx.runStore,
+      secretsStore: ctx.secretsStore,
+      variablesStore: ctx.variablesStore,
+    },
+  );
 
-    if (run.status !== 'completed' || !run.result) {
-      res.json({ ok: false, error: run.error ?? `Analysis failed (status: ${run.status}).`, runId: run.id });
-      return;
+  // Wait briefly for the run row to be created (near-instant).
+  await Promise.race([
+    runPromise,
+    new Promise((resolve) => setTimeout(resolve, 200)),
+  ]);
+
+  // Find the running analyzer run.
+  const { rows } = ctx.runStore.queryRuns({
+    agentName: ANALYZER_AGENT_ID,
+    statuses: ['running', 'completed', 'failed'] as RunStatus[],
+    limit: 1,
+    offset: 0,
+  });
+
+  if (rows.length > 0) {
+    res.json({ ok: true, status: 'started', runId: rows[0].id, currentYaml: targetYaml });
+  } else {
+    // Fallback: wait for the full run.
+    try {
+      const run = await runPromise;
+      res.json({ ok: true, status: 'started', runId: run.id, currentYaml: targetYaml });
+    } catch (err) {
+      res.json({ ok: false, error: (err as Error).message });
     }
-
-    const extract = (tag: string): string | undefined => {
-      const m = run.result!.match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`, 'i'));
-      return m ? m[1].trim() : undefined;
-    };
-    const classRaw = extract('classification')?.toUpperCase().trim() ?? 'SUGGESTIONS';
-    const classification = ['NO_IMPROVEMENTS', 'SUGGESTIONS', 'REWRITE'].includes(classRaw) ? classRaw : 'SUGGESTIONS';
-
-    const suggestedYaml = extract('yaml') || undefined;
-    let yamlError: string | undefined;
-    if (suggestedYaml && suggestedYaml.length > 10) {
-      try {
-        parseAgent(suggestedYaml);
-      } catch (e) {
-        yamlError = e instanceof Error ? e.message : String(e);
-      }
-    }
-
-    res.json({
-      ok: true,
-      runId: run.id,
-      classification,
-      summary: extract('summary') ?? '',
-      details: extract('details') ?? run.result,
-      yaml: suggestedYaml,
-      yamlError,
-      currentYaml: targetYaml,
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    res.json({ ok: false, error: message });
   }
+});
+
+/**
+ * GET /agents/:name/analyze/:runId — poll the analyzer run status.
+ * Returns progress events while running, parsed results when done.
+ */
+runNowRouter.get('/agents/:name/analyze/:runId', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
+  const runId = Array.isArray(req.params.runId) ? req.params.runId[0] : req.params.runId;
+
+  const run = ctx.runStore.getRun(runId);
+  if (!run) {
+    res.json({ ok: false, status: 'not_found' });
+    return;
+  }
+
+  // Still running — return progress from node executions.
+  if (run.status === 'running' || run.status === 'pending') {
+    const execs = ctx.runStore.listNodeExecutions(runId);
+    const runningNode = execs.find((e) => e.status === 'running');
+    let progress: unknown[] = [];
+    if (runningNode?.progressJson) {
+      try { progress = JSON.parse(runningNode.progressJson); } catch { /* ignore */ }
+    }
+    res.json({ ok: true, status: 'running', progress });
+    return;
+  }
+
+  // Done — parse the result.
+  if (run.status !== 'completed' || !run.result) {
+    res.json({ ok: true, status: 'failed', error: run.error ?? `Analysis failed (${run.status}).` });
+    return;
+  }
+
+  const extract = (tag: string): string | undefined => {
+    const m = run.result!.match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`, 'i'));
+    return m ? m[1].trim() : undefined;
+  };
+  const classRaw = extract('classification')?.toUpperCase().trim() ?? 'SUGGESTIONS';
+  const classification = ['NO_IMPROVEMENTS', 'SUGGESTIONS', 'REWRITE'].includes(classRaw) ? classRaw : 'SUGGESTIONS';
+
+  const suggestedYaml = extract('yaml') || undefined;
+  let yamlError: string | undefined;
+  if (suggestedYaml && suggestedYaml.length > 10) {
+    try { parseAgent(suggestedYaml); } catch (e) { yamlError = e instanceof Error ? e.message : String(e); }
+  }
+
+  const target = ctx.agentStore.getAgent(name);
+  const currentYaml = target ? exportAgent(target) : '';
+
+  res.json({
+    ok: true,
+    status: 'done',
+    classification,
+    summary: extract('summary') ?? '',
+    details: extract('details') ?? run.result,
+    yaml: suggestedYaml,
+    yamlError,
+    currentYaml,
+  });
 });

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -590,6 +590,17 @@ export const DASHBOARD_JS = `
     function esc(s) { var d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
     function closeModal() { modal.classList.remove('is-open'); }
 
+    // Lightweight markdown to HTML for analysis output.
+    function renderMd(text) {
+      var h = esc(text);
+      h = h.replace(/\\*\\*(.+?)\\*\\*/g, '<strong>' + '$' + '1</strong>');
+      h = h.replace(/\\*(.+?)\\*/g, '<em>' + '$' + '1</em>');
+      h = h.replace(/^- (.+)$/gm, function(m,p1) { return '<li style="margin-left:var(--space-4);list-style:disc;">' + p1 + '</li>'; });
+      h = h.replace(/\\n{2,}/g, '<br><br>');
+      h = h.replace(/\\n/g, '<br>');
+      return h;
+    }
+
     function coloredDiff(oldT, newT) {
       var oL = oldT.split('\\n'), nL = newT.split('\\n');
       var oS = {}, nS = {};
@@ -611,8 +622,8 @@ export const DASHBOARD_JS = `
       var bc = data.classification === 'NO_IMPROVEMENTS' ? 'badge--ok' : data.classification === 'REWRITE' ? 'badge--err' : 'badge--warn';
       var bl = data.classification === 'NO_IMPROVEMENTS' ? 'No improvements needed' : data.classification === 'REWRITE' ? 'Recommend rewrite' : 'Suggested improvements';
       var h = '<div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3);"><span class="badge ' + bc + '">' + esc(bl) + '</span></div>';
-      if (data.summary) h += '<p style="font-weight:var(--weight-medium);margin:0 0 var(--space-3);">' + esc(data.summary) + '</p>';
-      if (data.details) h += '<pre style="white-space:pre-wrap;font-family:inherit;font-size:var(--font-size-sm);line-height:1.6;margin:0 0 var(--space-3);color:var(--color-text-muted);max-height:250px;overflow-y:auto;">' + esc(data.details) + '</pre>';
+      if (data.summary) h += '<p style="font-weight:var(--weight-medium);margin:0 0 var(--space-3);">' + renderMd(data.summary) + '</p>';
+      if (data.details) h += '<div style="font-size:var(--font-size-sm);line-height:1.6;margin:0 0 var(--space-3);color:var(--color-text-muted);max-height:250px;overflow-y:auto;">' + renderMd(data.details) + '</div>';
       if (data.yaml && data.currentYaml) {
         h += coloredDiff(data.currentYaml, data.yaml);
       } else if (data.yaml) {

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -607,88 +607,134 @@ export const DASHBOARD_JS = `
       return h;
     }
 
+    function renderResult(data) {
+      var bc = data.classification === 'NO_IMPROVEMENTS' ? 'badge--ok' : data.classification === 'REWRITE' ? 'badge--err' : 'badge--warn';
+      var bl = data.classification === 'NO_IMPROVEMENTS' ? 'No improvements needed' : data.classification === 'REWRITE' ? 'Recommend rewrite' : 'Suggested improvements';
+      var h = '<div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3);"><span class="badge ' + bc + '">' + esc(bl) + '</span></div>';
+      if (data.summary) h += '<p style="font-weight:var(--weight-medium);margin:0 0 var(--space-3);">' + esc(data.summary) + '</p>';
+      if (data.details) h += '<pre style="white-space:pre-wrap;font-family:inherit;font-size:var(--font-size-sm);line-height:1.6;margin:0 0 var(--space-3);color:var(--color-text-muted);max-height:250px;overflow-y:auto;">' + esc(data.details) + '</pre>';
+      if (data.yaml && data.currentYaml) {
+        h += coloredDiff(data.currentYaml, data.yaml);
+      } else if (data.yaml) {
+        h += '<pre style="font-size:var(--font-size-xs);background:var(--color-surface-raised);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-3);margin-bottom:var(--space-3);max-height:300px;overflow-y:auto;white-space:pre-wrap;">' + esc(data.yaml) + '</pre>';
+      }
+      if (data.yamlError) {
+        h += '<div class="flash flash--error" style="margin-bottom:var(--space-3);font-size:var(--font-size-xs);">' +
+          '<strong>Suggested YAML has validation errors:</strong> ' + esc(data.yamlError) +
+          '<br>Click "Edit YAML" to fix manually.</div>';
+      }
+      h += '<div style="display:flex;gap:var(--space-2);justify-content:flex-end;flex-wrap:wrap;">';
+      if (data.yaml) {
+        var applyLabel = data.yamlError ? 'Edit YAML to fix' : 'Review + apply';
+        h += '<button type="button" class="btn btn--primary btn--sm" id="sg-apply">' + esc(applyLabel) + '</button>';
+      }
+      h += '<button type="button" class="btn btn--ghost btn--sm" id="sg-dismiss">Dismiss</button></div>';
+      content.innerHTML = h;
+      var ab = document.getElementById('sg-apply');
+      if (ab && data.yaml) ab.addEventListener('click', function () {
+        var f = document.createElement('form'); f.method = 'POST';
+        f.action = '/agents/' + encodeURIComponent(agentId) + '/yaml';
+        var t = document.createElement('textarea'); t.name = 'prefillYaml'; t.value = data.yaml; t.style.display = 'none';
+        f.appendChild(t); document.body.appendChild(f); f.submit();
+      });
+      var db = document.getElementById('sg-dismiss');
+      if (db) db.addEventListener('click', closeModal);
+    }
+
     btn.addEventListener('click', function () {
       modal.classList.add('is-open');
       var t0 = Date.now();
-      content.innerHTML =
-        '<div style="padding:var(--space-4);">' +
-        '<div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-4);">' +
-          '<div class="spinner"></div>' +
-          '<div style="flex:1;"><div style="font-weight:var(--weight-medium);">Analyzing ' + esc(agentId) + '</div>' +
-          '<div class="dim" style="font-size:var(--font-size-xs);" id="sg-phase">' + PHASES[0][1] + '</div></div>' +
-          '<div style="font-family:var(--font-mono);font-size:var(--font-size-lg);color:var(--color-text-muted);min-width:3rem;text-align:right;" id="sg-timer">0s</div>' +
-        '</div>' +
-        '<div style="height:4px;background:var(--color-border);border-radius:2px;overflow:hidden;margin-bottom:var(--space-3);">' +
-          '<div id="sg-bar" style="height:100%;background:var(--color-primary);border-radius:2px;width:0%;transition:width 1s linear;"></div>' +
-        '</div>' +
-        '<div style="text-align:right;"><button type="button" class="btn btn--ghost btn--sm" id="sg-cancel">Cancel</button></div>' +
-        '</div>';
+      var cancelled = false;
+      var pollTimer = null;
+      var tickTimer = null;
 
-      var tick = setInterval(function () {
+      function showProgress(phaseMsg) {
+        var s = Math.round((Date.now() - t0) / 1000);
+        content.innerHTML =
+          '<div style="padding:var(--space-4);">' +
+          '<div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-4);">' +
+            '<div class="spinner"></div>' +
+            '<div style="flex:1;"><div style="font-weight:var(--weight-medium);">Analyzing ' + esc(agentId) + '</div>' +
+            '<div class="dim" style="font-size:var(--font-size-xs);" id="sg-phase">' + esc(phaseMsg) + '</div></div>' +
+            '<div style="font-family:var(--font-mono);font-size:var(--font-size-lg);color:var(--color-text-muted);min-width:3rem;text-align:right;" id="sg-timer">' + s + 's</div>' +
+          '</div>' +
+          '<div style="height:4px;background:var(--color-border);border-radius:2px;overflow:hidden;margin-bottom:var(--space-3);">' +
+            '<div style="height:100%;background:var(--color-primary);border-radius:2px;width:' + Math.min(s/120*100, 98) + '%;transition:width 1s linear;"></div>' +
+          '</div>' +
+          '<div style="text-align:right;"><button type="button" class="btn btn--ghost btn--sm" id="sg-cancel">Cancel</button></div>' +
+          '</div>';
+        var ce = document.getElementById('sg-cancel');
+        if (ce) ce.addEventListener('click', function () { cancelled = true; clearInterval(tickTimer); clearTimeout(pollTimer); closeModal(); });
+      }
+
+      // Initial progress display.
+      showProgress(PHASES[0][1]);
+
+      // Timer tick updates the elapsed time + phase messages.
+      tickTimer = setInterval(function () {
         var s = Math.round((Date.now() - t0) / 1000);
         var te = document.getElementById('sg-timer'); if (te) te.textContent = s + 's';
-        var be = document.getElementById('sg-bar'); if (be) be.style.width = Math.min(s/120*100, 98) + '%';
+        var be = content.querySelector('[style*="background:var(--color-primary)"]'); if (be) be.style.width = Math.min(s/120*100, 98) + '%';
         var pe = document.getElementById('sg-phase'); if (pe) {
           var m = PHASES[0][1]; for (var i = 0; i < PHASES.length; i++) { if (s >= PHASES[i][0]) m = PHASES[i][1]; }
           pe.textContent = m;
         }
       }, 1000);
 
-      var ctrl = new AbortController();
-      var ce = document.getElementById('sg-cancel');
-      if (ce) ce.addEventListener('click', function () { ctrl.abort(); clearInterval(tick); closeModal(); });
-
+      // Start the analysis.
       fetch('/agents/' + encodeURIComponent(agentId) + '/analyze', {
         method: 'POST', credentials: 'same-origin',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: '', signal: ctrl.signal,
+        body: '',
       })
       .then(function (r) { return r.json(); })
-      .then(function (data) {
-        clearInterval(tick);
-        if (!data.ok) {
+      .then(function (startData) {
+        if (!startData.ok || !startData.runId) {
+          clearInterval(tickTimer);
           content.innerHTML =
             '<h3 style="margin:0 0 var(--space-3);">Analysis failed</h3>' +
-            '<div class="flash flash--error">' + esc(data.error || 'Unknown error') + '</div>' +
-            (data.runId ? '<p class="dim" style="font-size:var(--font-size-xs);margin:var(--space-2) 0 0;">Run: <a href="/runs/' + esc(data.runId) + '">' + esc(data.runId.slice(0,8)) + '</a></p>' : '') +
+            '<div class="flash flash--error">' + esc(startData.error || 'Failed to start') + '</div>' +
             '<div style="margin-top:var(--space-3);text-align:right;"><button type="button" class="btn btn--ghost btn--sm" data-close-modal="1">Close</button></div>';
           return;
         }
-        var bc = data.classification === 'NO_IMPROVEMENTS' ? 'badge--ok' : data.classification === 'REWRITE' ? 'badge--err' : 'badge--warn';
-        var bl = data.classification === 'NO_IMPROVEMENTS' ? 'No improvements needed' : data.classification === 'REWRITE' ? 'Recommend rewrite' : 'Suggested improvements';
-        var h = '<div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-3);"><span class="badge ' + bc + '">' + esc(bl) + '</span></div>';
-        if (data.summary) h += '<p style="font-weight:var(--weight-medium);margin:0 0 var(--space-3);">' + esc(data.summary) + '</p>';
-        if (data.details) h += '<pre style="white-space:pre-wrap;font-family:inherit;font-size:var(--font-size-sm);line-height:1.6;margin:0 0 var(--space-3);color:var(--color-text-muted);max-height:250px;overflow-y:auto;">' + esc(data.details) + '</pre>';
-        if (data.yaml && data.currentYaml) {
-          h += coloredDiff(data.currentYaml, data.yaml);
-        } else if (data.yaml) {
-          h += '<pre style="font-size:var(--font-size-xs);background:var(--color-surface-raised);border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-3);margin-bottom:var(--space-3);max-height:300px;overflow-y:auto;white-space:pre-wrap;">' + esc(data.yaml) + '</pre>';
+
+        var runId = startData.runId;
+        var savedCurrentYaml = startData.currentYaml;
+
+        // Poll for progress + results.
+        function poll() {
+          if (cancelled) return;
+          fetch('/agents/' + encodeURIComponent(agentId) + '/analyze/' + encodeURIComponent(runId), { credentials: 'same-origin' })
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+              if (cancelled) return;
+              if (data.status === 'running') {
+                // Update phase from real progress events.
+                if (data.progress && data.progress.length > 0) {
+                  var latest = data.progress[data.progress.length - 1];
+                  var pe = document.getElementById('sg-phase');
+                  if (pe && latest.message) pe.textContent = latest.message;
+                }
+                pollTimer = setTimeout(poll, 2000);
+              } else if (data.status === 'done') {
+                clearInterval(tickTimer);
+                data.currentYaml = data.currentYaml || savedCurrentYaml;
+                renderResult(data);
+              } else {
+                clearInterval(tickTimer);
+                content.innerHTML =
+                  '<h3 style="margin:0 0 var(--space-3);">Analysis failed</h3>' +
+                  '<div class="flash flash--error">' + esc(data.error || 'Unknown error') + '</div>' +
+                  '<div style="margin-top:var(--space-3);text-align:right;"><button type="button" class="btn btn--ghost btn--sm" data-close-modal="1">Close</button></div>';
+              }
+            })
+            .catch(function () { if (!cancelled) pollTimer = setTimeout(poll, 3000); });
         }
-        if (data.yamlError) {
-          h += '<div class="flash flash--error" style="margin-bottom:var(--space-3);font-size:var(--font-size-xs);">' +
-            '<strong>Suggested YAML has validation errors:</strong> ' + esc(data.yamlError) +
-            '<br>Click "Edit YAML" to fix manually.</div>';
-        }
-        h += '<div style="display:flex;gap:var(--space-2);justify-content:flex-end;flex-wrap:wrap;">';
-        if (data.yaml) {
-          var applyLabel = data.yamlError ? 'Edit YAML to fix' : 'Review + apply';
-          h += '<button type="button" class="btn btn--primary btn--sm" id="sg-apply">' + esc(applyLabel) + '</button>';
-        }
-        h += '<button type="button" class="btn btn--ghost btn--sm" id="sg-dismiss">Dismiss</button></div>';
-        content.innerHTML = h;
-        var ab = document.getElementById('sg-apply');
-        if (ab && data.yaml) ab.addEventListener('click', function () {
-          var f = document.createElement('form'); f.method = 'POST';
-          f.action = '/agents/' + encodeURIComponent(agentId) + '/yaml';
-          var t = document.createElement('textarea'); t.name = 'prefillYaml'; t.value = data.yaml; t.style.display = 'none';
-          f.appendChild(t); document.body.appendChild(f); f.submit();
-        });
-        var db = document.getElementById('sg-dismiss');
-        if (db) db.addEventListener('click', closeModal);
+
+        pollTimer = setTimeout(poll, 2000);
       })
       .catch(function (err) {
-        clearInterval(tick);
-        if (err.name === 'AbortError') return;
+        clearInterval(tickTimer);
         content.innerHTML =
           '<h3 style="margin:0 0 var(--space-3);">Error</h3>' +
           '<div class="flash flash--error">' + esc(String(err)) + '</div>' +

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -253,6 +253,28 @@ function renderNodeVarsPanel(e: NodeExecutionRecord): SafeHtml | null {
 }
 
 /**
+ * Render a turn/progress indicator from the node's progressJson.
+ * Shows the latest progress event as a small inline label.
+ */
+function renderProgressIndicator(e: NodeExecutionRecord): SafeHtml {
+  if (!e.progressJson) return html``;
+  try {
+    const events = JSON.parse(e.progressJson) as Array<{ type: string; turn?: number; message?: string }>;
+    if (events.length === 0) return html``;
+    const latest = events[events.length - 1];
+    const label = latest.message ?? latest.type;
+    if (e.status === 'running') {
+      return html`<span class="dim" style="font-size: var(--font-size-xs); margin-left: var(--space-2);">${label}</span>`;
+    }
+    // For completed nodes, show the turn count if available.
+    if (latest.turn && latest.turn > 1) {
+      return html`<span class="dim" style="font-size: var(--font-size-xs); margin-left: var(--space-2);">${String(latest.turn)} turns</span>`;
+    }
+  } catch { /* malformed */ }
+  return html``;
+}
+
+/**
  * Render one collapsible card per node execution. Failed/errored nodes
  * open by default so the user doesn't have to hunt for failures; others
  * are collapsed to reduce scroll.
@@ -266,6 +288,9 @@ function renderNodeCards(execs: NodeExecutionRecord[], runId?: string, canReplay
     const category = e.errorCategory
       ? html` <span class="badge badge--err">${e.errorCategory}</span>`
       : html``;
+
+    // Parse progress events for turn indicator.
+    const progressIndicator = renderProgressIndicator(e);
 
     const bodyBlocks: SafeHtml[] = [];
 
@@ -288,6 +313,7 @@ function renderNodeCards(execs: NodeExecutionRecord[], runId?: string, canReplay
           <span class="run-node__id">${e.nodeId}</span>
           ${statusBadge(e.status)}
           ${category}
+          ${progressIndicator}
           <span class="run-node__meta">
             <span>${duration}</span>
             ${exitLabel ? html`<span class="mono">${exitLabel}</span>` : html``}


### PR DESCRIPTION
## Summary
PR 4 of the DAG executor refactor. The dashboard now shows real-time progress from multi-turn LLM executions instead of time-based guesses.

## Run detail
- Node execution cards show turn progress from `progressJson`
- Running nodes display the latest progress message ("Claude is responding...", "Using a tool...")
- Completed multi-turn nodes show the turn count ("2 turns")

## Suggest modal — polling replaces blocking fetch
- **Before**: POST to `/analyze` blocked for 30-60+ seconds waiting for the full run
- **After**: POST returns immediately with `{ runId }`, modal polls every 2s

### New endpoints
| Method | Path | Response |
|--------|------|----------|
| POST | `/agents/:name/analyze` | `{ ok, runId, currentYaml }` — starts run, returns immediately |
| GET | `/agents/:name/analyze/:runId` | `{ status: 'running', progress: [...] }` or `{ status: 'done', classification, yaml, ... }` |

### Modal UX
- Spinner + timer + progress bar (same chrome as before)
- Phase messages update from **real progress events** (`progressJson`) when available
- Falls back to time-based phases when no progress events yet
- Cancel stops polling and closes modal
- Results render inline when poll returns `status: 'done'`

## Test plan
- [x] `npm run build` passes
- [x] JS parse check passes
- [x] `npm test` — 561 tests pass
- [ ] Manual: run multi-turn claude-code agent → see turn indicator on node card
- [ ] Manual: suggest improvements → modal polls with real progress → results render

🤖 Generated with [Claude Code](https://claude.com/claude-code)