### PR TITLE
feat: provider field on claude-code nodes (claude/codex selection)

### DIFF
--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -91,6 +91,7 @@ export const agentNodeSchema = z.object({
   model: z.string().optional(),
   maxTurns: z.number().int().positive().optional(),
   allowedTools: z.array(z.string()).optional(),
+  provider: z.enum(['claude', 'codex']).optional(),
 
   timeout: z.number().positive().optional(),
   env: z.record(z.string()).optional(),

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -156,6 +156,13 @@ export interface AgentNode {
   maxTurns?: number;
   allowedTools?: string[];
 
+  /**
+   * v0.17+: LLM provider for claude-code nodes. Defaults to 'claude'.
+   * Determines which CLI binary and argument format the spawner uses.
+   * Shell nodes ignore this field.
+   */
+  provider?: 'claude' | 'codex';
+
   // Common per-node
   timeout?: number;
   env?: Record<string, string>;

--- a/packages/core/src/agent-yaml.ts
+++ b/packages/core/src/agent-yaml.ts
@@ -102,7 +102,7 @@ const AGENT_KEY_ORDER = [
 
 const NODE_KEY_ORDER = [
   'id', 'type',
-  'command', 'prompt', 'model', 'maxTurns', 'allowedTools',
+  'command', 'prompt', 'model', 'maxTurns', 'allowedTools', 'provider',
   'timeout', 'env', 'envAllowlist', 'secrets', 'redactSecrets', 'workingDirectory',
   'dependsOn',
   'position',

--- a/packages/core/src/node-spawner.ts
+++ b/packages/core/src/node-spawner.ts
@@ -224,7 +224,7 @@ export async function spawnNodeReal(
   resolvedPrompt = resolveVarsTemplate(resolvedPrompt, env);
   resolvedPrompt = substituteInputs(resolvedPrompt, env);
 
-  const spawner = getSpawner('claude');
+  const spawner = getSpawner(node.provider ?? 'claude');
   const args = spawner.buildArgs({
     prompt: resolvedPrompt,
     model: node.model,

--- a/packages/dashboard/src/routes/agents.ts
+++ b/packages/dashboard/src/routes/agents.ts
@@ -328,9 +328,13 @@ agentsRouter.post('/agents/:name/nodes/:nodeId/edit', (req: Request, res: Respon
   // edit (inputs, secrets, env, envAllowlist, allowedTools, model,
   // maxTurns, timeout, redactSecrets, position) — those come back in
   // a follow-up when the inspector can render them.
+  const provider = typeof body.provider === 'string' && ['claude', 'codex'].includes(body.provider)
+    ? body.provider as 'claude' | 'codex'
+    : undefined;
+
   const updatedNode = values.type === 'shell'
-    ? { ...node, type: 'shell' as const, command: values.command!, prompt: undefined, ...(dependsOn.length > 0 ? { dependsOn } : { dependsOn: undefined }) }
-    : { ...node, type: 'claude-code' as const, prompt: values.prompt!, command: undefined, ...(dependsOn.length > 0 ? { dependsOn } : { dependsOn: undefined }) };
+    ? { ...node, type: 'shell' as const, command: values.command!, prompt: undefined, provider: undefined, ...(dependsOn.length > 0 ? { dependsOn } : { dependsOn: undefined }) }
+    : { ...node, type: 'claude-code' as const, prompt: values.prompt!, command: undefined, ...(provider ? { provider } : {}), ...(dependsOn.length > 0 ? { dependsOn } : { dependsOn: undefined }) };
 
   const updatedNodes = agent.nodes.map((n) => n.id === nodeId ? updatedNode : n);
 

--- a/packages/dashboard/src/views/agent-edit-node.ts
+++ b/packages/dashboard/src/views/agent-edit-node.ts
@@ -91,6 +91,17 @@ export function renderAgentEditNode(args: {
           ${renderToolInputsSection(node.tool ?? (v.type === 'claude-code' ? 'claude-code' : 'shell-exec'), allTools, node.toolInputs as Record<string, unknown> | undefined)}
         `}
 
+      ${node.type === 'claude-code' || v.type === 'claude-code' ? html`
+        <fieldset style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--space-3); margin-bottom: var(--space-4);">
+          <legend style="padding: 0 var(--space-2); font-size: var(--font-size-xs); font-weight: var(--weight-semibold); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em;">LLM Provider</legend>
+          <select name="provider" style="padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm);">
+            <option value="claude" ${node.provider !== 'codex' ? 'selected' : ''}>Claude</option>
+            <option value="codex" ${node.provider === 'codex' ? 'selected' : ''}>Codex</option>
+          </select>
+          <span class="dim" style="font-size: var(--font-size-xs); margin-left: var(--space-2);">Which LLM CLI to use for this node.</span>
+        </fieldset>
+      ` : html``}
+
       <fieldset style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--space-3); margin-bottom: var(--space-4);">
         <legend style="padding: 0 var(--space-2); font-size: var(--font-size-xs); font-weight: var(--weight-semibold); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em;">Depends on</legend>
         <p class="dim" style="margin: 0 0 var(--space-2); font-size: var(--font-size-xs);">Pick upstream nodes. Downstream nodes + self are excluded to prevent cycles.</p>


### PR DESCRIPTION
## Summary
PR 5 of the DAG executor refactor. Adds a `provider` field to claude-code nodes for selecting which LLM CLI to use.

## Changes

### Schema
- `AgentNode.provider?: 'claude' | 'codex'` — defaults to claude
- Zod validation for the enum
- YAML export preserves the field

### Spawner
- `spawnNodeReal` reads `node.provider` and dispatches to the matching `LlmSpawner` via `getSpawner()`
- Claude nodes get stream-json progress tracking, codex nodes get basic exec

### Dashboard
- Edit-node form shows "LLM Provider" dropdown for claude-code nodes
- POST route reads and saves the provider field

## YAML example
```yaml
- id: analyze
  type: claude-code
  provider: codex
  prompt: Review this code...
```

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 561 tests pass
- [ ] Manual: edit a claude-code node → see provider dropdown → save with codex → YAML shows provider field

🤖 Generated with [Claude Code](https://claude.com/claude-code)