### PR TITLE
docs: README, CHANGELOG, and 4 ADRs for 2026-04-17 session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+## 2026-04-17
+
+### Variables scoping (PRs #87-#92)
+- Global variables store (`.sua/variables.json`) with `sua vars` CLI
+- Executor wiring: `$NAME` in shell, `{{vars.NAME}}` in prompts
+- Template palette autocomplete includes global variables with group separators
+- `/settings/variables` dashboard tab with full CRUD
+- Agent-detail Variables section: inline type editing, defaults, add-new-row
+- Type/value validation on save (number/boolean defaults checked)
+- YAML editor: GET/POST `/agents/:name/yaml` with Zod validation
+- Secrets save modal: copy-before-save warning, value never shown again
+- 3-layer secret redaction in run logs: declared secrets, sensitive name patterns, credential value patterns
+- Edit links on variables in node edit form (agent inputs, global vars, secrets)
+
+### Suggest improvements (PRs #93-#94, #101)
+- "Suggest improvements" button on agent detail opens inline modal
+- Agent-analyzer example: self-correcting 3-node pipeline (analyze, validate, fix)
+- Modal shows real progress from `progressJson` while analyzing
+- Side-by-side colored diff (red for removed, green for added)
+- "Review + apply" opens YAML editor pre-filled with suggestions
+- YAML validation with error display before apply
+
+### DAG executor refactor (PRs #95-#99)
+- Split 1482-line `dag-executor.ts` into 6 focused modules
+- `LlmSpawner` interface with claude (stream-json) and codex implementations
+- `progressJson` column on `node_executions` for real-time turn tracking
+- Dashboard shows turn indicators on running nodes
+- `provider` field on claude-code nodes: select claude or codex per node
+
+### Dashboard UX (PRs #92, #93, #98)
+- Run-now modal with input fields for agents that declare inputs
+- Non-blocking run execution: immediate redirect to polling page
+- Replay modal with pre-flight validation (upstream outputs + node config)
+- Resolved variables panel on run detail with live filter
+- Markdown rendering in analysis output
+- CSS overflow fix for long variable values
+- Spinner CSS component
+
+### Example agents (PR #100)
+- `llm-tells-a-joke`: configurable topic input, clean prompt rules
+
+### Bug fixes
+- Fixed `{{inputs.X}}` template resolution for claude-code node prompts
+- Fixed inline onclick handlers breaking JS template literal parsing
+- Fixed form disconnection on run-now submit (setTimeout defer)
+- Fixed prefillYaml handler for Review + apply flow

--- a/README.md
+++ b/README.md
@@ -7,12 +7,15 @@ MIT-licensed. Published to npm at `@some-useful-agents/*`.
 ## What you get
 
 - **Agents as flows** — each agent is a DAG of nodes. Nodes execute shell commands, Claude Code prompts, or named tools. Flow control (conditional, switch, loop, agent-invoke, branch, end, break) lets agents make decisions and orchestrate sub-agents.
+- **Multi-provider LLM support** — claude-code nodes can use Claude or Codex via the `provider` field. Stream-json progress tracking shows real-time turn status during execution.
 - **9 built-in tools** — `shell-exec`, `claude-code`, `http-get`, `http-post`, `file-read`, `file-write`, `json-parse`, `json-path`, `template`. User-authored tools sit alongside in `tools/`.
-- **Dashboard** — web UI for managing agents, tools, runs, secrets, and settings. Visual DAG editor, click-to-replay, template palette autocomplete, per-node action dialogs.
+- **Dashboard** — web UI for managing agents, tools, runs, secrets, variables, and settings. Visual DAG editor, click-to-replay, YAML editor, template palette autocomplete, per-node action dialogs.
+- **AI suggest improvements** — one-click agent analysis via the built-in `agent-analyzer`. Reviews your agent's YAML, classifies changes as "no improvements" / "suggestions" / "recommend rewrite", shows a colored diff, and auto-validates + fixes the suggested YAML before presenting it.
+- **Global variables** — plain-text, non-sensitive values available to every agent. CRUD via `/settings/variables` or `sua vars` CLI. Referenced as `$NAME` in shell, `{{vars.NAME}}` in prompts.
 - **MCP server** — expose agents to Claude Desktop and other MCP clients over HTTP/SSE.
-- **Secrets store** — passphrase-encrypted at rest (scrypt N=2^17). Dashboard CRUD with session-cached passphrase.
+- **Secrets store** — passphrase-encrypted at rest (scrypt N=2^17). Dashboard CRUD with copy-before-save modal and 3-layer redaction (declared secrets + sensitive name patterns + credential value patterns).
 - **Scheduling** — cron expressions on any agent. Temporal provider available for durable workflows.
-- **8 bundled examples** — from "hello world" to conditional routing to agent orchestration. Auto-installed on `sua init`.
+- **9 bundled examples** — from "hello world" to conditional routing to AI-powered agent analysis. Auto-installed on `sua init`.
 
 ## Quick start
 
@@ -40,6 +43,8 @@ Installed automatically by `sua init`. Manage with `sua examples install/remove/
 | `research-digest` | Agent-invoke + loop (nested sub-flows) |
 | `daily-joke` | HTTP tool fetching from icanhazdadjoke.com |
 | `parameterised-greet-claude` | Claude Code companion (requires API key) |
+| `llm-tells-a-joke` | Configurable topic input + clean prompt design |
+| `agent-analyzer` | Self-correcting 3-node pipeline: analyze, validate, fix |
 
 ## CLI commands
 
@@ -77,6 +82,15 @@ sua examples remove                     # remove example agents from DB
 sua examples list                       # show install status
 ```
 
+### Variables
+
+```bash
+sua vars list                           # all global variables (names + values)
+sua vars get <NAME>                     # get a variable's value
+sua vars set <NAME> <VALUE>             # set/update a variable
+sua vars delete <NAME>                  # remove a variable
+```
+
 ### Secrets
 
 ```bash
@@ -99,10 +113,12 @@ sua schedule list                       # show scheduled agents
 
 Start with `sua dashboard start`. Features:
 
-- **Agents** — card grid, DAG visualization, click nodes for actions (edit, replay), per-node status
+- **Agents** — card grid, DAG visualization, click nodes for actions (edit, replay), per-node status, YAML editor, suggest improvements (AI analysis)
+- **Variables** — inline editing of agent input defaults and types, add/remove variables, global variables tab in Settings
+- **Run now** — modal with input fields for agents that declare inputs, pre-filled with defaults
 - **Tools** — browse all 9 built-in tools + user tools, inspect inputs/outputs
-- **Runs** — filter by agent/status, replay from any node, nested run linking
-- **Settings** — secrets CRUD with passphrase unlock, MCP token rotation, retention policy
+- **Runs** — filter by agent/status, replay from any node with pre-flight validation, resolved variables panel with filter, real-time turn progress for multi-turn LLM nodes
+- **Settings** — secrets CRUD with copy-before-save modal, global variables CRUD, MCP token rotation, retention policy
 - **Tutorial** — 7-step guided walkthrough that scaffolds agents from the dashboard
 
 ## Flow control
@@ -139,6 +155,7 @@ Available node types: `conditional`, `switch`, `loop`, `agent-invoke`, `branch`,
 ## Security
 
 - **Secrets encrypted at rest** — scrypt N=2^17, passphrase-derived key
+- **3-layer redaction in run logs** — declared secrets, sensitive name patterns (TOKEN, KEY, PASS), known credential value patterns (GitHub PATs, AWS keys, JWTs)
 - **MCP binds localhost** — bearer token auth, loopback-only by default
 - **Community shell gate** — community agents require explicit `--allow-untrusted-shell`
 - **Dashboard CSRF defense** — Origin header check on all mutations

--- a/docs/adr/0015-global-variables-store.md
+++ b/docs/adr/0015-global-variables-store.md
@@ -1,0 +1,20 @@
+# ADR-0015: Global variables store (plain-text, non-sensitive)
+
+## Status
+Accepted
+
+## Context
+The system had secrets (encrypted, global), agent inputs (per-agent, runtime-only), per-node env, and upstream outputs. There was no first-class concept for "plain, non-sensitive values configured once and used across agents" (e.g. API_BASE_URL, DEFAULT_TIMEOUT, REGION). Users had to duplicate values across agents or misuse the secrets store for non-sensitive config.
+
+## Decision
+Add a global variables store at `.sua/variables.json` (plain JSON, not encrypted). Variables are referenced as `$NAME` in shell nodes and `{{vars.NAME}}` in claude-code prompts. Precedence: `--input` override > agent input default > global variable > secret.
+
+Dashboard surfaces via `/settings/variables` tab (CRUD with values shown, unlike secrets) and the template palette autocomplete. CLI via `sua vars list/get/set/delete`.
+
+Variables are explicitly NOT sensitive. Names that look like secrets (TOKEN, KEY, PASS) trigger a warning suggesting the secrets store instead.
+
+## Consequences
+- Simple JSON file is easy to version-control alongside the project
+- No encryption overhead for config values
+- Clear separation: sensitive = secrets store, non-sensitive = variables store
+- The `looksLikeSensitive()` heuristic may have false positives, but warnings are non-blocking

--- a/docs/adr/0016-llm-spawner-abstraction.md
+++ b/docs/adr/0016-llm-spawner-abstraction.md
@@ -1,0 +1,30 @@
+# ADR-0016: LlmSpawner abstraction for multi-provider CLI support
+
+## Status
+Accepted
+
+## Context
+The DAG executor hardcoded `claude --print` for all claude-code nodes. Adding support for Codex, Gemini, or other LLM CLIs required touching the spawn path, and there was no way to stream real-time turn progress during multi-turn execution. The executor was also 1482 lines handling too many concerns.
+
+## Decision
+Split the executor into 6 focused modules and introduce an `LlmSpawner` interface in `node-spawner.ts`:
+
+```typescript
+interface LlmSpawner {
+  binary: string;
+  buildArgs(opts): string[];
+  parseProgress(line: string): SpawnProgress | null;
+  extractResult(stdout: string): string;
+}
+```
+
+Built-in implementations: `claudeSpawner` (stream-json mode with structured turn tracking), `claudeTextSpawner` (legacy text mode), `codexSpawner`. Nodes select their provider via a `provider` field (`claude` | `codex`).
+
+The Claude spawner uses `--output-format stream-json --verbose` for line-by-line JSON events. Each event is parsed for turn boundaries and written to a `progressJson` column on `node_executions`, which the dashboard polls.
+
+## Consequences
+- Adding a new LLM CLI is ~30 lines (implement the interface)
+- Real-time turn progress in the dashboard (no more time-based guesses)
+- `progressJson` writes per-event to SQLite, which is slightly more I/O than batching
+- Stream-json mode requires `--verbose` flag, adding some output overhead
+- The file split means more imports but each module is <350 lines and testable in isolation

--- a/docs/adr/0017-agent-analyzer-self-correcting.md
+++ b/docs/adr/0017-agent-analyzer-self-correcting.md
@@ -1,0 +1,27 @@
+# ADR-0017: Agent analyzer as a self-correcting agent pipeline
+
+## Status
+Accepted
+
+## Context
+The "Suggest improvements" feature initially used custom routes, views, polling JS, and an in-memory job store. This was a lot of infrastructure for one feature. The codebase already had everything needed: the DAG executor, agent inputs, the run system, and the dashboard run polling.
+
+Additionally, AI-generated YAML suggestions frequently had schema errors (lowercase input names, missing enum values, invalid template syntax). Users hit validation errors when trying to apply suggestions.
+
+## Decision
+Build the analyzer as an example agent (`agent-analyzer.yaml`) instead of custom infrastructure. The dashboard "Suggest improvements" button runs the agent with the target agent's YAML as an input, polls the run status, and renders results in a modal.
+
+The agent is a 3-node self-correcting pipeline:
+1. **analyze** (claude-code) — produces suggestions + YAML
+2. **validate** (shell) — extracts `<yaml>` from output, runs `parseAgent` deterministically
+3. **fix** (claude-code, onlyIf validate failed) — takes validation errors + original suggestions, produces corrected YAML
+
+The fix node only runs when needed. When validation passes, the analyze node's output is the final result.
+
+## Consequences
+- Zero new polling/job/progress infrastructure — reuses the existing run system
+- The analyzer itself is editable YAML (users can tune the prompt)
+- Every analysis is a run in history (auditable, replayable)
+- The validate node catches schema errors deterministically before the user sees them
+- Multi-node agents exercise their own flow-control features (onlyIf, dependsOn)
+- Analysis takes longer (3 nodes vs 1) but produces cleaner output

--- a/docs/adr/0018-three-layer-secret-redaction.md
+++ b/docs/adr/0018-three-layer-secret-redaction.md
@@ -1,0 +1,21 @@
+# ADR-0018: Three-layer secret redaction in run logs
+
+## Status
+Accepted
+
+## Context
+The executor captured the full resolved environment as `inputsJson` on each node execution for debugging. Previously, only secrets explicitly declared in the node's `secrets:` array were redacted. This missed: (1) variables with sensitive names the user forgot to declare as secrets, (2) values that look like credentials regardless of their variable name.
+
+## Decision
+Expand `filterEnvForLog()` to three layers, preferring false-positive redaction over credential leaks:
+
+1. **Declared secrets** — names in the node's `secrets:` array (existing behavior)
+2. **Sensitive name patterns** — names matching TOKEN, KEY, SECRET, PASS, PASSWORD, CREDENTIAL (via `looksLikeSensitive()` from the variables store)
+3. **Sensitive value patterns** — values matching known credential formats: GitHub PATs (`ghp_*`), OAuth tokens (`gho_*`), OpenAI/Stripe keys (`sk-*`), Slack tokens (`xox*-*`), AWS access key IDs (`AKIA*`), JWTs (`eyJ*.*`)
+
+All three layers apply at capture time, before `inputsJson` is written to the DB.
+
+## Consequences
+- Run logs never contain credentials, even for misconfigured agents
+- False positives: benign values matching patterns (e.g. a variable named `MY_KEY` with value "house key") are redacted unnecessarily. This is acceptable — the debug value is lower than the leak risk.
+- The pattern list is extensible. New credential formats (e.g. GCP, Azure) can be added to `SENSITIVE_VALUE_PATTERNS`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,11 @@ This directory captures the **why** behind architectural choices in
 | [0011](0011-slack-webhooks-not-oauth.md) | Slack via incoming webhooks, not OAuth | Proposed |
 | [0012](0012-local-cron-scheduler-node-cron.md) | Local cron scheduler via node-cron | Accepted |
 | [0013](0013-tutorial-and-dad-joke-example.md) | Onboarding tutorial + dad-joke example | Accepted |
+| [0014](0014-passphrase-kek-secrets-store.md) | Passphrase KEK for secrets store | Accepted |
+| [0015](0015-global-variables-store.md) | Global variables store (plain-text, non-sensitive) | Accepted |
+| [0016](0016-llm-spawner-abstraction.md) | LlmSpawner abstraction for multi-provider CLI support | Accepted |
+| [0017](0017-agent-analyzer-self-correcting.md) | Agent analyzer as a self-correcting agent pipeline | Accepted |
+| [0018](0018-three-layer-secret-redaction.md) | Three-layer secret redaction in run logs | Accepted |
 
 ## Template
 


### PR DESCRIPTION
## Summary
Documentation covering 20 PRs (#82-#101) shipped in this session.

## Changes

### README
- Added: multi-provider LLM, global variables, suggest improvements, YAML editor, secrets modal
- Updated: example agents table (+2), dashboard features, security section, CLI commands
- New `sua vars` CLI section

### CHANGELOG
- New file organized by feature area: variables, suggest, executor, dashboard, examples, bug fixes

### ADRs
| # | Title |
|---|---|
| 0015 | Global variables store (plain-text, non-sensitive) |
| 0016 | LlmSpawner abstraction for multi-provider CLI support |
| 0017 | Agent analyzer as self-correcting pipeline |
| 0018 | Three-layer secret redaction in run logs |

Also added ADR 0014 (already existed) to the index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)