### PR TITLE
feat: add llm-tells-a-joke example agent

### DIFF
--- a/agents/examples/llm-tells-a-joke.yaml
+++ b/agents/examples/llm-tells-a-joke.yaml
@@ -1,0 +1,29 @@
+id: llm-tells-a-joke
+name: LLM tells a joke
+description: Tells a groan-worthy dad joke, optionally on a specific topic.
+status: active
+source: examples
+
+inputs:
+  TOPIC:
+    type: string
+    default: coffee
+    required: false
+    description: Optional topic for the joke (e.g. programming, animals, coffee)
+
+nodes:
+  - id: main
+    type: claude-code
+    prompt: |
+      You are a world-class dad-joke comedian. Tell exactly one groan-worthy dad joke.
+
+      Topic: {{inputs.TOPIC}}
+      If the topic is empty or blank, pick any random everyday topic.
+
+      Rules:
+      - Classic setup/punchline format.
+      - Keep it clean and family-friendly.
+      - Just the joke — no preamble, no explanation, no commentary, no emoji.
+      - Plain text only, no markdown formatting.
+    maxTurns: 1
+    timeout: 30


### PR DESCRIPTION
## Summary
New example agent based on AI-suggested improvements to the dadjoke agent. This was generated using the "Suggest improvements" feature and manually cleaned up.

## Agent
- **id**: llm-tells-a-joke
- **TOPIC** input with default "coffee" — configurable at run time
- Clean prompt with explicit rules (setup/punchline format, no emoji, plain text only)
- `maxTurns: 1`, `timeout: 30` for fast execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)