### PR TITLE
feat: Pulse information radiator + dashboard UX improvements

### DIFF
--- a/agents/examples/agent-analyzer.yaml
+++ b/agents/examples/agent-analyzer.yaml
@@ -17,12 +17,21 @@ inputs:
     required: false
     default: ""
     description: Optional focus area, e.g. "what variables am I missing to count loop iterations?"
+  LAST_RUN_OUTPUT:
+    type: string
+    required: false
+    default: ""
+    description: Output from the agent's most recent completed run. Injected automatically by the dashboard.
 
 nodes:
   - id: analyze
     type: claude-code
     prompt: |
       You are an expert agent architect reviewing a sua DAG agent.
+
+      IMPORTANT: Respond directly with your analysis. Do NOT use any tools
+      (no file reads, no searches, no bash commands). Everything you need
+      is provided below in this prompt.
 
       Analyze the FULL agent holistically — cross-node data flow, dependency
       ordering, input/variable usage, prompt quality, error handling, and
@@ -37,6 +46,10 @@ nodes:
       - Prompt improvements for claude-code nodes
 
       {{inputs.FOCUS}}
+
+      LAST RUN OUTPUT (if available, use this to identify runtime issues like
+      errors, timeouts, unexpected results, or missing data):
+      {{inputs.LAST_RUN_OUTPUT}}
 
       Classify your assessment as exactly one of:
       - NO_IMPROVEMENTS: The agent is well-designed, no changes needed.
@@ -82,7 +95,7 @@ nodes:
       Here is the agent YAML to review:
 
       {{inputs.AGENT_YAML}}
-    maxTurns: 3
+    maxTurns: 2
     timeout: 120
 
   - id: validate
@@ -128,6 +141,9 @@ nodes:
       field: valid
       equals: false
     prompt: |
+      IMPORTANT: Respond directly with the fixed YAML. Do NOT use any tools.
+      Everything you need is provided below.
+
       The agent analyzer suggested improvements but the suggested YAML has
       validation errors. Fix the YAML so it passes schema validation.
 

--- a/agents/examples/agent-builder.yaml
+++ b/agents/examples/agent-builder.yaml
@@ -41,6 +41,44 @@ nodes:
       AVAILABLE TOOLS (use these as node types or tool references):
       {{inputs.AVAILABLE_TOOLS}}
 
+      SIGNAL BLOCK (always include a signal block so the agent shows on the Pulse dashboard):
+      Every agent MUST include a signal: block. Pick the best template for the output:
+      - metric: Big number display. Slots: value (required), label, unit. Best for: counts, percentages, latency.
+      - text-headline: Headline + body text. Slots: headline (required), body. Best for: summaries, jokes, greetings.
+      - table: Data table. Slots: rows (required, array), columns. Best for: search results, listings.
+      - status: Colored dot + label. Slots: status (required: healthy/degraded/down), label, message. Best for: health checks, monitors.
+      - media: Image or video player. Slots: url (required), title, caption. Best for: generated images, screenshots.
+      - time-series: Sparkline chart. Slots: values (required, array of numbers), current, label. Best for: trends.
+      - text-image: Text alongside an image. Slots: text (required), imageUrl (required). Best for: cards with thumbnails.
+      - image: Full image. Slots: imageUrl (required), alt. Best for: generated visuals.
+
+      The mapping maps dot-paths from the agent's structured output to template slots.
+      Use "result" to reference the full raw output. Use literal strings for static labels.
+
+      Example signal blocks:
+        signal:
+          title: API Latency
+          icon: "\u26A1"
+          format: number
+          template: metric
+          mapping:
+            value: latency_ms
+            label: API Latency
+            unit: ms
+
+        signal:
+          title: Daily Summary
+          icon: "\U0001F4CA"
+          format: text
+          template: text-headline
+          mapping:
+            headline: Daily Summary
+            body: result
+          size: 2x1
+
+      The format: field is a universal output hint (text/number/table/json/chart).
+      The template: field selects the Pulse display. Always include both.
+
       DESIGN GUIDELINES:
       - Start simple. Prefer fewer nodes that do more over many tiny nodes.
       - Use shell nodes for deterministic work (curl, jq, file ops).
@@ -52,6 +90,7 @@ nodes:
         URLs, API keys (mark as secrets instead), thresholds, output paths.
       - Set reasonable timeouts (shell: 30-60s, claude-code: 60-120s).
       - Add a description that explains what the agent does.
+      - Shape output as JSON when using metric/table/status templates so field extraction works.
 
       CRITICAL YAML RULES:
       - Agent id: lowercase with hyphens only (e.g. job-scraper, daily-report).

--- a/agents/examples/agent-builder.yaml
+++ b/agents/examples/agent-builder.yaml
@@ -18,6 +18,11 @@ inputs:
     required: false
     default: ""
     description: Optional constraints or preferences (e.g. "use shell nodes only", "schedule daily").
+  AVAILABLE_TOOLS:
+    type: string
+    required: false
+    default: ""
+    description: Dynamically injected tool catalog. Populated by the dashboard at build time.
 
 nodes:
   - id: design
@@ -34,14 +39,7 @@ nodes:
       {{inputs.FOCUS}}
 
       AVAILABLE TOOLS (use these as node types or tool references):
-      - shell-exec (type: shell): Run shell commands. Inputs: command. Good for: data processing, file ops, API calls via curl.
-      - claude-code (type: claude-code): Run an LLM prompt. Inputs: prompt, model, maxTurns. Good for: analysis, summarization, decision-making, content generation.
-      - http-get: HTTP GET with auto-parsed JSON. Inputs: url, timeout. Good for: fetching APIs, scraping.
-      - http-post: HTTP POST with JSON body. Inputs: url, body, timeout. Good for: webhooks, API writes.
-      - file-read: Read a project file. Inputs: path. Good for: loading config, data files.
-      - file-write: Write to a project file. Inputs: path, content. Good for: saving results, generating reports.
-      - json-parse: Parse JSON string. Inputs: text. Good for: extracting structured data.
-      - json-path: Extract value from JSON. Inputs: data, path. Good for: picking fields from API responses.
+      {{inputs.AVAILABLE_TOOLS}}
 
       DESIGN GUIDELINES:
       - Start simple. Prefer fewer nodes that do more over many tiny nodes.

--- a/agents/examples/conditional-router.yaml
+++ b/agents/examples/conditional-router.yaml
@@ -10,7 +10,11 @@ signal:
   title: Router
   icon: "\U0001F500"
   format: json
-  field: merged
+  template: status
+  mapping:
+    status: matched
+    label: Router
+    message: result
 nodes:
   - id: classify
     type: shell

--- a/agents/examples/daily-greeting.yaml
+++ b/agents/examples/daily-greeting.yaml
@@ -11,6 +11,10 @@ signal:
   title: Morning Greeting
   icon: "\u2600\uFE0F"
   format: text
+  template: text-headline
+  mapping:
+    headline: Good Morning
+    body: result
   refresh: 24h
 nodes:
   - id: greet

--- a/agents/examples/daily-joke.yaml
+++ b/agents/examples/daily-joke.yaml
@@ -10,7 +10,10 @@ source: examples
 signal:
   title: Joke of the Day
   icon: "\U0001F3AD"
-  format: text
+  template: text-headline
+  mapping:
+    headline: Joke of the Day
+    body: result
   refresh: 24h
 nodes:
   - id: fetch

--- a/agents/examples/daily-summary.yaml
+++ b/agents/examples/daily-summary.yaml
@@ -1,0 +1,40 @@
+id: daily-summary
+name: Daily Summary
+description: >
+  Summarizes today's agent activity: how many runs, which agents ran,
+  what succeeded and what failed. Signal tile shows the summary on Pulse.
+status: active
+source: examples
+
+signal:
+  title: Today's Activity
+  icon: "\uD83D\uDCCA"
+  format: text
+  refresh: 1h
+  size: 2x1
+
+nodes:
+  - id: gather
+    type: shell
+    command: |
+      # Count today's runs from the runs database.
+      DATE_PREFIX=$(date -u +%Y-%m-%d)
+      echo "Report for ${DATE_PREFIX}"
+      echo ""
+      if [ -f data/runs.db ]; then
+        node --experimental-strip-types -e "
+          import { DatabaseSync } from 'node:sqlite';
+          const db = new DatabaseSync('data/runs.db');
+          const today = '${DATE_PREFIX}';
+          const runs = db.prepare(\"SELECT agentName, status FROM runs WHERE startedAt >= ? || 'T00:00:00Z'\").all(today);
+          const total = runs.length;
+          const ok = runs.filter(r => r.status === 'completed').length;
+          const fail = runs.filter(r => r.status === 'failed').length;
+          const agents = [...new Set(runs.map(r => r.agentName))];
+          console.log(total + ' runs total: ' + ok + ' completed, ' + fail + ' failed');
+          console.log('Agents: ' + (agents.length > 0 ? agents.join(', ') : 'none'));
+        " 2>/dev/null || echo "Could not read runs database."
+      else
+        echo "No runs database found."
+      fi
+    timeout: 15

--- a/agents/examples/daily-summary.yaml
+++ b/agents/examples/daily-summary.yaml
@@ -9,7 +9,10 @@ source: examples
 signal:
   title: Today's Activity
   icon: "\uD83D\uDCCA"
-  format: text
+  template: text-headline
+  mapping:
+    headline: Today's Activity
+    body: result
   refresh: 1h
   size: 2x1
 

--- a/agents/examples/hello.yaml
+++ b/agents/examples/hello.yaml
@@ -9,6 +9,10 @@ signal:
   title: Hello
   icon: "\U0001F44B"
   format: text
+  template: text-headline
+  mapping:
+    headline: Hello
+    body: result
 nodes:
   - id: greet
     type: shell

--- a/agents/examples/llm-tells-a-joke.yaml
+++ b/agents/examples/llm-tells-a-joke.yaml
@@ -11,6 +11,16 @@ inputs:
     required: false
     description: Optional topic for the joke (e.g. programming, animals, coffee)
 
+signal:
+  title: Dad Joke
+  icon: "\U0001F604"
+  format: text
+  template: text-headline
+  mapping:
+    headline: Dad Joke
+    body: result
+  refresh: 24h
+
 nodes:
   - id: main
     type: claude-code

--- a/agents/examples/parameterised-greet-claude.yaml
+++ b/agents/examples/parameterised-greet-claude.yaml
@@ -6,6 +6,15 @@ name: Parameterised greeting (Claude)
 description: Same concept as parameterised-greet, using Claude Code instead of shell.
 status: active
 source: examples
+signal:
+  title: Greeting (Claude)
+  icon: "\U0001F4AC"
+  format: text
+  template: text-headline
+  mapping:
+    headline: Greeting
+    body: result
+
 inputs:
   NAME: { type: string, default: "World" }
   STYLE: { type: enum, values: [formal, casual], default: casual }

--- a/agents/examples/parameterised-greet.yaml
+++ b/agents/examples/parameterised-greet.yaml
@@ -11,6 +11,10 @@ signal:
   title: Greeting
   icon: "\U0001F4AC"
   format: text
+  template: text-headline
+  mapping:
+    headline: Greeting
+    body: result
 inputs:
   NAME: { type: string, default: "World", description: "Who to greet" }
   STYLE: { type: enum, values: [formal, casual], default: casual }

--- a/agents/examples/research-digest.yaml
+++ b/agents/examples/research-digest.yaml
@@ -11,7 +11,9 @@ signal:
   title: Research
   icon: "\U0001F50D"
   format: table
-  field: items
+  template: table
+  mapping:
+    rows: items
   size: 2x1
 nodes:
   - id: source

--- a/agents/examples/system-health.yaml
+++ b/agents/examples/system-health.yaml
@@ -8,10 +8,13 @@ status: active
 source: examples
 
 signal:
-  title: Disk Usage
+  title: System Health
   icon: "\uD83D\uDCBE"
-  format: number
-  field: disk_percent
+  template: metric
+  mapping:
+    value: disk_percent
+    label: Disk Usage
+    unit: "%"
   refresh: 1h
   size: 1x1
 

--- a/agents/examples/system-health.yaml
+++ b/agents/examples/system-health.yaml
@@ -1,0 +1,26 @@
+id: system-health
+name: System Health
+description: >
+  Checks local system disk usage, memory, and CPU load.
+  Outputs a JSON object with key metrics. Signal tile shows
+  disk usage percentage on the Pulse dashboard.
+status: active
+source: examples
+
+signal:
+  title: Disk Usage
+  icon: "\uD83D\uDCBE"
+  format: number
+  field: disk_percent
+  refresh: 1h
+  size: 1x1
+
+nodes:
+  - id: check
+    type: shell
+    command: |
+      DISK=$(df -h / | awk 'NR==2 {print $5}' | tr -d '%')
+      MEM_TOTAL=$(sysctl -n hw.memsize 2>/dev/null || free -b 2>/dev/null | awk '/Mem:/{print $2}')
+      LOAD=$(sysctl -n vm.loadavg 2>/dev/null | awk '{print $2}' || uptime | awk -F'load average:' '{print $2}' | awk -F, '{print $1}' | tr -d ' ')
+      echo "{\"disk_percent\": ${DISK:-0}, \"load_avg\": \"${LOAD:-unknown}\", \"mem_bytes\": ${MEM_TOTAL:-0}}"
+    timeout: 15

--- a/agents/examples/two-step-digest.yaml
+++ b/agents/examples/two-step-digest.yaml
@@ -10,6 +10,10 @@ signal:
   title: Daily Digest
   icon: "\U0001F4F0"
   format: text
+  template: text-headline
+  mapping:
+    headline: Daily Digest
+    body: result
   size: 2x1
 nodes:
   - id: fetch

--- a/packages/core/src/agent-store.ts
+++ b/packages/core/src/agent-store.ts
@@ -341,7 +341,10 @@ export class AgentStore {
       id: agent.id,
       nodes: agent.nodes.map(cloneNode),
     };
+    if (agent.provider) dag.provider = agent.provider;
+    if (agent.model) dag.model = agent.model;
     if (agent.inputs) dag.inputs = agent.inputs;
+    if (agent.signal) dag.signal = agent.signal;
     if (agent.author !== undefined) dag.author = agent.author;
     if (agent.tags) dag.tags = agent.tags;
     return dag;
@@ -373,8 +376,11 @@ export class AgentStore {
       mcp: (row.mcp as number) === 1,
       starred: (row.starred as number) === 1,
       version: row.current_version as number,
+      provider: dag.provider,
+      model: dag.model,
       inputs: dag.inputs,
       nodes: dag.nodes,
+      signal: dag.signal,
       author: dag.author,
       tags: dag.tags,
     };

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -158,6 +158,11 @@ export const agentV2Schema = z.object({
     refresh: z.string().optional(),
     size: z.enum(['1x1', '2x1', '1x2', '2x2']).optional(),
     hidden: z.boolean().optional(),
+    thresholds: z.array(z.object({
+      above: z.number().optional(),
+      below: z.number().optional(),
+      palette: z.string(),
+    })).optional(),
   }).refine(
     (s) => s.format !== undefined || s.template !== undefined,
     { message: 'Signal must declare either "format" (v1) or "template" (v2).' },

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -136,6 +136,9 @@ export const agentV2Schema = z.object({
   mcp: z.boolean().default(false),
   version: z.number().int().positive().default(1),
 
+  provider: z.enum(['claude', 'codex']).optional(),
+  model: z.string().optional(),
+
   inputs: z.record(
     z.string().regex(INPUT_NAME_RE, 'Input names must be UPPERCASE_WITH_UNDERSCORES'),
     inputSpecSchema,

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -149,11 +149,19 @@ export const agentV2Schema = z.object({
   signal: z.object({
     title: z.string().min(1),
     icon: z.string().optional(),
-    format: z.enum(['text', 'number', 'table', 'json', 'chart']),
+    // v2 template system
+    template: z.enum(['metric', 'time-series', 'text-headline', 'text-image', 'image', 'table', 'status']).optional(),
+    mapping: z.record(z.string()).optional(),
+    // v1 (deprecated, still accepted)
+    format: z.enum(['text', 'number', 'table', 'json', 'chart']).optional(),
     field: z.string().optional(),
     refresh: z.string().optional(),
     size: z.enum(['1x1', '2x1', '1x2', '2x2']).optional(),
-  }).optional(),
+    hidden: z.boolean().optional(),
+  }).refine(
+    (s) => s.format !== undefined || s.template !== undefined,
+    { message: 'Signal must declare either "format" (v1) or "template" (v2).' },
+  ).optional(),
 
   author: z.string().optional(),
   tags: z.array(z.string()).optional(),

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -150,7 +150,7 @@ export const agentV2Schema = z.object({
     title: z.string().min(1),
     icon: z.string().optional(),
     // v2 template system
-    template: z.enum(['metric', 'time-series', 'text-headline', 'text-image', 'image', 'table', 'status']).optional(),
+    template: z.enum(['metric', 'time-series', 'text-headline', 'text-image', 'image', 'table', 'status', 'media']).optional(),
     mapping: z.record(z.string()).optional(),
     // v1 (deprecated, still accepted)
     format: z.enum(['text', 'number', 'table', 'json', 'chart']).optional(),

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -256,16 +256,36 @@ export interface Agent {
 
 export type SignalFormat = 'text' | 'number' | 'table' | 'json' | 'chart';
 
+export type SignalTemplate =
+  | 'metric'
+  | 'time-series'
+  | 'text-headline'
+  | 'text-image'
+  | 'image'
+  | 'table'
+  | 'status';
+
 export interface AgentSignal {
   title: string;
   icon?: string;
-  format: SignalFormat;
-  /** Dot-path into the last node's structured output (default: "result"). */
+
+  /** v2: display template name (preferred over format). */
+  template?: SignalTemplate;
+  /** v2: maps output fields to template slots. Keys are slot names, values are
+   *  dot-paths into structured output or literal strings. */
+  mapping?: Record<string, string>;
+
+  /** v1 (deprecated): renderer selector. Use `template` instead. */
+  format?: SignalFormat;
+  /** v1 (deprecated): single dot-path extractor. Use `mapping` instead. */
   field?: string;
+
   /** Hint for auto-refresh interval (e.g. "24h", "1h", "5m"). */
   refresh?: string;
   /** Grid tile size on the Pulse board (default: "1x1"). */
   size?: '1x1' | '2x1' | '1x2' | '2x2';
+  /** Hidden from Pulse dashboard. Toggle via the tile's visibility button. */
+  hidden?: boolean;
 }
 
 /**

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -287,6 +287,12 @@ export interface AgentSignal {
   size?: '1x1' | '2x1' | '1x2' | '2x2';
   /** Hidden from Pulse dashboard. Toggle via the tile's visibility button. */
   hidden?: boolean;
+  /** Conditional palette thresholds for metric tiles. Evaluated top-to-bottom, first match wins. */
+  thresholds?: Array<{
+    above?: number;
+    below?: number;
+    palette: string;
+  }>;
 }
 
 /**

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -230,6 +230,11 @@ export interface Agent {
    */
   version: number;
 
+  /** Default LLM provider for all claude-code nodes. Nodes can override. */
+  provider?: 'claude' | 'codex';
+  /** Default model for all claude-code nodes. Nodes can override. */
+  model?: string;
+
   /** Agent-level runtime inputs. Nodes reference these as `{{inputs.X}}`. */
   inputs?: Record<string, AgentInputSpec>;
 
@@ -289,6 +294,8 @@ export interface AgentVersion {
  */
 export interface AgentVersionDag {
   id: string;
+  provider?: 'claude' | 'codex';
+  model?: string;
   inputs?: Record<string, AgentInputSpec>;
   nodes: AgentNode[];
   signal?: AgentSignal;

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -263,7 +263,8 @@ export type SignalTemplate =
   | 'text-image'
   | 'image'
   | 'table'
-  | 'status';
+  | 'status'
+  | 'media';
 
 export interface AgentSignal {
   title: string;

--- a/packages/core/src/agent-yaml.ts
+++ b/packages/core/src/agent-yaml.ts
@@ -59,6 +59,7 @@ function parsedToAgent(p: AgentV2Parsed): Agent {
     ...(n.model !== undefined && { model: n.model }),
     ...(n.maxTurns !== undefined && { maxTurns: n.maxTurns }),
     ...(n.allowedTools && { allowedTools: n.allowedTools }),
+    ...(n.provider !== undefined && { provider: n.provider }),
     ...(n.timeout !== undefined && { timeout: n.timeout }),
     ...(n.env && { env: n.env }),
     ...(n.envAllowlist && { envAllowlist: n.envAllowlist }),
@@ -79,8 +80,11 @@ function parsedToAgent(p: AgentV2Parsed): Agent {
     source: p.source as AgentSource,
     mcp: p.mcp,
     version: p.version,
+    ...(p.provider !== undefined && { provider: p.provider }),
+    ...(p.model !== undefined && { model: p.model }),
     ...(p.inputs && { inputs: p.inputs }),
     nodes,
+    ...(p.signal && { signal: p.signal }),
     ...(p.author !== undefined && { author: p.author }),
     ...(p.tags && { tags: p.tags }),
   };
@@ -95,8 +99,10 @@ const AGENT_KEY_ORDER = [
   'id', 'name', 'description',
   'status', 'schedule', 'allowHighFrequency',
   'source', 'mcp', 'version',
+  'provider', 'model',
   'inputs',
   'nodes',
+  'signal',
   'author', 'tags',
 ] as const;
 

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -624,11 +624,14 @@ export async function executeAgentDag(
         const spawnFn = deps.spawnNode ?? spawnNodeReal;
         // Build a synthetic node shape matching the tool's implementation
         // so the existing spawner doesn't need to change.
+        // Merge agent-level provider/model defaults (node overrides take precedence).
         const synthNode: AgentNode = {
           ...node,
           type: userTool.implementation.type === 'claude-code' ? 'claude-code' : 'shell',
           command: userTool.implementation.command,
           prompt: userTool.implementation.prompt,
+          provider: node.provider ?? agent.provider,
+          model: node.model ?? agent.model,
         };
         const spawnOpts = { agentId: agent.id, agentSource: agent.source, allowUntrustedShell: deps.allowUntrustedShell };
         const spawnResult = spawnFn === spawnNodeReal
@@ -638,11 +641,17 @@ export async function executeAgentDag(
         structuredOutput = buildToolOutput(spawnResult.result);
       } else {
         // v0.15 legacy path: no tool field, dispatch by type directly.
+        // Merge agent-level provider/model defaults (node overrides take precedence).
+        const nodeWithDefaults: AgentNode = {
+          ...node,
+          provider: node.provider ?? agent.provider,
+          model: node.model ?? agent.model,
+        };
         const spawnFn = deps.spawnNode ?? spawnNodeReal;
         const spawnOpts = { agentId: agent.id, agentSource: agent.source, allowUntrustedShell: deps.allowUntrustedShell };
         const spawnResult = spawnFn === spawnNodeReal
-          ? await spawnNodeReal(node, env, spawnOpts, onProgress, options.signal)
-          : await spawnFn(node, env, spawnOpts);
+          ? await spawnNodeReal(nodeWithDefaults, env, spawnOpts, onProgress, options.signal)
+          : await spawnFn(nodeWithDefaults, env, spawnOpts);
         result = spawnResult;
         // Try to extract framed output from stdout even for legacy nodes,
         // so users who upgrade their shell scripts to emit framed JSON get

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -721,7 +721,13 @@ main.main--wide {
   flex-direction: column;
   gap: var(--space-3);
   min-height: 120px;
+  max-height: 400px;
+  overflow-y: auto;
+  transition: padding 150ms ease-out, min-height 150ms ease-out, gap 150ms ease-out;
 }
+
+.pulse-tile--2x2 { max-height: 600px; }
+.pulse-tile--1x2 { max-height: 600px; }
 
 .pulse-tile--2x1 { grid-column: span 2; }
 .pulse-tile--1x2 { grid-row: span 2; }
@@ -848,6 +854,12 @@ main.main--wide {
   margin: var(--space-3) 0;
 }
 
+/* -- Markdown body in tiles -- */
+.pulse-tile__body--md { line-height: 1.6; }
+.pulse-tile__body--md a { color: var(--color-primary); }
+.pulse-tile__body--md strong { font-weight: 600; }
+.pulse-tile__body--md .pulse-table { margin: var(--space-2) 0; }
+
 /* -- Template: metric -- */
 .pulse-tile__unit {
   font-size: var(--font-size-sm);
@@ -939,6 +951,41 @@ main.main--wide {
   max-height: none;
   flex: 1;
   width: 100%;
+}
+
+/* -- Collapse/expand -- */
+.pulse-tile__collapse {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: 10px;
+  padding: 0;
+  line-height: 1;
+  transition: transform 150ms ease-out;
+  flex-shrink: 0;
+}
+
+.pulse-tile--collapsed .pulse-tile__collapse {
+  transform: rotate(-90deg);
+}
+
+.pulse-tile.pulse-tile--collapsed {
+  min-height: 0 !important;
+  max-height: fit-content !important;
+  height: fit-content !important;
+  padding: var(--space-2) var(--space-4) !important;
+  gap: 0 !important;
+  overflow: hidden !important;
+  grid-row: span 1 !important;
+}
+
+.pulse-tile.pulse-tile--collapsed > *:not(.pulse-tile__header) {
+  display: none !important;
+  height: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  overflow: hidden !important;
 }
 
 /* -- Hide/show toggle -- */

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -667,3 +667,183 @@ main.main--wide {
   word-break: break-all;
   overflow-wrap: anywhere;
 }
+
+/* ---------- Pulse ---------- */
+
+.pulse-health {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-4);
+  margin-bottom: var(--space-8);
+}
+
+.pulse-health__stat {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  text-align: center;
+}
+
+.pulse-health__value {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+  margin-bottom: var(--space-1);
+}
+
+.pulse-health__value--warn {
+  color: var(--color-err);
+}
+
+.pulse-health__label {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+}
+
+.pulse-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--space-4);
+}
+
+.pulse-tile {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-height: 120px;
+}
+
+.pulse-tile--2x1 { grid-column: span 2; }
+.pulse-tile--1x2 { grid-row: span 2; }
+.pulse-tile--2x2 { grid-column: span 2; grid-row: span 2; }
+
+.pulse-tile__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.pulse-tile__icon {
+  font-size: var(--font-size-lg);
+}
+
+.pulse-tile__title {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+}
+
+.pulse-tile__value {
+  font-family: var(--font-mono);
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1;
+  flex: 1;
+  display: flex;
+  align-items: center;
+}
+
+.pulse-tile__text {
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+  color: var(--color-text);
+  flex: 1;
+  overflow: hidden;
+}
+
+.pulse-tile__code {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2);
+  overflow: auto;
+  max-height: 200px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  flex: 1;
+  margin: 0;
+}
+
+.pulse-tile__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: var(--font-size-xs);
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--space-2);
+  margin-top: auto;
+}
+
+.pulse-tile__agent {
+  font-family: var(--font-mono);
+  color: var(--color-primary);
+}
+
+.pulse-tile__age {
+  color: var(--color-text-muted);
+}
+
+.pulse-table {
+  width: 100%;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  border-collapse: collapse;
+  flex: 1;
+}
+
+.pulse-table th,
+.pulse-table td {
+  text-align: left;
+  padding: var(--space-1) var(--space-2);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.pulse-table th {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+}
+
+.pulse-empty {
+  text-align: center;
+  padding: var(--space-12) var(--space-4);
+  color: var(--color-text-muted);
+}
+
+.pulse-empty h2 {
+  margin: 0 0 var(--space-3);
+  color: var(--color-text);
+}
+
+.pulse-empty p {
+  font-size: var(--font-size-sm);
+  margin: 0 0 var(--space-3);
+}
+
+.pulse-empty__example {
+  display: inline-block;
+  text-align: left;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-3);
+  margin: var(--space-3) 0;
+}

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -847,3 +847,117 @@ main.main--wide {
   padding: var(--space-3);
   margin: var(--space-3) 0;
 }
+
+/* -- Template: metric -- */
+.pulse-tile__unit {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin-left: var(--space-1);
+  font-weight: 400;
+}
+
+.pulse-tile__trend {
+  font-size: var(--font-size-sm);
+  margin-left: var(--space-2);
+}
+
+.pulse-tile__trend--up { color: var(--color-success); }
+.pulse-tile__trend--down { color: var(--color-err); }
+.pulse-tile__trend--flat { color: var(--color-text-muted); }
+
+.pulse-tile__label {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+/* -- Template: text-headline -- */
+.pulse-tile__headline {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.pulse-tile__body {
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+  color: var(--color-text);
+  flex: 1;
+  overflow: hidden;
+}
+
+/* -- Template: status -- */
+.pulse-tile__status-dot {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.pulse-tile__status-dot--healthy { background: var(--color-success); }
+.pulse-tile__status-dot--degraded { background: var(--color-warning); }
+.pulse-tile__status-dot--down { background: var(--color-err); }
+
+.pulse-tile__status-label {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+}
+
+.pulse-tile__status-message {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+/* -- Template: time-series -- */
+.pulse-tile__sparkline {
+  flex: 1;
+  min-height: 40px;
+}
+
+.pulse-tile__sparkline svg {
+  width: 100%;
+  height: 100%;
+}
+
+.pulse-tile__sparkline polyline {
+  fill: none;
+  stroke: var(--color-primary);
+  stroke-width: 1.5;
+}
+
+/* -- Template: image -- */
+.pulse-tile__image {
+  border-radius: var(--radius-sm);
+  object-fit: cover;
+  max-width: 100%;
+  max-height: 200px;
+}
+
+.pulse-tile--image .pulse-tile__image {
+  max-height: none;
+  flex: 1;
+  width: 100%;
+}
+
+/* -- Hide/show toggle -- */
+.pulse-tile__toggle {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  padding: 0 var(--space-1);
+  line-height: 1;
+  opacity: 0;
+  transition: opacity 100ms ease;
+}
+
+.pulse-tile:hover .pulse-tile__toggle {
+  opacity: 1;
+}
+
+.pulse-tile__toggle:hover {
+  color: var(--color-text);
+}

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -939,7 +939,7 @@ main.main--wide {
   line-height: 1.5;
   color: var(--color-text);
   flex: 1;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 /* -- Template: status -- */
@@ -1066,7 +1066,11 @@ body:not(.pulse-edit-mode) .pulse-container__label {
 
 body.pulse-edit-mode .pulse-tile {
   cursor: grab;
-  overflow: hidden;
+  overflow: hidden !important;
+}
+
+body:not(.pulse-edit-mode) .pulse-tile {
+  overflow-y: auto;
 }
 
 body.pulse-edit-mode .pulse-tile:active {
@@ -1079,6 +1083,60 @@ body.pulse-edit-mode .pulse-container__empty {
 
 body:not(.pulse-edit-mode) .pulse-container__empty {
   display: none;
+}
+
+/* -- Resize handle -- */
+.pulse-tile__resize-handle {
+  display: none;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 16px;
+  height: 16px;
+  cursor: nwse-resize;
+  z-index: 2;
+}
+
+.pulse-tile__resize-handle::after {
+  content: '';
+  position: absolute;
+  bottom: 4px;
+  right: 4px;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid var(--color-text-muted);
+  border-bottom: 2px solid var(--color-text-muted);
+  opacity: 0.6;
+}
+
+body.pulse-edit-mode .pulse-tile {
+  position: relative;
+}
+
+body.pulse-edit-mode .pulse-tile__resize-handle {
+  display: block;
+}
+
+body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
+  opacity: 1;
+  border-color: var(--color-primary);
+}
+
+.pulse-tile--resizing {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -1px;
+  z-index: 10;
+}
+
+/* Resize ghost overlay shown during drag */
+.pulse-resize-ghost {
+  position: absolute;
+  border: 2px dashed var(--color-primary);
+  border-radius: var(--radius-md);
+  background: var(--color-primary-soft, rgba(45,212,191,0.08));
+  pointer-events: none;
+  z-index: 100;
+  transition: width 100ms ease, height 100ms ease;
 }
 
 /* -- Drag and drop -- */

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -670,46 +670,90 @@ main.main--wide {
 
 /* ---------- Pulse ---------- */
 
-.pulse-health {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: var(--space-4);
-  margin-bottom: var(--space-8);
+/* -- Containers -- */
+.pulse-container {
+  margin-bottom: var(--space-6);
 }
 
-.pulse-health__stat {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: var(--space-4);
-  text-align: center;
+.pulse-container__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+  min-height: 28px;
 }
 
-.pulse-health__value {
-  display: block;
-  font-family: var(--font-mono);
-  font-size: var(--font-size-xl);
-  font-weight: 700;
-  margin-bottom: var(--space-1);
-}
-
-.pulse-health__value--warn {
-  color: var(--color-err);
-}
-
-.pulse-health__label {
+.pulse-container__label {
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--color-text-muted);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  outline: none;
+  cursor: text;
 }
 
+.pulse-container__label:focus {
+  border-color: var(--color-border-strong);
+  background: var(--color-surface-raised);
+}
+
+.pulse-container__delete {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  opacity: 0;
+  transition: opacity 100ms ease;
+  padding: 0 var(--space-1);
+}
+
+.pulse-container:hover .pulse-container__delete {
+  opacity: 1;
+}
+
+.pulse-container__delete:hover {
+  color: var(--color-err);
+}
+
+.pulse-container__empty {
+  border: 2px dashed var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-6);
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  min-height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pulse-container--drop-target .pulse-grid,
+.pulse-container--drop-target .pulse-container__empty {
+  border-color: var(--color-primary);
+  background: var(--color-primary-soft, rgba(45,212,191,0.05));
+}
+
+/* -- Grid: fixed 4 columns -- */
 .pulse-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  grid-template-columns: repeat(4, 1fr);
   gap: var(--space-4);
+  min-height: 20px;
+  border: 2px solid transparent;
+  border-radius: var(--radius-md);
+  transition: border-color 150ms ease, background 150ms ease;
+}
+
+@media (max-width: 900px) {
+  .pulse-grid { grid-template-columns: repeat(2, 1fr); }
 }
 
 .pulse-tile {
@@ -1007,4 +1051,103 @@ main.main--wide {
 
 .pulse-tile__toggle:hover {
   color: var(--color-text);
+}
+
+/* -- Edit mode -- */
+body:not(.pulse-edit-mode) .pulse-container__delete,
+body:not(.pulse-edit-mode) .pulse-tile__palette-btn,
+body:not(.pulse-edit-mode) .pulse-tile__toggle {
+  display: none !important;
+}
+
+body:not(.pulse-edit-mode) .pulse-container__label {
+  pointer-events: none;
+}
+
+body.pulse-edit-mode .pulse-tile {
+  cursor: grab;
+  overflow: hidden;
+}
+
+body.pulse-edit-mode .pulse-tile:active {
+  cursor: grabbing;
+}
+
+body.pulse-edit-mode .pulse-container__empty {
+  display: flex;
+}
+
+body:not(.pulse-edit-mode) .pulse-container__empty {
+  display: none;
+}
+
+/* -- Drag and drop -- */
+.pulse-tile--dragging {
+  opacity: 0.4;
+}
+
+.pulse-drop-indicator {
+  height: 3px;
+  background: var(--color-primary);
+  border-radius: 2px;
+  grid-column: 1 / -1;
+  pointer-events: none;
+}
+
+/* -- Palette button -- */
+.pulse-tile__palette-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 10px;
+  padding: 0 var(--space-1);
+  line-height: 1;
+  opacity: 0;
+  transition: opacity 100ms ease;
+  color: var(--color-text-muted);
+}
+
+.pulse-tile:hover .pulse-tile__palette-btn {
+  opacity: 1;
+}
+
+/* -- Palette overrides -- */
+.pulse-tile[data-palette="dark"] {
+  --color-surface: #1a1918;
+  --color-text: #e7e5e4;
+  --color-text-muted: #a8a29e;
+  --color-border: #3d3a37;
+  --color-surface-raised: #2e2c2a;
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.pulse-tile[data-palette="light"] {
+  --color-surface: #ffffff;
+  --color-text: #1c1917;
+  --color-text-muted: #78716c;
+  --color-border: #e7e5e4;
+  --color-surface-raised: #f5f4f2;
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.pulse-tile[data-palette="accent-teal"] {
+  background: rgba(45,212,191,0.08);
+  border-color: var(--color-primary);
+}
+
+.pulse-tile[data-palette="accent-red"] {
+  background: rgba(248,113,113,0.08);
+  border-color: var(--color-err);
+}
+
+.pulse-tile[data-palette="accent-green"] {
+  background: rgba(74,222,128,0.08);
+  border-color: var(--color-success);
+}
+
+.pulse-tile[data-palette="accent-orange"] {
+  background: rgba(251,191,36,0.08);
+  border-color: var(--color-warning);
 }

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -32,6 +32,7 @@ import { assetsRouter } from './routes/assets.js';
 import { settingsRouter } from './routes/settings.js';
 import { helpRouter } from './routes/help.js';
 import { versionsRouter } from './routes/versions.js';
+import { pulseRouter } from './routes/pulse.js';
 
 export interface StartDashboardOptions {
   port: number;
@@ -126,6 +127,7 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   app.use(helpRouter);
   app.use(versionsRouter);
   app.use(toolsRouter);
+  app.use(pulseRouter);
 
   // Catch-all 404 for authenticated routes.
   app.use((_req, res) => {

--- a/packages/dashboard/src/routes/agent-nodes.ts
+++ b/packages/dashboard/src/routes/agent-nodes.ts
@@ -1,6 +1,7 @@
 import { Router, type Request, type Response } from 'express';
 import type { Agent, AgentInputSpec } from '@some-useful-agents/core';
 import { exportAgent, parseAgent, AgentYamlParseError } from '@some-useful-agents/core';
+import { parse as parseRawYaml, stringify as stringifyRawYaml } from 'yaml';
 import { html as h, render as renderHtml } from '../views/html.js';
 import { layout } from '../views/layout.js';
 import { pageHeader } from '../views/page-header.js';
@@ -408,7 +409,27 @@ agentNodesRouter.post('/agents/:name/yaml', (req: Request, res: Response) => {
     return;
   }
 
-  const yamlText = typeof body.yaml === 'string' ? body.yaml : '';
+  let yamlText = typeof body.yaml === 'string' ? body.yaml : '';
+
+  // Auto-fix common analyzer mistake: {{inputs.X}} in shell commands → $X.
+  // The schema validator rejects double-brace templates in shell nodes,
+  // but the analyzer LLM sometimes generates them. Fix before parsing.
+  try {
+    const raw = parseRawYaml(yamlText);
+    if (raw?.nodes && Array.isArray(raw.nodes)) {
+      let changed = false;
+      for (const node of raw.nodes) {
+        if (node.type === 'shell' && typeof node.command === 'string') {
+          const fixed = node.command.replace(
+            /\{\{inputs\.([A-Z_][A-Z0-9_]*)\}\}/g,
+            (_: string, name: string) => '$' + name,
+          );
+          if (fixed !== node.command) { node.command = fixed; changed = true; }
+        }
+      }
+      if (changed) yamlText = stringifyRawYaml(raw, { lineWidth: 0 });
+    }
+  } catch { /* if raw parse fails, let the real parser report the error */ }
 
   let parsed: Agent;
   try {

--- a/packages/dashboard/src/routes/pulse.ts
+++ b/packages/dashboard/src/routes/pulse.ts
@@ -1,0 +1,104 @@
+import { Router, type Request, type Response } from 'express';
+import { parseAgent, type Run } from '@some-useful-agents/core';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { getContext } from '../context.js';
+import { renderPulsePage, extractSignalValue, type PulseTile } from '../views/pulse.js';
+
+export const pulseRouter: Router = Router();
+
+/**
+ * Auto-import any example agents that have a `signal:` field so they
+ * show up on the Pulse page without manual CLI steps.
+ */
+function autoImportSignalExamples(ctx: ReturnType<typeof getContext>): void {
+  try {
+    const dir = join(resolve('agents/examples'));
+    for (const file of readdirSync(dir)) {
+      if (!file.endsWith('.yaml')) continue;
+      try {
+        const text = readFileSync(join(dir, file), 'utf-8');
+        if (!text.includes('signal:')) continue;
+        const parsed = parseAgent(text);
+        if (!parsed.signal) continue;
+        // Only import if the agent doesn't already exist. Never overwrite
+        // dashboard-configured agents (provider, model, signal edits, etc.).
+        if (!ctx.agentStore.getAgent(parsed.id)) {
+          ctx.agentStore.upsertAgent(parsed, 'import', 'Auto-imported for Pulse');
+        }
+      } catch { /* skip invalid files */ }
+    }
+  } catch { /* examples dir may not exist */ }
+}
+
+/**
+ * GET /pulse — Signal tile dashboard. Shows live output from agents
+ * that declare a `signal:` field in their YAML.
+ */
+pulseRouter.get('/pulse', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+
+  // Ensure signal-enabled example agents are imported.
+  autoImportSignalExamples(ctx);
+
+  const agents = ctx.agentStore.listAgents();
+
+  // Collect agents with a signal declaration.
+  const tiles: PulseTile[] = [];
+  for (const agent of agents) {
+    if (!agent.signal) continue;
+
+    // Fetch the most recent completed run for this agent.
+    let lastRun: Run | undefined;
+    let outputsJson: string | undefined;
+    try {
+      const runs = ctx.runStore.listRuns({ agentName: agent.id, status: 'completed', limit: 1 });
+      if (runs.length > 0) {
+        lastRun = runs[0];
+        // Try to get structured output from the last node execution.
+        const execs = ctx.runStore.listNodeExecutions(lastRun.id);
+        const lastExec = execs.filter((e) => e.status === 'completed').pop();
+        if (lastExec?.outputsJson) {
+          outputsJson = lastExec.outputsJson;
+        }
+      }
+    } catch { /* run store may not have runs for this agent */ }
+
+    const value = extractSignalValue(lastRun, agent.signal, outputsJson);
+    tiles.push({ agent, signal: agent.signal, lastRun, value });
+  }
+
+  // Compute health stats.
+  const now = new Date();
+  const dayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+  let runsToday = 0;
+  let failedToday = 0;
+  let totalDurationSec = 0;
+  let completedCount = 0;
+  try {
+    const allRecent = ctx.runStore.queryRuns({ limit: 200, offset: 0 });
+    for (const r of allRecent.rows) {
+      if (r.startedAt >= dayAgo) {
+        runsToday++;
+        if (r.status === 'failed') failedToday++;
+        if (r.status === 'completed' && r.completedAt) {
+          const dur = (new Date(r.completedAt).getTime() - new Date(r.startedAt).getTime()) / 1000;
+          totalDurationSec += dur;
+          completedCount++;
+        }
+      }
+    }
+  } catch { /* ignore */ }
+
+  const avgDurationSec = completedCount > 0 ? Math.round(totalDurationSec / completedCount) : 0;
+
+  res.type('html').send(renderPulsePage({
+    tiles,
+    stats: {
+      runsToday,
+      failedToday,
+      avgDurationSec,
+      agentCount: agents.length,
+    },
+  }));
+});

--- a/packages/dashboard/src/routes/pulse.ts
+++ b/packages/dashboard/src/routes/pulse.ts
@@ -3,7 +3,8 @@ import { parseAgent, type Run } from '@some-useful-agents/core';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { getContext } from '../context.js';
-import { renderPulsePage, extractSignalValue, type PulseTile } from '../views/pulse.js';
+import { renderPulsePage, type PulseTile } from '../views/pulse.js';
+import { normalizeSignal, extractMappedValues } from '../views/pulse-templates.js';
 
 export const pulseRouter: Router = Router();
 
@@ -32,45 +33,50 @@ function autoImportSignalExamples(ctx: ReturnType<typeof getContext>): void {
 }
 
 /**
- * GET /pulse — Signal tile dashboard. Shows live output from agents
- * that declare a `signal:` field in their YAML.
+ * Build a PulseTile for an agent with a signal declaration.
+ */
+function buildTile(agent: ReturnType<ReturnType<typeof getContext>['agentStore']['getAgent']> & { signal: NonNullable<unknown> }, ctx: ReturnType<typeof getContext>): PulseTile {
+  const signal = agent.signal!;
+  let lastRun: Run | undefined;
+  let outputsJson: string | undefined;
+  try {
+    const runs = ctx.runStore.listRuns({ agentName: agent.id, status: 'completed', limit: 1 });
+    if (runs.length > 0) {
+      lastRun = runs[0];
+      const execs = ctx.runStore.listNodeExecutions(lastRun.id);
+      const lastExec = execs.filter((e) => e.status === 'completed').pop();
+      if (lastExec?.outputsJson) outputsJson = lastExec.outputsJson;
+    }
+  } catch { /* run store may not have runs */ }
+
+  const { mapping } = normalizeSignal(signal);
+  const slots = extractMappedValues(lastRun, mapping, outputsJson);
+  return { agent, signal, lastRun, slots };
+}
+
+/**
+ * GET /pulse — Signal tile dashboard.
  */
 pulseRouter.get('/pulse', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
-
-  // Ensure signal-enabled example agents are imported.
   autoImportSignalExamples(ctx);
 
   const agents = ctx.agentStore.listAgents();
-
-  // Collect agents with a signal declaration.
   const tiles: PulseTile[] = [];
+  const hiddenTiles: PulseTile[] = [];
+
   for (const agent of agents) {
     if (!agent.signal) continue;
-
-    // Fetch the most recent completed run for this agent.
-    let lastRun: Run | undefined;
-    let outputsJson: string | undefined;
-    try {
-      const runs = ctx.runStore.listRuns({ agentName: agent.id, status: 'completed', limit: 1 });
-      if (runs.length > 0) {
-        lastRun = runs[0];
-        // Try to get structured output from the last node execution.
-        const execs = ctx.runStore.listNodeExecutions(lastRun.id);
-        const lastExec = execs.filter((e) => e.status === 'completed').pop();
-        if (lastExec?.outputsJson) {
-          outputsJson = lastExec.outputsJson;
-        }
-      }
-    } catch { /* run store may not have runs for this agent */ }
-
-    const value = extractSignalValue(lastRun, agent.signal, outputsJson);
-    tiles.push({ agent, signal: agent.signal, lastRun, value });
+    const tile = buildTile(agent as typeof agent & { signal: NonNullable<unknown> }, ctx);
+    if (agent.signal.hidden) {
+      hiddenTiles.push(tile);
+    } else {
+      tiles.push(tile);
+    }
   }
 
   // Compute health stats.
-  const now = new Date();
-  const dayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+  const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
   let runsToday = 0;
   let failedToday = 0;
   let totalDurationSec = 0;
@@ -90,15 +96,39 @@ pulseRouter.get('/pulse', (req: Request, res: Response) => {
     }
   } catch { /* ignore */ }
 
-  const avgDurationSec = completedCount > 0 ? Math.round(totalDurationSec / completedCount) : 0;
-
   res.type('html').send(renderPulsePage({
     tiles,
+    hiddenTiles,
     stats: {
       runsToday,
       failedToday,
-      avgDurationSec,
+      avgDurationSec: completedCount > 0 ? Math.round(totalDurationSec / completedCount) : 0,
       agentCount: agents.length,
     },
   }));
+});
+
+/**
+ * POST /agents/:id/signal/toggle — toggle the hidden state of a signal tile.
+ * Creates a new version with signal.hidden flipped.
+ */
+pulseRouter.post('/agents/:id/signal/toggle', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const agent = ctx.agentStore.getAgent(id);
+  if (!agent || !agent.signal) {
+    res.redirect(303, '/pulse');
+    return;
+  }
+
+  try {
+    const updated = {
+      ...agent,
+      signal: { ...agent.signal, hidden: !agent.signal.hidden },
+    };
+    ctx.agentStore.upsertAgent(updated, 'dashboard', agent.signal.hidden ? 'Unhide signal tile' : 'Hide signal tile');
+    res.redirect(303, '/pulse');
+  } catch {
+    res.redirect(303, '/pulse');
+  }
 });

--- a/packages/dashboard/src/routes/pulse.ts
+++ b/packages/dashboard/src/routes/pulse.ts
@@ -1,5 +1,5 @@
 import { Router, type Request, type Response } from 'express';
-import { parseAgent, type Run } from '@some-useful-agents/core';
+import { parseAgent, type Agent, type AgentSignal, type Run } from '@some-useful-agents/core';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { getContext } from '../context.js';
@@ -8,10 +8,8 @@ import { normalizeSignal, extractMappedValues } from '../views/pulse-templates.j
 
 export const pulseRouter: Router = Router();
 
-/**
- * Auto-import any example agents that have a `signal:` field so they
- * show up on the Pulse page without manual CLI steps.
- */
+// ── Auto-import ──────────────────────────────────────────────────────────
+
 function autoImportSignalExamples(ctx: ReturnType<typeof getContext>): void {
   try {
     const dir = join(resolve('agents/examples'));
@@ -22,21 +20,18 @@ function autoImportSignalExamples(ctx: ReturnType<typeof getContext>): void {
         if (!text.includes('signal:')) continue;
         const parsed = parseAgent(text);
         if (!parsed.signal) continue;
-        // Only import if the agent doesn't already exist. Never overwrite
-        // dashboard-configured agents (provider, model, signal edits, etc.).
         if (!ctx.agentStore.getAgent(parsed.id)) {
           ctx.agentStore.upsertAgent(parsed, 'import', 'Auto-imported for Pulse');
         }
-      } catch { /* skip invalid files */ }
+      } catch { /* skip */ }
     }
-  } catch { /* examples dir may not exist */ }
+  } catch { /* dir may not exist */ }
 }
 
-/**
- * Build a PulseTile for an agent with a signal declaration.
- */
-function buildTile(agent: ReturnType<ReturnType<typeof getContext>['agentStore']['getAgent']> & { signal: NonNullable<unknown> }, ctx: ReturnType<typeof getContext>): PulseTile {
-  const signal = agent.signal!;
+// ── Tile building ────────────────────────────────────────────────────────
+
+function buildTile(agent: Agent & { signal: AgentSignal }, ctx: ReturnType<typeof getContext>): PulseTile {
+  const signal = agent.signal;
   let lastRun: Run | undefined;
   let outputsJson: string | undefined;
   try {
@@ -47,16 +42,89 @@ function buildTile(agent: ReturnType<ReturnType<typeof getContext>['agentStore']
       const lastExec = execs.filter((e) => e.status === 'completed').pop();
       if (lastExec?.outputsJson) outputsJson = lastExec.outputsJson;
     }
-  } catch { /* run store may not have runs */ }
+  } catch { /* no runs */ }
 
   const { mapping } = normalizeSignal(signal);
   const slots = extractMappedValues(lastRun, mapping, outputsJson);
   return { agent, signal, lastRun, slots };
 }
 
-/**
- * GET /pulse — Signal tile dashboard.
- */
+// ── Virtual system tiles ─────────────────────────────────────────────────
+
+const SYSTEM_IDS = [
+  '_system-runs-today',
+  '_system-failure-rate',
+  '_system-avg-duration',
+  '_system-agent-count',
+] as const;
+
+function virtualAgent(id: string, name: string): Agent {
+  return {
+    id,
+    name,
+    status: 'active',
+    source: 'local',
+    version: 0,
+    nodes: [],
+  };
+}
+
+function buildSystemTiles(ctx: ReturnType<typeof getContext>): PulseTile[] {
+  const dayAgo = new Date(Date.now() - 86400000).toISOString();
+  let runsToday = 0;
+  let failedToday = 0;
+  let totalDurationSec = 0;
+  let completedCount = 0;
+  try {
+    const allRecent = ctx.runStore.queryRuns({ limit: 500, offset: 0 });
+    for (const r of allRecent.rows) {
+      if (r.startedAt >= dayAgo) {
+        runsToday++;
+        if (r.status === 'failed') failedToday++;
+        if (r.status === 'completed' && r.completedAt) {
+          totalDurationSec += (new Date(r.completedAt).getTime() - new Date(r.startedAt).getTime()) / 1000;
+          completedCount++;
+        }
+      }
+    }
+  } catch { /* ignore */ }
+
+  const failRate = runsToday > 0 ? Math.round((failedToday / runsToday) * 100) : 0;
+  const avgDur = completedCount > 0 ? Math.round(totalDurationSec / completedCount) : 0;
+  const agentCount = ctx.agentStore.listAgents().length;
+
+  return [
+    {
+      agent: virtualAgent('_system-runs-today', 'Runs Today'),
+      signal: { title: 'Runs Today', icon: '\uD83D\uDCCA', template: 'metric', format: 'number' },
+      slots: { value: runsToday, label: 'Runs Today' },
+    },
+    {
+      agent: virtualAgent('_system-failure-rate', 'Failure Rate'),
+      signal: {
+        title: 'Failure Rate', icon: '\u26A0\uFE0F', template: 'metric', format: 'number',
+        thresholds: [
+          { above: 20, palette: 'accent-red' },
+          { below: 5, palette: 'accent-green' },
+        ],
+      },
+      slots: { value: failRate, label: 'Failure Rate', unit: '%' },
+    },
+    {
+      agent: virtualAgent('_system-avg-duration', 'Avg Duration'),
+      signal: { title: 'Avg Duration', icon: '\u23F1\uFE0F', template: 'metric', format: 'number' },
+      slots: { value: avgDur > 0 ? avgDur : '--', label: 'Avg Duration', unit: avgDur > 0 ? 's' : '' },
+    },
+    {
+      agent: virtualAgent('_system-agent-count', 'Agents'),
+      signal: { title: 'Agents', icon: '\uD83E\uDD16', template: 'metric', format: 'number' },
+      slots: { value: agentCount, label: 'Agents' },
+    },
+  ];
+}
+
+// ── Routes ───────────────────────────────────────────────────────────────
+
 pulseRouter.get('/pulse', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
   autoImportSignalExamples(ctx);
@@ -65,9 +133,13 @@ pulseRouter.get('/pulse', (req: Request, res: Response) => {
   const tiles: PulseTile[] = [];
   const hiddenTiles: PulseTile[] = [];
 
+  // System tiles (virtual, not from the agent store).
+  const systemTiles = buildSystemTiles(ctx);
+
+  // Agent tiles.
   for (const agent of agents) {
     if (!agent.signal) continue;
-    const tile = buildTile(agent as typeof agent & { signal: NonNullable<unknown> }, ctx);
+    const tile = buildTile(agent as Agent & { signal: AgentSignal }, ctx);
     if (agent.signal.hidden) {
       hiddenTiles.push(tile);
     } else {
@@ -75,43 +147,13 @@ pulseRouter.get('/pulse', (req: Request, res: Response) => {
     }
   }
 
-  // Compute health stats.
-  const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-  let runsToday = 0;
-  let failedToday = 0;
-  let totalDurationSec = 0;
-  let completedCount = 0;
-  try {
-    const allRecent = ctx.runStore.queryRuns({ limit: 200, offset: 0 });
-    for (const r of allRecent.rows) {
-      if (r.startedAt >= dayAgo) {
-        runsToday++;
-        if (r.status === 'failed') failedToday++;
-        if (r.status === 'completed' && r.completedAt) {
-          const dur = (new Date(r.completedAt).getTime() - new Date(r.startedAt).getTime()) / 1000;
-          totalDurationSec += dur;
-          completedCount++;
-        }
-      }
-    }
-  } catch { /* ignore */ }
-
   res.type('html').send(renderPulsePage({
+    systemTiles,
     tiles,
     hiddenTiles,
-    stats: {
-      runsToday,
-      failedToday,
-      avgDurationSec: completedCount > 0 ? Math.round(totalDurationSec / completedCount) : 0,
-      agentCount: agents.length,
-    },
   }));
 });
 
-/**
- * POST /agents/:id/signal/toggle — toggle the hidden state of a signal tile.
- * Creates a new version with signal.hidden flipped.
- */
 pulseRouter.post('/agents/:id/signal/toggle', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
   const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;

--- a/packages/dashboard/src/routes/run-now.ts
+++ b/packages/dashboard/src/routes/run-now.ts
@@ -1,5 +1,6 @@
 import { Router, type Request, type Response } from 'express';
 import { executeAgentDag, exportAgent, listBuiltinTools, parseAgent, type RunStatus, type ToolDefinition } from '@some-useful-agents/core';
+import { parse as parseRawYaml, stringify as stringifyRawYaml } from 'yaml';
 import { readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { getContext } from '../context.js';
@@ -333,9 +334,27 @@ runNowRouter.get('/agents/:name/analyze/:runId', (req: Request, res: Response) =
   const classRaw = extract('classification')?.toUpperCase().trim() ?? 'SUGGESTIONS';
   const classification = ['NO_IMPROVEMENTS', 'SUGGESTIONS', 'REWRITE'].includes(classRaw) ? classRaw : 'SUGGESTIONS';
 
-  const suggestedYaml = extract('yaml') || undefined;
+  // Extract suggested YAML and auto-fix common analyzer mistakes before validation.
+  let suggestedYaml = extract('yaml') || undefined;
   let yamlError: string | undefined;
   if (suggestedYaml && suggestedYaml.length > 10) {
+    // Fix {{inputs.X}} → $X in shell node commands (analyzer LLM gets this wrong often).
+    try {
+      const raw = parseRawYaml(suggestedYaml);
+      if (raw?.nodes && Array.isArray(raw.nodes)) {
+        let changed = false;
+        for (const n of raw.nodes) {
+          if (n.type === 'shell' && typeof n.command === 'string') {
+            const fixed = n.command.replace(
+              /\{\{inputs\.([A-Z_][A-Z0-9_]*)\}\}/g,
+              (_: string, name: string) => '$' + name,
+            );
+            if (fixed !== n.command) { n.command = fixed; changed = true; }
+          }
+        }
+        if (changed) suggestedYaml = stringifyRawYaml(raw, { lineWidth: 0 });
+      }
+    } catch { /* let the real parser report the error */ }
     try { parseAgent(suggestedYaml); } catch (e) { yamlError = e instanceof Error ? e.message : String(e); }
   }
 

--- a/packages/dashboard/src/routes/run-now.ts
+++ b/packages/dashboard/src/routes/run-now.ts
@@ -1,5 +1,5 @@
 import { Router, type Request, type Response } from 'express';
-import { executeAgentDag, exportAgent, parseAgent, type RunStatus } from '@some-useful-agents/core';
+import { executeAgentDag, exportAgent, listBuiltinTools, parseAgent, type RunStatus, type ToolDefinition } from '@some-useful-agents/core';
 import { readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { getContext } from '../context.js';
@@ -8,6 +8,21 @@ export const runNowRouter: Router = Router();
 
 const ANALYZER_AGENT_ID = 'agent-analyzer';
 const BUILDER_AGENT_ID = 'agent-builder';
+
+/**
+ * Format a list of tool definitions into a human-readable catalog string
+ * for injection into the builder agent prompt.
+ */
+function formatToolCatalog(tools: ToolDefinition[]): string {
+  return tools
+    .map((t) => {
+      const inputNames = Object.keys(t.inputs ?? {}).join(', ');
+      const desc = t.description ? t.description.replace(/\n/g, ' ').trim() : '';
+      const implType = t.implementation?.type ?? 'builtin';
+      return `- ${t.id} (type: ${implType}): ${desc}${inputNames ? ` Inputs: ${inputNames}.` : ''}`;
+    })
+    .join('\n');
+}
 
 /**
  * POST /agents/:name/run — trigger an agent with YAML defaults.
@@ -182,6 +197,18 @@ runNowRouter.post('/agents/:name/analyze', async (req: Request, res: Response) =
   const focus = typeof body.focus === 'string' ? body.focus.trim() : '';
   const targetYaml = exportAgent(target);
 
+  // Fetch the most recent completed run for this agent so the analyzer
+  // can consider real execution output (errors, timeouts, etc.).
+  let lastRunOutput = '';
+  try {
+    const recent = ctx.runStore.listRuns({ agentName: name, status: 'completed', limit: 1 });
+    if (recent.length > 0 && recent[0].result) {
+      const raw = recent[0].result;
+      // Cap at 2000 chars to keep the prompt focused.
+      lastRunOutput = raw.length > 2000 ? raw.slice(0, 2000) + '\n...(truncated)' : raw;
+    }
+  } catch { /* run store may not have runs yet */ }
+
   // Fire-and-forget: start the analyzer but don't await it.
   // Return the runId immediately so the client can poll.
   const runPromise = executeAgentDag(
@@ -191,6 +218,7 @@ runNowRouter.post('/agents/:name/analyze', async (req: Request, res: Response) =
       inputs: {
         AGENT_YAML: targetYaml,
         ...(focus ? { FOCUS: `Focus your analysis on: ${focus}` } : {}),
+        ...(lastRunOutput ? { LAST_RUN_OUTPUT: lastRunOutput } : {}),
       },
     },
     {
@@ -261,23 +289,38 @@ runNowRouter.get('/agents/:name/analyze/:runId', (req: Request, res: Response) =
     return;
   }
 
-  // Done — parse the result.
-  if (run.status !== 'completed' || !run.result) {
-    res.json({ ok: true, status: 'failed', error: run.error ?? `Analysis failed (${run.status}).` });
-    return;
+  // Done — parse the result. Even if the run failed (e.g. fix node hit
+  // max_turns), the analyze node may have completed successfully. Try to
+  // extract results from individual node executions before giving up.
+  const execs = ctx.runStore.listNodeExecutions(runId);
+  const analyzeExec = execs.find((e) => e.nodeId === 'analyze');
+  const fixExec = execs.find((e) => e.nodeId === 'fix');
+
+  // Pick the best available result text:
+  // 1. Fix node output (corrected YAML) if it completed
+  // 2. Run-level result if the run completed
+  // 3. Analyze node output as fallback (even if later nodes failed)
+  let resultText = '';
+  if (fixExec?.status === 'completed' && fixExec.result) {
+    resultText = fixExec.result;
+  } else if (run.status === 'completed' && run.result) {
+    resultText = run.result;
+  } else if (analyzeExec?.status === 'completed' && analyzeExec.result) {
+    resultText = analyzeExec.result;
   }
 
-  // The run.result is the last completed node's output. In the multi-node
-  // analyzer pipeline:
-  //   - If fix ran (validation failed): fix node's output has the corrected XML
-  //   - If fix was skipped (validation passed): validate node's JSON is the
-  //     run result, but we want the analyze node's output with the XML tags
-  // Detect by checking for <classification> tag.
-  let resultText = run.result;
+  if (!resultText || !resultText.includes('<classification>')) {
+    // Try the analyze node one more time — its result may be in stream-json format
+    if (analyzeExec?.result && analyzeExec.result.includes('<classification>')) {
+      resultText = analyzeExec.result;
+    } else if (!resultText) {
+      res.json({ ok: true, status: 'failed', error: run.error ?? `Analysis failed (${run.status}).` });
+      return;
+    }
+  }
+
   if (!resultText.includes('<classification>')) {
     // Result is probably the validate node's JSON. Find the analyze node's output.
-    const execs = ctx.runStore.listNodeExecutions(runId);
-    const analyzeExec = execs.find((e) => e.nodeId === 'analyze');
     if (analyzeExec?.result) {
       resultText = analyzeExec.result;
     }
@@ -343,6 +386,15 @@ runNowRouter.post('/agents/build', async (req: Request, res: Response) => {
     return;
   }
 
+  // Build a dynamic tool catalog so the builder LLM knows about all
+  // registered tools, not just the 9 hardcoded built-ins.
+  const builtins = listBuiltinTools();
+  let userTools: ToolDefinition[] = [];
+  try {
+    if (ctx.toolStore) userTools = ctx.toolStore.listTools();
+  } catch { /* store not available */ }
+  const catalog = formatToolCatalog([...builtins, ...userTools]);
+
   const runPromise = executeAgentDag(
     builder,
     {
@@ -350,6 +402,7 @@ runNowRouter.post('/agents/build', async (req: Request, res: Response) => {
       inputs: {
         GOAL: goal,
         ...(focus ? { FOCUS: `Constraints: ${focus}` } : {}),
+        AVAILABLE_TOOLS: catalog,
       },
     },
     {

--- a/packages/dashboard/src/routes/versions.ts
+++ b/packages/dashboard/src/routes/versions.ts
@@ -146,3 +146,50 @@ versionsRouter.post('/agents/:id/status', (req: Request, res: Response) => {
     res.redirect(303, `/agents/${encodeURIComponent(id)}?flash=${encodeURIComponent(`Status change failed: ${msg}`)}`);
   }
 });
+
+const VALID_PROVIDERS = new Set(['claude', 'codex']);
+
+/**
+ * POST /agents/:id/llm — update agent-level provider and model defaults.
+ * Creates a new version since these are part of the versioned DAG.
+ */
+versionsRouter.post('/agents/:id/llm', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const body = (req.body ?? {}) as Record<string, unknown>;
+
+  const provider = typeof body.provider === 'string' ? body.provider.trim() : '';
+  const model = typeof body.model === 'string' ? body.model.trim() : '';
+
+  if (provider && !VALID_PROVIDERS.has(provider)) {
+    res.redirect(303, `/agents/${encodeURIComponent(id)}?flash=${encodeURIComponent('Invalid provider. Must be claude or codex.')}`);
+    return;
+  }
+
+  const agent = ctx.agentStore.getAgent(id);
+  if (!agent) {
+    res.status(404).redirect(303, '/agents');
+    return;
+  }
+
+  // Check for no-op.
+  const newProvider = (provider || undefined) as 'claude' | 'codex' | undefined;
+  const newModel = model || undefined;
+  if (agent.provider === newProvider && agent.model === newModel) {
+    res.redirect(303, `/agents/${encodeURIComponent(id)}?flash=${encodeURIComponent('LLM defaults unchanged.')}`);
+    return;
+  }
+
+  try {
+    const updated = { ...agent, provider: newProvider, model: newModel };
+    ctx.agentStore.upsertAgent(updated, 'dashboard', 'Updated LLM defaults');
+    const parts: string[] = [];
+    if (newProvider) parts.push(`provider: ${newProvider}`);
+    if (newModel) parts.push(`model: ${newModel}`);
+    const summary = parts.length > 0 ? parts.join(', ') : 'defaults cleared';
+    res.redirect(303, `/agents/${encodeURIComponent(id)}?flash=${encodeURIComponent(`LLM defaults updated (${summary}).`)}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/agents/${encodeURIComponent(id)}?flash=${encodeURIComponent(`LLM update failed: ${msg}`)}`);
+  }
+});

--- a/packages/dashboard/src/views/agent-detail-v2.ts
+++ b/packages/dashboard/src/views/agent-detail-v2.ts
@@ -163,6 +163,32 @@ export async function renderAgentDetailV2(args: {
       </section>
 
       <section class="inspector__section">
+        <h4>LLM defaults</h4>
+        <form method="POST" action="/agents/${agent.id}/llm" id="llm-form" style="display: flex; flex-direction: column; gap: var(--space-2);">
+          <div style="display: flex; gap: var(--space-2); align-items: center;">
+            <label style="font-size: var(--font-size-xs); color: var(--color-text-muted); min-width: 55px;">Provider</label>
+            <select name="provider" id="llm-provider" class="form-field" style="flex: 1; padding: var(--space-1) var(--space-2); font-size: var(--font-size-sm);">
+              ${providerOption('claude', agent.provider)}
+              ${providerOption('codex', agent.provider)}
+            </select>
+          </div>
+          <div style="display: flex; gap: var(--space-2); align-items: center;">
+            <label style="font-size: var(--font-size-xs); color: var(--color-text-muted); min-width: 55px;">Model</label>
+            <select name="model" id="llm-model" class="form-field" style="flex: 1; padding: var(--space-1) var(--space-2); font-size: var(--font-size-sm); font-family: var(--font-mono);">
+              ${renderModelOptions(agent.provider, agent.model)}
+            </select>
+          </div>
+          <div id="llm-model-desc" class="dim" style="font-size: var(--font-size-xs); padding: 0 0 0 calc(55px + var(--space-2)); min-height: 1.2em;"></div>
+          <div style="display: flex; justify-content: flex-end;">
+            <button type="submit" class="btn btn--sm">Apply</button>
+          </div>
+          <p class="dim" style="font-size: var(--font-size-xs); margin: 0;">
+            Applies to all claude-code nodes. Individual nodes can override in YAML.
+          </p>
+        </form>
+      </section>
+
+      <section class="inspector__section">
         <h4>Metadata</h4>
         <dl class="kv">
           <dt>Version</dt>
@@ -535,6 +561,44 @@ function vStatusBadge(status: string): SafeHtml {
 function statusOption(value: string, current: string): SafeHtml {
   const selected = value === current ? unsafeHtml(' selected') : unsafeHtml('');
   return html`<option value="${value}"${selected}>${value}</option>`;
+}
+
+function providerOption(value: string, current?: string): SafeHtml {
+  const effective = current ?? 'claude';
+  const selected = value === effective ? unsafeHtml(' selected') : unsafeHtml('');
+  return html`<option value="${value}"${selected}>${value}</option>`;
+}
+
+interface ModelEntry { id: string; label: string; desc: string }
+
+const CLAUDE_MODELS: ModelEntry[] = [
+  { id: '', label: 'default', desc: 'Uses the Claude CLI default model' },
+  { id: 'claude-opus-4-6', label: 'Opus 4.6', desc: 'Most capable. Deep analysis, complex reasoning, long outputs' },
+  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', desc: 'Fast + capable. Good balance of speed and quality' },
+  { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5', desc: 'Fastest. Best for simple tasks, classification, extraction' },
+];
+
+const CODEX_MODELS: ModelEntry[] = [
+  { id: '', label: 'default', desc: 'Uses the Codex CLI default model' },
+  { id: 'o4-mini', label: 'o4-mini', desc: 'Fast reasoning model. Good for code analysis and generation' },
+  { id: 'o3', label: 'o3', desc: 'Most capable reasoning model. Deep multi-step analysis' },
+  { id: 'gpt-4.1', label: 'GPT-4.1', desc: 'Latest GPT. Strong at code, instruction following' },
+  { id: 'gpt-4.1-mini', label: 'GPT-4.1 Mini', desc: 'Compact GPT-4.1. Fast, lower cost' },
+  { id: 'gpt-4.1-nano', label: 'GPT-4.1 Nano', desc: 'Smallest GPT-4.1. Very fast, simple tasks' },
+];
+
+function renderModelOptions(provider?: string, currentModel?: string): SafeHtml {
+  const models = (provider === 'codex') ? CODEX_MODELS : CLAUDE_MODELS;
+  const effective = currentModel ?? '';
+  const options = models.map((m) => {
+    const sel = m.id === effective ? unsafeHtml(' selected') : unsafeHtml('');
+    return html`<option value="${m.id}" title="${m.desc}"${sel}>${m.label}</option>`;
+  });
+  // If the current model isn't in the list, add it as a custom entry.
+  if (effective && !models.some((m) => m.id === effective)) {
+    options.push(html`<option value="${effective}" selected>${effective}</option>`);
+  }
+  return html`${options as unknown as SafeHtml[]}`;
 }
 
 function oneLine(text: string, max = 120): string {

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -842,6 +842,75 @@ export const DASHBOARD_JS = `
       if (e.target === modal) closeModal();
       if (e.target && e.target.getAttribute && e.target.getAttribute('data-close-modal')) closeModal();
     });
+
+    // Auto-open from run detail page: ?suggest=1&focus=<error text>
+    var params = new URLSearchParams(window.location.search);
+    if (params.get('suggest') === '1') {
+      btn.click();
+      // Pre-fill focus after the modal renders.
+      setTimeout(function () {
+        var ta = document.getElementById('sg-focus');
+        var focusParam = params.get('focus');
+        if (ta && focusParam) ta.value = focusParam;
+      }, 50);
+    }
+  })();
+
+  // ── LLM provider/model sync ─────────────────────────────────────────
+  // When the provider dropdown changes, repopulate the model dropdown
+  // with the correct models and show the selected model's description.
+  (function () {
+    var providerSel = document.getElementById('llm-provider');
+    var modelSel = document.getElementById('llm-model');
+    var descEl = document.getElementById('llm-model-desc');
+    if (!providerSel || !modelSel || !descEl) return;
+
+    var MODELS = {
+      claude: [
+        { id: '', label: 'default', desc: 'Uses the Claude CLI default model' },
+        { id: 'claude-opus-4-6', label: 'Opus 4.6', desc: 'Most capable. Deep analysis, complex reasoning, long outputs' },
+        { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', desc: 'Fast + capable. Good balance of speed and quality' },
+        { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5', desc: 'Fastest. Best for simple tasks, classification, extraction' }
+      ],
+      codex: [
+        { id: '', label: 'default', desc: 'Uses the Codex CLI default model' },
+        { id: 'o4-mini', label: 'o4-mini', desc: 'Fast reasoning model. Good for code analysis and generation' },
+        { id: 'o3', label: 'o3', desc: 'Most capable reasoning model. Deep multi-step analysis' },
+        { id: 'gpt-4.1', label: 'GPT-4.1', desc: 'Latest GPT. Strong at code, instruction following' },
+        { id: 'gpt-4.1-mini', label: 'GPT-4.1 Mini', desc: 'Compact GPT-4.1. Fast, lower cost' },
+        { id: 'gpt-4.1-nano', label: 'GPT-4.1 Nano', desc: 'Smallest GPT-4.1. Very fast, simple tasks' }
+      ]
+    };
+
+    function updateModels() {
+      var provider = providerSel.value || 'claude';
+      var models = MODELS[provider] || MODELS.claude;
+      var currentVal = modelSel.value;
+      modelSel.innerHTML = '';
+      for (var i = 0; i < models.length; i++) {
+        var opt = document.createElement('option');
+        opt.value = models[i].id;
+        opt.textContent = models[i].label;
+        opt.title = models[i].desc;
+        if (models[i].id === currentVal) opt.selected = true;
+        modelSel.appendChild(opt);
+      }
+      // If previous value isn't in the new list, select default.
+      if (modelSel.value !== currentVal) modelSel.selectedIndex = 0;
+      updateDesc();
+    }
+
+    function updateDesc() {
+      var provider = providerSel.value || 'claude';
+      var models = MODELS[provider] || MODELS.claude;
+      var selOpt = modelSel.options[modelSel.selectedIndex];
+      descEl.textContent = selOpt ? (selOpt.title || '') : '';
+    }
+
+    providerSel.addEventListener('change', updateModels);
+    modelSel.addEventListener('change', updateDesc);
+    // Show description for initial selection.
+    updateDesc();
   })();
 
   // ── Secret save confirmation ───────────────────────────────────────

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -985,6 +985,7 @@ export const DASHBOARD_JS = `
           renderLayout();
           restoreCollapsed();
           restorePalettes();
+          applySizes();
           setEditMode(editMode);
         }; })(c));
         header.appendChild(delBtn);
@@ -1119,6 +1120,7 @@ export const DASHBOARD_JS = `
       renderLayout();
       restoreCollapsed();
       restorePalettes();
+      applySizes();
       setEditMode(editMode);
     });
 
@@ -1134,6 +1136,7 @@ export const DASHBOARD_JS = `
         renderLayout();
         restoreCollapsed();
         restorePalettes();
+        applySizes();
         setEditMode(editMode);
       });
     }
@@ -1178,6 +1181,115 @@ export const DASHBOARD_JS = `
         }
       }
     }
+
+    // ── Tile resize via drag handle ─────────────────────────────────
+    // Mousedown on the bottom-right handle, track mouse, snap to grid
+    // columns (1-4) and rows (1-4), update inline style + localStorage.
+    var SIZES_KEY = 'sua-pulse-sizes';
+    function getSizes() {
+      try { return JSON.parse(localStorage.getItem(SIZES_KEY) || '{}'); } catch { return {}; }
+    }
+    function saveSizes(s) {
+      try { localStorage.setItem(SIZES_KEY, JSON.stringify(s)); } catch {}
+    }
+
+    function applySizes() {
+      var sizes = getSizes();
+      var allT = document.querySelectorAll('.pulse-tile[data-agent-id]');
+      for (var i = 0; i < allT.length; i++) {
+        var id = allT[i].getAttribute('data-agent-id');
+        var s = sizes[id];
+        if (s) {
+          allT[i].style.gridColumn = 'span ' + (s.cols || 1);
+          allT[i].style.gridRow = 'span ' + (s.rows || 1);
+          // Remove preset size classes — inline style takes over.
+          allT[i].classList.remove('pulse-tile--2x1', 'pulse-tile--1x2', 'pulse-tile--2x2');
+        }
+      }
+    }
+
+    var resizing = null; // { tile, startX, startY, startCols, startRows, gridCellW, gridCellH, gap }
+
+    document.addEventListener('mousedown', function(e) {
+      if (!editMode) return;
+      var handle = e.target.closest ? e.target.closest('.pulse-tile__resize-handle') : null;
+      if (!handle) return;
+      e.preventDefault();
+      e.stopPropagation();
+
+      var tile = handle.closest('.pulse-tile');
+      if (!tile) return;
+
+      var grid = tile.closest('.pulse-grid');
+      if (!grid) return;
+
+      // Compute grid cell dimensions from the grid's actual layout.
+      var gridRect = grid.getBoundingClientRect();
+      var gridStyle = window.getComputedStyle(grid);
+      var gapStr = gridStyle.gap || gridStyle.gridGap || '16px';
+      var gap = parseInt(gapStr) || 16;
+      var cols = 4; // fixed 4-column grid
+      var gridCellW = (gridRect.width - gap * (cols - 1)) / cols;
+      var gridCellH = gridCellW * 0.6; // approximate row height (aspect ratio)
+
+      var tileRect = tile.getBoundingClientRect();
+      var currentCols = Math.round(tileRect.width / (gridCellW + gap)) || 1;
+      var currentRows = Math.max(1, Math.round(tileRect.height / (gridCellH + gap)));
+
+      tile.classList.add('pulse-tile--resizing');
+
+      resizing = {
+        tile: tile,
+        agentId: tile.getAttribute('data-agent-id'),
+        startX: e.clientX,
+        startY: e.clientY,
+        startCols: currentCols,
+        startRows: currentRows,
+        gridCellW: gridCellW,
+        gridCellH: gridCellH,
+        gap: gap
+      };
+    });
+
+    document.addEventListener('mousemove', function(e) {
+      if (!resizing) return;
+      e.preventDefault();
+
+      var dx = e.clientX - resizing.startX;
+      var dy = e.clientY - resizing.startY;
+
+      var newCols = Math.max(1, Math.min(4, resizing.startCols + Math.round(dx / (resizing.gridCellW + resizing.gap))));
+      var newRows = Math.max(1, Math.min(4, resizing.startRows + Math.round(dy / (resizing.gridCellH + resizing.gap))));
+
+      resizing.tile.style.gridColumn = 'span ' + newCols;
+      resizing.tile.style.gridRow = 'span ' + newRows;
+      resizing.newCols = newCols;
+      resizing.newRows = newRows;
+    });
+
+    document.addEventListener('mouseup', function() {
+      if (!resizing) return;
+
+      resizing.tile.classList.remove('pulse-tile--resizing');
+      resizing.tile.classList.remove('pulse-tile--2x1', 'pulse-tile--1x2', 'pulse-tile--2x2');
+
+      var newCols = resizing.newCols || resizing.startCols;
+      var newRows = resizing.newRows || resizing.startRows;
+
+      // Persist size override.
+      var sizes = getSizes();
+      if (newCols === 1 && newRows === 1) {
+        delete sizes[resizing.agentId]; // back to default
+        resizing.tile.style.gridColumn = '';
+        resizing.tile.style.gridRow = '';
+      } else {
+        sizes[resizing.agentId] = { cols: newCols, rows: newRows };
+      }
+      saveSizes(sizes);
+      resizing = null;
+    });
+
+    applySizes();
 
     function restoreCollapsed() {
       // Re-apply collapsed state after layout re-render.
@@ -1243,18 +1355,41 @@ export const DASHBOARD_JS = `
   })();
 
   // ── Pulse media: click-to-play YouTube embeds ───────────────────────
-  // Thumbnail clicks swap to an autoplay iframe in-place.
+  // Click thumbnail to swap to iframe embed. If embed fails (video
+  // disallows embedding), show a "blocked" message with link.
   (function () {
     document.addEventListener('click', function (e) {
       var el = e.target;
-      // Walk up to find the .pulse-media-yt container.
       while (el && !el.classList?.contains('pulse-media-yt')) el = el.parentElement;
       if (!el) return;
       var embedUrl = el.getAttribute('data-embed');
+      var watchUrl = el.getAttribute('data-watch') || '';
       if (!embedUrl) return;
       e.preventDefault();
-      el.innerHTML = '<iframe src="' + embedUrl + '" style="width:100%;aspect-ratio:16/9;border:0;border-radius:var(--radius-sm);" allow="accelerometer;autoplay;clipboard-write;encrypted-media;gyroscope;picture-in-picture" allowfullscreen></iframe>';
+
+      // Save the original thumbnail HTML so we can restore on error.
+      var originalHtml = el.innerHTML;
       el.style.cursor = 'default';
+
+      var iframe = document.createElement('iframe');
+      iframe.src = embedUrl;
+      iframe.style.cssText = 'width:100%;aspect-ratio:16/9;border:0;border-radius:var(--radius-sm);';
+      iframe.allow = 'accelerometer;autoplay;clipboard-write;encrypted-media;gyroscope;picture-in-picture';
+      iframe.allowFullscreen = true;
+
+      // Detect embed failures. YouTube returns a 200 with an error page,
+      // so we can't catch HTTP errors. Instead, set a timeout: if the
+      // iframe loads the error page, the user can click "open externally".
+      el.innerHTML = '';
+      el.appendChild(iframe);
+
+      // Add a small "can't play? open externally" link below.
+      if (watchUrl) {
+        var fallback = document.createElement('div');
+        fallback.style.cssText = 'text-align:center;margin-top:var(--space-1);font-size:var(--font-size-xs);';
+        fallback.innerHTML = '<a href="' + watchUrl + '" target="_blank" rel="noopener" style="color:var(--color-text-muted);">Not loading? Open on YouTube \u2197</a>';
+        el.parentElement.appendChild(fallback);
+      }
     });
   })();
 

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -716,6 +716,25 @@ export const DASHBOARD_JS = `
 
     btn.addEventListener('click', function () {
       modal.classList.add('is-open');
+
+      // Step 1: Show a prompt form so the user can optionally describe what to focus on.
+      content.innerHTML =
+        '<div style="padding:var(--space-4);">' +
+          '<h3 style="margin:0 0 var(--space-2);">Suggest improvements for ' + esc(agentId) + '</h3>' +
+          '<p class="dim" style="font-size:var(--font-size-xs);margin:0 0 var(--space-3);">Optionally describe what you want the analysis to focus on. Leave blank for a general review.</p>' +
+          '<textarea id="sg-focus" rows="3" placeholder="e.g. &quot;Are there missing error handlers?&quot; or &quot;The last run timed out, what can I improve?&quot;" style="width:100%;padding:var(--space-2) var(--space-3);border:1px solid var(--color-border-strong);border-radius:var(--radius-sm);font-size:var(--font-size-sm);font-family:var(--font-mono);resize:vertical;background:var(--color-surface-raised);color:var(--color-text);"></textarea>' +
+          '<div style="display:flex;gap:var(--space-2);justify-content:flex-end;margin-top:var(--space-3);">' +
+            '<button type="button" class="btn btn--ghost btn--sm" id="sg-prompt-cancel">Cancel</button>' +
+            '<button type="button" class="btn btn--primary btn--sm" id="sg-prompt-go">Analyze</button>' +
+          '</div>' +
+        '</div>';
+      document.getElementById('sg-prompt-cancel').addEventListener('click', closeModal);
+      document.getElementById('sg-focus').focus();
+
+      document.getElementById('sg-prompt-go').addEventListener('click', function () {
+      var focusText = (document.getElementById('sg-focus').value || '').trim();
+
+      // Step 2: Switch to progress view and start analysis.
       var t0 = Date.now();
       var cancelled = false;
       var pollTimer = null;
@@ -754,11 +773,11 @@ export const DASHBOARD_JS = `
         }
       }, 1000);
 
-      // Start the analysis.
+      // Start the analysis with optional focus text.
       fetch('/agents/' + encodeURIComponent(agentId) + '/analyze', {
         method: 'POST', credentials: 'same-origin',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: '',
+        body: focusText ? 'focus=' + encodeURIComponent(focusText) : '',
       })
       .then(function (r) { return r.json(); })
       .then(function (startData) {
@@ -816,7 +835,8 @@ export const DASHBOARD_JS = `
           '<div class="flash flash--error">' + esc(String(err)) + '</div>' +
           '<div style="margin-top:var(--space-3);text-align:right;"><button type="button" class="btn btn--ghost btn--sm" data-close-modal="1">Close</button></div>';
       });
-    });
+    }); // end sg-prompt-go click
+    }); // end suggest-btn click
 
     modal.addEventListener('click', function (e) {
       if (e.target === modal) closeModal();

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -867,6 +867,72 @@ export const DASHBOARD_JS = `
     }
   })();
 
+  // ── Pulse tile collapse/expand ──────────────────────────────────────
+  // Clicking the chevron or header title toggles the tile body.
+  // Collapsed state persists in localStorage per agent id.
+  (function () {
+    var STORAGE_KEY = 'sua-pulse-collapsed';
+    function getCollapsed() {
+      try { return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}'); } catch { return {}; }
+    }
+    function setCollapsed(map) {
+      try { localStorage.setItem(STORAGE_KEY, JSON.stringify(map)); } catch {}
+    }
+
+    // Restore collapsed state on load.
+    var collapsed = getCollapsed();
+    var tiles = document.querySelectorAll('.pulse-tile');
+    for (var i = 0; i < tiles.length; i++) {
+      var btn = tiles[i].querySelector('.pulse-tile__collapse');
+      if (btn) {
+        var id = btn.getAttribute('data-tile-id');
+        if (id && collapsed[id]) tiles[i].classList.add('pulse-tile--collapsed');
+      }
+    }
+
+    // Toggle on click.
+    document.addEventListener('click', function (e) {
+      var target = e.target;
+      // Check if click is on the collapse button or the header trigger area.
+      var tileId = null;
+      if (target.classList && target.classList.contains('pulse-tile__collapse')) {
+        tileId = target.getAttribute('data-tile-id');
+      } else if (target.closest && target.closest('[data-collapse-trigger]')) {
+        tileId = target.closest('[data-collapse-trigger]').getAttribute('data-tile-id');
+      }
+      if (!tileId) return;
+
+      // Find the parent tile.
+      var tile = target.closest('.pulse-tile');
+      if (!tile) return;
+
+      tile.classList.toggle('pulse-tile--collapsed');
+      var map = getCollapsed();
+      if (tile.classList.contains('pulse-tile--collapsed')) {
+        map[tileId] = true;
+      } else {
+        delete map[tileId];
+      }
+      setCollapsed(map);
+    });
+  })();
+
+  // ── Pulse media: click-to-play YouTube embeds ───────────────────────
+  // Thumbnail clicks swap to an autoplay iframe in-place.
+  (function () {
+    document.addEventListener('click', function (e) {
+      var el = e.target;
+      // Walk up to find the .pulse-media-yt container.
+      while (el && !el.classList?.contains('pulse-media-yt')) el = el.parentElement;
+      if (!el) return;
+      var embedUrl = el.getAttribute('data-embed');
+      if (!embedUrl) return;
+      e.preventDefault();
+      el.innerHTML = '<iframe src="' + embedUrl + '" style="width:100%;aspect-ratio:16/9;border:0;border-radius:var(--radius-sm);" allow="accelerometer;autoplay;clipboard-write;encrypted-media;gyroscope;picture-in-picture" allowfullscreen></iframe>';
+      el.style.cursor = 'default';
+    });
+  })();
+
   // ── LLM provider/model sync ─────────────────────────────────────────
   // When the provider dropdown changes, repopulate the model dropdown
   // with the correct models and show the selected model's description.

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -867,6 +867,331 @@ export const DASHBOARD_JS = `
     }
   })();
 
+  // ── Pulse layout: containers, drag-and-drop, palette ────────────────
+  (function () {
+    var host = document.getElementById('pulse-containers');
+    var dataEl = document.getElementById('pulse-tile-data');
+    if (!host || !dataEl) return;
+
+    var tileData = JSON.parse(dataEl.textContent || '{}');
+    var allIds = tileData.allTileIds || [];
+    var systemIds = tileData.systemTileIds || [];
+
+    var LAYOUT_KEY = 'sua-pulse-layout';
+    var PALETTE_KEY = 'sua-pulse-palettes';
+    var PALETTES = ['default', 'dark', 'light', 'accent-teal', 'accent-red', 'accent-green'];
+
+    function getLayout() {
+      try { return JSON.parse(localStorage.getItem(LAYOUT_KEY) || 'null'); } catch { return null; }
+    }
+    function saveLayout(layout) {
+      try { localStorage.setItem(LAYOUT_KEY, JSON.stringify(layout)); } catch {}
+    }
+    function getPalettes() {
+      try { return JSON.parse(localStorage.getItem(PALETTE_KEY) || '{}'); } catch { return {}; }
+    }
+    function savePalettes(p) {
+      try { localStorage.setItem(PALETTE_KEY, JSON.stringify(p)); } catch {}
+    }
+
+    // Build default layout if none exists.
+    var layout = getLayout();
+    if (!layout || !layout.containers) {
+      layout = {
+        containers: [
+          { id: 'health', label: 'Health', tiles: systemIds.slice() },
+          { id: 'agents', label: 'Agents', tiles: allIds.filter(function(id) { return systemIds.indexOf(id) === -1; }) }
+        ]
+      };
+      saveLayout(layout);
+    }
+
+    // Merge any new tiles not in the layout into an "Other" container.
+    var assigned = {};
+    for (var ci = 0; ci < layout.containers.length; ci++) {
+      for (var ti = 0; ti < layout.containers[ci].tiles.length; ti++) {
+        assigned[layout.containers[ci].tiles[ti]] = true;
+      }
+    }
+    var unassigned = allIds.filter(function(id) { return !assigned[id]; });
+    if (unassigned.length > 0) {
+      var other = layout.containers.find(function(c) { return c.id === '_other'; });
+      if (!other) {
+        other = { id: '_other', label: 'Other', tiles: [] };
+        layout.containers.push(other);
+      }
+      for (var u = 0; u < unassigned.length; u++) other.tiles.push(unassigned[u]);
+      saveLayout(layout);
+    }
+
+    // Get all rendered tiles by agent ID.
+    var tileEls = {};
+    var allTileNodes = host.querySelectorAll('.pulse-tile[data-agent-id]');
+    for (var i = 0; i < allTileNodes.length; i++) {
+      tileEls[allTileNodes[i].getAttribute('data-agent-id')] = allTileNodes[i];
+    }
+
+    // Apply palettes: auto-palette as default, manual overrides on top.
+    var palettes = getPalettes();
+    for (var aid in tileEls) {
+      var manual = palettes[aid];
+      if (manual && manual !== 'default') {
+        tileEls[aid].setAttribute('data-palette', manual);
+      } else if (!manual) {
+        var auto = tileEls[aid].getAttribute('data-auto-palette');
+        if (auto) tileEls[aid].setAttribute('data-palette', auto);
+      }
+    }
+
+    // Re-render containers from layout.
+    function renderLayout() {
+      host.innerHTML = '';
+      for (var ci = 0; ci < layout.containers.length; ci++) {
+        var c = layout.containers[ci];
+        var section = document.createElement('section');
+        section.className = 'pulse-container';
+        section.setAttribute('data-container-id', c.id);
+
+        // Header.
+        var header = document.createElement('div');
+        header.className = 'pulse-container__header';
+        var label = document.createElement('span');
+        label.className = 'pulse-container__label';
+        label.contentEditable = 'true';
+        label.textContent = c.label;
+        label.addEventListener('blur', (function(cont) { return function(e) {
+          cont.label = e.target.textContent.trim() || cont.label;
+          saveLayout(layout);
+        }; })(c));
+        label.addEventListener('keydown', function(e) {
+          if (e.key === 'Enter') { e.preventDefault(); e.target.blur(); }
+        });
+        header.appendChild(label);
+
+        var delBtn = document.createElement('button');
+        delBtn.className = 'pulse-container__delete';
+        delBtn.title = 'Remove group';
+        delBtn.textContent = '\u00D7';
+        delBtn.addEventListener('click', (function(cont) { return function() {
+          // Move tiles to Other.
+          var otherCont = layout.containers.find(function(x) { return x.id === '_other'; });
+          if (!otherCont) {
+            otherCont = { id: '_other', label: 'Other', tiles: [] };
+            layout.containers.push(otherCont);
+          }
+          for (var t = 0; t < cont.tiles.length; t++) otherCont.tiles.push(cont.tiles[t]);
+          layout.containers = layout.containers.filter(function(x) { return x.id !== cont.id; });
+          saveLayout(layout);
+          renderLayout();
+          restoreCollapsed();
+          restorePalettes();
+          setEditMode(editMode);
+        }; })(c));
+        header.appendChild(delBtn);
+        section.appendChild(header);
+
+        // Grid.
+        var grid = document.createElement('div');
+        grid.className = 'pulse-grid';
+        grid.setAttribute('data-container-id', c.id);
+
+        var hasTiles = false;
+        for (var ti = 0; ti < c.tiles.length; ti++) {
+          var el = tileEls[c.tiles[ti]];
+          if (el) { grid.appendChild(el); hasTiles = true; }
+        }
+
+        if (!hasTiles) {
+          var empty = document.createElement('div');
+          empty.className = 'pulse-container__empty';
+          empty.textContent = 'Drag widgets here';
+          grid.appendChild(empty);
+        }
+
+        section.appendChild(grid);
+        host.appendChild(section);
+      }
+    }
+
+    renderLayout();
+
+    // ── Edit mode toggle ─────────────────────────────────────────────
+    var editMode = false;
+    var editBtn = document.getElementById('pulse-edit-toggle');
+    var addContainerBtn = document.getElementById('pulse-add-container');
+
+    function setEditMode(on) {
+      editMode = on;
+      document.body.classList.toggle('pulse-edit-mode', on);
+      if (editBtn) editBtn.textContent = on ? '\u2713 Done editing' : '\u270E Edit layout';
+      if (editBtn) editBtn.classList.toggle('btn--primary', on);
+      if (editBtn) editBtn.classList.toggle('btn--ghost', !on);
+      if (addContainerBtn) addContainerBtn.style.display = on ? '' : 'none';
+      // Toggle draggable on all tiles.
+      var allTiles = document.querySelectorAll('.pulse-tile[data-agent-id]');
+      for (var i = 0; i < allTiles.length; i++) {
+        allTiles[i].setAttribute('draggable', on ? 'true' : 'false');
+      }
+    }
+
+    if (editBtn) {
+      editBtn.addEventListener('click', function() { setEditMode(!editMode); });
+    }
+
+    // ── Drag and drop ────────────────────────────────────────────────
+    var draggedId = null;
+    var draggedEl = null;
+
+    document.addEventListener('dragstart', function(e) {
+      if (!editMode) { e.preventDefault(); return; }
+      var tile = e.target.closest ? e.target.closest('.pulse-tile[data-agent-id]') : null;
+      if (!tile) return;
+      draggedId = tile.getAttribute('data-agent-id');
+      draggedEl = tile;
+      tile.classList.add('pulse-tile--dragging');
+      e.dataTransfer.effectAllowed = 'move';
+      e.dataTransfer.setData('text/plain', draggedId);
+    });
+
+    document.addEventListener('dragend', function() {
+      if (draggedEl) draggedEl.classList.remove('pulse-tile--dragging');
+      draggedId = null;
+      draggedEl = null;
+      // Remove all drop targets.
+      var targets = document.querySelectorAll('.pulse-container--drop-target');
+      for (var i = 0; i < targets.length; i++) targets[i].classList.remove('pulse-container--drop-target');
+    });
+
+    document.addEventListener('dragover', function(e) {
+      var grid = e.target.closest ? e.target.closest('.pulse-grid') : null;
+      if (!grid || !draggedId) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      var container = grid.closest('.pulse-container');
+      if (container) container.classList.add('pulse-container--drop-target');
+    });
+
+    document.addEventListener('dragleave', function(e) {
+      var container = e.target.closest ? e.target.closest('.pulse-container') : null;
+      if (container && !container.contains(e.relatedTarget)) {
+        container.classList.remove('pulse-container--drop-target');
+      }
+    });
+
+    document.addEventListener('drop', function(e) {
+      var grid = e.target.closest ? e.target.closest('.pulse-grid') : null;
+      if (!grid || !draggedId) return;
+      e.preventDefault();
+
+      var targetContainerId = grid.getAttribute('data-container-id');
+      if (!targetContainerId) return;
+
+      // Find drop position: which tile are we dropping before?
+      var tiles = grid.querySelectorAll('.pulse-tile[data-agent-id]');
+      var dropIndex = tiles.length; // default: end
+      for (var i = 0; i < tiles.length; i++) {
+        var rect = tiles[i].getBoundingClientRect();
+        var midY = rect.top + rect.height / 2;
+        var midX = rect.left + rect.width / 2;
+        if (e.clientY < midY || (e.clientY < rect.bottom && e.clientX < midX)) {
+          dropIndex = i;
+          break;
+        }
+      }
+
+      // Remove from source container in layout.
+      for (var ci = 0; ci < layout.containers.length; ci++) {
+        var idx = layout.containers[ci].tiles.indexOf(draggedId);
+        if (idx !== -1) {
+          layout.containers[ci].tiles.splice(idx, 1);
+          break;
+        }
+      }
+
+      // Insert into target container.
+      var targetCont = layout.containers.find(function(c) { return c.id === targetContainerId; });
+      if (targetCont) {
+        // Adjust drop index if the dragged element was before the drop point in the same container.
+        targetCont.tiles.splice(dropIndex, 0, draggedId);
+      }
+
+      saveLayout(layout);
+      renderLayout();
+      restoreCollapsed();
+      restorePalettes();
+      setEditMode(editMode);
+    });
+
+    // ── Add container ────────────────────────────────────────────────
+    var addBtn = document.getElementById('pulse-add-container');
+    if (addBtn) {
+      addBtn.addEventListener('click', function() {
+        var name = prompt('Group name:');
+        if (!name || !name.trim()) return;
+        var id = 'custom-' + Date.now();
+        layout.containers.push({ id: id, label: name.trim(), tiles: [] });
+        saveLayout(layout);
+        renderLayout();
+        restoreCollapsed();
+        restorePalettes();
+        setEditMode(editMode);
+      });
+    }
+
+    // ── Palette cycling ──────────────────────────────────────────────
+    document.addEventListener('click', function(e) {
+      var btn = e.target.closest ? e.target.closest('.pulse-tile__palette-btn') : null;
+      if (!btn) return;
+      var tileId = btn.getAttribute('data-tile-id');
+      if (!tileId) return;
+      var tile = document.querySelector('.pulse-tile[data-agent-id=\"' + tileId + '\"]');
+      if (!tile) return;
+
+      var current = tile.getAttribute('data-palette') || 'default';
+      var idx = PALETTES.indexOf(current);
+      var next = PALETTES[(idx + 1) % PALETTES.length];
+
+      if (next === 'default') {
+        tile.removeAttribute('data-palette');
+      } else {
+        tile.setAttribute('data-palette', next);
+      }
+
+      var p = getPalettes();
+      if (next === 'default') { delete p[tileId]; } else { p[tileId] = next; }
+      savePalettes(p);
+    });
+
+    function restorePalettes() {
+      var p = getPalettes();
+      // Apply auto-palettes first, then manual overrides.
+      var allT = document.querySelectorAll('.pulse-tile[data-agent-id]');
+      for (var i = 0; i < allT.length; i++) {
+        var id = allT[i].getAttribute('data-agent-id');
+        var manual = p[id];
+        if (manual && manual !== 'default') {
+          allT[i].setAttribute('data-palette', manual);
+        } else if (!manual) {
+          // Use auto-palette from server-rendered attribute.
+          var auto = allT[i].getAttribute('data-auto-palette');
+          if (auto) allT[i].setAttribute('data-palette', auto);
+        }
+      }
+    }
+
+    function restoreCollapsed() {
+      // Re-apply collapsed state after layout re-render.
+      try {
+        var collapsed = JSON.parse(localStorage.getItem('sua-pulse-collapsed') || '{}');
+        for (var id in collapsed) {
+          var el = document.querySelector('.pulse-tile[data-agent-id=\"' + id + '\"]');
+          if (el) el.classList.add('pulse-tile--collapsed');
+        }
+      } catch {}
+    }
+    restoreCollapsed();
+  })();
+
   // ── Pulse tile collapse/expand ──────────────────────────────────────
   // Clicking the chevron or header title toggles the tile body.
   // Collapsed state persists in localStorage per agent id.

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -697,14 +697,25 @@ export const DASHBOARD_JS = `
           '<br>Click "Edit YAML" to fix manually.</div>';
       }
       h += '<div style="display:flex;gap:var(--space-2);justify-content:flex-end;flex-wrap:wrap;">';
-      if (data.yaml) {
-        var applyLabel = data.yamlError ? 'Edit YAML to fix' : 'Review + apply';
-        h += '<button type="button" class="btn btn--primary btn--sm" id="sg-apply">' + esc(applyLabel) + '</button>';
+      if (data.yaml && !data.yamlError) {
+        h += '<button type="button" class="btn btn--primary btn--sm" id="sg-apply-now">Apply now</button>';
+        h += '<button type="button" class="btn btn--ghost btn--sm" id="sg-review">Review first</button>';
+      } else if (data.yaml) {
+        h += '<button type="button" class="btn btn--primary btn--sm" id="sg-review">Edit YAML to fix</button>';
       }
       h += '<button type="button" class="btn btn--ghost btn--sm" id="sg-dismiss">Dismiss</button></div>';
       content.innerHTML = h;
-      var ab = document.getElementById('sg-apply');
-      if (ab && data.yaml) ab.addEventListener('click', function () {
+      // "Apply now" — save the YAML directly without opening the editor.
+      var an = document.getElementById('sg-apply-now');
+      if (an && data.yaml) an.addEventListener('click', function () {
+        var f = document.createElement('form'); f.method = 'POST';
+        f.action = '/agents/' + encodeURIComponent(agentId) + '/yaml';
+        var t = document.createElement('textarea'); t.name = 'yaml'; t.value = data.yaml; t.style.display = 'none';
+        f.appendChild(t); document.body.appendChild(f); f.submit();
+      });
+      // "Review first" — open the YAML editor pre-filled.
+      var rv = document.getElementById('sg-review');
+      if (rv && data.yaml) rv.addEventListener('click', function () {
         var f = document.createElement('form'); f.method = 'POST';
         f.action = '/agents/' + encodeURIComponent(agentId) + '/yaml';
         var t = document.createElement('textarea'); t.name = 'prefillYaml'; t.value = data.yaml; t.style.display = 'none';

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -4,8 +4,8 @@ import { footer } from './footer.js';
 
 export interface LayoutOptions {
   title: string;
-  /** Highlight in the nav (one of: agents, tools, runs, settings, help). */
-  activeNav?: 'agents' | 'tools' | 'runs' | 'settings' | 'help';
+  /** Highlight in the nav (one of: agents, tools, runs, pulse, settings, help). */
+  activeNav?: 'agents' | 'tools' | 'runs' | 'pulse' | 'settings' | 'help';
   /** Flash banner shown at the top of the body (errors from prior actions). */
   flash?: { kind: 'error' | 'info' | 'ok'; message: string };
   /** Widen the main column (for screens with 2-col layouts). */
@@ -44,6 +44,7 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
     <a href="/agents" class="${opts.activeNav === 'agents' ? 'is-active' : ''}">Agents</a>
     <a href="/tools" class="${opts.activeNav === 'tools' ? 'is-active' : ''}">Tools</a>
     <a href="/runs" class="${opts.activeNav === 'runs' ? 'is-active' : ''}">Runs</a>
+    <a href="/pulse" class="${opts.activeNav === 'pulse' ? 'is-active' : ''}">Pulse</a>
     <a href="/settings" class="${opts.activeNav === 'settings' ? 'is-active' : ''}">Settings</a>
     <a href="/help" class="${opts.activeNav === 'help' ? 'is-active' : ''}">Help</a>
   </nav>

--- a/packages/dashboard/src/views/pulse-helpers.ts
+++ b/packages/dashboard/src/views/pulse-helpers.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared helpers for Pulse tile rendering: HTML escaping, markdown,
+ * JSON detection, and value stringification.
+ */
+
+/** HTML-escape a string for safe insertion into markup. */
+export function esc(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+/** Convert any value to a display string. Handles objects that would show as [object Object]. */
+export function stringify(val: unknown): string {
+  if (val === null || val === undefined) return '';
+  if (typeof val === 'string') return val;
+  if (typeof val === 'number' || typeof val === 'boolean') return String(val);
+  try { return JSON.stringify(val, null, 2); } catch { return String(val); }
+}
+
+/**
+ * Lightweight markdown to HTML. Handles the common patterns agents produce:
+ * headers, bold, italic, links, tables, lists, inline code, line breaks.
+ */
+export function renderMarkdown(text: string): string {
+  let h = esc(text);
+
+  h = h.replace(/```(\w*)\n([\s\S]*?)```/g, '<pre class="pulse-tile__code">$2</pre>');
+  h = h.replace(/`([^`]+)`/g, '<code style="background:var(--color-surface-raised);padding:0 var(--space-1);border-radius:3px;font-size:var(--font-size-xs);">$1</code>');
+  h = h.replace(/^### (.+)$/gm, '<strong style="font-size:var(--font-size-sm);display:block;margin-top:var(--space-2);">$1</strong>');
+  h = h.replace(/^## (.+)$/gm, '<strong style="font-size:var(--font-size-md);display:block;margin-top:var(--space-2);">$1</strong>');
+  h = h.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+  h = h.replace(/\*(.+?)\*/g, '<em>$1</em>');
+  h = h.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" style="color:var(--color-primary);" target="_blank" rel="noopener">$1</a>');
+
+  const tableRe = /^(\|.+\|)\n(\|[-| :]+\|)\n((?:\|.+\|\n?)+)/gm;
+  h = h.replace(tableRe, (_, headerRow: string, _sep: string, bodyRows: string) => {
+    const headers = headerRow.split('|').filter(Boolean).map((c: string) => c.trim());
+    const rows = bodyRows.trim().split('\n').map((r: string) => r.split('|').filter(Boolean).map((c: string) => c.trim()));
+    return '<table class="pulse-table" style="margin:var(--space-2) 0;"><thead><tr>' + headers.map((h: string) => `<th>${h}</th>`).join('') + '</tr></thead><tbody>' + rows.map((r: string[]) => '<tr>' + r.map((c: string) => `<td>${c}</td>`).join('') + '</tr>').join('') + '</tbody></table>';
+  });
+
+  h = h.replace(/^- (.+)$/gm, '<li style="margin-left:var(--space-4);list-style:disc;">$1</li>');
+  h = h.replace(/\n{2,}/g, '<br><br>');
+  h = h.replace(/\n/g, '<br>');
+
+  return h;
+}
+
+/** Check if a string looks like JSON (starts with { or [). */
+export function looksLikeJson(s: string): boolean {
+  const t = s.trimStart();
+  if (!t.startsWith('{') && !t.startsWith('[')) return false;
+  try { JSON.parse(t); return true; } catch { return false; }
+}
+
+/** Pretty-print a JSON string with 2-space indent. */
+export function prettyJson(s: string): string {
+  try { return JSON.stringify(JSON.parse(s.trim()), null, 2); } catch { return s; }
+}

--- a/packages/dashboard/src/views/pulse-renderers.ts
+++ b/packages/dashboard/src/views/pulse-renderers.ts
@@ -1,0 +1,197 @@
+/**
+ * Pulse tile template renderers. Each function takes a PulseTile and returns
+ * SafeHtml for the tile's inner content (wrapped by tileWrap in pulse.ts).
+ */
+
+import type { SignalTemplate } from '@some-useful-agents/core';
+import { html, unsafeHtml, type SafeHtml } from './html.js';
+import { normalizeSignal } from './pulse-templates.js';
+import { esc, stringify, renderMarkdown, looksLikeJson, prettyJson } from './pulse-helpers.js';
+import type { PulseTile, TileWrapFn } from './pulse.js';
+
+// ── Renderers ────────────────────────────────────────────────────────────
+
+function renderMetric(tile: PulseTile, wrap: TileWrapFn): SafeHtml {
+  const val = tile.slots.value !== undefined ? stringify(tile.slots.value) : '--';
+  const unit = tile.slots.unit ? String(tile.slots.unit) : '';
+  const label = tile.slots.label ? String(tile.slots.label) : '';
+  const prev = tile.slots.previous !== undefined ? Number(tile.slots.previous) : undefined;
+  const curr = tile.slots.value !== undefined ? Number(tile.slots.value) : undefined;
+
+  let trend = '';
+  if (prev !== undefined && curr !== undefined && !isNaN(prev) && !isNaN(curr)) {
+    if (curr > prev) trend = '\u2191';
+    else if (curr < prev) trend = '\u2193';
+    else trend = '\u2192';
+  }
+  const trendClass = trend === '\u2191' ? 'pulse-tile__trend--up'
+    : trend === '\u2193' ? 'pulse-tile__trend--down'
+    : 'pulse-tile__trend--flat';
+
+  return wrap(tile, html`
+    <div class="pulse-tile__value">
+      ${val}${unit ? html`<span class="pulse-tile__unit">${unit}</span>` : html``}${trend ? html`<span class="pulse-tile__trend ${trendClass}">${trend}</span>` : html``}
+    </div>
+    ${label ? html`<div class="pulse-tile__label">${label}</div>` : html``}
+  `);
+}
+
+function renderTextHeadline(tile: PulseTile, wrap: TileWrapFn): SafeHtml {
+  const headline = tile.slots.headline ? stringify(tile.slots.headline) : '';
+  const rawBody = tile.slots.body ?? 'No data yet';
+  const bodyStr = stringify(rawBody);
+  const isJson = looksLikeJson(bodyStr);
+  let bodyHtml: SafeHtml;
+  if (isJson) {
+    const pretty = prettyJson(bodyStr);
+    const truncated = pretty.length > 800 ? pretty.slice(0, 800) + '\n...' : pretty;
+    bodyHtml = html`<pre class="pulse-tile__code">${truncated}</pre>`;
+  } else {
+    const truncBody = bodyStr.length > 800 ? bodyStr.slice(0, 800) + '...' : bodyStr;
+    bodyHtml = unsafeHtml(`<div class="pulse-tile__body pulse-tile__body--md">${renderMarkdown(truncBody)}</div>`);
+  }
+
+  return wrap(tile, html`
+    ${headline ? html`<div class="pulse-tile__headline">${headline}</div>` : html``}
+    ${bodyHtml}
+  `);
+}
+
+function renderTable(tile: PulseTile, wrap: TileWrapFn): SafeHtml {
+  let rows: Record<string, unknown>[] = [];
+  const rawRows = tile.slots.rows;
+  if (Array.isArray(rawRows)) rows = rawRows.slice(0, 10) as Record<string, unknown>[];
+  else if (typeof rawRows === 'string') {
+    try { const p = JSON.parse(rawRows); if (Array.isArray(p)) rows = p.slice(0, 10) as Record<string, unknown>[]; } catch { /* */ }
+  }
+  let cols: string[] = [];
+  if (tile.slots.columns && Array.isArray(tile.slots.columns)) cols = tile.slots.columns.map(String);
+  else if (rows.length > 0) cols = Object.keys(rows[0]);
+
+  const tableHtml = rows.length === 0
+    ? html`<p class="dim" style="font-size: var(--font-size-xs);">No data</p>`
+    : unsafeHtml(`<table class="pulse-table"><thead><tr>${cols.map((c) => `<th>${esc(c)}</th>`).join('')}</tr></thead><tbody>${rows.map((r) => `<tr>${cols.map((c) => `<td>${esc(String(r[c] ?? ''))}</td>`).join('')}</tr>`).join('')}</tbody></table>`);
+
+  return wrap(tile, tableHtml);
+}
+
+function renderStatus(tile: PulseTile, wrap: TileWrapFn): SafeHtml {
+  const status = tile.slots.status ? String(tile.slots.status).toLowerCase() : 'unknown';
+  const label = tile.slots.label ? String(tile.slots.label) : status;
+  const message = tile.slots.message ? String(tile.slots.message) : '';
+  const dotClass = status === 'healthy' || status === 'ok' || status === 'up'
+    ? 'pulse-tile__status-dot--healthy'
+    : status === 'degraded' || status === 'warn' || status === 'warning'
+    ? 'pulse-tile__status-dot--degraded'
+    : 'pulse-tile__status-dot--down';
+
+  return wrap(tile, html`
+    <div style="display: flex; align-items: center; gap: var(--space-2); flex: 1;">
+      <span class="pulse-tile__status-dot ${dotClass}"></span>
+      <span class="pulse-tile__status-label">${label}</span>
+    </div>
+    ${message ? html`<div class="pulse-tile__status-message">${message}</div>` : html``}
+  `);
+}
+
+function renderTimeSeries(tile: PulseTile, wrap: TileWrapFn): SafeHtml {
+  const values = Array.isArray(tile.slots.values) ? tile.slots.values.map(Number).filter((n) => !isNaN(n)) : [];
+  const current = tile.slots.current !== undefined ? String(tile.slots.current) : (values.length > 0 ? String(values[values.length - 1]) : '--');
+  const label = tile.slots.label ? String(tile.slots.label) : '';
+
+  let sparkline = html`<div class="dim" style="font-size: var(--font-size-xs);">No data points</div>`;
+  if (values.length >= 2) {
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const range = max - min || 1;
+    const h = 40, w = 200;
+    const points = values.map((v, i) => `${((i / (values.length - 1)) * w).toFixed(1)},${(h - ((v - min) / range) * h).toFixed(1)}`).join(' ');
+    sparkline = unsafeHtml(`<div class="pulse-tile__sparkline"><svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="none"><polyline points="${points}"/></svg></div>`);
+  }
+
+  return wrap(tile, html`
+    <div class="pulse-tile__value" style="font-size: var(--font-size-xl);">${current}</div>
+    ${sparkline}
+    ${label ? html`<div class="pulse-tile__label">${label}</div>` : html``}
+  `);
+}
+
+function renderImage(tile: PulseTile, wrap: TileWrapFn): SafeHtml {
+  const url = tile.slots.imageUrl ? String(tile.slots.imageUrl) : '';
+  const alt = tile.slots.alt ? String(tile.slots.alt) : tile.signal.title;
+  return wrap(tile, url
+    ? unsafeHtml(`<img class="pulse-tile__image" src="${esc(url)}" alt="${esc(alt)}" loading="lazy" style="width:100%;border-radius:var(--radius-sm);object-fit:cover;max-height:240px;">`)
+    : html`<div class="dim" style="font-size: var(--font-size-xs);">No image URL</div>`
+  );
+}
+
+function renderTextImage(tile: PulseTile, wrap: TileWrapFn): SafeHtml {
+  const text = tile.slots.text ? String(tile.slots.text) : '';
+  const url = tile.slots.imageUrl ? String(tile.slots.imageUrl) : '';
+  const truncText = text.length > 300 ? text.slice(0, 300) + '...' : text;
+  return wrap(tile, html`
+    <div style="display: flex; gap: var(--space-3); flex: 1;">
+      <div class="pulse-tile__body" style="flex: 1;">${truncText || 'No text'}</div>
+      ${url ? unsafeHtml(`<img class="pulse-tile__image" src="${esc(url)}" alt="" style="max-width:120px;max-height:120px;" loading="lazy">`) : html``}
+    </div>
+  `);
+}
+
+function renderMedia(tile: PulseTile, wrap: TileWrapFn): SafeHtml {
+  const rawUrl = tile.slots.url ? String(tile.slots.url).trim() : '';
+  const title = tile.slots.title ? String(tile.slots.title) : '';
+  const caption = tile.slots.caption ? String(tile.slots.caption) : '';
+  const mediaType = tile.slots.mediaType ? String(tile.slots.mediaType).toLowerCase() : '';
+
+  const ytMatch = rawUrl.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/);
+  const isYoutube = !!ytMatch;
+  const isVideo = !isYoutube && (mediaType === 'video' || /\.(mp4|webm|ogg)(\?|$)/i.test(rawUrl));
+  const isImage = !isYoutube && !isVideo && /\.(png|jpe?g|gif|webp|svg|bmp)(\?|$)/i.test(rawUrl);
+
+  let mediaEl: SafeHtml;
+  if (!rawUrl) {
+    mediaEl = html`<div class="dim" style="font-size: var(--font-size-xs); padding: var(--space-4); text-align: center;">No media URL</div>`;
+  } else if (isYoutube) {
+    const videoId = ytMatch![1];
+    const thumbUrl = `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
+    const watchUrl = `https://www.youtube.com/watch?v=${videoId}`;
+    const embedUrl = `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0&modestbranding=1`;
+    mediaEl = unsafeHtml(
+      `<div class="pulse-media-yt" data-embed="${esc(embedUrl)}" data-watch="${esc(watchUrl)}" style="position:relative;border-radius:var(--radius-sm);overflow:hidden;cursor:pointer;">` +
+      `<img src="${esc(thumbUrl)}" alt="${esc(title || 'YouTube video')}" loading="lazy" style="width:100%;display:block;aspect-ratio:16/9;object-fit:cover;">` +
+      `<span style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:48px;height:48px;background:rgba(0,0,0,0.7);border-radius:50%;display:flex;align-items:center;justify-content:center;">` +
+      `<span style="width:0;height:0;border-style:solid;border-width:8px 0 8px 16px;border-color:transparent transparent transparent #fff;margin-left:3px;"></span>` +
+      `</span></div>` +
+      `<a href="${esc(watchUrl)}" target="_blank" rel="noopener" style="display:block;font-size:var(--font-size-xs);color:var(--color-text-muted);margin-top:var(--space-1);text-align:right;">Open on YouTube \u2197</a>`
+    );
+  } else if (isVideo) {
+    mediaEl = unsafeHtml(`<video src="${esc(rawUrl)}" controls preload="metadata" style="width:100%;border-radius:var(--radius-sm);"></video>`);
+  } else if (isImage) {
+    mediaEl = unsafeHtml(`<img src="${esc(rawUrl)}" alt="${esc(title)}" loading="lazy" style="width:100%;border-radius:var(--radius-sm);object-fit:cover;max-height:240px;">`);
+  } else {
+    mediaEl = unsafeHtml(`<a href="${esc(rawUrl)}" target="_blank" rel="noopener" style="color:var(--color-primary);font-family:var(--font-mono);font-size:var(--font-size-xs);word-break:break-all;">${esc(rawUrl)}</a>`);
+  }
+
+  return wrap(tile, html`
+    ${title ? html`<div class="pulse-tile__headline" style="font-size: var(--font-size-sm);">${title}</div>` : html``}
+    ${mediaEl}
+    ${caption ? html`<div class="dim" style="font-size: var(--font-size-xs);">${caption}</div>` : html``}
+  `);
+}
+
+// ── Dispatcher ───────────────────────────────────────────────────────────
+
+export function renderTile(tile: PulseTile, wrap: TileWrapFn): SafeHtml {
+  const { template } = normalizeSignal(tile.signal);
+  switch (template as SignalTemplate) {
+    case 'metric': return renderMetric(tile, wrap);
+    case 'text-headline': return renderTextHeadline(tile, wrap);
+    case 'table': return renderTable(tile, wrap);
+    case 'status': return renderStatus(tile, wrap);
+    case 'time-series': return renderTimeSeries(tile, wrap);
+    case 'image': return renderImage(tile, wrap);
+    case 'text-image': return renderTextImage(tile, wrap);
+    case 'media': return renderMedia(tile, wrap);
+    default: return renderTextHeadline(tile, wrap);
+  }
+}

--- a/packages/dashboard/src/views/pulse-templates.ts
+++ b/packages/dashboard/src/views/pulse-templates.ts
@@ -1,0 +1,212 @@
+/**
+ * Pulse display template registry, backward-compat normalization,
+ * and multi-field value extraction.
+ */
+
+import type { AgentSignal, SignalTemplate, Run } from '@some-useful-agents/core';
+
+// ── Template registry ────────────────────────────────────────────────────
+
+export interface TemplateSlot {
+  name: string;
+  label: string;
+  required: boolean;
+  type: 'string' | 'number' | 'url' | 'array' | 'boolean';
+}
+
+export interface TemplateDefinition {
+  name: string;
+  displayName: string;
+  description: string;
+  icon: string;
+  slots: TemplateSlot[];
+  defaultSize: '1x1' | '2x1' | '1x2' | '2x2';
+}
+
+export const TEMPLATE_REGISTRY: Record<string, TemplateDefinition> = {
+  metric: {
+    name: 'metric',
+    displayName: 'Metric',
+    description: 'Big number with label and unit',
+    icon: '#',
+    slots: [
+      { name: 'value', label: 'Value', required: true, type: 'number' },
+      { name: 'label', label: 'Label', required: false, type: 'string' },
+      { name: 'unit', label: 'Unit', required: false, type: 'string' },
+      { name: 'previous', label: 'Previous value', required: false, type: 'number' },
+    ],
+    defaultSize: '1x1',
+  },
+  'time-series': {
+    name: 'time-series',
+    displayName: 'Time Series',
+    description: 'Sparkline chart with current value',
+    icon: '~',
+    slots: [
+      { name: 'values', label: 'Data points', required: true, type: 'array' },
+      { name: 'current', label: 'Current value', required: false, type: 'number' },
+      { name: 'label', label: 'Label', required: false, type: 'string' },
+    ],
+    defaultSize: '2x1',
+  },
+  'text-headline': {
+    name: 'text-headline',
+    displayName: 'Text + Headline',
+    description: 'Headline with body text',
+    icon: 'T',
+    slots: [
+      { name: 'headline', label: 'Headline', required: true, type: 'string' },
+      { name: 'body', label: 'Body text', required: false, type: 'string' },
+    ],
+    defaultSize: '1x1',
+  },
+  'text-image': {
+    name: 'text-image',
+    displayName: 'Text + Image',
+    description: 'Text alongside an image',
+    icon: 'P',
+    slots: [
+      { name: 'text', label: 'Text', required: true, type: 'string' },
+      { name: 'imageUrl', label: 'Image URL', required: true, type: 'url' },
+    ],
+    defaultSize: '2x1',
+  },
+  image: {
+    name: 'image',
+    displayName: 'Image',
+    description: 'Full image display',
+    icon: 'I',
+    slots: [
+      { name: 'imageUrl', label: 'Image URL', required: true, type: 'url' },
+      { name: 'alt', label: 'Alt text', required: false, type: 'string' },
+    ],
+    defaultSize: '2x2',
+  },
+  table: {
+    name: 'table',
+    displayName: 'Table',
+    description: 'Data table with rows and columns',
+    icon: '=',
+    slots: [
+      { name: 'rows', label: 'Rows', required: true, type: 'array' },
+      { name: 'columns', label: 'Column names', required: false, type: 'array' },
+    ],
+    defaultSize: '2x1',
+  },
+  status: {
+    name: 'status',
+    displayName: 'Status',
+    description: 'Colored dot with status label',
+    icon: '*',
+    slots: [
+      { name: 'status', label: 'Status', required: true, type: 'string' },
+      { name: 'label', label: 'Label', required: false, type: 'string' },
+      { name: 'message', label: 'Message', required: false, type: 'string' },
+    ],
+    defaultSize: '1x1',
+  },
+};
+
+// ── Backward compatibility ───────────────────────────────────────────────
+
+export interface NormalizedSignal {
+  template: SignalTemplate;
+  mapping: Record<string, string>;
+}
+
+/**
+ * Normalize a v1 format+field signal to a v2 template+mapping.
+ * If template is already set, passes through. Never mutates the input.
+ */
+export function normalizeSignal(signal: AgentSignal): NormalizedSignal {
+  if (signal.template) {
+    return {
+      template: signal.template,
+      mapping: signal.mapping ?? {},
+    };
+  }
+
+  // v1 → v2 mapping
+  const field = signal.field ?? 'result';
+  switch (signal.format) {
+    case 'number':
+      return { template: 'metric', mapping: { value: field } };
+    case 'text':
+      return { template: 'text-headline', mapping: { headline: signal.title, body: field } };
+    case 'table':
+      return { template: 'table', mapping: { rows: field } };
+    case 'json':
+      return { template: 'text-headline', mapping: { headline: 'JSON', body: field } };
+    case 'chart':
+      return { template: 'time-series', mapping: { values: field } };
+    default:
+      return { template: 'text-headline', mapping: { body: field } };
+  }
+}
+
+// ── Value extraction ─────────────────────────────────────────────────────
+
+/**
+ * Resolve a mapping against a run's output. For each mapping key:
+ * 1. Try to extract via dot-path from structured output (outputsJson)
+ * 2. Try to extract via dot-path from JSON-parsed run.result
+ * 3. If the mapping value is "result", use the raw run result
+ * 4. Otherwise treat the mapping value as a literal string
+ */
+export function extractMappedValues(
+  run: Run | undefined,
+  mapping: Record<string, string>,
+  outputsJson?: string,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  if (!run) return result;
+
+  // Pre-parse available structured data
+  let structured: Record<string, unknown> | undefined;
+  if (outputsJson) {
+    try { structured = JSON.parse(outputsJson); } catch { /* ignore */ }
+  }
+
+  let parsedResult: Record<string, unknown> | undefined;
+  if (run.result) {
+    try {
+      const p = JSON.parse(run.result);
+      if (typeof p === 'object' && p !== null) parsedResult = p as Record<string, unknown>;
+    } catch { /* not JSON */ }
+  }
+
+  for (const [slot, pathOrLiteral] of Object.entries(mapping)) {
+    // Try structured output first
+    if (structured) {
+      const val = dotGet(structured, pathOrLiteral);
+      if (val !== undefined) { result[slot] = val; continue; }
+    }
+
+    // Try parsed result
+    if (parsedResult) {
+      const val = dotGet(parsedResult, pathOrLiteral);
+      if (val !== undefined) { result[slot] = val; continue; }
+    }
+
+    // "result" is the special key for raw output
+    if (pathOrLiteral === 'result' && run.result) {
+      result[slot] = run.result;
+      continue;
+    }
+
+    // Treat as literal string
+    result[slot] = pathOrLiteral;
+  }
+
+  return result;
+}
+
+function dotGet(obj: unknown, path: string): unknown {
+  const parts = path.split('.');
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (current === null || current === undefined) return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}

--- a/packages/dashboard/src/views/pulse-templates.ts
+++ b/packages/dashboard/src/views/pulse-templates.ts
@@ -105,6 +105,19 @@ export const TEMPLATE_REGISTRY: Record<string, TemplateDefinition> = {
     ],
     defaultSize: '1x1',
   },
+  media: {
+    name: 'media',
+    displayName: 'Media Player',
+    description: 'Image or video with optional title and caption',
+    icon: '\u25B6',
+    slots: [
+      { name: 'url', label: 'Media URL', required: true, type: 'url' },
+      { name: 'title', label: 'Title', required: false, type: 'string' },
+      { name: 'caption', label: 'Caption', required: false, type: 'string' },
+      { name: 'mediaType', label: 'Type (image/video)', required: false, type: 'string' },
+    ],
+    defaultSize: '2x1',
+  },
 };
 
 // ── Backward compatibility ───────────────────────────────────────────────

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -29,7 +29,7 @@ export interface PulsePageInput {
 // ── Template renderers ───────────────────────────────────────────────────
 
 function renderMetric(tile: PulseTile): SafeHtml {
-  const val = tile.slots.value !== undefined ? String(tile.slots.value) : '--';
+  const val = tile.slots.value !== undefined ? stringify(tile.slots.value) : '--';
   const unit = tile.slots.unit ? String(tile.slots.unit) : '';
   const label = tile.slots.label ? String(tile.slots.label) : '';
   const prev = tile.slots.previous !== undefined ? Number(tile.slots.previous) : undefined;
@@ -58,14 +58,27 @@ function renderMetric(tile: PulseTile): SafeHtml {
 }
 
 function renderTextHeadline(tile: PulseTile): SafeHtml {
-  const headline = tile.slots.headline ? String(tile.slots.headline) : '';
-  const body = tile.slots.body ? String(tile.slots.body) : 'No data yet';
-  const truncBody = body.length > 500 ? body.slice(0, 500) + '...' : body;
+  const headline = tile.slots.headline ? stringify(tile.slots.headline) : '';
+  const rawBody = tile.slots.body ?? 'No data yet';
+
+  // Detect JSON content and pretty-print it in a code block.
+  const bodyStr = stringify(rawBody);
+  const isJson = looksLikeJson(bodyStr);
+  let bodyHtml: SafeHtml;
+  if (isJson) {
+    const pretty = prettyJson(bodyStr);
+    const truncated = pretty.length > 800 ? pretty.slice(0, 800) + '\n...' : pretty;
+    bodyHtml = html`<pre class="pulse-tile__code">${truncated}</pre>`;
+  } else {
+    const truncBody = bodyStr.length > 800 ? bodyStr.slice(0, 800) + '...' : bodyStr;
+    bodyHtml = unsafeHtml(`<div class="pulse-tile__body pulse-tile__body--md">${renderMarkdown(truncBody)}</div>`);
+  }
+
   return html`
     <div class="pulse-tile pulse-tile--text-headline ${sizeClass(tile.signal.size)}">
       ${tileHeader(tile)}
       ${headline ? html`<div class="pulse-tile__headline">${headline}</div>` : html``}
-      <div class="pulse-tile__body">${truncBody}</div>
+      ${bodyHtml}
       ${tileFooter(tile)}
     </div>
   `;
@@ -196,6 +209,56 @@ function renderTextImage(tile: PulseTile): SafeHtml {
   `;
 }
 
+function renderMedia(tile: PulseTile): SafeHtml {
+  const rawUrl = tile.slots.url ? String(tile.slots.url).trim() : '';
+  const title = tile.slots.title ? String(tile.slots.title) : '';
+  const caption = tile.slots.caption ? String(tile.slots.caption) : '';
+  const mediaType = tile.slots.mediaType ? String(tile.slots.mediaType).toLowerCase() : '';
+
+  // Extract YouTube video ID from various URL formats.
+  const ytMatch = rawUrl.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/);
+  const isYoutube = !!ytMatch;
+  const isVideo = !isYoutube && (mediaType === 'video' || /\.(mp4|webm|ogg)(\?|$)/i.test(rawUrl));
+  const isImage = !isYoutube && !isVideo && /\.(png|jpe?g|gif|webp|svg|bmp)(\?|$)/i.test(rawUrl);
+
+  let mediaEl: SafeHtml;
+  if (!rawUrl) {
+    mediaEl = html`<div class="dim" style="font-size: var(--font-size-xs); padding: var(--space-4); text-align: center;">No media URL</div>`;
+  } else if (isYoutube) {
+    const videoId = ytMatch![1];
+    const thumbUrl = `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
+    const watchUrl = `https://www.youtube.com/watch?v=${videoId}`;
+    const embedUrl = `https://www.youtube.com/embed/${videoId}?autoplay=1`;
+    // Thumbnail with play button. Click swaps to iframe embed in-place.
+    // External link opens YouTube in a new tab.
+    mediaEl = unsafeHtml(
+      `<div class="pulse-media-yt" data-embed="${esc(embedUrl)}" style="position:relative;border-radius:var(--radius-sm);overflow:hidden;cursor:pointer;">` +
+      `<img src="${esc(thumbUrl)}" alt="${esc(title || 'YouTube video')}" loading="lazy" style="width:100%;display:block;aspect-ratio:16/9;object-fit:cover;">` +
+      `<span style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:48px;height:48px;background:rgba(0,0,0,0.7);border-radius:50%;display:flex;align-items:center;justify-content:center;">` +
+      `<span style="width:0;height:0;border-style:solid;border-width:8px 0 8px 16px;border-color:transparent transparent transparent #fff;margin-left:3px;"></span>` +
+      `</span></div>` +
+      `<a href="${esc(watchUrl)}" target="_blank" rel="noopener" style="display:block;font-size:var(--font-size-xs);color:var(--color-text-muted);margin-top:var(--space-1);text-align:right;">Open on YouTube \u2197</a>`
+    );
+  } else if (isVideo) {
+    mediaEl = unsafeHtml(`<video class="pulse-tile__media" src="${esc(rawUrl)}" controls preload="metadata" style="width:100%;border-radius:var(--radius-sm);"></video>`);
+  } else if (isImage) {
+    mediaEl = unsafeHtml(`<img class="pulse-tile__media" src="${esc(rawUrl)}" alt="${esc(title)}" loading="lazy" style="width:100%;border-radius:var(--radius-sm);object-fit:cover;max-height:240px;">`);
+  } else {
+    // Unknown media type — render as a clickable link.
+    mediaEl = unsafeHtml(`<a href="${esc(rawUrl)}" target="_blank" rel="noopener" style="color:var(--color-primary);font-family:var(--font-mono);font-size:var(--font-size-xs);word-break:break-all;">${esc(rawUrl)}</a>`);
+  }
+
+  return html`
+    <div class="pulse-tile pulse-tile--media ${sizeClass(tile.signal.size)}">
+      ${tileHeader(tile)}
+      ${title ? html`<div class="pulse-tile__headline" style="font-size: var(--font-size-sm);">${title}</div>` : html``}
+      ${mediaEl}
+      ${caption ? html`<div class="dim" style="font-size: var(--font-size-xs);">${caption}</div>` : html``}
+      ${tileFooter(tile)}
+    </div>
+  `;
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────────
 
 function sizeClass(size?: string): string {
@@ -209,7 +272,8 @@ function tileHeader(tile: PulseTile): SafeHtml {
   const icon = tile.signal.icon ?? '';
   return html`
     <div class="pulse-tile__header">
-      <div style="display: flex; align-items: center; gap: var(--space-2); flex: 1;">
+      <button type="button" class="pulse-tile__collapse" data-tile-id="${tile.agent.id}" title="Collapse/expand">\u25BC</button>
+      <div style="display: flex; align-items: center; gap: var(--space-2); flex: 1; cursor: pointer;" data-tile-id="${tile.agent.id}" data-collapse-trigger>
         ${icon ? html`<span class="pulse-tile__icon">${icon}</span>` : html``}
         <span class="pulse-tile__title">${tile.signal.title}</span>
       </div>
@@ -238,6 +302,78 @@ function esc(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
+/** Convert any value to a display string. Handles objects that would show as [object Object]. */
+function stringify(val: unknown): string {
+  if (val === null || val === undefined) return '';
+  if (typeof val === 'string') return val;
+  if (typeof val === 'number' || typeof val === 'boolean') return String(val);
+  try { return JSON.stringify(val, null, 2); } catch { return String(val); }
+}
+
+/**
+ * Lightweight markdown to HTML. Handles the common patterns agents produce:
+ * headers, bold, italic, links, tables, lists, inline code, line breaks.
+ * No library dependency. Input must be pre-escaped or trusted.
+ */
+function renderMarkdown(text: string): string {
+  let h = esc(text);
+
+  // Code blocks (``` ... ```)
+  h = h.replace(/```(\w*)\n([\s\S]*?)```/g, '<pre class="pulse-tile__code">$2</pre>');
+
+  // Inline code
+  h = h.replace(/`([^`]+)`/g, '<code style="background:var(--color-surface-raised);padding:0 var(--space-1);border-radius:3px;font-size:var(--font-size-xs);">$1</code>');
+
+  // Headers (## and ###)
+  h = h.replace(/^### (.+)$/gm, '<strong style="font-size:var(--font-size-sm);display:block;margin-top:var(--space-2);">$1</strong>');
+  h = h.replace(/^## (.+)$/gm, '<strong style="font-size:var(--font-size-md);display:block;margin-top:var(--space-2);">$1</strong>');
+
+  // Bold and italic
+  h = h.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+  h = h.replace(/\*(.+?)\*/g, '<em>$1</em>');
+
+  // Links [text](url)
+  h = h.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" style="color:var(--color-primary);" target="_blank" rel="noopener">$1</a>');
+
+  // Markdown tables
+  const tableRe = /^(\|.+\|)\n(\|[-| :]+\|)\n((?:\|.+\|\n?)+)/gm;
+  h = h.replace(tableRe, (_, headerRow: string, _sep: string, bodyRows: string) => {
+    const headers = headerRow.split('|').filter(Boolean).map((c: string) => c.trim());
+    const rows = bodyRows.trim().split('\n').map((r: string) =>
+      r.split('|').filter(Boolean).map((c: string) => c.trim())
+    );
+    return '<table class="pulse-table" style="margin:var(--space-2) 0;">' +
+      '<thead><tr>' + headers.map((h: string) => `<th>${h}</th>`).join('') + '</tr></thead>' +
+      '<tbody>' + rows.map((r: string[]) => '<tr>' + r.map((c: string) => `<td>${c}</td>`).join('') + '</tr>').join('') + '</tbody>' +
+      '</table>';
+  });
+
+  // Unordered lists
+  h = h.replace(/^- (.+)$/gm, '<li style="margin-left:var(--space-4);list-style:disc;">$1</li>');
+
+  // Double newline → paragraph break, single newline → <br>
+  h = h.replace(/\n{2,}/g, '<br><br>');
+  h = h.replace(/\n/g, '<br>');
+
+  return h;
+}
+
+/** Check if a string looks like JSON (starts with { or [). */
+function looksLikeJson(s: string): boolean {
+  const trimmed = s.trimStart();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return false;
+  try { JSON.parse(trimmed); return true; } catch { return false; }
+}
+
+/** Pretty-print a JSON string with 2-space indent. */
+function prettyJson(s: string): string {
+  try {
+    return JSON.stringify(JSON.parse(s.trim()), null, 2);
+  } catch {
+    return s;
+  }
+}
+
 function renderTile(tile: PulseTile): SafeHtml {
   const { template } = normalizeSignal(tile.signal);
   switch (template as SignalTemplate) {
@@ -248,6 +384,7 @@ function renderTile(tile: PulseTile): SafeHtml {
     case 'time-series': return renderTimeSeries(tile);
     case 'image': return renderImage(tile);
     case 'text-image': return renderTextImage(tile);
+    case 'media': return renderMedia(tile);
     default: return renderTextHeadline(tile);
   }
 }

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -168,9 +168,10 @@ function renderMedia(tile: PulseTile): SafeHtml {
     const videoId = ytMatch![1];
     const thumbUrl = `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
     const watchUrl = `https://www.youtube.com/watch?v=${videoId}`;
-    const embedUrl = `https://www.youtube.com/embed/${videoId}?autoplay=1`;
+    // Use nocookie domain for better embed compatibility. Autoplay on click.
+    const embedUrl = `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0&modestbranding=1`;
     mediaEl = unsafeHtml(
-      `<div class="pulse-media-yt" data-embed="${esc(embedUrl)}" style="position:relative;border-radius:var(--radius-sm);overflow:hidden;cursor:pointer;">` +
+      `<div class="pulse-media-yt" data-embed="${esc(embedUrl)}" data-watch="${esc(watchUrl)}" style="position:relative;border-radius:var(--radius-sm);overflow:hidden;cursor:pointer;">` +
       `<img src="${esc(thumbUrl)}" alt="${esc(title || 'YouTube video')}" loading="lazy" style="width:100%;display:block;aspect-ratio:16/9;object-fit:cover;">` +
       `<span style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:48px;height:48px;background:rgba(0,0,0,0.7);border-radius:50%;display:flex;align-items:center;justify-content:center;">` +
       `<span style="width:0;height:0;border-style:solid;border-width:8px 0 8px 16px;border-color:transparent transparent transparent #fff;margin-left:3px;"></span>` +
@@ -208,6 +209,7 @@ function tileWrap(tile: PulseTile, content: SafeHtml): SafeHtml {
     tileHeader(tile, isSystem).toString() +
     content.toString() +
     (isSystem ? '' : tileFooter(tile).toString()) +
+    '<div class="pulse-tile__resize-handle" data-agent-id="' + esc(tile.agent.id) + '"></div>' +
     '</div>'
   );
 }

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -2,7 +2,7 @@ import type { Agent, AgentSignal, Run, SignalTemplate } from '@some-useful-agent
 import { html, render, unsafeHtml, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { formatAge } from './components.js';
-import { normalizeSignal, extractMappedValues } from './pulse-templates.js';
+import { normalizeSignal } from './pulse-templates.js';
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -10,20 +10,16 @@ export interface PulseTile {
   agent: Agent;
   signal: AgentSignal;
   lastRun?: Run;
-  /** Resolved slot values from extractMappedValues. */
   slots: Record<string, unknown>;
 }
 
 export interface PulsePageInput {
+  /** Virtual system metric tiles (runs today, failure rate, etc.). */
+  systemTiles: PulseTile[];
+  /** Visible agent tiles. */
   tiles: PulseTile[];
-  /** Hidden tiles (for the show/hide panel). */
+  /** Hidden agent tiles. */
   hiddenTiles: PulseTile[];
-  stats: {
-    runsToday: number;
-    failedToday: number;
-    avgDurationSec: number;
-    agentCount: number;
-  };
 }
 
 // ── Template renderers ───────────────────────────────────────────────────
@@ -37,31 +33,25 @@ function renderMetric(tile: PulseTile): SafeHtml {
 
   let trend = '';
   if (prev !== undefined && curr !== undefined && !isNaN(prev) && !isNaN(curr)) {
-    if (curr > prev) trend = '\u2191';       // ↑
-    else if (curr < prev) trend = '\u2193';  // ↓
-    else trend = '\u2192';                   // →
+    if (curr > prev) trend = '\u2191';
+    else if (curr < prev) trend = '\u2193';
+    else trend = '\u2192';
   }
   const trendClass = trend === '\u2191' ? 'pulse-tile__trend--up'
     : trend === '\u2193' ? 'pulse-tile__trend--down'
     : 'pulse-tile__trend--flat';
 
-  return html`
-    <div class="pulse-tile pulse-tile--metric ${sizeClass(tile.signal.size)}">
-      ${tileHeader(tile)}
-      <div class="pulse-tile__value">
-        ${val}${unit ? html`<span class="pulse-tile__unit">${unit}</span>` : html``}${trend ? html`<span class="pulse-tile__trend ${trendClass}">${trend}</span>` : html``}
-      </div>
-      ${label ? html`<div class="pulse-tile__label">${label}</div>` : html``}
-      ${tileFooter(tile)}
+  return tileWrap(tile, html`
+    <div class="pulse-tile__value">
+      ${val}${unit ? html`<span class="pulse-tile__unit">${unit}</span>` : html``}${trend ? html`<span class="pulse-tile__trend ${trendClass}">${trend}</span>` : html``}
     </div>
-  `;
+    ${label ? html`<div class="pulse-tile__label">${label}</div>` : html``}
+  `);
 }
 
 function renderTextHeadline(tile: PulseTile): SafeHtml {
   const headline = tile.slots.headline ? stringify(tile.slots.headline) : '';
   const rawBody = tile.slots.body ?? 'No data yet';
-
-  // Detect JSON content and pretty-print it in a code block.
   const bodyStr = stringify(rawBody);
   const isJson = looksLikeJson(bodyStr);
   let bodyHtml: SafeHtml;
@@ -74,53 +64,28 @@ function renderTextHeadline(tile: PulseTile): SafeHtml {
     bodyHtml = unsafeHtml(`<div class="pulse-tile__body pulse-tile__body--md">${renderMarkdown(truncBody)}</div>`);
   }
 
-  return html`
-    <div class="pulse-tile pulse-tile--text-headline ${sizeClass(tile.signal.size)}">
-      ${tileHeader(tile)}
-      ${headline ? html`<div class="pulse-tile__headline">${headline}</div>` : html``}
-      ${bodyHtml}
-      ${tileFooter(tile)}
-    </div>
-  `;
+  return tileWrap(tile, html`
+    ${headline ? html`<div class="pulse-tile__headline">${headline}</div>` : html``}
+    ${bodyHtml}
+  `);
 }
 
 function renderTable(tile: PulseTile): SafeHtml {
   let rows: Record<string, unknown>[] = [];
   const rawRows = tile.slots.rows;
-  if (Array.isArray(rawRows)) {
-    rows = rawRows.slice(0, 10) as Record<string, unknown>[];
-  } else if (typeof rawRows === 'string') {
-    try {
-      const parsed = JSON.parse(rawRows);
-      if (Array.isArray(parsed)) rows = parsed.slice(0, 10) as Record<string, unknown>[];
-    } catch { /* not JSON */ }
+  if (Array.isArray(rawRows)) rows = rawRows.slice(0, 10) as Record<string, unknown>[];
+  else if (typeof rawRows === 'string') {
+    try { const p = JSON.parse(rawRows); if (Array.isArray(p)) rows = p.slice(0, 10) as Record<string, unknown>[]; } catch { /* */ }
   }
-
   let cols: string[] = [];
-  if (tile.slots.columns && Array.isArray(tile.slots.columns)) {
-    cols = tile.slots.columns.map(String);
-  } else if (rows.length > 0) {
-    cols = Object.keys(rows[0]);
-  }
+  if (tile.slots.columns && Array.isArray(tile.slots.columns)) cols = tile.slots.columns.map(String);
+  else if (rows.length > 0) cols = Object.keys(rows[0]);
 
   const tableHtml = rows.length === 0
     ? html`<p class="dim" style="font-size: var(--font-size-xs);">No data</p>`
-    : unsafeHtml(`
-      <table class="pulse-table">
-        <thead><tr>${cols.map((c) => `<th>${esc(c)}</th>`).join('')}</tr></thead>
-        <tbody>${rows.map((r) =>
-          `<tr>${cols.map((c) => `<td>${esc(String(r[c] ?? ''))}</td>`).join('')}</tr>`
-        ).join('')}</tbody>
-      </table>
-    `);
+    : unsafeHtml(`<table class="pulse-table"><thead><tr>${cols.map((c) => `<th>${esc(c)}</th>`).join('')}</tr></thead><tbody>${rows.map((r) => `<tr>${cols.map((c) => `<td>${esc(String(r[c] ?? ''))}</td>`).join('')}</tr>`).join('')}</tbody></table>`);
 
-  return html`
-    <div class="pulse-tile pulse-tile--table ${sizeClass(tile.signal.size)}">
-      ${tileHeader(tile)}
-      ${tableHtml}
-      ${tileFooter(tile)}
-    </div>
-  `;
+  return tileWrap(tile, tableHtml);
 }
 
 function renderStatus(tile: PulseTile): SafeHtml {
@@ -133,17 +98,13 @@ function renderStatus(tile: PulseTile): SafeHtml {
     ? 'pulse-tile__status-dot--degraded'
     : 'pulse-tile__status-dot--down';
 
-  return html`
-    <div class="pulse-tile pulse-tile--status ${sizeClass(tile.signal.size)}">
-      ${tileHeader(tile)}
-      <div style="display: flex; align-items: center; gap: var(--space-2); flex: 1;">
-        <span class="pulse-tile__status-dot ${dotClass}"></span>
-        <span class="pulse-tile__status-label">${label}</span>
-      </div>
-      ${message ? html`<div class="pulse-tile__status-message">${message}</div>` : html``}
-      ${tileFooter(tile)}
+  return tileWrap(tile, html`
+    <div style="display: flex; align-items: center; gap: var(--space-2); flex: 1;">
+      <span class="pulse-tile__status-dot ${dotClass}"></span>
+      <span class="pulse-tile__status-label">${label}</span>
     </div>
-  `;
+    ${message ? html`<div class="pulse-tile__status-message">${message}</div>` : html``}
+  `);
 }
 
 function renderTimeSeries(tile: PulseTile): SafeHtml {
@@ -156,57 +117,37 @@ function renderTimeSeries(tile: PulseTile): SafeHtml {
     const min = Math.min(...values);
     const max = Math.max(...values);
     const range = max - min || 1;
-    const h = 40;
-    const w = 200;
-    const points = values.map((v, i) => {
-      const x = (i / (values.length - 1)) * w;
-      const y = h - ((v - min) / range) * h;
-      return `${x.toFixed(1)},${y.toFixed(1)}`;
-    }).join(' ');
+    const h = 40, w = 200;
+    const points = values.map((v, i) => `${((i / (values.length - 1)) * w).toFixed(1)},${(h - ((v - min) / range) * h).toFixed(1)}`).join(' ');
     sparkline = unsafeHtml(`<div class="pulse-tile__sparkline"><svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="none"><polyline points="${points}"/></svg></div>`);
   }
 
-  return html`
-    <div class="pulse-tile pulse-tile--time-series ${sizeClass(tile.signal.size)}">
-      ${tileHeader(tile)}
-      <div class="pulse-tile__value" style="font-size: var(--font-size-xl);">${current}</div>
-      ${sparkline}
-      ${label ? html`<div class="pulse-tile__label">${label}</div>` : html``}
-      ${tileFooter(tile)}
-    </div>
-  `;
+  return tileWrap(tile, html`
+    <div class="pulse-tile__value" style="font-size: var(--font-size-xl);">${current}</div>
+    ${sparkline}
+    ${label ? html`<div class="pulse-tile__label">${label}</div>` : html``}
+  `);
 }
 
 function renderImage(tile: PulseTile): SafeHtml {
   const url = tile.slots.imageUrl ? String(tile.slots.imageUrl) : '';
   const alt = tile.slots.alt ? String(tile.slots.alt) : tile.signal.title;
-  return html`
-    <div class="pulse-tile pulse-tile--image ${sizeClass(tile.signal.size)}">
-      ${tileHeader(tile)}
-      ${url
-        ? unsafeHtml(`<img class="pulse-tile__image" src="${esc(url)}" alt="${esc(alt)}" loading="lazy">`)
-        : html`<div class="dim" style="font-size: var(--font-size-xs);">No image URL</div>`}
-      ${tileFooter(tile)}
-    </div>
-  `;
+  return tileWrap(tile, url
+    ? unsafeHtml(`<img class="pulse-tile__image" src="${esc(url)}" alt="${esc(alt)}" loading="lazy" style="width:100%;border-radius:var(--radius-sm);object-fit:cover;max-height:240px;">`)
+    : html`<div class="dim" style="font-size: var(--font-size-xs);">No image URL</div>`
+  );
 }
 
 function renderTextImage(tile: PulseTile): SafeHtml {
   const text = tile.slots.text ? String(tile.slots.text) : '';
   const url = tile.slots.imageUrl ? String(tile.slots.imageUrl) : '';
   const truncText = text.length > 300 ? text.slice(0, 300) + '...' : text;
-  return html`
-    <div class="pulse-tile pulse-tile--text-image ${sizeClass(tile.signal.size)}">
-      ${tileHeader(tile)}
-      <div style="display: flex; gap: var(--space-3); flex: 1;">
-        <div class="pulse-tile__body" style="flex: 1;">${truncText || 'No text'}</div>
-        ${url
-          ? unsafeHtml(`<img class="pulse-tile__image" src="${esc(url)}" alt="" style="max-width:120px;max-height:120px;" loading="lazy">`)
-          : html``}
-      </div>
-      ${tileFooter(tile)}
+  return tileWrap(tile, html`
+    <div style="display: flex; gap: var(--space-3); flex: 1;">
+      <div class="pulse-tile__body" style="flex: 1;">${truncText || 'No text'}</div>
+      ${url ? unsafeHtml(`<img class="pulse-tile__image" src="${esc(url)}" alt="" style="max-width:120px;max-height:120px;" loading="lazy">`) : html``}
     </div>
-  `;
+  `);
 }
 
 function renderMedia(tile: PulseTile): SafeHtml {
@@ -215,7 +156,6 @@ function renderMedia(tile: PulseTile): SafeHtml {
   const caption = tile.slots.caption ? String(tile.slots.caption) : '';
   const mediaType = tile.slots.mediaType ? String(tile.slots.mediaType).toLowerCase() : '';
 
-  // Extract YouTube video ID from various URL formats.
   const ytMatch = rawUrl.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/);
   const isYoutube = !!ytMatch;
   const isVideo = !isYoutube && (mediaType === 'video' || /\.(mp4|webm|ogg)(\?|$)/i.test(rawUrl));
@@ -229,8 +169,6 @@ function renderMedia(tile: PulseTile): SafeHtml {
     const thumbUrl = `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
     const watchUrl = `https://www.youtube.com/watch?v=${videoId}`;
     const embedUrl = `https://www.youtube.com/embed/${videoId}?autoplay=1`;
-    // Thumbnail with play button. Click swaps to iframe embed in-place.
-    // External link opens YouTube in a new tab.
     mediaEl = unsafeHtml(
       `<div class="pulse-media-yt" data-embed="${esc(embedUrl)}" style="position:relative;border-radius:var(--radius-sm);overflow:hidden;cursor:pointer;">` +
       `<img src="${esc(thumbUrl)}" alt="${esc(title || 'YouTube video')}" loading="lazy" style="width:100%;display:block;aspect-ratio:16/9;object-fit:cover;">` +
@@ -240,35 +178,82 @@ function renderMedia(tile: PulseTile): SafeHtml {
       `<a href="${esc(watchUrl)}" target="_blank" rel="noopener" style="display:block;font-size:var(--font-size-xs);color:var(--color-text-muted);margin-top:var(--space-1);text-align:right;">Open on YouTube \u2197</a>`
     );
   } else if (isVideo) {
-    mediaEl = unsafeHtml(`<video class="pulse-tile__media" src="${esc(rawUrl)}" controls preload="metadata" style="width:100%;border-radius:var(--radius-sm);"></video>`);
+    mediaEl = unsafeHtml(`<video src="${esc(rawUrl)}" controls preload="metadata" style="width:100%;border-radius:var(--radius-sm);"></video>`);
   } else if (isImage) {
-    mediaEl = unsafeHtml(`<img class="pulse-tile__media" src="${esc(rawUrl)}" alt="${esc(title)}" loading="lazy" style="width:100%;border-radius:var(--radius-sm);object-fit:cover;max-height:240px;">`);
+    mediaEl = unsafeHtml(`<img src="${esc(rawUrl)}" alt="${esc(title)}" loading="lazy" style="width:100%;border-radius:var(--radius-sm);object-fit:cover;max-height:240px;">`);
   } else {
-    // Unknown media type — render as a clickable link.
     mediaEl = unsafeHtml(`<a href="${esc(rawUrl)}" target="_blank" rel="noopener" style="color:var(--color-primary);font-family:var(--font-mono);font-size:var(--font-size-xs);word-break:break-all;">${esc(rawUrl)}</a>`);
   }
 
-  return html`
-    <div class="pulse-tile pulse-tile--media ${sizeClass(tile.signal.size)}">
-      ${tileHeader(tile)}
-      ${title ? html`<div class="pulse-tile__headline" style="font-size: var(--font-size-sm);">${title}</div>` : html``}
-      ${mediaEl}
-      ${caption ? html`<div class="dim" style="font-size: var(--font-size-xs);">${caption}</div>` : html``}
-      ${tileFooter(tile)}
-    </div>
-  `;
+  return tileWrap(tile, html`
+    ${title ? html`<div class="pulse-tile__headline" style="font-size: var(--font-size-sm);">${title}</div>` : html``}
+    ${mediaEl}
+    ${caption ? html`<div class="dim" style="font-size: var(--font-size-xs);">${caption}</div>` : html``}
+  `);
 }
 
-// ── Helpers ──────────────────────────────────────────────────────────────
+// ── Tile wrapper ─────────────────────────────────────────────────────────
 
-function sizeClass(size?: string): string {
+/** Wraps tile content with the standard tile chrome: header, content, footer.
+ *  Each tile gets draggable + data attributes for the layout system. */
+function tileWrap(tile: PulseTile, content: SafeHtml): SafeHtml {
+  const isSystem = tile.agent.id.startsWith('_system-');
+  const sizeAttr = tile.signal.size ?? '1x1';
+  const autoPalette = resolveAutoPalette(tile);
+  const paletteAttr = autoPalette && autoPalette !== 'default'
+    ? ` data-auto-palette="${autoPalette}"`
+    : '';
+  return unsafeHtml(
+    `<div class="pulse-tile ${sizeClass(sizeAttr)}" data-agent-id="${esc(tile.agent.id)}" data-tile-size="${esc(sizeAttr)}"${paletteAttr}>` +
+    tileHeader(tile, isSystem).toString() +
+    content.toString() +
+    (isSystem ? '' : tileFooter(tile).toString()) +
+    '</div>'
+  );
+}
+
+/**
+ * Resolve auto-palette for a tile based on:
+ * 1. Conditional thresholds (if declared in signal.thresholds)
+ * 2. Template-type defaults (metric→teal, status→auto by value)
+ * 3. null = no auto-palette (inherit page theme)
+ */
+function resolveAutoPalette(tile: PulseTile): string | null {
+  const { template } = normalizeSignal(tile.signal);
+
+  // 1. Conditional thresholds (metric tiles with numeric value).
+  if (tile.signal.thresholds && tile.signal.thresholds.length > 0) {
+    const numVal = Number(tile.slots.value);
+    if (!isNaN(numVal)) {
+      for (const t of tile.signal.thresholds) {
+        if (t.above !== undefined && numVal > t.above) return t.palette;
+        if (t.below !== undefined && numVal < t.below) return t.palette;
+      }
+    }
+  }
+
+  // 2. Status tiles auto-color by status value.
+  if (template === 'status') {
+    const status = tile.slots.status ? String(tile.slots.status).toLowerCase() : '';
+    if (status === 'healthy' || status === 'ok' || status === 'up') return 'accent-green';
+    if (status === 'degraded' || status === 'warn' || status === 'warning') return 'accent-orange';
+    if (status === 'down' || status === 'error' || status === 'critical') return 'accent-red';
+  }
+
+  // 3. Template-type defaults.
+  if (template === 'metric') return 'accent-teal';
+
+  return null;
+}
+
+function sizeClass(size: string): string {
   if (size === '2x1') return 'pulse-tile--2x1';
   if (size === '1x2') return 'pulse-tile--1x2';
   if (size === '2x2') return 'pulse-tile--2x2';
   return '';
 }
 
-function tileHeader(tile: PulseTile): SafeHtml {
+function tileHeader(tile: PulseTile, isSystem: boolean): SafeHtml {
   const icon = tile.signal.icon ?? '';
   return html`
     <div class="pulse-tile__header">
@@ -277,9 +262,14 @@ function tileHeader(tile: PulseTile): SafeHtml {
         ${icon ? html`<span class="pulse-tile__icon">${icon}</span>` : html``}
         <span class="pulse-tile__title">${tile.signal.title}</span>
       </div>
-      <form method="POST" action="/agents/${tile.agent.id}/signal/toggle" style="margin: 0;">
-        <button type="submit" class="pulse-tile__toggle" title="Hide from Pulse">\u00D7</button>
-      </form>
+      <div style="display: flex; gap: var(--space-1); align-items: center;">
+        <button type="button" class="pulse-tile__palette-btn" data-tile-id="${tile.agent.id}" title="Change palette">\u25CF</button>
+        ${isSystem ? html`` : html`
+          <form method="POST" action="/agents/${tile.agent.id}/signal/toggle" style="margin: 0;">
+            <button type="submit" class="pulse-tile__toggle" title="Hide from Pulse">\u00D7</button>
+          </form>
+        `}
+      </div>
     </div>
   `;
 }
@@ -298,82 +288,6 @@ function tileFooter(tile: PulseTile): SafeHtml {
   `;
 }
 
-function esc(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
-
-/** Convert any value to a display string. Handles objects that would show as [object Object]. */
-function stringify(val: unknown): string {
-  if (val === null || val === undefined) return '';
-  if (typeof val === 'string') return val;
-  if (typeof val === 'number' || typeof val === 'boolean') return String(val);
-  try { return JSON.stringify(val, null, 2); } catch { return String(val); }
-}
-
-/**
- * Lightweight markdown to HTML. Handles the common patterns agents produce:
- * headers, bold, italic, links, tables, lists, inline code, line breaks.
- * No library dependency. Input must be pre-escaped or trusted.
- */
-function renderMarkdown(text: string): string {
-  let h = esc(text);
-
-  // Code blocks (``` ... ```)
-  h = h.replace(/```(\w*)\n([\s\S]*?)```/g, '<pre class="pulse-tile__code">$2</pre>');
-
-  // Inline code
-  h = h.replace(/`([^`]+)`/g, '<code style="background:var(--color-surface-raised);padding:0 var(--space-1);border-radius:3px;font-size:var(--font-size-xs);">$1</code>');
-
-  // Headers (## and ###)
-  h = h.replace(/^### (.+)$/gm, '<strong style="font-size:var(--font-size-sm);display:block;margin-top:var(--space-2);">$1</strong>');
-  h = h.replace(/^## (.+)$/gm, '<strong style="font-size:var(--font-size-md);display:block;margin-top:var(--space-2);">$1</strong>');
-
-  // Bold and italic
-  h = h.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
-  h = h.replace(/\*(.+?)\*/g, '<em>$1</em>');
-
-  // Links [text](url)
-  h = h.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" style="color:var(--color-primary);" target="_blank" rel="noopener">$1</a>');
-
-  // Markdown tables
-  const tableRe = /^(\|.+\|)\n(\|[-| :]+\|)\n((?:\|.+\|\n?)+)/gm;
-  h = h.replace(tableRe, (_, headerRow: string, _sep: string, bodyRows: string) => {
-    const headers = headerRow.split('|').filter(Boolean).map((c: string) => c.trim());
-    const rows = bodyRows.trim().split('\n').map((r: string) =>
-      r.split('|').filter(Boolean).map((c: string) => c.trim())
-    );
-    return '<table class="pulse-table" style="margin:var(--space-2) 0;">' +
-      '<thead><tr>' + headers.map((h: string) => `<th>${h}</th>`).join('') + '</tr></thead>' +
-      '<tbody>' + rows.map((r: string[]) => '<tr>' + r.map((c: string) => `<td>${c}</td>`).join('') + '</tr>').join('') + '</tbody>' +
-      '</table>';
-  });
-
-  // Unordered lists
-  h = h.replace(/^- (.+)$/gm, '<li style="margin-left:var(--space-4);list-style:disc;">$1</li>');
-
-  // Double newline → paragraph break, single newline → <br>
-  h = h.replace(/\n{2,}/g, '<br><br>');
-  h = h.replace(/\n/g, '<br>');
-
-  return h;
-}
-
-/** Check if a string looks like JSON (starts with { or [). */
-function looksLikeJson(s: string): boolean {
-  const trimmed = s.trimStart();
-  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return false;
-  try { JSON.parse(trimmed); return true; } catch { return false; }
-}
-
-/** Pretty-print a JSON string with 2-space indent. */
-function prettyJson(s: string): string {
-  try {
-    return JSON.stringify(JSON.parse(s.trim()), null, 2);
-  } catch {
-    return s;
-  }
-}
-
 function renderTile(tile: PulseTile): SafeHtml {
   const { template } = normalizeSignal(tile.signal);
   switch (template as SignalTemplate) {
@@ -389,65 +303,85 @@ function renderTile(tile: PulseTile): SafeHtml {
   }
 }
 
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function esc(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function stringify(val: unknown): string {
+  if (val === null || val === undefined) return '';
+  if (typeof val === 'string') return val;
+  if (typeof val === 'number' || typeof val === 'boolean') return String(val);
+  try { return JSON.stringify(val, null, 2); } catch { return String(val); }
+}
+
+function renderMarkdown(text: string): string {
+  let h = esc(text);
+  h = h.replace(/```(\w*)\n([\s\S]*?)```/g, '<pre class="pulse-tile__code">$2</pre>');
+  h = h.replace(/`([^`]+)`/g, '<code style="background:var(--color-surface-raised);padding:0 var(--space-1);border-radius:3px;font-size:var(--font-size-xs);">$1</code>');
+  h = h.replace(/^### (.+)$/gm, '<strong style="font-size:var(--font-size-sm);display:block;margin-top:var(--space-2);">$1</strong>');
+  h = h.replace(/^## (.+)$/gm, '<strong style="font-size:var(--font-size-md);display:block;margin-top:var(--space-2);">$1</strong>');
+  h = h.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+  h = h.replace(/\*(.+?)\*/g, '<em>$1</em>');
+  h = h.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" style="color:var(--color-primary);" target="_blank" rel="noopener">$1</a>');
+  const tableRe = /^(\|.+\|)\n(\|[-| :]+\|)\n((?:\|.+\|\n?)+)/gm;
+  h = h.replace(tableRe, (_, headerRow: string, _sep: string, bodyRows: string) => {
+    const headers = headerRow.split('|').filter(Boolean).map((c: string) => c.trim());
+    const rows = bodyRows.trim().split('\n').map((r: string) => r.split('|').filter(Boolean).map((c: string) => c.trim()));
+    return '<table class="pulse-table" style="margin:var(--space-2) 0;"><thead><tr>' + headers.map((h: string) => `<th>${h}</th>`).join('') + '</tr></thead><tbody>' + rows.map((r: string[]) => '<tr>' + r.map((c: string) => `<td>${c}</td>`).join('') + '</tr>').join('') + '</tbody></table>';
+  });
+  h = h.replace(/^- (.+)$/gm, '<li style="margin-left:var(--space-4);list-style:disc;">$1</li>');
+  h = h.replace(/\n{2,}/g, '<br><br>');
+  h = h.replace(/\n/g, '<br>');
+  return h;
+}
+
+function looksLikeJson(s: string): boolean {
+  const t = s.trimStart();
+  if (!t.startsWith('{') && !t.startsWith('[')) return false;
+  try { JSON.parse(t); return true; } catch { return false; }
+}
+
+function prettyJson(s: string): string {
+  try { return JSON.stringify(JSON.parse(s.trim()), null, 2); } catch { return s; }
+}
+
 // ── Page ─────────────────────────────────────────────────────────────────
 
 export function renderPulsePage(input: PulsePageInput): string {
-  const { tiles, hiddenTiles, stats } = input;
-  const failRate = stats.runsToday > 0 ? Math.round((stats.failedToday / stats.runsToday) * 100) : 0;
-  const visibleCount = tiles.length;
+  const { systemTiles, tiles, hiddenTiles } = input;
+  const allTileCount = systemTiles.length + tiles.length;
   const hiddenCount = hiddenTiles.length;
+
+  // Build a JSON blob of all tile IDs so the JS can construct the default layout.
+  const allTileIds = [...systemTiles.map((t) => t.agent.id), ...tiles.map((t) => t.agent.id)];
+  const systemTileIds = systemTiles.map((t) => t.agent.id);
 
   const body = html`
     <div style="display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-6);">
       <h1 style="margin: 0;">Pulse</h1>
       <span style="font-size: var(--font-size-sm); color: var(--color-text-muted);">
-        ${String(visibleCount)} signal${visibleCount !== 1 ? 's' : ''} active${hiddenCount > 0 ? html`, ${String(hiddenCount)} hidden` : html``}
+        ${String(allTileCount)} signal${allTileCount !== 1 ? 's' : ''}${hiddenCount > 0 ? html`, ${String(hiddenCount)} hidden` : html``}
       </span>
-    </div>
-
-    <!-- Health strip -->
-    <div class="pulse-health">
-      <div class="pulse-health__stat">
-        <span class="pulse-health__value">${String(stats.runsToday)}</span>
-        <span class="pulse-health__label">runs today</span>
-      </div>
-      <div class="pulse-health__stat">
-        <span class="pulse-health__value ${failRate > 20 ? 'pulse-health__value--warn' : ''}">${String(failRate)}%</span>
-        <span class="pulse-health__label">failure rate</span>
-      </div>
-      <div class="pulse-health__stat">
-        <span class="pulse-health__value">${stats.avgDurationSec > 0 ? String(stats.avgDurationSec) + 's' : '--'}</span>
-        <span class="pulse-health__label">avg duration</span>
-      </div>
-      <div class="pulse-health__stat">
-        <span class="pulse-health__value">${String(stats.agentCount)}</span>
-        <span class="pulse-health__label">agents</span>
+      <div style="margin-left: auto; display: flex; gap: var(--space-2);">
+        <button type="button" class="btn btn--ghost btn--sm" id="pulse-edit-toggle">\u270E Edit layout</button>
+        <button type="button" class="btn btn--ghost btn--sm" id="pulse-add-container" style="display: none;">+ Add group</button>
       </div>
     </div>
 
-    <!-- Signal tiles -->
-    ${visibleCount === 0 && hiddenCount === 0
-      ? html`
-        <div class="pulse-empty">
-          <h2>No signals yet</h2>
-          <p>Add a <code>signal:</code> field to any agent's YAML to show its output here.</p>
-          <pre class="pulse-empty__example">signal:
-  title: API Latency
-  template: metric
-  mapping:
-    value: latency_ms
-    unit: "%"</pre>
-          <p><a href="/agents">Browse agents &rarr;</a></p>
-        </div>
-      `
-      : html`
-        <div class="pulse-grid">
+    <!-- Container host — JS reads layout from localStorage and arranges tiles -->
+    <div id="pulse-containers">
+      <!-- Default: all tiles in order. JS will reorganize into containers. -->
+      <section class="pulse-container" data-container-id="_default">
+        <div class="pulse-grid" data-container-id="_default">
+          ${systemTiles.map((t) => renderTile(t)) as unknown as SafeHtml[]}
           ${tiles.map((t) => renderTile(t)) as unknown as SafeHtml[]}
         </div>
-      `
-    }
+      </section>
+    </div>
 
-    <!-- Hidden tiles section -->
+    <!-- Hidden tiles -->
     ${hiddenCount > 0 ? html`
       <details class="pulse-hidden-section" style="margin-top: var(--space-6);">
         <summary style="cursor: pointer; font-family: var(--font-mono); font-size: var(--font-size-xs); font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-text-muted);">
@@ -464,6 +398,9 @@ export function renderPulsePage(input: PulsePageInput): string {
         </div>
       </details>
     ` : html``}
+
+    <!-- Layout data for JS -->
+    ${unsafeHtml(`<script type="application/json" id="pulse-tile-data">${JSON.stringify({ allTileIds, systemTileIds })}</script>`)}
   `;
 
   return render(layout({ title: 'Pulse', activeNav: 'pulse' }, body));

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -1,8 +1,19 @@
+/**
+ * Pulse page layout: types, tile chrome (header/footer/wrapper),
+ * auto-palette resolution, and the page renderer.
+ *
+ * Template renderers live in pulse-renderers.ts.
+ * Helpers (markdown, stringify, etc.) live in pulse-helpers.ts.
+ * Template registry + extraction live in pulse-templates.ts.
+ */
+
 import type { Agent, AgentSignal, Run, SignalTemplate } from '@some-useful-agents/core';
 import { html, render, unsafeHtml, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { formatAge } from './components.js';
 import { normalizeSignal } from './pulse-templates.js';
+import { esc } from './pulse-helpers.js';
+import { renderTile } from './pulse-renderers.js';
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -14,190 +25,18 @@ export interface PulseTile {
 }
 
 export interface PulsePageInput {
-  /** Virtual system metric tiles (runs today, failure rate, etc.). */
   systemTiles: PulseTile[];
-  /** Visible agent tiles. */
   tiles: PulseTile[];
-  /** Hidden agent tiles. */
   hiddenTiles: PulseTile[];
 }
 
-// ── Template renderers ───────────────────────────────────────────────────
+/** Signature for the tile wrapper function, passed to renderers. */
+export type TileWrapFn = (tile: PulseTile, content: SafeHtml) => SafeHtml;
 
-function renderMetric(tile: PulseTile): SafeHtml {
-  const val = tile.slots.value !== undefined ? stringify(tile.slots.value) : '--';
-  const unit = tile.slots.unit ? String(tile.slots.unit) : '';
-  const label = tile.slots.label ? String(tile.slots.label) : '';
-  const prev = tile.slots.previous !== undefined ? Number(tile.slots.previous) : undefined;
-  const curr = tile.slots.value !== undefined ? Number(tile.slots.value) : undefined;
+// ── Tile chrome ──────────────────────────────────────────────────────────
 
-  let trend = '';
-  if (prev !== undefined && curr !== undefined && !isNaN(prev) && !isNaN(curr)) {
-    if (curr > prev) trend = '\u2191';
-    else if (curr < prev) trend = '\u2193';
-    else trend = '\u2192';
-  }
-  const trendClass = trend === '\u2191' ? 'pulse-tile__trend--up'
-    : trend === '\u2193' ? 'pulse-tile__trend--down'
-    : 'pulse-tile__trend--flat';
-
-  return tileWrap(tile, html`
-    <div class="pulse-tile__value">
-      ${val}${unit ? html`<span class="pulse-tile__unit">${unit}</span>` : html``}${trend ? html`<span class="pulse-tile__trend ${trendClass}">${trend}</span>` : html``}
-    </div>
-    ${label ? html`<div class="pulse-tile__label">${label}</div>` : html``}
-  `);
-}
-
-function renderTextHeadline(tile: PulseTile): SafeHtml {
-  const headline = tile.slots.headline ? stringify(tile.slots.headline) : '';
-  const rawBody = tile.slots.body ?? 'No data yet';
-  const bodyStr = stringify(rawBody);
-  const isJson = looksLikeJson(bodyStr);
-  let bodyHtml: SafeHtml;
-  if (isJson) {
-    const pretty = prettyJson(bodyStr);
-    const truncated = pretty.length > 800 ? pretty.slice(0, 800) + '\n...' : pretty;
-    bodyHtml = html`<pre class="pulse-tile__code">${truncated}</pre>`;
-  } else {
-    const truncBody = bodyStr.length > 800 ? bodyStr.slice(0, 800) + '...' : bodyStr;
-    bodyHtml = unsafeHtml(`<div class="pulse-tile__body pulse-tile__body--md">${renderMarkdown(truncBody)}</div>`);
-  }
-
-  return tileWrap(tile, html`
-    ${headline ? html`<div class="pulse-tile__headline">${headline}</div>` : html``}
-    ${bodyHtml}
-  `);
-}
-
-function renderTable(tile: PulseTile): SafeHtml {
-  let rows: Record<string, unknown>[] = [];
-  const rawRows = tile.slots.rows;
-  if (Array.isArray(rawRows)) rows = rawRows.slice(0, 10) as Record<string, unknown>[];
-  else if (typeof rawRows === 'string') {
-    try { const p = JSON.parse(rawRows); if (Array.isArray(p)) rows = p.slice(0, 10) as Record<string, unknown>[]; } catch { /* */ }
-  }
-  let cols: string[] = [];
-  if (tile.slots.columns && Array.isArray(tile.slots.columns)) cols = tile.slots.columns.map(String);
-  else if (rows.length > 0) cols = Object.keys(rows[0]);
-
-  const tableHtml = rows.length === 0
-    ? html`<p class="dim" style="font-size: var(--font-size-xs);">No data</p>`
-    : unsafeHtml(`<table class="pulse-table"><thead><tr>${cols.map((c) => `<th>${esc(c)}</th>`).join('')}</tr></thead><tbody>${rows.map((r) => `<tr>${cols.map((c) => `<td>${esc(String(r[c] ?? ''))}</td>`).join('')}</tr>`).join('')}</tbody></table>`);
-
-  return tileWrap(tile, tableHtml);
-}
-
-function renderStatus(tile: PulseTile): SafeHtml {
-  const status = tile.slots.status ? String(tile.slots.status).toLowerCase() : 'unknown';
-  const label = tile.slots.label ? String(tile.slots.label) : status;
-  const message = tile.slots.message ? String(tile.slots.message) : '';
-  const dotClass = status === 'healthy' || status === 'ok' || status === 'up'
-    ? 'pulse-tile__status-dot--healthy'
-    : status === 'degraded' || status === 'warn' || status === 'warning'
-    ? 'pulse-tile__status-dot--degraded'
-    : 'pulse-tile__status-dot--down';
-
-  return tileWrap(tile, html`
-    <div style="display: flex; align-items: center; gap: var(--space-2); flex: 1;">
-      <span class="pulse-tile__status-dot ${dotClass}"></span>
-      <span class="pulse-tile__status-label">${label}</span>
-    </div>
-    ${message ? html`<div class="pulse-tile__status-message">${message}</div>` : html``}
-  `);
-}
-
-function renderTimeSeries(tile: PulseTile): SafeHtml {
-  const values = Array.isArray(tile.slots.values) ? tile.slots.values.map(Number).filter((n) => !isNaN(n)) : [];
-  const current = tile.slots.current !== undefined ? String(tile.slots.current) : (values.length > 0 ? String(values[values.length - 1]) : '--');
-  const label = tile.slots.label ? String(tile.slots.label) : '';
-
-  let sparkline = html`<div class="dim" style="font-size: var(--font-size-xs);">No data points</div>`;
-  if (values.length >= 2) {
-    const min = Math.min(...values);
-    const max = Math.max(...values);
-    const range = max - min || 1;
-    const h = 40, w = 200;
-    const points = values.map((v, i) => `${((i / (values.length - 1)) * w).toFixed(1)},${(h - ((v - min) / range) * h).toFixed(1)}`).join(' ');
-    sparkline = unsafeHtml(`<div class="pulse-tile__sparkline"><svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="none"><polyline points="${points}"/></svg></div>`);
-  }
-
-  return tileWrap(tile, html`
-    <div class="pulse-tile__value" style="font-size: var(--font-size-xl);">${current}</div>
-    ${sparkline}
-    ${label ? html`<div class="pulse-tile__label">${label}</div>` : html``}
-  `);
-}
-
-function renderImage(tile: PulseTile): SafeHtml {
-  const url = tile.slots.imageUrl ? String(tile.slots.imageUrl) : '';
-  const alt = tile.slots.alt ? String(tile.slots.alt) : tile.signal.title;
-  return tileWrap(tile, url
-    ? unsafeHtml(`<img class="pulse-tile__image" src="${esc(url)}" alt="${esc(alt)}" loading="lazy" style="width:100%;border-radius:var(--radius-sm);object-fit:cover;max-height:240px;">`)
-    : html`<div class="dim" style="font-size: var(--font-size-xs);">No image URL</div>`
-  );
-}
-
-function renderTextImage(tile: PulseTile): SafeHtml {
-  const text = tile.slots.text ? String(tile.slots.text) : '';
-  const url = tile.slots.imageUrl ? String(tile.slots.imageUrl) : '';
-  const truncText = text.length > 300 ? text.slice(0, 300) + '...' : text;
-  return tileWrap(tile, html`
-    <div style="display: flex; gap: var(--space-3); flex: 1;">
-      <div class="pulse-tile__body" style="flex: 1;">${truncText || 'No text'}</div>
-      ${url ? unsafeHtml(`<img class="pulse-tile__image" src="${esc(url)}" alt="" style="max-width:120px;max-height:120px;" loading="lazy">`) : html``}
-    </div>
-  `);
-}
-
-function renderMedia(tile: PulseTile): SafeHtml {
-  const rawUrl = tile.slots.url ? String(tile.slots.url).trim() : '';
-  const title = tile.slots.title ? String(tile.slots.title) : '';
-  const caption = tile.slots.caption ? String(tile.slots.caption) : '';
-  const mediaType = tile.slots.mediaType ? String(tile.slots.mediaType).toLowerCase() : '';
-
-  const ytMatch = rawUrl.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/);
-  const isYoutube = !!ytMatch;
-  const isVideo = !isYoutube && (mediaType === 'video' || /\.(mp4|webm|ogg)(\?|$)/i.test(rawUrl));
-  const isImage = !isYoutube && !isVideo && /\.(png|jpe?g|gif|webp|svg|bmp)(\?|$)/i.test(rawUrl);
-
-  let mediaEl: SafeHtml;
-  if (!rawUrl) {
-    mediaEl = html`<div class="dim" style="font-size: var(--font-size-xs); padding: var(--space-4); text-align: center;">No media URL</div>`;
-  } else if (isYoutube) {
-    const videoId = ytMatch![1];
-    const thumbUrl = `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
-    const watchUrl = `https://www.youtube.com/watch?v=${videoId}`;
-    // Use nocookie domain for better embed compatibility. Autoplay on click.
-    const embedUrl = `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0&modestbranding=1`;
-    mediaEl = unsafeHtml(
-      `<div class="pulse-media-yt" data-embed="${esc(embedUrl)}" data-watch="${esc(watchUrl)}" style="position:relative;border-radius:var(--radius-sm);overflow:hidden;cursor:pointer;">` +
-      `<img src="${esc(thumbUrl)}" alt="${esc(title || 'YouTube video')}" loading="lazy" style="width:100%;display:block;aspect-ratio:16/9;object-fit:cover;">` +
-      `<span style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:48px;height:48px;background:rgba(0,0,0,0.7);border-radius:50%;display:flex;align-items:center;justify-content:center;">` +
-      `<span style="width:0;height:0;border-style:solid;border-width:8px 0 8px 16px;border-color:transparent transparent transparent #fff;margin-left:3px;"></span>` +
-      `</span></div>` +
-      `<a href="${esc(watchUrl)}" target="_blank" rel="noopener" style="display:block;font-size:var(--font-size-xs);color:var(--color-text-muted);margin-top:var(--space-1);text-align:right;">Open on YouTube \u2197</a>`
-    );
-  } else if (isVideo) {
-    mediaEl = unsafeHtml(`<video src="${esc(rawUrl)}" controls preload="metadata" style="width:100%;border-radius:var(--radius-sm);"></video>`);
-  } else if (isImage) {
-    mediaEl = unsafeHtml(`<img src="${esc(rawUrl)}" alt="${esc(title)}" loading="lazy" style="width:100%;border-radius:var(--radius-sm);object-fit:cover;max-height:240px;">`);
-  } else {
-    mediaEl = unsafeHtml(`<a href="${esc(rawUrl)}" target="_blank" rel="noopener" style="color:var(--color-primary);font-family:var(--font-mono);font-size:var(--font-size-xs);word-break:break-all;">${esc(rawUrl)}</a>`);
-  }
-
-  return tileWrap(tile, html`
-    ${title ? html`<div class="pulse-tile__headline" style="font-size: var(--font-size-sm);">${title}</div>` : html``}
-    ${mediaEl}
-    ${caption ? html`<div class="dim" style="font-size: var(--font-size-xs);">${caption}</div>` : html``}
-  `);
-}
-
-// ── Tile wrapper ─────────────────────────────────────────────────────────
-
-/** Wraps tile content with the standard tile chrome: header, content, footer.
- *  Each tile gets draggable + data attributes for the layout system. */
-function tileWrap(tile: PulseTile, content: SafeHtml): SafeHtml {
+/** Wraps tile content with header, footer, resize handle, and data attributes. */
+export function tileWrap(tile: PulseTile, content: SafeHtml): SafeHtml {
   const isSystem = tile.agent.id.startsWith('_system-');
   const sizeAttr = tile.signal.size ?? '1x1';
   const autoPalette = resolveAutoPalette(tile);
@@ -214,16 +53,9 @@ function tileWrap(tile: PulseTile, content: SafeHtml): SafeHtml {
   );
 }
 
-/**
- * Resolve auto-palette for a tile based on:
- * 1. Conditional thresholds (if declared in signal.thresholds)
- * 2. Template-type defaults (metric→teal, status→auto by value)
- * 3. null = no auto-palette (inherit page theme)
- */
 function resolveAutoPalette(tile: PulseTile): string | null {
   const { template } = normalizeSignal(tile.signal);
 
-  // 1. Conditional thresholds (metric tiles with numeric value).
   if (tile.signal.thresholds && tile.signal.thresholds.length > 0) {
     const numVal = Number(tile.slots.value);
     if (!isNaN(numVal)) {
@@ -234,7 +66,6 @@ function resolveAutoPalette(tile: PulseTile): string | null {
     }
   }
 
-  // 2. Status tiles auto-color by status value.
   if (template === 'status') {
     const status = tile.slots.status ? String(tile.slots.status).toLowerCase() : '';
     if (status === 'healthy' || status === 'ok' || status === 'up') return 'accent-green';
@@ -242,9 +73,7 @@ function resolveAutoPalette(tile: PulseTile): string | null {
     if (status === 'down' || status === 'error' || status === 'critical') return 'accent-red';
   }
 
-  // 3. Template-type defaults.
   if (template === 'metric') return 'accent-teal';
-
   return null;
 }
 
@@ -290,65 +119,6 @@ function tileFooter(tile: PulseTile): SafeHtml {
   `;
 }
 
-function renderTile(tile: PulseTile): SafeHtml {
-  const { template } = normalizeSignal(tile.signal);
-  switch (template as SignalTemplate) {
-    case 'metric': return renderMetric(tile);
-    case 'text-headline': return renderTextHeadline(tile);
-    case 'table': return renderTable(tile);
-    case 'status': return renderStatus(tile);
-    case 'time-series': return renderTimeSeries(tile);
-    case 'image': return renderImage(tile);
-    case 'text-image': return renderTextImage(tile);
-    case 'media': return renderMedia(tile);
-    default: return renderTextHeadline(tile);
-  }
-}
-
-// ── Helpers ──────────────────────────────────────────────────────────────
-
-function esc(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-}
-
-function stringify(val: unknown): string {
-  if (val === null || val === undefined) return '';
-  if (typeof val === 'string') return val;
-  if (typeof val === 'number' || typeof val === 'boolean') return String(val);
-  try { return JSON.stringify(val, null, 2); } catch { return String(val); }
-}
-
-function renderMarkdown(text: string): string {
-  let h = esc(text);
-  h = h.replace(/```(\w*)\n([\s\S]*?)```/g, '<pre class="pulse-tile__code">$2</pre>');
-  h = h.replace(/`([^`]+)`/g, '<code style="background:var(--color-surface-raised);padding:0 var(--space-1);border-radius:3px;font-size:var(--font-size-xs);">$1</code>');
-  h = h.replace(/^### (.+)$/gm, '<strong style="font-size:var(--font-size-sm);display:block;margin-top:var(--space-2);">$1</strong>');
-  h = h.replace(/^## (.+)$/gm, '<strong style="font-size:var(--font-size-md);display:block;margin-top:var(--space-2);">$1</strong>');
-  h = h.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
-  h = h.replace(/\*(.+?)\*/g, '<em>$1</em>');
-  h = h.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" style="color:var(--color-primary);" target="_blank" rel="noopener">$1</a>');
-  const tableRe = /^(\|.+\|)\n(\|[-| :]+\|)\n((?:\|.+\|\n?)+)/gm;
-  h = h.replace(tableRe, (_, headerRow: string, _sep: string, bodyRows: string) => {
-    const headers = headerRow.split('|').filter(Boolean).map((c: string) => c.trim());
-    const rows = bodyRows.trim().split('\n').map((r: string) => r.split('|').filter(Boolean).map((c: string) => c.trim()));
-    return '<table class="pulse-table" style="margin:var(--space-2) 0;"><thead><tr>' + headers.map((h: string) => `<th>${h}</th>`).join('') + '</tr></thead><tbody>' + rows.map((r: string[]) => '<tr>' + r.map((c: string) => `<td>${c}</td>`).join('') + '</tr>').join('') + '</tbody></table>';
-  });
-  h = h.replace(/^- (.+)$/gm, '<li style="margin-left:var(--space-4);list-style:disc;">$1</li>');
-  h = h.replace(/\n{2,}/g, '<br><br>');
-  h = h.replace(/\n/g, '<br>');
-  return h;
-}
-
-function looksLikeJson(s: string): boolean {
-  const t = s.trimStart();
-  if (!t.startsWith('{') && !t.startsWith('[')) return false;
-  try { JSON.parse(t); return true; } catch { return false; }
-}
-
-function prettyJson(s: string): string {
-  try { return JSON.stringify(JSON.parse(s.trim()), null, 2); } catch { return s; }
-}
-
 // ── Page ─────────────────────────────────────────────────────────────────
 
 export function renderPulsePage(input: PulsePageInput): string {
@@ -356,9 +126,10 @@ export function renderPulsePage(input: PulsePageInput): string {
   const allTileCount = systemTiles.length + tiles.length;
   const hiddenCount = hiddenTiles.length;
 
-  // Build a JSON blob of all tile IDs so the JS can construct the default layout.
   const allTileIds = [...systemTiles.map((t) => t.agent.id), ...tiles.map((t) => t.agent.id)];
   const systemTileIds = systemTiles.map((t) => t.agent.id);
+
+  const doRenderTile = (tile: PulseTile) => renderTile(tile, tileWrap);
 
   const body = html`
     <div style="display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-6);">
@@ -372,18 +143,15 @@ export function renderPulsePage(input: PulsePageInput): string {
       </div>
     </div>
 
-    <!-- Container host — JS reads layout from localStorage and arranges tiles -->
     <div id="pulse-containers">
-      <!-- Default: all tiles in order. JS will reorganize into containers. -->
       <section class="pulse-container" data-container-id="_default">
         <div class="pulse-grid" data-container-id="_default">
-          ${systemTiles.map((t) => renderTile(t)) as unknown as SafeHtml[]}
-          ${tiles.map((t) => renderTile(t)) as unknown as SafeHtml[]}
+          ${systemTiles.map(doRenderTile) as unknown as SafeHtml[]}
+          ${tiles.map(doRenderTile) as unknown as SafeHtml[]}
         </div>
       </section>
     </div>
 
-    <!-- Hidden tiles -->
     ${hiddenCount > 0 ? html`
       <details class="pulse-hidden-section" style="margin-top: var(--space-6);">
         <summary style="cursor: pointer; font-family: var(--font-mono); font-size: var(--font-size-xs); font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-text-muted);">
@@ -401,7 +169,6 @@ export function renderPulsePage(input: PulsePageInput): string {
       </details>
     ` : html``}
 
-    <!-- Layout data for JS -->
     ${unsafeHtml(`<script type="application/json" id="pulse-tile-data">${JSON.stringify({ allTileIds, systemTileIds })}</script>`)}
   `;
 

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -1,0 +1,266 @@
+import type { Agent, AgentSignal, Run } from '@some-useful-agents/core';
+import { html, render, unsafeHtml, type SafeHtml } from './html.js';
+import { layout } from './layout.js';
+import { formatAge } from './components.js';
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+export interface PulseTile {
+  agent: Agent;
+  signal: AgentSignal;
+  lastRun?: Run;
+  /** Extracted value from the run output via signal.field or raw result. */
+  value?: unknown;
+}
+
+export interface PulsePageInput {
+  tiles: PulseTile[];
+  /** Stats for the health strip. */
+  stats: {
+    runsToday: number;
+    failedToday: number;
+    avgDurationSec: number;
+    agentCount: number;
+  };
+}
+
+// ── Value extraction ─────────────────────────────────────────────────────
+
+/**
+ * Extract the display value from a run's output using the signal's field
+ * dot-path. Falls back to the raw result text.
+ */
+export function extractSignalValue(
+  run: Run | undefined,
+  signal: AgentSignal,
+  outputsJson?: string,
+): unknown {
+  if (!run?.result) return undefined;
+
+  // Try structured output first (outputsJson from the last node).
+  if (outputsJson && signal.field) {
+    try {
+      const obj = JSON.parse(outputsJson);
+      const val = dotGet(obj, signal.field);
+      if (val !== undefined) return val;
+    } catch { /* fall through to raw result */ }
+  }
+
+  // Try parsing result as JSON and extracting via field path.
+  if (signal.field) {
+    try {
+      const parsed = JSON.parse(run.result);
+      const val = dotGet(parsed, signal.field);
+      if (val !== undefined) return val;
+    } catch { /* not JSON, use raw */ }
+  }
+
+  // Raw result text.
+  return run.result;
+}
+
+function dotGet(obj: unknown, path: string): unknown {
+  const parts = path.split('.');
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (current === null || current === undefined) return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+// ── Tile renderers ───────────────────────────────────────────────────────
+
+function renderNumberTile(tile: PulseTile): SafeHtml {
+  const val = tile.value !== undefined ? String(tile.value) : '--';
+  const icon = tile.signal.icon ?? '';
+  return html`
+    <div class="pulse-tile pulse-tile--number ${sizeClass(tile.signal.size)}">
+      <div class="pulse-tile__header">
+        ${icon ? html`<span class="pulse-tile__icon">${icon}</span>` : html``}
+        <span class="pulse-tile__title">${tile.signal.title}</span>
+      </div>
+      <div class="pulse-tile__value">${val}</div>
+      ${tileFooter(tile)}
+    </div>
+  `;
+}
+
+function renderTextTile(tile: PulseTile): SafeHtml {
+  const val = tile.value !== undefined ? String(tile.value) : 'No data yet';
+  const truncated = val.length > 400 ? val.slice(0, 400) + '...' : val;
+  const icon = tile.signal.icon ?? '';
+  return html`
+    <div class="pulse-tile pulse-tile--text ${sizeClass(tile.signal.size)}">
+      <div class="pulse-tile__header">
+        ${icon ? html`<span class="pulse-tile__icon">${icon}</span>` : html``}
+        <span class="pulse-tile__title">${tile.signal.title}</span>
+      </div>
+      <div class="pulse-tile__text">${truncated}</div>
+      ${tileFooter(tile)}
+    </div>
+  `;
+}
+
+function renderTableTile(tile: PulseTile): SafeHtml {
+  const icon = tile.signal.icon ?? '';
+  let rows: Record<string, unknown>[] = [];
+  if (Array.isArray(tile.value)) {
+    rows = tile.value.slice(0, 10) as Record<string, unknown>[];
+  } else if (typeof tile.value === 'string') {
+    try {
+      const parsed = JSON.parse(tile.value);
+      if (Array.isArray(parsed)) rows = parsed.slice(0, 10) as Record<string, unknown>[];
+    } catch { /* not JSON */ }
+  }
+
+  const cols = rows.length > 0 ? Object.keys(rows[0]) : [];
+  const tableHtml = rows.length === 0
+    ? html`<p class="dim" style="font-size: var(--font-size-xs);">No data</p>`
+    : unsafeHtml(`
+      <table class="pulse-table">
+        <thead><tr>${cols.map((c) => `<th>${escHtml(c)}</th>`).join('')}</tr></thead>
+        <tbody>${rows.map((r) =>
+          `<tr>${cols.map((c) => `<td>${escHtml(String(r[c] ?? ''))}</td>`).join('')}</tr>`
+        ).join('')}</tbody>
+      </table>
+    `);
+
+  return html`
+    <div class="pulse-tile pulse-tile--table ${sizeClass(tile.signal.size)}">
+      <div class="pulse-tile__header">
+        ${icon ? html`<span class="pulse-tile__icon">${icon}</span>` : html``}
+        <span class="pulse-tile__title">${tile.signal.title}</span>
+      </div>
+      ${tableHtml}
+      ${tileFooter(tile)}
+    </div>
+  `;
+}
+
+function renderJsonTile(tile: PulseTile): SafeHtml {
+  const icon = tile.signal.icon ?? '';
+  let formatted = '';
+  if (tile.value !== undefined) {
+    try {
+      const obj = typeof tile.value === 'string' ? JSON.parse(tile.value) : tile.value;
+      formatted = JSON.stringify(obj, null, 2);
+    } catch {
+      formatted = String(tile.value);
+    }
+  }
+  const truncated = formatted.length > 600 ? formatted.slice(0, 600) + '\n...' : formatted;
+  return html`
+    <div class="pulse-tile pulse-tile--json ${sizeClass(tile.signal.size)}">
+      <div class="pulse-tile__header">
+        ${icon ? html`<span class="pulse-tile__icon">${icon}</span>` : html``}
+        <span class="pulse-tile__title">${tile.signal.title}</span>
+      </div>
+      <pre class="pulse-tile__code">${truncated || 'No data'}</pre>
+      ${tileFooter(tile)}
+    </div>
+  `;
+}
+
+function renderChartTile(tile: PulseTile): SafeHtml {
+  // v1: chart is rendered as a number with a placeholder note.
+  // SVG sparklines come in Phase 5.
+  return renderNumberTile(tile);
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function sizeClass(size?: string): string {
+  if (size === '2x1') return 'pulse-tile--2x1';
+  if (size === '1x2') return 'pulse-tile--1x2';
+  if (size === '2x2') return 'pulse-tile--2x2';
+  return '';
+}
+
+function tileFooter(tile: PulseTile): SafeHtml {
+  const agentLink = `/agents/${tile.agent.id}`;
+  const runLink = tile.lastRun ? `/runs/${tile.lastRun.id}` : '';
+  const age = tile.lastRun ? formatAge(tile.lastRun.completedAt ?? tile.lastRun.startedAt) : 'never';
+  return html`
+    <div class="pulse-tile__footer">
+      <a href="${agentLink}" class="pulse-tile__agent">${tile.agent.id}</a>
+      ${runLink
+        ? html`<a href="${runLink}" class="pulse-tile__age">${age}</a>`
+        : html`<span class="pulse-tile__age">${age}</span>`}
+    </div>
+  `;
+}
+
+function escHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function renderTile(tile: PulseTile): SafeHtml {
+  switch (tile.signal.format) {
+    case 'number': return renderNumberTile(tile);
+    case 'text': return renderTextTile(tile);
+    case 'table': return renderTableTile(tile);
+    case 'json': return renderJsonTile(tile);
+    case 'chart': return renderChartTile(tile);
+    default: return renderTextTile(tile);
+  }
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────
+
+export function renderPulsePage(input: PulsePageInput): string {
+  const { tiles, stats } = input;
+  const failRate = stats.runsToday > 0 ? Math.round((stats.failedToday / stats.runsToday) * 100) : 0;
+
+  const body = html`
+    <div style="display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-6);">
+      <h1 style="margin: 0;">Pulse</h1>
+      <span style="font-size: var(--font-size-sm); color: var(--color-text-muted);">
+        ${String(tiles.length)} signal${tiles.length !== 1 ? 's' : ''} active
+      </span>
+    </div>
+
+    <!-- Health strip -->
+    <div class="pulse-health">
+      <div class="pulse-health__stat">
+        <span class="pulse-health__value">${String(stats.runsToday)}</span>
+        <span class="pulse-health__label">runs today</span>
+      </div>
+      <div class="pulse-health__stat">
+        <span class="pulse-health__value ${failRate > 20 ? 'pulse-health__value--warn' : ''}">${String(failRate)}%</span>
+        <span class="pulse-health__label">failure rate</span>
+      </div>
+      <div class="pulse-health__stat">
+        <span class="pulse-health__value">${stats.avgDurationSec > 0 ? String(stats.avgDurationSec) + 's' : '--'}</span>
+        <span class="pulse-health__label">avg duration</span>
+      </div>
+      <div class="pulse-health__stat">
+        <span class="pulse-health__value">${String(stats.agentCount)}</span>
+        <span class="pulse-health__label">agents</span>
+      </div>
+    </div>
+
+    <!-- Signal tiles -->
+    ${tiles.length === 0
+      ? html`
+        <div class="pulse-empty">
+          <h2>No signals yet</h2>
+          <p>Add a <code>signal:</code> field to any agent's YAML to show its output here.</p>
+          <pre class="pulse-empty__example">signal:
+  title: API Latency
+  icon: "\u26A1"
+  format: number
+  field: latency_ms</pre>
+          <p><a href="/agents">Browse agents &rarr;</a></p>
+        </div>
+      `
+      : html`
+        <div class="pulse-grid">
+          ${tiles.map((t) => renderTile(t)) as unknown as SafeHtml[]}
+        </div>
+      `
+    }
+  `;
+
+  return render(layout({ title: 'Pulse', activeNav: 'pulse' }, body));
+}

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -1,7 +1,8 @@
-import type { Agent, AgentSignal, Run } from '@some-useful-agents/core';
+import type { Agent, AgentSignal, Run, SignalTemplate } from '@some-useful-agents/core';
 import { html, render, unsafeHtml, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { formatAge } from './components.js';
+import { normalizeSignal, extractMappedValues } from './pulse-templates.js';
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -9,13 +10,14 @@ export interface PulseTile {
   agent: Agent;
   signal: AgentSignal;
   lastRun?: Run;
-  /** Extracted value from the run output via signal.field or raw result. */
-  value?: unknown;
+  /** Resolved slot values from extractMappedValues. */
+  slots: Record<string, unknown>;
 }
 
 export interface PulsePageInput {
   tiles: PulseTile[];
-  /** Stats for the health strip. */
+  /** Hidden tiles (for the show/hide panel). */
+  hiddenTiles: PulseTile[];
   stats: {
     runsToday: number;
     failedToday: number;
@@ -24,148 +26,174 @@ export interface PulsePageInput {
   };
 }
 
-// ── Value extraction ─────────────────────────────────────────────────────
+// ── Template renderers ───────────────────────────────────────────────────
 
-/**
- * Extract the display value from a run's output using the signal's field
- * dot-path. Falls back to the raw result text.
- */
-export function extractSignalValue(
-  run: Run | undefined,
-  signal: AgentSignal,
-  outputsJson?: string,
-): unknown {
-  if (!run?.result) return undefined;
+function renderMetric(tile: PulseTile): SafeHtml {
+  const val = tile.slots.value !== undefined ? String(tile.slots.value) : '--';
+  const unit = tile.slots.unit ? String(tile.slots.unit) : '';
+  const label = tile.slots.label ? String(tile.slots.label) : '';
+  const prev = tile.slots.previous !== undefined ? Number(tile.slots.previous) : undefined;
+  const curr = tile.slots.value !== undefined ? Number(tile.slots.value) : undefined;
 
-  // Try structured output first (outputsJson from the last node).
-  if (outputsJson && signal.field) {
-    try {
-      const obj = JSON.parse(outputsJson);
-      const val = dotGet(obj, signal.field);
-      if (val !== undefined) return val;
-    } catch { /* fall through to raw result */ }
+  let trend = '';
+  if (prev !== undefined && curr !== undefined && !isNaN(prev) && !isNaN(curr)) {
+    if (curr > prev) trend = '\u2191';       // ↑
+    else if (curr < prev) trend = '\u2193';  // ↓
+    else trend = '\u2192';                   // →
   }
+  const trendClass = trend === '\u2191' ? 'pulse-tile__trend--up'
+    : trend === '\u2193' ? 'pulse-tile__trend--down'
+    : 'pulse-tile__trend--flat';
 
-  // Try parsing result as JSON and extracting via field path.
-  if (signal.field) {
-    try {
-      const parsed = JSON.parse(run.result);
-      const val = dotGet(parsed, signal.field);
-      if (val !== undefined) return val;
-    } catch { /* not JSON, use raw */ }
-  }
-
-  // Raw result text.
-  return run.result;
-}
-
-function dotGet(obj: unknown, path: string): unknown {
-  const parts = path.split('.');
-  let current: unknown = obj;
-  for (const part of parts) {
-    if (current === null || current === undefined) return undefined;
-    current = (current as Record<string, unknown>)[part];
-  }
-  return current;
-}
-
-// ── Tile renderers ───────────────────────────────────────────────────────
-
-function renderNumberTile(tile: PulseTile): SafeHtml {
-  const val = tile.value !== undefined ? String(tile.value) : '--';
-  const icon = tile.signal.icon ?? '';
   return html`
-    <div class="pulse-tile pulse-tile--number ${sizeClass(tile.signal.size)}">
-      <div class="pulse-tile__header">
-        ${icon ? html`<span class="pulse-tile__icon">${icon}</span>` : html``}
-        <span class="pulse-tile__title">${tile.signal.title}</span>
+    <div class="pulse-tile pulse-tile--metric ${sizeClass(tile.signal.size)}">
+      ${tileHeader(tile)}
+      <div class="pulse-tile__value">
+        ${val}${unit ? html`<span class="pulse-tile__unit">${unit}</span>` : html``}${trend ? html`<span class="pulse-tile__trend ${trendClass}">${trend}</span>` : html``}
       </div>
-      <div class="pulse-tile__value">${val}</div>
+      ${label ? html`<div class="pulse-tile__label">${label}</div>` : html``}
       ${tileFooter(tile)}
     </div>
   `;
 }
 
-function renderTextTile(tile: PulseTile): SafeHtml {
-  const val = tile.value !== undefined ? String(tile.value) : 'No data yet';
-  const truncated = val.length > 400 ? val.slice(0, 400) + '...' : val;
-  const icon = tile.signal.icon ?? '';
+function renderTextHeadline(tile: PulseTile): SafeHtml {
+  const headline = tile.slots.headline ? String(tile.slots.headline) : '';
+  const body = tile.slots.body ? String(tile.slots.body) : 'No data yet';
+  const truncBody = body.length > 500 ? body.slice(0, 500) + '...' : body;
   return html`
-    <div class="pulse-tile pulse-tile--text ${sizeClass(tile.signal.size)}">
-      <div class="pulse-tile__header">
-        ${icon ? html`<span class="pulse-tile__icon">${icon}</span>` : html``}
-        <span class="pulse-tile__title">${tile.signal.title}</span>
-      </div>
-      <div class="pulse-tile__text">${truncated}</div>
+    <div class="pulse-tile pulse-tile--text-headline ${sizeClass(tile.signal.size)}">
+      ${tileHeader(tile)}
+      ${headline ? html`<div class="pulse-tile__headline">${headline}</div>` : html``}
+      <div class="pulse-tile__body">${truncBody}</div>
       ${tileFooter(tile)}
     </div>
   `;
 }
 
-function renderTableTile(tile: PulseTile): SafeHtml {
-  const icon = tile.signal.icon ?? '';
+function renderTable(tile: PulseTile): SafeHtml {
   let rows: Record<string, unknown>[] = [];
-  if (Array.isArray(tile.value)) {
-    rows = tile.value.slice(0, 10) as Record<string, unknown>[];
-  } else if (typeof tile.value === 'string') {
+  const rawRows = tile.slots.rows;
+  if (Array.isArray(rawRows)) {
+    rows = rawRows.slice(0, 10) as Record<string, unknown>[];
+  } else if (typeof rawRows === 'string') {
     try {
-      const parsed = JSON.parse(tile.value);
+      const parsed = JSON.parse(rawRows);
       if (Array.isArray(parsed)) rows = parsed.slice(0, 10) as Record<string, unknown>[];
     } catch { /* not JSON */ }
   }
 
-  const cols = rows.length > 0 ? Object.keys(rows[0]) : [];
+  let cols: string[] = [];
+  if (tile.slots.columns && Array.isArray(tile.slots.columns)) {
+    cols = tile.slots.columns.map(String);
+  } else if (rows.length > 0) {
+    cols = Object.keys(rows[0]);
+  }
+
   const tableHtml = rows.length === 0
     ? html`<p class="dim" style="font-size: var(--font-size-xs);">No data</p>`
     : unsafeHtml(`
       <table class="pulse-table">
-        <thead><tr>${cols.map((c) => `<th>${escHtml(c)}</th>`).join('')}</tr></thead>
+        <thead><tr>${cols.map((c) => `<th>${esc(c)}</th>`).join('')}</tr></thead>
         <tbody>${rows.map((r) =>
-          `<tr>${cols.map((c) => `<td>${escHtml(String(r[c] ?? ''))}</td>`).join('')}</tr>`
+          `<tr>${cols.map((c) => `<td>${esc(String(r[c] ?? ''))}</td>`).join('')}</tr>`
         ).join('')}</tbody>
       </table>
     `);
 
   return html`
     <div class="pulse-tile pulse-tile--table ${sizeClass(tile.signal.size)}">
-      <div class="pulse-tile__header">
-        ${icon ? html`<span class="pulse-tile__icon">${icon}</span>` : html``}
-        <span class="pulse-tile__title">${tile.signal.title}</span>
-      </div>
+      ${tileHeader(tile)}
       ${tableHtml}
       ${tileFooter(tile)}
     </div>
   `;
 }
 
-function renderJsonTile(tile: PulseTile): SafeHtml {
-  const icon = tile.signal.icon ?? '';
-  let formatted = '';
-  if (tile.value !== undefined) {
-    try {
-      const obj = typeof tile.value === 'string' ? JSON.parse(tile.value) : tile.value;
-      formatted = JSON.stringify(obj, null, 2);
-    } catch {
-      formatted = String(tile.value);
-    }
-  }
-  const truncated = formatted.length > 600 ? formatted.slice(0, 600) + '\n...' : formatted;
+function renderStatus(tile: PulseTile): SafeHtml {
+  const status = tile.slots.status ? String(tile.slots.status).toLowerCase() : 'unknown';
+  const label = tile.slots.label ? String(tile.slots.label) : status;
+  const message = tile.slots.message ? String(tile.slots.message) : '';
+  const dotClass = status === 'healthy' || status === 'ok' || status === 'up'
+    ? 'pulse-tile__status-dot--healthy'
+    : status === 'degraded' || status === 'warn' || status === 'warning'
+    ? 'pulse-tile__status-dot--degraded'
+    : 'pulse-tile__status-dot--down';
+
   return html`
-    <div class="pulse-tile pulse-tile--json ${sizeClass(tile.signal.size)}">
-      <div class="pulse-tile__header">
-        ${icon ? html`<span class="pulse-tile__icon">${icon}</span>` : html``}
-        <span class="pulse-tile__title">${tile.signal.title}</span>
+    <div class="pulse-tile pulse-tile--status ${sizeClass(tile.signal.size)}">
+      ${tileHeader(tile)}
+      <div style="display: flex; align-items: center; gap: var(--space-2); flex: 1;">
+        <span class="pulse-tile__status-dot ${dotClass}"></span>
+        <span class="pulse-tile__status-label">${label}</span>
       </div>
-      <pre class="pulse-tile__code">${truncated || 'No data'}</pre>
+      ${message ? html`<div class="pulse-tile__status-message">${message}</div>` : html``}
       ${tileFooter(tile)}
     </div>
   `;
 }
 
-function renderChartTile(tile: PulseTile): SafeHtml {
-  // v1: chart is rendered as a number with a placeholder note.
-  // SVG sparklines come in Phase 5.
-  return renderNumberTile(tile);
+function renderTimeSeries(tile: PulseTile): SafeHtml {
+  const values = Array.isArray(tile.slots.values) ? tile.slots.values.map(Number).filter((n) => !isNaN(n)) : [];
+  const current = tile.slots.current !== undefined ? String(tile.slots.current) : (values.length > 0 ? String(values[values.length - 1]) : '--');
+  const label = tile.slots.label ? String(tile.slots.label) : '';
+
+  let sparkline = html`<div class="dim" style="font-size: var(--font-size-xs);">No data points</div>`;
+  if (values.length >= 2) {
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const range = max - min || 1;
+    const h = 40;
+    const w = 200;
+    const points = values.map((v, i) => {
+      const x = (i / (values.length - 1)) * w;
+      const y = h - ((v - min) / range) * h;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    }).join(' ');
+    sparkline = unsafeHtml(`<div class="pulse-tile__sparkline"><svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="none"><polyline points="${points}"/></svg></div>`);
+  }
+
+  return html`
+    <div class="pulse-tile pulse-tile--time-series ${sizeClass(tile.signal.size)}">
+      ${tileHeader(tile)}
+      <div class="pulse-tile__value" style="font-size: var(--font-size-xl);">${current}</div>
+      ${sparkline}
+      ${label ? html`<div class="pulse-tile__label">${label}</div>` : html``}
+      ${tileFooter(tile)}
+    </div>
+  `;
+}
+
+function renderImage(tile: PulseTile): SafeHtml {
+  const url = tile.slots.imageUrl ? String(tile.slots.imageUrl) : '';
+  const alt = tile.slots.alt ? String(tile.slots.alt) : tile.signal.title;
+  return html`
+    <div class="pulse-tile pulse-tile--image ${sizeClass(tile.signal.size)}">
+      ${tileHeader(tile)}
+      ${url
+        ? unsafeHtml(`<img class="pulse-tile__image" src="${esc(url)}" alt="${esc(alt)}" loading="lazy">`)
+        : html`<div class="dim" style="font-size: var(--font-size-xs);">No image URL</div>`}
+      ${tileFooter(tile)}
+    </div>
+  `;
+}
+
+function renderTextImage(tile: PulseTile): SafeHtml {
+  const text = tile.slots.text ? String(tile.slots.text) : '';
+  const url = tile.slots.imageUrl ? String(tile.slots.imageUrl) : '';
+  const truncText = text.length > 300 ? text.slice(0, 300) + '...' : text;
+  return html`
+    <div class="pulse-tile pulse-tile--text-image ${sizeClass(tile.signal.size)}">
+      ${tileHeader(tile)}
+      <div style="display: flex; gap: var(--space-3); flex: 1;">
+        <div class="pulse-tile__body" style="flex: 1;">${truncText || 'No text'}</div>
+        ${url
+          ? unsafeHtml(`<img class="pulse-tile__image" src="${esc(url)}" alt="" style="max-width:120px;max-height:120px;" loading="lazy">`)
+          : html``}
+      </div>
+      ${tileFooter(tile)}
+    </div>
+  `;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────
@@ -175,6 +203,21 @@ function sizeClass(size?: string): string {
   if (size === '1x2') return 'pulse-tile--1x2';
   if (size === '2x2') return 'pulse-tile--2x2';
   return '';
+}
+
+function tileHeader(tile: PulseTile): SafeHtml {
+  const icon = tile.signal.icon ?? '';
+  return html`
+    <div class="pulse-tile__header">
+      <div style="display: flex; align-items: center; gap: var(--space-2); flex: 1;">
+        ${icon ? html`<span class="pulse-tile__icon">${icon}</span>` : html``}
+        <span class="pulse-tile__title">${tile.signal.title}</span>
+      </div>
+      <form method="POST" action="/agents/${tile.agent.id}/signal/toggle" style="margin: 0;">
+        <button type="submit" class="pulse-tile__toggle" title="Hide from Pulse">\u00D7</button>
+      </form>
+    </div>
+  `;
 }
 
 function tileFooter(tile: PulseTile): SafeHtml {
@@ -191,32 +234,37 @@ function tileFooter(tile: PulseTile): SafeHtml {
   `;
 }
 
-function escHtml(s: string): string {
+function esc(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
 function renderTile(tile: PulseTile): SafeHtml {
-  switch (tile.signal.format) {
-    case 'number': return renderNumberTile(tile);
-    case 'text': return renderTextTile(tile);
-    case 'table': return renderTableTile(tile);
-    case 'json': return renderJsonTile(tile);
-    case 'chart': return renderChartTile(tile);
-    default: return renderTextTile(tile);
+  const { template } = normalizeSignal(tile.signal);
+  switch (template as SignalTemplate) {
+    case 'metric': return renderMetric(tile);
+    case 'text-headline': return renderTextHeadline(tile);
+    case 'table': return renderTable(tile);
+    case 'status': return renderStatus(tile);
+    case 'time-series': return renderTimeSeries(tile);
+    case 'image': return renderImage(tile);
+    case 'text-image': return renderTextImage(tile);
+    default: return renderTextHeadline(tile);
   }
 }
 
 // ── Page ─────────────────────────────────────────────────────────────────
 
 export function renderPulsePage(input: PulsePageInput): string {
-  const { tiles, stats } = input;
+  const { tiles, hiddenTiles, stats } = input;
   const failRate = stats.runsToday > 0 ? Math.round((stats.failedToday / stats.runsToday) * 100) : 0;
+  const visibleCount = tiles.length;
+  const hiddenCount = hiddenTiles.length;
 
   const body = html`
     <div style="display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-6);">
       <h1 style="margin: 0;">Pulse</h1>
       <span style="font-size: var(--font-size-sm); color: var(--color-text-muted);">
-        ${String(tiles.length)} signal${tiles.length !== 1 ? 's' : ''} active
+        ${String(visibleCount)} signal${visibleCount !== 1 ? 's' : ''} active${hiddenCount > 0 ? html`, ${String(hiddenCount)} hidden` : html``}
       </span>
     </div>
 
@@ -241,16 +289,17 @@ export function renderPulsePage(input: PulsePageInput): string {
     </div>
 
     <!-- Signal tiles -->
-    ${tiles.length === 0
+    ${visibleCount === 0 && hiddenCount === 0
       ? html`
         <div class="pulse-empty">
           <h2>No signals yet</h2>
           <p>Add a <code>signal:</code> field to any agent's YAML to show its output here.</p>
           <pre class="pulse-empty__example">signal:
   title: API Latency
-  icon: "\u26A1"
-  format: number
-  field: latency_ms</pre>
+  template: metric
+  mapping:
+    value: latency_ms
+    unit: "%"</pre>
           <p><a href="/agents">Browse agents &rarr;</a></p>
         </div>
       `
@@ -260,6 +309,24 @@ export function renderPulsePage(input: PulsePageInput): string {
         </div>
       `
     }
+
+    <!-- Hidden tiles section -->
+    ${hiddenCount > 0 ? html`
+      <details class="pulse-hidden-section" style="margin-top: var(--space-6);">
+        <summary style="cursor: pointer; font-family: var(--font-mono); font-size: var(--font-size-xs); font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-text-muted);">
+          ${String(hiddenCount)} hidden signal${hiddenCount !== 1 ? 's' : ''}
+        </summary>
+        <div style="display: flex; flex-wrap: wrap; gap: var(--space-2); margin-top: var(--space-3);">
+          ${hiddenTiles.map((t) => html`
+            <form method="POST" action="/agents/${t.agent.id}/signal/toggle" style="margin: 0; display: inline;">
+              <button type="submit" class="btn btn--ghost btn--sm" style="font-family: var(--font-mono);">
+                ${t.signal.icon ?? ''} ${t.signal.title} (${t.agent.id})
+              </button>
+            </form>
+          `) as unknown as SafeHtml[]}
+        </div>
+      </details>
+    ` : html``}
   `;
 
   return render(layout({ title: 'Pulse', activeNav: 'pulse' }, body));

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -122,7 +122,11 @@ export function renderRunDetail(opts: RunDetailOptions): string {
 
       ${run.error ? html`
         <h2>Error</h2>
-        <div class="flash flash--error">${run.error}</div>
+        <div class="flash flash--error" style="display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-3);">
+          <span>${run.error}</span>
+          <a href="/agents/${run.agentName}?suggest=1&focus=${encodeURIComponent(run.error)}"
+            class="btn btn--sm btn--primary" style="white-space: nowrap; flex-shrink: 0;">Suggest improvements</a>
+        </div>
       ` : html``}
 
       ${isDagRun ? html`


### PR DESCRIPTION
## Summary

- **Pulse dashboard** (`/pulse`): customizable information radiator with signal tiles showing agent output as live widgets
- **Display templates**: 9 templates (metric, text-headline, table, status, time-series, image, text-image, media, + backward-compat for v1 format field)
- **Container layout system**: named groups, drag-and-drop reorder, localStorage persistence
- **Edit mode**: toggle between read-only view (tiles scroll normally) and layout editing (drag, resize, palette, hide/show)
- **Drag-to-resize**: bottom-right handle, 1x1 to 4x4 grid snap
- **Auto-theming**: metric tiles get teal accent, status tiles auto-color by value, conditional thresholds (e.g. failure rate > 20% = red)
- **Widget palette**: 6 options per tile (default, dark, light, accent-teal, accent-red, accent-green)
- **System tiles**: virtual metric tiles for Runs Today, Failure Rate, Avg Duration, Agents replace hardcoded health strip
- **Media player**: YouTube click-to-play (nocookie embed), video/image detection, fallback links
- **Markdown rendering** in text tiles (tables, bold, links, headers, lists, code blocks)
- **Agent-level provider/model defaults**: claude/codex dropdown with model picker in agent detail inspector
- **Builder tool injection**: dynamic tool catalog from registry injected into builder prompt
- **Suggest improvements UX**: focus prompt, last-run context, "Apply now" button, auto-fix shell template mistakes, suggest from failed run page
- **All agents wired to Pulse**: every example + user agent has a signal block with appropriate template

11 commits, 4 new files, ~2500 lines added.

## Test plan

- [ ] `npx tsc --build` clean
- [ ] `npx vitest run` — 564 tests pass
- [ ] `/pulse` shows containers with system tiles + agent tiles
- [ ] Edit mode: drag tiles, resize via handle, cycle palettes, add/rename/delete groups
- [ ] Normal mode: tiles scroll, no drag, layout controls hidden
- [ ] Suggest improvements from failed run page opens modal with error pre-filled
- [ ] LLM defaults (provider/model) persist on agent detail page
- [ ] Build from goal includes signal block in generated YAML
- [ ] Clear localStorage to reset layout: `localStorage.removeItem('sua-pulse-layout')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)