### PR TITLE
feat: self-correcting agent-analyzer pipeline

### DIFF
--- a/agents/examples/agent-analyzer.yaml
+++ b/agents/examples/agent-analyzer.yaml
@@ -1,9 +1,9 @@
 id: agent-analyzer
 name: Agent Analyzer
 description: >
-  AI-powered agent review. Analyzes an agent's YAML holistically and suggests
-  improvements — missing variables, hardcoded values, prompt quality, cross-node
-  data flow. Run via "Suggest improvements" on any agent's detail page.
+  AI-powered agent review with self-correction. Analyzes an agent's YAML,
+  validates the suggested improvements against the schema, and fixes any
+  errors automatically. Run via "Suggest improvements" on any agent's detail page.
 status: active
 source: examples
 
@@ -63,6 +63,9 @@ nodes:
             type: enum
             values: [haiku, limerick, prose]
             default: haiku
+      - Template refs in prompts use {{inputs.NAME}} (not {{NAME}} or {{#inputs.NAME}}).
+      - conditional nodes MUST have conditionalConfig with a predicate.
+      - switch nodes MUST have switchConfig with field + cases.
 
       Respond in EXACTLY this format (keep the XML tags):
       <classification>NO_IMPROVEMENTS | SUGGESTIONS | REWRITE</classification>
@@ -81,3 +84,75 @@ nodes:
       {{inputs.AGENT_YAML}}
     maxTurns: 3
     timeout: 120
+
+  - id: validate
+    type: shell
+    dependsOn:
+      - analyze
+    command: |
+      # Extract <yaml>...</yaml> from the analysis output.
+      YAML_BLOCK=$(echo "$UPSTREAM_ANALYZE_RESULT" | sed -n '/<yaml>/,/<\/yaml>/p' | sed '1d;$d')
+
+      if [ -z "$YAML_BLOCK" ] || [ ${#YAML_BLOCK} -lt 10 ]; then
+        echo '{"valid":true,"skipped":true,"reason":"No YAML suggestions to validate"}'
+        exit 0
+      fi
+
+      # Write to temp file and validate with parseAgent.
+      TMPFILE=$(mktemp /tmp/sua-validate-XXXXXX.yaml)
+      echo "$YAML_BLOCK" > "$TMPFILE"
+
+      RESULT=$(node -e "
+        const { parseAgent } = require('$(pwd)/packages/core/dist/agent-yaml.js');
+        const { readFileSync } = require('fs');
+        try {
+          const yaml = readFileSync('$TMPFILE', 'utf-8');
+          parseAgent(yaml);
+          console.log(JSON.stringify({ valid: true }));
+        } catch(e) {
+          console.log(JSON.stringify({ valid: false, error: e.message }));
+        }
+      " 2>/dev/null)
+
+      rm -f "$TMPFILE"
+      echo "$RESULT"
+    timeout: 15
+
+  - id: fix
+    type: claude-code
+    dependsOn:
+      - analyze
+      - validate
+    onlyIf:
+      upstream: validate
+      field: valid
+      equals: false
+    prompt: |
+      The agent analyzer suggested improvements but the suggested YAML has
+      validation errors. Fix the YAML so it passes schema validation.
+
+      VALIDATION ERROR:
+      {{upstream.validate.result}}
+
+      ORIGINAL ANALYSIS (with the broken YAML):
+      {{upstream.analyze.result}}
+
+      Fix ONLY the YAML errors identified above. Keep all the analysis text
+      (classification, summary, details) exactly as-is. Output the complete
+      corrected response in the same XML format:
+
+      <classification>same as original</classification>
+      <summary>same as original</summary>
+      <details>same as original</details>
+      <yaml>
+      The FIXED YAML that passes validation. Apply these rules:
+      - Input names: UPPERCASE_WITH_UNDERSCORES
+      - inputs: must be an object/map, not an array
+      - enum inputs: must have a non-empty `values` array
+      - Template refs: use {{inputs.NAME}} not {{NAME}}
+      - conditional nodes: must have conditionalConfig
+      - switch nodes: must have switchConfig
+      - Keep the same agent id as the original
+      </yaml>
+    maxTurns: 2
+    timeout: 90

--- a/packages/dashboard/src/routes/run-now.ts
+++ b/packages/dashboard/src/routes/run-now.ts
@@ -229,11 +229,18 @@ runNowRouter.get('/agents/:name/analyze/:runId', (req: Request, res: Response) =
   if (run.status === 'running' || run.status === 'pending') {
     const execs = ctx.runStore.listNodeExecutions(runId);
     const runningNode = execs.find((e) => e.status === 'running');
+    const completedNodes = execs.filter((e) => e.status === 'completed').map((e) => e.nodeId);
     let progress: unknown[] = [];
     if (runningNode?.progressJson) {
       try { progress = JSON.parse(runningNode.progressJson); } catch { /* ignore */ }
     }
-    res.json({ ok: true, status: 'running', progress });
+    // Add a phase message based on which node is running.
+    const phaseMessage = runningNode?.nodeId === 'analyze' ? 'Analyzing agent...'
+      : runningNode?.nodeId === 'validate' ? 'Validating suggested YAML...'
+      : runningNode?.nodeId === 'fix' ? 'Fixing validation errors...'
+      : runningNode ? `Running ${runningNode.nodeId}...`
+      : 'Starting...';
+    res.json({ ok: true, status: 'running', progress, phase: phaseMessage, completedNodes });
     return;
   }
 
@@ -243,8 +250,24 @@ runNowRouter.get('/agents/:name/analyze/:runId', (req: Request, res: Response) =
     return;
   }
 
+  // The run.result is the last completed node's output. In the multi-node
+  // analyzer pipeline:
+  //   - If fix ran (validation failed): fix node's output has the corrected XML
+  //   - If fix was skipped (validation passed): validate node's JSON is the
+  //     run result, but we want the analyze node's output with the XML tags
+  // Detect by checking for <classification> tag.
+  let resultText = run.result;
+  if (!resultText.includes('<classification>')) {
+    // Result is probably the validate node's JSON. Find the analyze node's output.
+    const execs = ctx.runStore.listNodeExecutions(runId);
+    const analyzeExec = execs.find((e) => e.nodeId === 'analyze');
+    if (analyzeExec?.result) {
+      resultText = analyzeExec.result;
+    }
+  }
+
   const extract = (tag: string): string | undefined => {
-    const m = run.result!.match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`, 'i'));
+    const m = resultText.match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`, 'i'));
     return m ? m[1].trim() : undefined;
   };
   const classRaw = extract('classification')?.toUpperCase().trim() ?? 'SUGGESTIONS';

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -720,11 +720,14 @@ export const DASHBOARD_JS = `
             .then(function (data) {
               if (cancelled) return;
               if (data.status === 'running') {
-                // Update phase from real progress events.
-                if (data.progress && data.progress.length > 0) {
-                  var latest = data.progress[data.progress.length - 1];
-                  var pe = document.getElementById('sg-phase');
-                  if (pe && latest.message) pe.textContent = latest.message;
+                // Update phase from server-provided phase message or progress events.
+                var pe = document.getElementById('sg-phase');
+                if (pe) {
+                  if (data.phase) pe.textContent = data.phase;
+                  else if (data.progress && data.progress.length > 0) {
+                    var latest = data.progress[data.progress.length - 1];
+                    if (latest.message) pe.textContent = latest.message;
+                  }
                 }
                 pollTimer = setTimeout(poll, 2000);
               } else if (data.status === 'done') {


### PR DESCRIPTION
## Summary
Extends the agent-analyzer from a single node to a 3-node self-correcting pipeline that validates its own suggestions and fixes errors before presenting results.

## Pipeline
1. **analyze** — claude-code node produces suggestions + YAML (unchanged prompt)
2. **validate** — shell node extracts `<yaml>` from output, runs `parseAgent` to catch schema errors. Deterministic, fast (~1s)
3. **fix** — claude-code node (onlyIf validate failed) takes validation errors + original suggestions, produces corrected YAML with specific errors fixed

## Dashboard
- Poll endpoint returns phase message ("Analyzing...", "Validating...", "Fixing validation errors...")
- Result extraction handles multi-node: falls back to analyze node's output when run.result is validate's JSON

## What this catches
- Enum inputs without `values` array
- Lowercase input names (should be UPPERCASE_WITH_UNDERSCORES)
- inputs as array instead of object
- Missing conditionalConfig/switchConfig
- Unsupported template syntax ({{#...}}, {{NAME}} instead of {{inputs.NAME}})

## Test plan
- [x] `npm run build` passes
- [x] JS parse check passes
- [x] `npm test` — 561 tests pass
- [ ] Manual: suggest improvements on an agent → if YAML has errors, see "Fixing validation errors..." phase, then clean results

🤖 Generated with [Claude Code](https://claude.com/claude-code)