### PR TITLE
refactor: agent detail page tabbed layout

### DIFF
--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -63,86 +63,18 @@ main.main--wide {
   color: var(--color-text);
 }
 
-/* ---------- Agent detail: 2-col grid ---------- */
-.agent-detail {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: var(--space-6);
-}
-
-@media (min-width: 900px) {
-  .agent-detail {
-    grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
-  }
-}
-
-.agent-detail__main {
-  min-width: 0;
+/* ---------- Agent detail: tabbed layout ---------- */
+.agent-detail__tab-content {
   display: flex;
   flex-direction: column;
   gap: var(--space-6);
 }
 
-.agent-detail__aside {
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-4);
-}
-
-/* ---------- Inspector (right-column panel on agent detail) ---------- */
-.inspector {
-  position: sticky;
-  top: var(--space-4);
+.agent-stats {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
-  padding: var(--space-4) var(--space-6);
-  box-shadow: var(--shadow-sm);
-  max-height: calc(100vh - var(--topbar-height) - var(--space-8));
-  overflow-y: auto;
-}
-
-.inspector__header {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding-bottom: var(--space-3);
-  border-bottom: 1px solid var(--color-border);
-  margin-bottom: var(--space-4);
-}
-
-.inspector__title {
-  font-size: var(--font-size-md);
-  font-weight: var(--weight-semibold);
-  margin: 0;
-}
-
-.inspector__hint {
-  color: var(--color-text-muted);
-  font-size: var(--font-size-xs);
-  font-style: italic;
-}
-
-.inspector__section + .inspector__section {
-  margin-top: var(--space-4);
-  padding-top: var(--space-4);
-  border-top: 1px solid var(--color-border);
-}
-
-.inspector__section h4 {
-  font-size: var(--font-size-xs);
-  font-weight: var(--weight-semibold);
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin: 0 0 var(--space-2);
-}
-
-.inspector__actions {
-  display: flex;
-  gap: var(--space-2);
-  margin-top: var(--space-4);
+  padding: var(--space-4);
 }
 
 /* ---------- DAG viz frame (holds Cytoscape canvas) ---------- */

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -831,12 +831,17 @@ describe('Dashboard version history + status toggle (PR 2)', () => {
       id: 'detail-ver', name: 'X', status: 'active', source: 'local', mcp: false,
       nodes: [{ id: 'n', type: 'shell', command: 'echo' }],
     }, 'cli');
-    const res = await request(app).get('/agents/detail-ver')
+    // Status dropdown is now on the Config tab.
+    const res = await request(app).get('/agents/detail-ver/config')
       .set('Host', `127.0.0.1:${PORT}`)
       .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
     expect(res.status).toBe(200);
     expect(res.text).toContain('action="/agents/detail-ver/status"');
-    expect(res.text).toContain('/agents/detail-ver/versions');
+    // Version history link is on the Overview tab.
+    const overviewRes = await request(app).get('/agents/detail-ver')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(overviewRes.text).toContain('/agents/detail-ver/versions');
   });
 });
 
@@ -946,7 +951,8 @@ describe('Dashboard node edit + delete (PR 3a)', () => {
   it('agent detail renders Edit + Delete buttons on every node row', async () => {
     const app = await makeApp();
     await seedChainAgent();
-    const res = await request(app).get('/agents/chain-edit')
+    // Node edit buttons are now on the Nodes tab.
+    const res = await request(app).get('/agents/chain-edit/nodes')
       .set('Host', `127.0.0.1:${PORT}`)
       .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
     expect(res.status).toBe(200);

--- a/packages/dashboard/src/routes/agent-inputs.ts
+++ b/packages/dashboard/src/routes/agent-inputs.ts
@@ -108,7 +108,7 @@ agentInputsRouter.post('/agents/:name/inputs/update', (req: Request, res: Respon
   }
 
   if (errors.length > 0) {
-    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}?flash=${encodeURIComponent(errors.join(' '))}#variables`);
+    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/config?flash=${encodeURIComponent(errors.join(' '))}#variables`);
     return;
   }
 
@@ -134,9 +134,9 @@ agentInputsRouter.post('/agents/:name/inputs/update', (req: Request, res: Respon
       'dashboard',
       'Updated input defaults via dashboard',
     );
-    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}?flash=${encodeURIComponent('Updated input defaults. New version created.')}#variables`);
+    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/config?flash=${encodeURIComponent('Updated input defaults. New version created.')}#variables`);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}?flash=${encodeURIComponent(`Save failed: ${msg}`)}#variables`);
+    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/config?flash=${encodeURIComponent(`Save failed: ${msg}`)}#variables`);
   }
 });

--- a/packages/dashboard/src/routes/agent-nodes.ts
+++ b/packages/dashboard/src/routes/agent-nodes.ts
@@ -4,8 +4,8 @@ import { exportAgent, parseAgent, AgentYamlParseError } from '@some-useful-agent
 import { parse as parseRawYaml, stringify as stringifyRawYaml } from 'yaml';
 import { html as h, render as renderHtml } from '../views/html.js';
 import { layout } from '../views/layout.js';
-import { pageHeader } from '../views/page-header.js';
-import { agentTabStrip } from '../views/agent-detail-v2.js';
+import { pageHeader, deriveBack } from '../views/page-header.js';
+import { renderAgentYaml } from '../views/agent-detail-v2.js';
 import { getContext } from '../context.js';
 import { renderAgentAddNode, type AddNodeFormValues } from '../views/agent-add-node.js';
 import { renderAgentEditNode, type EditNodeFormValues } from '../views/agent-edit-node.js';
@@ -352,26 +352,22 @@ agentNodesRouter.get('/agents/:name/yaml', (req: Request, res: Response) => {
   const yaml = exportAgent(agent);
   const error = typeof req.query.error === 'string' ? req.query.error : undefined;
 
-  const body = h`
-    <h1 style="margin: 0 0 var(--space-4);">${agent.id}</h1>
-    ${agentTabStrip(agent.id, 'yaml')}
-    ${error ? h`<div class="flash flash--error">${error}</div>` : h``}
-    <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-3);">
-      v${String(agent.version)}. Saving creates a new version. The YAML is validated before save.
-    </p>
-    <form method="POST" action="/agents/${agent.id}/yaml" class="card" style="max-width: 800px;">
-      <label style="display: flex; flex-direction: column; gap: var(--space-2);">
-        <textarea name="yaml" rows="30" required
-          style="padding: var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-family: var(--font-mono); font-size: var(--font-size-xs); resize: vertical; line-height: 1.5; tab-size: 2;">${yaml}</textarea>
-      </label>
-      <div style="margin-top: var(--space-3); display: flex; gap: var(--space-2); justify-content: flex-end;">
-        <a class="btn btn--ghost" href="/agents/${agent.id}">Cancel</a>
-        <button type="submit" class="btn btn--primary">Save YAML</button>
-      </div>
-    </form>
-  `;
+  const flashParam = typeof req.query.flash === 'string' ? req.query.flash : undefined;
+  const fromParam = typeof req.query.from === 'string' ? req.query.from : undefined;
+  const referer = typeof req.headers.referer === 'string' ? req.headers.referer : undefined;
+  const back = deriveBack(referer, `127.0.0.1:${ctx.port}`, fromParam);
 
-  res.type('html').send(renderHtml(layout({ title: `Edit YAML \u2014 ${agent.id}`, activeNav: 'agents' }, body)));
+  res.type('html').send(renderAgentYaml({
+    agent,
+    recentRuns: [],
+    secretsStore: ctx.secretsStore,
+    activeTab: 'yaml',
+    flash: flashParam ? { kind: 'ok' as const, message: flashParam } : undefined,
+    back,
+    from: fromParam,
+    yaml,
+    error,
+  }));
 });
 
 agentNodesRouter.post('/agents/:name/yaml', (req: Request, res: Response) => {

--- a/packages/dashboard/src/routes/agent-nodes.ts
+++ b/packages/dashboard/src/routes/agent-nodes.ts
@@ -5,6 +5,7 @@ import { parse as parseRawYaml, stringify as stringifyRawYaml } from 'yaml';
 import { html as h, render as renderHtml } from '../views/html.js';
 import { layout } from '../views/layout.js';
 import { pageHeader } from '../views/page-header.js';
+import { agentTabStrip } from '../views/agent-detail-v2.js';
 import { getContext } from '../context.js';
 import { renderAgentAddNode, type AddNodeFormValues } from '../views/agent-add-node.js';
 import { renderAgentEditNode, type EditNodeFormValues } from '../views/agent-edit-node.js';
@@ -352,12 +353,12 @@ agentNodesRouter.get('/agents/:name/yaml', (req: Request, res: Response) => {
   const error = typeof req.query.error === 'string' ? req.query.error : undefined;
 
   const body = h`
-    ${pageHeader({
-      title: `Edit YAML \u2014 ${agent.id}`,
-      back: { href: `/agents/${agent.id}`, label: `Back to ${agent.id}` },
-      description: `v${String(agent.version)}. Saving creates a new version. The YAML is validated before save.`,
-    })}
+    <h1 style="margin: 0 0 var(--space-4);">${agent.id}</h1>
+    ${agentTabStrip(agent.id, 'yaml')}
     ${error ? h`<div class="flash flash--error">${error}</div>` : h``}
+    <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-3);">
+      v${String(agent.version)}. Saving creates a new version. The YAML is validated before save.
+    </p>
     <form method="POST" action="/agents/${agent.id}/yaml" class="card" style="max-width: 800px;">
       <label style="display: flex; flex-direction: column; gap: var(--space-2);">
         <textarea name="yaml" rows="30" required

--- a/packages/dashboard/src/routes/agents.ts
+++ b/packages/dashboard/src/routes/agents.ts
@@ -1,5 +1,5 @@
 import { Router, type Request, type Response } from 'express';
-import type { Agent, AgentDefinition, RunStatus } from '@some-useful-agents/core';
+import type { Agent, AgentDefinition, Run, RunStatus } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 import { renderAgentsList, type HomeStats } from '../views/agents-list.js';
 import { renderAgentDetail } from '../views/agent-detail.js';
@@ -124,17 +124,42 @@ agentsRouter.post('/agents/:name/star', (req: Request, res: Response) => {
 agentsRouter.get('/agents', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
   const v1Agents = ctx.loadAgents().agents;
-  const v2Agents = ctx.agentStore.listAgents();
 
-  // Unify for the list view. v2 agents take precedence when ids collide
-  // (expected post-migration: the user imported their YAML into the DB).
+  // Parse filter/sort query params.
+  const qStatus = typeof req.query.status === 'string' && req.query.status ? req.query.status : undefined;
+  const qSource = typeof req.query.source === 'string' && req.query.source ? req.query.source : undefined;
+  const qSearch = typeof req.query.q === 'string' && req.query.q.trim() ? req.query.q.trim().toLowerCase() : undefined;
+  const qSort = typeof req.query.sort === 'string' ? req.query.sort : 'name';
+
+  // Use store-level filtering for status and source.
+  const storeFilter: { status?: 'active' | 'paused' | 'archived' | 'draft'; source?: 'local' | 'examples' | 'community' } = {};
+  if (qStatus && ['active', 'paused', 'draft', 'archived'].includes(qStatus)) {
+    storeFilter.status = qStatus as 'active' | 'paused' | 'archived' | 'draft';
+  }
+  if (qSource && ['local', 'examples', 'community'].includes(qSource)) {
+    storeFilter.source = qSource as 'local' | 'examples' | 'community';
+  }
+  let v2Agents = ctx.agentStore.listAgents(Object.keys(storeFilter).length > 0 ? storeFilter : undefined);
+
+  // Client-side search filter (id or description substring).
+  if (qSearch) {
+    v2Agents = v2Agents.filter((a) =>
+      a.id.toLowerCase().includes(qSearch) ||
+      (a.description ?? '').toLowerCase().includes(qSearch) ||
+      a.name.toLowerCase().includes(qSearch)
+    );
+  }
+
+  // Unify for the list view. v2 agents take precedence when ids collide.
   const mergedV1: AgentDefinition[] = [];
   const v2Ids = new Set(v2Agents.map((a) => a.id));
   for (const [id, a] of v1Agents) {
     if (!v2Ids.has(id)) mergedV1.push(a);
   }
   mergedV1.sort((a, b) => a.name.localeCompare(b.name));
-  v2Agents.sort((a, b) => a.id.localeCompare(b.id));
+
+  // Sort v2 agents based on query param.
+  // "recent" sort needs the run lookup below, so we defer it.
 
   // Stats for the overview strip. One queryRuns per dimension keeps the
   // SQL simple and the numbers honest — this page loads once per view.
@@ -167,12 +192,33 @@ agentsRouter.get('/agents', (req: Request, res: Response) => {
     if (invokers.length > 0) invokerCounts.set(a.id, invokers.length);
   }
 
+  // Apply sorting.
+  const lastRunByAgent = new Map<string, Run>();
+  for (const r of recent.rows) {
+    if (!lastRunByAgent.has(r.agentName)) lastRunByAgent.set(r.agentName, r);
+  }
+
+  if (qSort === 'status') {
+    v2Agents.sort((a, b) => a.status.localeCompare(b.status) || a.id.localeCompare(b.id));
+  } else if (qSort === 'recent') {
+    v2Agents.sort((a, b) => {
+      const ra = lastRunByAgent.get(a.id)?.startedAt ?? '';
+      const rb = lastRunByAgent.get(b.id)?.startedAt ?? '';
+      return rb.localeCompare(ra) || a.id.localeCompare(b.id);
+    });
+  } else if (qSort === 'starred') {
+    v2Agents.sort((a, b) => (b.starred ? 1 : 0) - (a.starred ? 1 : 0) || a.id.localeCompare(b.id));
+  } else {
+    v2Agents.sort((a, b) => a.id.localeCompare(b.id));
+  }
+
   res.type('html').send(renderAgentsList({
     v1: mergedV1,
     v2: v2Agents,
     recentRuns: recent.rows,
     stats,
     invokerCounts,
+    filter: { status: qStatus, source: qSource, q: qSearch, sort: qSort },
   }));
 });
 

--- a/packages/dashboard/src/routes/agents.ts
+++ b/packages/dashboard/src/routes/agents.ts
@@ -130,6 +130,8 @@ agentsRouter.get('/agents', (req: Request, res: Response) => {
   const qSource = typeof req.query.source === 'string' && req.query.source ? req.query.source : undefined;
   const qSearch = typeof req.query.q === 'string' && req.query.q.trim() ? req.query.q.trim().toLowerCase() : undefined;
   const qSort = typeof req.query.sort === 'string' ? req.query.sort : 'name';
+  const limit = Math.min(100, Math.max(1, parseInt(String(req.query.limit), 10) || 12));
+  const offset = Math.max(0, parseInt(String(req.query.offset), 10) || 0);
 
   // Use store-level filtering for status and source.
   const storeFilter: { status?: 'active' | 'paused' | 'archived' | 'draft'; source?: 'local' | 'examples' | 'community' } = {};
@@ -212,13 +214,20 @@ agentsRouter.get('/agents', (req: Request, res: Response) => {
     v2Agents.sort((a, b) => a.id.localeCompare(b.id));
   }
 
+  // Paginate v2 agents.
+  const totalV2 = v2Agents.length;
+  const paginatedV2 = v2Agents.slice(offset, offset + limit);
+
   res.type('html').send(renderAgentsList({
     v1: mergedV1,
-    v2: v2Agents,
+    v2: paginatedV2,
     recentRuns: recent.rows,
     stats,
     invokerCounts,
     filter: { status: qStatus, source: qSource, q: qSearch, sort: qSort },
+    limit,
+    offset,
+    total: totalV2,
   }));
 });
 
@@ -274,7 +283,7 @@ agentsRouter.get('/agents/:name', async (req: Request, res: Response) => {
       runningRuns: inFlight404.total,
       latestRunAt: recent404.rows[0]?.startedAt,
     };
-    res.status(404).type('html').send(renderAgentsList({ v1, v2, recentRuns: recent404.rows, stats }));
+    res.status(404).type('html').send(renderAgentsList({ v1, v2, recentRuns: recent404.rows, stats, limit: 12, offset: 0, total: v2.length }));
     return;
   }
 

--- a/packages/dashboard/src/routes/agents.ts
+++ b/packages/dashboard/src/routes/agents.ts
@@ -3,7 +3,7 @@ import type { Agent, AgentDefinition, RunStatus } from '@some-useful-agents/core
 import { getContext } from '../context.js';
 import { renderAgentsList, type HomeStats } from '../views/agents-list.js';
 import { renderAgentDetail } from '../views/agent-detail.js';
-import { renderAgentDetailV2 } from '../views/agent-detail-v2.js';
+import { renderAgentDetailV2, renderAgentOverview, renderAgentNodes, renderAgentConfig, renderAgentRuns } from '../views/agent-detail-v2.js';
 import { renderAgentNew, type AgentNewFormValues } from '../views/agent-new.js';
 import { deriveBack } from '../views/page-header.js';
 
@@ -249,4 +249,45 @@ agentsRouter.get('/agents/:name', async (req: Request, res: Response) => {
     flash,
   });
   res.type('html').send(html);
+});
+
+// ── Agent detail tab routes ──────────────────────────────────────────────
+
+/** Shared helper: build the common args for all agent detail tabs. */
+async function buildTabArgs(req: Request, ctx: ReturnType<typeof getContext>, name: string) {
+  const agent = ctx.agentStore.getAgent(name);
+  if (!agent) return null;
+  const flashParam = typeof req.query.flash === 'string' ? req.query.flash : undefined;
+  const fromParam = typeof req.query.from === 'string' ? req.query.from : undefined;
+  const flash = flashParam ? { kind: 'ok' as const, message: flashParam } : undefined;
+  const referer = typeof req.headers.referer === 'string' ? req.headers.referer : undefined;
+  const back = deriveBack(referer, `127.0.0.1:${ctx.port}`, fromParam);
+  const { rows } = ctx.runStore.queryRuns({
+    agentName: agent.id, limit: 50, offset: 0, statuses: [] as RunStatus[],
+  });
+  return { agent, recentRuns: rows, secretsStore: ctx.secretsStore, flash, back, from: fromParam };
+}
+
+agentsRouter.get('/agents/:name/nodes', async (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
+  const args = await buildTabArgs(req, ctx, name);
+  if (!args) { res.status(404).redirect(303, '/agents'); return; }
+  res.type('html').send(await renderAgentNodes({ ...args, activeTab: 'nodes' }));
+});
+
+agentsRouter.get('/agents/:name/config', async (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
+  const args = await buildTabArgs(req, ctx, name);
+  if (!args) { res.status(404).redirect(303, '/agents'); return; }
+  res.type('html').send(await renderAgentConfig({ ...args, activeTab: 'config' }));
+});
+
+agentsRouter.get('/agents/:name/runs', async (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
+  const args = await buildTabArgs(req, ctx, name);
+  if (!args) { res.status(404).redirect(303, '/agents'); return; }
+  res.type('html').send(renderAgentRuns({ ...args, activeTab: 'runs' }));
 });

--- a/packages/dashboard/src/routes/tools.ts
+++ b/packages/dashboard/src/routes/tools.ts
@@ -20,7 +20,9 @@ toolsRouter.get('/tools', (req: Request, res: Response) => {
   }
   const q = typeof req.query.q === 'string' && req.query.q.trim() ? req.query.q.trim() : undefined;
   const type = typeof req.query.type === 'string' && req.query.type ? req.query.type : undefined;
-  res.type('html').send(renderToolsList({ builtins, userTools, filter: { q, type } }));
+  const limit = Math.min(100, Math.max(1, parseInt(String(req.query.limit), 10) || 12));
+  const offset = Math.max(0, parseInt(String(req.query.offset), 10) || 0);
+  res.type('html').send(renderToolsList({ builtins, userTools, filter: { q, type }, limit, offset }));
 });
 
 toolsRouter.get('/tools/:id', (req: Request, res: Response) => {

--- a/packages/dashboard/src/routes/tools.ts
+++ b/packages/dashboard/src/routes/tools.ts
@@ -18,7 +18,9 @@ toolsRouter.get('/tools', (req: Request, res: Response) => {
   } catch {
     // Store not available — show builtins only.
   }
-  res.type('html').send(renderToolsList({ builtins, userTools }));
+  const q = typeof req.query.q === 'string' && req.query.q.trim() ? req.query.q.trim() : undefined;
+  const type = typeof req.query.type === 'string' && req.query.type ? req.query.type : undefined;
+  res.type('html').send(renderToolsList({ builtins, userTools, filter: { q, type } }));
 });
 
 toolsRouter.get('/tools/:id', (req: Request, res: Response) => {

--- a/packages/dashboard/src/routes/versions.ts
+++ b/packages/dashboard/src/routes/versions.ts
@@ -123,7 +123,7 @@ versionsRouter.post('/agents/:id/status', (req: Request, res: Response) => {
   const newStatus = typeof body.newStatus === 'string' ? body.newStatus : undefined;
 
   if (!newStatus || !VALID_STATUSES.has(newStatus)) {
-    res.redirect(303, `/agents/${encodeURIComponent(id)}?flash=${encodeURIComponent(`Invalid status. Must be one of: ${[...VALID_STATUSES].join(', ')}.`)}`);
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent(`Invalid status. Must be one of: ${[...VALID_STATUSES].join(', ')}.`)}`);
     return;
   }
 
@@ -134,16 +134,16 @@ versionsRouter.post('/agents/:id/status', (req: Request, res: Response) => {
   }
 
   if (agent.status === newStatus) {
-    res.redirect(303, `/agents/${encodeURIComponent(id)}?flash=${encodeURIComponent(`Already ${newStatus}.`)}`);
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent(`Already ${newStatus}.`)}`);
     return;
   }
 
   try {
     ctx.agentStore.updateAgentMeta(id, { status: newStatus as 'active' | 'paused' | 'archived' | 'draft' });
-    res.redirect(303, `/agents/${encodeURIComponent(id)}?flash=${encodeURIComponent(`Status set to "${newStatus}".`)}`);
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent(`Status set to "${newStatus}".`)}`);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    res.redirect(303, `/agents/${encodeURIComponent(id)}?flash=${encodeURIComponent(`Status change failed: ${msg}`)}`);
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent(`Status change failed: ${msg}`)}`);
   }
 });
 
@@ -162,7 +162,7 @@ versionsRouter.post('/agents/:id/llm', (req: Request, res: Response) => {
   const model = typeof body.model === 'string' ? body.model.trim() : '';
 
   if (provider && !VALID_PROVIDERS.has(provider)) {
-    res.redirect(303, `/agents/${encodeURIComponent(id)}?flash=${encodeURIComponent('Invalid provider. Must be claude or codex.')}`);
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent('Invalid provider. Must be claude or codex.')}`);
     return;
   }
 
@@ -176,7 +176,7 @@ versionsRouter.post('/agents/:id/llm', (req: Request, res: Response) => {
   const newProvider = (provider || undefined) as 'claude' | 'codex' | undefined;
   const newModel = model || undefined;
   if (agent.provider === newProvider && agent.model === newModel) {
-    res.redirect(303, `/agents/${encodeURIComponent(id)}?flash=${encodeURIComponent('LLM defaults unchanged.')}`);
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent('LLM defaults unchanged.')}`);
     return;
   }
 
@@ -187,9 +187,9 @@ versionsRouter.post('/agents/:id/llm', (req: Request, res: Response) => {
     if (newProvider) parts.push(`provider: ${newProvider}`);
     if (newModel) parts.push(`model: ${newModel}`);
     const summary = parts.length > 0 ? parts.join(', ') : 'defaults cleared';
-    res.redirect(303, `/agents/${encodeURIComponent(id)}?flash=${encodeURIComponent(`LLM defaults updated (${summary}).`)}`);
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent(`LLM defaults updated (${summary}).`)}`);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    res.redirect(303, `/agents/${encodeURIComponent(id)}?flash=${encodeURIComponent(`LLM update failed: ${msg}`)}`);
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent(`LLM update failed: ${msg}`)}`);
   }
 });

--- a/packages/dashboard/src/views/agent-detail-v2.ts
+++ b/packages/dashboard/src/views/agent-detail-v2.ts
@@ -345,6 +345,32 @@ export function renderAgentRuns(args: AgentDetailArgs): string {
   return agentPageShell({ ...args, activeTab: 'runs' }, content);
 }
 
+// ── YAML tab ─────────────────────────────────────────────────────────────
+
+export function renderAgentYaml(args: AgentDetailArgs & { yaml: string; error?: string }): string {
+  const { yaml, error } = args;
+  const agent = args.agent;
+
+  const content = html`
+    ${error ? html`<div class="flash flash--error">${error}</div>` : html``}
+    <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-3);">
+      v${String(agent.version)}. Saving creates a new version. The YAML is validated before save.
+    </p>
+    <form method="POST" action="/agents/${agent.id}/yaml" class="card" style="max-width: 800px;">
+      <label style="display: flex; flex-direction: column; gap: var(--space-2);">
+        <textarea name="yaml" rows="30" required
+          style="padding: var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-family: var(--font-mono); font-size: var(--font-size-xs); resize: vertical; line-height: 1.5; tab-size: 2;">${yaml}</textarea>
+      </label>
+      <div style="margin-top: var(--space-3); display: flex; gap: var(--space-2); justify-content: flex-end;">
+        <a class="btn btn--ghost" href="/agents/${agent.id}">Cancel</a>
+        <button type="submit" class="btn btn--primary">Save YAML</button>
+      </div>
+    </form>
+  `;
+
+  return agentPageShell({ ...args, activeTab: 'yaml' }, content);
+}
+
 // ── Shared helpers ───────────────────────────────────────────────────────
 
 function renderRunInputsForm(agent: Agent, from?: string): SafeHtml {

--- a/packages/dashboard/src/views/agent-detail-v2.ts
+++ b/packages/dashboard/src/views/agent-detail-v2.ts
@@ -78,7 +78,11 @@ function agentPageShell(args: AgentDetailArgs, content: SafeHtml): string {
         vStatusBadge(agent.status),
         sourceBadge(source),
       ],
-      cta: runNowButton,
+      cta: html`<span style="display: inline-flex; gap: var(--space-2);">
+        <button type="button" class="btn btn--ghost btn--sm" id="suggest-btn" data-agent-id="${agent.id}">Suggest improvements</button>
+        <a class="btn btn--ghost btn--sm" href="/agents/${agent.id}/versions">Versions</a>
+        ${runNowButton}
+      </span>`,
       description: agent.description ?? undefined,
       back,
     })}
@@ -150,12 +154,6 @@ export async function renderAgentOverview(args: AgentDetailArgs): Promise<string
       <div style="display: flex; gap: var(--space-2); flex-wrap: wrap; margin-top: var(--space-2);">
         ${toolBadges as unknown as SafeHtml[]}
       </div>
-    </div>
-
-    <!-- Actions -->
-    <div style="display: flex; gap: var(--space-2); flex-wrap: wrap;">
-      <button type="button" class="btn btn--sm" id="suggest-btn" data-agent-id="${agent.id}">Suggest improvements</button>
-      <a class="btn btn--sm" href="/agents/${agent.id}/versions">Versions</a>
     </div>
 
     <!-- Recent runs -->

--- a/packages/dashboard/src/views/agent-detail-v2.ts
+++ b/packages/dashboard/src/views/agent-detail-v2.ts
@@ -1,3 +1,14 @@
+/**
+ * Agent detail page — tabbed layout.
+ *
+ * Tabs:
+ *   Overview  /agents/:id         — DAG + stats + recent runs + suggest
+ *   Nodes     /agents/:id/nodes   — node table + add/edit/delete
+ *   Config    /agents/:id/config  — LLM, variables, secrets, status
+ *   Runs      /agents/:id/runs    — paginated run history
+ *   YAML      /agents/:id/yaml    — already exists (separate route)
+ */
+
 import type { Agent, Run, SecretsStore } from '@some-useful-agents/core';
 import { html, render, unsafeHtml, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
@@ -5,234 +16,64 @@ import { pageHeader, type PageHeaderBack } from './page-header.js';
 import { sourceBadge, statusBadge, formatDuration, formatAge } from './components.js';
 import { renderDagView, renderDagFallback } from './dag-view.js';
 
-export async function renderAgentDetailV2(args: {
+// ── Tab types ────────────────────────────────────────────────────────────
+
+export type AgentTab = 'overview' | 'nodes' | 'config' | 'runs' | 'yaml';
+
+export interface AgentDetailArgs {
   agent: Agent;
   recentRuns: Run[];
   secretsStore: SecretsStore;
   flash?: { kind: 'error' | 'info' | 'ok'; message: string };
-  /** Contextual back link ("Back to tutorial", "Back to runs", etc.). */
   back?: PageHeaderBack;
-  /**
-   * Origin-marker propagated via ?from=… query param. When set, we
-   * thread it through the Run-now form as a hidden field so the run
-   * detail page knows the user's original origin was (e.g.) the
-   * tutorial — not just the immediate Referer.
-   */
   from?: string;
-}): Promise<string> {
-  const { agent, recentRuns, secretsStore, flash, back, from } = args;
+  activeTab: AgentTab;
+}
+
+// ── Tab strip ────────────────────────────────────────────────────────────
+
+export function agentTabStrip(agentId: string, active: AgentTab): SafeHtml {
+  const tabs: Array<{ id: AgentTab; label: string; href: string }> = [
+    { id: 'overview', label: 'Overview', href: `/agents/${agentId}` },
+    { id: 'nodes', label: 'Nodes', href: `/agents/${agentId}/nodes` },
+    { id: 'config', label: 'Config', href: `/agents/${agentId}/config` },
+    { id: 'runs', label: 'Runs', href: `/agents/${agentId}/runs` },
+    { id: 'yaml', label: 'YAML', href: `/agents/${agentId}/yaml` },
+  ];
+  return html`
+    <nav class="tab-strip">
+      ${tabs.map((t) => html`<a href="${t.href}" class="${t.id === active ? 'is-active' : ''}">${t.label}</a>`) as unknown as SafeHtml[]}
+    </nav>
+  `;
+}
+
+// ── Page shell ───────────────────────────────────────────────────────────
+
+function agentPageShell(args: AgentDetailArgs, content: SafeHtml): string {
+  const { agent, flash, back, from } = args;
   const source = agent.source;
   const hasCommunityShellNode = source === 'community' && agent.nodes.some((n) => n.type === 'shell');
 
-  // Secret presence lookup (never reveals values).
-  let secretsSet = 0;
-  let secretsMissing = 0;
-  let secretsUnknown = 0;
-  const secretRows: SafeHtml[] = [];
-  const seenSecrets = new Set<string>();
-  for (const node of agent.nodes) {
-    for (const name of node.secrets ?? []) {
-      const key = `${node.id}:${name}`;
-      if (seenSecrets.has(key)) continue;
-      seenSecrets.add(key);
-      let present: 'ok' | 'missing' | 'unknown';
-      try {
-        present = (await secretsStore.has(name)) ? 'ok' : 'missing';
-      } catch {
-        present = 'unknown';
-      }
-      if (present === 'ok') secretsSet++;
-      else if (present === 'missing') secretsMissing++;
-      else secretsUnknown++;
-      const badge = present === 'ok'
-        ? html`<span class="badge badge--ok">set</span>`
-        : present === 'missing'
-        ? html`<span class="badge badge--err">missing</span>`
-        : html`<span class="badge badge--warn">locked</span>`;
-      secretRows.push(html`
-        <tr>
-          <td class="mono">${node.id}</td>
-          <td class="mono">${name}</td>
-          <td>${badge}</td>
-        </tr>
-      `);
-    }
-  }
-
-  const fromHidden = from
-    ? html`<input type="hidden" name="from" value="${from}">`
-    : html``;
+  const fromHidden = from ? html`<input type="hidden" name="from" value="${from}">` : html``;
   const runNowButton = hasCommunityShellNode
-    ? html`
-        <form method="POST" action="/agents/${agent.id}/run">
-          <input type="hidden" name="confirm_community_shell" value="yes">
-          ${fromHidden}
-          <button type="submit" class="btn btn--warn"
-            onclick="return confirm('This agent contains community shell nodes. Run anyway?');">
-            Run now (community)
-          </button>
-        </form>
-      `
+    ? html`<form method="POST" action="/agents/${agent.id}/run">
+        <input type="hidden" name="confirm_community_shell" value="yes">${fromHidden}
+        <button type="submit" class="btn btn--warn" onclick="return confirm('This agent contains community shell nodes. Run anyway?');">Run now (community)</button>
+      </form>`
     : Object.keys(agent.inputs ?? {}).length > 0
-    ? html`
-        <button type="button" class="btn btn--primary" id="run-with-inputs-btn">Run now</button>
-      `
-    : html`
-        <form method="POST" action="/agents/${agent.id}/run" style="display: inline;" data-run-form="${agent.id}">
-          ${fromHidden}
-          <button type="submit" class="btn btn--primary">Run now</button>
-        </form>
-      `;
+    ? html`<button type="button" class="btn btn--primary" id="run-with-inputs-btn">Run now</button>`
+    : html`<form method="POST" action="/agents/${agent.id}/run" style="display: inline;" data-run-form="${agent.id}">${fromHidden}<button type="submit" class="btn btn--primary">Run now</button></form>`;
 
   const warningBanner = source === 'community'
-    ? html`<div class="community-banner">
-        <strong>Community agent.</strong> Read the DAG before running. See
-        <a href="https://github.com/gregmeyer/some-useful-agents/blob/main/docs/SECURITY.md#trust-model">docs/SECURITY.md</a> for the trust model.
-      </div>`
+    ? html`<div class="community-banner"><strong>Community agent.</strong> Read the DAG before running.</div>`
     : html``;
-
-  // Per-node table below the DAG. Each row gets Edit + Delete actions
-  // that POST to the node-edit routes (PR 3). Delete is refused server-side
-  // if any downstream node depends on this one.
-  const nodeRows = agent.nodes.map((n) => {
-    const body = n.type === 'shell' ? oneLine(n.command ?? '') : oneLine(n.prompt ?? '');
-    const deps = n.dependsOn?.length ? n.dependsOn.join(', ') : html`<span class="dim">—</span>`;
-    const secrets = n.secrets?.length ? n.secrets.join(', ') : html`<span class="dim">—</span>`;
-    return html`
-      <tr id="node-${n.id}">
-        <td class="mono">${n.id}</td>
-        <td>${n.type === 'shell' ? html`<span class="badge badge--ok">shell</span>` : html`<span class="badge badge--info">claude-code</span>`}</td>
-        <td class="mono">${deps}</td>
-        <td class="mono">${secrets}</td>
-        <td class="dim">${body}</td>
-        <td style="white-space: nowrap;">
-          <a class="btn btn--sm" href="/agents/${agent.id}/nodes/${n.id}/edit">Edit</a>
-          <form method="POST" action="/agents/${agent.id}/nodes/${n.id}/delete" style="display: inline; margin: 0;"
-                data-confirm="Delete node '${n.id}'? This creates a new version. Refuses if downstream nodes depend on it.">
-            <button type="submit" class="btn btn--sm btn--ghost" style="color: var(--color-err);">Delete</button>
-          </form>
-        </td>
-      </tr>
-    `;
-  });
-
-  const runRows = recentRuns.map((r) => html`
-    <tr>
-      <td><a href="/runs/${r.id}" class="mono">${r.id.slice(0, 8)}</a></td>
-      <td>${statusBadge(r.status)}</td>
-      <td class="dim">${formatAge(r.startedAt)}</td>
-      <td class="dim">${formatDuration(r.startedAt, r.completedAt)}</td>
-      <td class="dim">${r.triggeredBy}</td>
-    </tr>
-  `);
-
-  const secretsSummary = seenSecrets.size === 0
-    ? html`<span class="dim">No secrets declared.</span>`
-    : html`
-        <span class="badge badge--ok">${String(secretsSet)} set</span>
-        ${secretsMissing > 0 ? html`<span class="badge badge--err">${String(secretsMissing)} missing</span>` : html``}
-        ${secretsUnknown > 0 ? html`<span class="badge badge--warn">${String(secretsUnknown)} locked</span>` : html``}
-      `;
-
-  // Latest completed run powers the DAG's "Replay from here" node-click
-  // action. Without one, clicking a node still opens the action dialog
-  // (Edit node is always offered) but the replay button is absent.
-  const latestCompletedRun = recentRuns.find((r) => r.status === 'completed');
-
-  // Inspector (right-column) default state: agent-level summary card.
-  // Node inspection happens via a dialog triggered by clicks on the
-  // DAG viz — not this panel. The inspector stays as an agent-scoped
-  // overview.
-  const inspector = html`
-    <aside class="inspector" id="inspector">
-      <header class="inspector__header">
-        <h2 class="inspector__title">Overview</h2>
-      </header>
-
-      <section class="inspector__section">
-        <h4>Status</h4>
-        <form method="POST" action="/agents/${agent.id}/status" style="display: flex; gap: var(--space-2); align-items: center;">
-          <select name="newStatus" style="padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm);">
-            ${statusOption('active', agent.status)}
-            ${statusOption('paused', agent.status)}
-            ${statusOption('draft', agent.status)}
-            ${statusOption('archived', agent.status)}
-          </select>
-          <button type="submit" class="btn btn--sm">Apply</button>
-        </form>
-      </section>
-
-      <section class="inspector__section">
-        <h4>LLM defaults</h4>
-        <form method="POST" action="/agents/${agent.id}/llm" id="llm-form" style="display: flex; flex-direction: column; gap: var(--space-2);">
-          <div style="display: flex; gap: var(--space-2); align-items: center;">
-            <label style="font-size: var(--font-size-xs); color: var(--color-text-muted); min-width: 55px;">Provider</label>
-            <select name="provider" id="llm-provider" class="form-field" style="flex: 1; padding: var(--space-1) var(--space-2); font-size: var(--font-size-sm);">
-              ${providerOption('claude', agent.provider)}
-              ${providerOption('codex', agent.provider)}
-            </select>
-          </div>
-          <div style="display: flex; gap: var(--space-2); align-items: center;">
-            <label style="font-size: var(--font-size-xs); color: var(--color-text-muted); min-width: 55px;">Model</label>
-            <select name="model" id="llm-model" class="form-field" style="flex: 1; padding: var(--space-1) var(--space-2); font-size: var(--font-size-sm); font-family: var(--font-mono);">
-              ${renderModelOptions(agent.provider, agent.model)}
-            </select>
-          </div>
-          <div id="llm-model-desc" class="dim" style="font-size: var(--font-size-xs); padding: 0 0 0 calc(55px + var(--space-2)); min-height: 1.2em;"></div>
-          <div style="display: flex; justify-content: flex-end;">
-            <button type="submit" class="btn btn--sm">Apply</button>
-          </div>
-          <p class="dim" style="font-size: var(--font-size-xs); margin: 0;">
-            Applies to all claude-code nodes. Individual nodes can override in YAML.
-          </p>
-        </form>
-      </section>
-
-      <section class="inspector__section">
-        <h4>Metadata</h4>
-        <dl class="kv">
-          <dt>Version</dt>
-          <dd class="mono">
-            v${String(agent.version)}
-            <a href="/agents/${agent.id}/versions" class="dim" style="margin-left: var(--space-2); font-size: var(--font-size-xs);">history \u2192</a>
-          </dd>
-          <dt>Schedule</dt><dd>${agent.schedule ?? html`<span class="dim">none</span>`}</dd>
-          <dt>MCP</dt><dd>${agent.mcp ? 'exposed' : html`<span class="dim">not exposed</span>`}</dd>
-          <dt>Nodes</dt><dd>${String(agent.nodes.length)}</dd>
-        </dl>
-      </section>
-
-      ${renderInputsSection(agent)}
-
-      <section class="inspector__section">
-        <h4>Secrets</h4>
-        <div style="display:flex; gap:var(--space-2); flex-wrap:wrap;">
-          ${secretsSummary}
-        </div>
-      </section>
-
-      ${renderToolsSection(agent)}
-
-      <div class="inspector__actions" style="flex-wrap: wrap;">
-        <a class="btn btn--primary btn--sm" href="/agents/${agent.id}/add-node">+ Add node</a>
-        <a class="btn btn--sm" href="/agents/${agent.id}/yaml">Edit YAML</a>
-        <button type="button" class="btn btn--sm" id="suggest-btn" data-agent-id="${agent.id}">Suggest improvements</button>
-        <a class="btn btn--sm" href="/agents/${agent.id}/versions">Versions</a>
-        <a class="btn btn--sm" href="#runs">Recent runs</a>
-      </div>
-    </aside>
-  `;
 
   const body = html`
     ${pageHeader({
       title: agent.id,
       meta: [
         html`<form method="POST" action="/agents/${agent.id}/star" style="display:inline;margin:0;">
-          <button type="submit" class="btn-star${agent.starred ? ' is-starred' : ''}"
-                  title="${agent.starred ? 'Unstar' : 'Star'}"
-                  aria-label="${agent.starred ? 'Unstar' : 'Star'}">
-            ${agent.starred ? '\u2605' : '\u2606'}
-          </button>
+          <button type="submit" class="btn-star${agent.starred ? ' is-starred' : ''}" title="${agent.starred ? 'Unstar' : 'Star'}" aria-label="${agent.starred ? 'Unstar' : 'Star'}">${agent.starred ? '\u2605' : '\u2606'}</button>
         </form>`,
         vStatusBadge(agent.status),
         sourceBadge(source),
@@ -241,61 +82,10 @@ export async function renderAgentDetailV2(args: {
       description: agent.description ?? undefined,
       back,
     })}
-
     ${warningBanner}
-
-    <div class="agent-detail">
-      <div class="agent-detail__main">
-        ${renderDagFallback(agent)}
-        ${renderDagView({
-          agent,
-          editBase: `/agents/${agent.id}/nodes`,
-          replay: latestCompletedRun
-            ? {
-                priorRunId: latestCompletedRun.id,
-                requiresCommunityConfirm: hasCommunityShellNode,
-              }
-            : undefined,
-        })}
-
-        <section id="nodes">
-          <h2>Nodes</h2>
-          <table class="table">
-            <thead>
-              <tr>
-                <th>Id</th><th>Type</th><th>Depends on</th><th>Secrets</th><th>Body</th><th></th>
-              </tr>
-            </thead>
-            <tbody>${nodeRows as unknown as SafeHtml[]}</tbody>
-          </table>
-        </section>
-
-        ${secretRows.length > 0 ? html`
-          <section>
-            <h2>Secrets by node</h2>
-            <table class="table">
-              <thead><tr><th>Node</th><th>Secret</th><th>Status</th></tr></thead>
-              <tbody>${secretRows}</tbody>
-            </table>
-          </section>
-        ` : html``}
-
-        ${renderInputDefaultsSection(agent)}
-
-        <section id="runs">
-          <h2>Recent runs</h2>
-          ${recentRuns.length === 0
-            ? html`<p class="dim">No runs yet.</p>`
-            : html`<table class="table">
-                <thead><tr><th>ID</th><th>Status</th><th>Started</th><th>Duration</th><th>Triggered</th></tr></thead>
-                <tbody>${runRows as unknown as SafeHtml[]}</tbody>
-              </table>`}
-        </section>
-      </div>
-
-      <div class="agent-detail__aside">
-        ${inspector}
-      </div>
+    ${agentTabStrip(agent.id, args.activeTab)}
+    <div class="agent-detail__tab-content">
+      ${content}
     </div>
 
     <div id="suggest-modal" class="modal-backdrop">
@@ -313,20 +103,255 @@ export async function renderAgentDetailV2(args: {
     </div>
   `;
 
-  return render(layout({ title: agent.id, activeNav: 'agents', flash, wide: true }, body));
+  return render(layout({ title: agent.id, activeNav: 'agents', flash }, body));
 }
 
-/**
- * Render the Run Now inputs form for the run modal. Shows each declared
- * input with its type, default value pre-filled, description, and whether
- * it's required. Submits to POST /agents/:id/run with input_NAME fields.
- */
+// ── Overview tab ─────────────────────────────────────────────────────────
+
+export async function renderAgentOverview(args: AgentDetailArgs): Promise<string> {
+  const { agent, recentRuns } = args;
+  const latestCompletedRun = recentRuns.find((r) => r.status === 'completed');
+  const hasCommunityShellNode = agent.source === 'community' && agent.nodes.some((n) => n.type === 'shell');
+
+  // Quick stats row
+  const toolIds = new Set<string>();
+  for (const n of agent.nodes) toolIds.add(n.tool ?? (n.type === 'shell' ? 'shell-exec' : 'claude-code'));
+  const toolBadges = [...toolIds].sort().map((id) => html`<a href="/tools/${id}" class="badge badge--muted" style="text-decoration: none;">${id}</a>`);
+
+  const runRows = recentRuns.slice(0, 5).map((r) => html`
+    <tr>
+      <td><a href="/runs/${r.id}" class="mono">${r.id.slice(0, 8)}</a></td>
+      <td>${statusBadge(r.status)}</td>
+      <td class="dim">${formatAge(r.startedAt)}</td>
+      <td class="dim">${formatDuration(r.startedAt, r.completedAt)}</td>
+    </tr>
+  `);
+
+  const content = html`
+    <!-- DAG -->
+    ${renderDagFallback(agent)}
+    ${renderDagView({
+      agent,
+      editBase: `/agents/${agent.id}/nodes`,
+      replay: latestCompletedRun
+        ? { priorRunId: latestCompletedRun.id, requiresCommunityConfirm: hasCommunityShellNode }
+        : undefined,
+    })}
+
+    <!-- Quick stats -->
+    <div class="agent-stats">
+      <dl class="kv">
+        <dt>Version</dt><dd class="mono">v${String(agent.version)} <a href="/agents/${agent.id}/versions" class="dim" style="font-size: var(--font-size-xs);">history</a></dd>
+        <dt>Provider</dt><dd class="mono">${agent.provider ?? 'claude'} / ${agent.model ?? 'default'}</dd>
+        <dt>Schedule</dt><dd>${agent.schedule ?? html`<span class="dim">none</span>`}</dd>
+        <dt>MCP</dt><dd>${agent.mcp ? 'exposed' : html`<span class="dim">not exposed</span>`}</dd>
+        <dt>Nodes</dt><dd>${String(agent.nodes.length)}</dd>
+      </dl>
+      <div style="display: flex; gap: var(--space-2); flex-wrap: wrap; margin-top: var(--space-2);">
+        ${toolBadges as unknown as SafeHtml[]}
+      </div>
+    </div>
+
+    <!-- Actions -->
+    <div style="display: flex; gap: var(--space-2); flex-wrap: wrap;">
+      <button type="button" class="btn btn--sm" id="suggest-btn" data-agent-id="${agent.id}">Suggest improvements</button>
+      <a class="btn btn--sm" href="/agents/${agent.id}/versions">Versions</a>
+    </div>
+
+    <!-- Recent runs -->
+    <section>
+      <h2>Recent runs</h2>
+      ${recentRuns.length === 0
+        ? html`<p class="dim">No runs yet. Hit "Run now" to get started.</p>`
+        : html`
+          <table class="table">
+            <thead><tr><th>ID</th><th>Status</th><th>Started</th><th>Duration</th></tr></thead>
+            <tbody>${runRows as unknown as SafeHtml[]}</tbody>
+          </table>
+          ${recentRuns.length > 5 ? html`<p style="margin-top: var(--space-2);"><a href="/agents/${agent.id}/runs" style="font-size: var(--font-size-xs);">View all runs &rarr;</a></p>` : html``}
+        `}
+    </section>
+  `;
+
+  return agentPageShell({ ...args, activeTab: 'overview' }, content);
+}
+
+// ── Nodes tab ────────────────────────────────────────────────────────────
+
+export async function renderAgentNodes(args: AgentDetailArgs): Promise<string> {
+  const { agent, secretsStore } = args;
+
+  const nodeRows = agent.nodes.map((n) => {
+    const body = n.type === 'shell' ? oneLine(n.command ?? '') : oneLine(n.prompt ?? '');
+    const deps = n.dependsOn?.length ? n.dependsOn.join(', ') : html`<span class="dim">\u2014</span>`;
+    const secrets = n.secrets?.length ? n.secrets.join(', ') : html`<span class="dim">\u2014</span>`;
+    return html`
+      <tr id="node-${n.id}">
+        <td class="mono">${n.id}</td>
+        <td>${n.type === 'shell' ? html`<span class="badge badge--ok">shell</span>` : html`<span class="badge badge--info">claude-code</span>`}</td>
+        <td class="mono">${deps}</td>
+        <td class="mono">${secrets}</td>
+        <td class="dim">${body}</td>
+        <td style="white-space: nowrap;">
+          <a class="btn btn--sm" href="/agents/${agent.id}/nodes/${n.id}/edit">Edit</a>
+          <form method="POST" action="/agents/${agent.id}/nodes/${n.id}/delete" style="display: inline; margin: 0;"
+                data-confirm="Delete node '${n.id}'?">
+            <button type="submit" class="btn btn--sm btn--ghost" style="color: var(--color-err);">Delete</button>
+          </form>
+        </td>
+      </tr>
+    `;
+  });
+
+  // Secrets by node
+  const secretRows: SafeHtml[] = [];
+  for (const node of agent.nodes) {
+    for (const name of node.secrets ?? []) {
+      let present: 'ok' | 'missing' | 'unknown';
+      try { present = (await secretsStore.has(name)) ? 'ok' : 'missing'; } catch { present = 'unknown'; }
+      const badge = present === 'ok' ? html`<span class="badge badge--ok">set</span>`
+        : present === 'missing' ? html`<span class="badge badge--err">missing</span>`
+        : html`<span class="badge badge--warn">locked</span>`;
+      secretRows.push(html`<tr><td class="mono">${node.id}</td><td class="mono">${name}</td><td>${badge}</td></tr>`);
+    }
+  }
+
+  const content = html`
+    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--space-4);">
+      <h2 style="margin: 0;">Nodes</h2>
+      <a class="btn btn--primary btn--sm" href="/agents/${agent.id}/add-node">+ Add node</a>
+    </div>
+    <table class="table">
+      <thead><tr><th>Id</th><th>Type</th><th>Depends on</th><th>Secrets</th><th>Body</th><th></th></tr></thead>
+      <tbody>${nodeRows as unknown as SafeHtml[]}</tbody>
+    </table>
+
+    ${secretRows.length > 0 ? html`
+      <section style="margin-top: var(--space-6);">
+        <h2>Secrets by node</h2>
+        <table class="table">
+          <thead><tr><th>Node</th><th>Secret</th><th>Status</th></tr></thead>
+          <tbody>${secretRows}</tbody>
+        </table>
+      </section>
+    ` : html``}
+  `;
+
+  return agentPageShell({ ...args, activeTab: 'nodes' }, content);
+}
+
+// ── Config tab ───────────────────────────────────────────────────────────
+
+export async function renderAgentConfig(args: AgentDetailArgs): Promise<string> {
+  const { agent, secretsStore } = args;
+
+  // Secret counts for the secrets section
+  let secretsSet = 0;
+  let secretsMissing = 0;
+  const allSecrets = new Set<string>();
+  for (const node of agent.nodes) {
+    for (const name of node.secrets ?? []) allSecrets.add(name);
+  }
+  for (const name of allSecrets) {
+    try { if (await secretsStore.has(name)) secretsSet++; else secretsMissing++; } catch { /* unknown */ }
+  }
+
+  const content = html`
+    <!-- Status -->
+    <section class="card" style="margin-bottom: var(--space-6);">
+      <h3 style="margin: 0 0 var(--space-3);">Status</h3>
+      <form method="POST" action="/agents/${agent.id}/status" style="display: flex; gap: var(--space-2); align-items: center;">
+        <select name="newStatus" class="form-field" style="padding: var(--space-1) var(--space-2); font-size: var(--font-size-sm);">
+          ${statusOption('active', agent.status)}
+          ${statusOption('paused', agent.status)}
+          ${statusOption('draft', agent.status)}
+          ${statusOption('archived', agent.status)}
+        </select>
+        <button type="submit" class="btn btn--sm">Apply</button>
+      </form>
+    </section>
+
+    <!-- LLM defaults -->
+    <section class="card" style="margin-bottom: var(--space-6);">
+      <h3 style="margin: 0 0 var(--space-3);">LLM defaults</h3>
+      <form method="POST" action="/agents/${agent.id}/llm" id="llm-form" style="display: flex; flex-direction: column; gap: var(--space-2);">
+        <div style="display: flex; gap: var(--space-2); align-items: center;">
+          <label style="font-size: var(--font-size-xs); color: var(--color-text-muted); min-width: 55px;">Provider</label>
+          <select name="provider" id="llm-provider" class="form-field" style="flex: 1; padding: var(--space-1) var(--space-2); font-size: var(--font-size-sm);">
+            ${providerOption('claude', agent.provider)}
+            ${providerOption('codex', agent.provider)}
+          </select>
+        </div>
+        <div style="display: flex; gap: var(--space-2); align-items: center;">
+          <label style="font-size: var(--font-size-xs); color: var(--color-text-muted); min-width: 55px;">Model</label>
+          <select name="model" id="llm-model" class="form-field" style="flex: 1; padding: var(--space-1) var(--space-2); font-size: var(--font-size-sm); font-family: var(--font-mono);">
+            ${renderModelOptions(agent.provider, agent.model)}
+          </select>
+        </div>
+        <div id="llm-model-desc" class="dim" style="font-size: var(--font-size-xs); min-height: 1.2em;"></div>
+        <div style="display: flex; justify-content: flex-end;">
+          <button type="submit" class="btn btn--sm">Apply</button>
+        </div>
+        <p class="dim" style="font-size: var(--font-size-xs); margin: 0;">Applies to all claude-code nodes. Individual nodes can override in YAML.</p>
+      </form>
+    </section>
+
+    <!-- Variables -->
+    <section class="card" style="margin-bottom: var(--space-6);">
+      <h3 style="margin: 0 0 var(--space-3);">Variables</h3>
+      ${renderVariablesEditor(agent)}
+    </section>
+
+    <!-- Secrets -->
+    <section class="card">
+      <h3 style="margin: 0 0 var(--space-3);">Secrets</h3>
+      <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-2);">
+        ${String(allSecrets.size)} declared. ${String(secretsSet)} set, ${String(secretsMissing)} missing.
+      </p>
+      <a href="/settings/secrets" class="btn btn--sm">Manage secrets</a>
+    </section>
+  `;
+
+  return agentPageShell({ ...args, activeTab: 'config' }, content);
+}
+
+// ── Runs tab ─────────────────────────────────────────────────────────────
+
+export function renderAgentRuns(args: AgentDetailArgs): string {
+  const { agent, recentRuns } = args;
+
+  const runRows = recentRuns.map((r) => html`
+    <tr>
+      <td><a href="/runs/${r.id}" class="mono">${r.id.slice(0, 8)}</a></td>
+      <td>${statusBadge(r.status)}</td>
+      <td class="dim">${formatAge(r.startedAt)}</td>
+      <td class="dim">${formatDuration(r.startedAt, r.completedAt)}</td>
+      <td class="dim">${r.triggeredBy}</td>
+    </tr>
+  `);
+
+  const content = html`
+    <h2>Run history</h2>
+    ${recentRuns.length === 0
+      ? html`<p class="dim">No runs yet.</p>`
+      : html`
+        <table class="table">
+          <thead><tr><th>ID</th><th>Status</th><th>Started</th><th>Duration</th><th>Triggered</th></tr></thead>
+          <tbody>${runRows as unknown as SafeHtml[]}</tbody>
+        </table>
+      `}
+  `;
+
+  return agentPageShell({ ...args, activeTab: 'runs' }, content);
+}
+
+// ── Shared helpers ───────────────────────────────────────────────────────
+
 function renderRunInputsForm(agent: Agent, from?: string): SafeHtml {
   const inputs = Object.entries(agent.inputs ?? {});
   const FIELD = 'padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm); font-family: var(--font-mono); width: 100%;';
 
   if (inputs.length === 0) {
-    // No inputs — just a spinner (form submits immediately via JS).
     return html`
       <div style="text-align: center; padding: var(--space-6);">
         <div class="spinner" style="margin: 0 auto var(--space-3);"></div>
@@ -341,9 +366,7 @@ function renderRunInputsForm(agent: Agent, from?: string): SafeHtml {
     const reqLabel = spec.required !== false && spec.default === undefined
       ? html`<span style="color: var(--color-err); font-size: var(--font-size-xs);">required</span>`
       : html`<span class="dim" style="font-size: var(--font-size-xs);">optional</span>`;
-    const desc = spec.description
-      ? html`<span class="dim" style="font-size: var(--font-size-xs);">${spec.description}</span>`
-      : html``;
+    const desc = spec.description ? html`<span class="dim" style="font-size: var(--font-size-xs);">${spec.description}</span>` : html``;
     return html`
       <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-3);">
         <div style="display: flex; align-items: baseline; gap: var(--space-2);">
@@ -351,10 +374,7 @@ function renderRunInputsForm(agent: Agent, from?: string): SafeHtml {
           <span class="badge badge--muted" style="font-size: 9px;">${spec.type}</span>
           ${reqLabel}
         </div>
-        <input type="text" name="input_${name}" value="${defVal}"
-          placeholder="${defVal || '(empty)'}"
-          style="${FIELD}"
-          ${spec.required !== false && spec.default === undefined ? 'required' : ''}>
+        <input type="text" name="input_${name}" value="${defVal}" placeholder="${defVal || '(empty)'}" style="${FIELD}" ${spec.required !== false && spec.default === undefined ? 'required' : ''}>
         ${desc}
       </label>
     `;
@@ -364,9 +384,7 @@ function renderRunInputsForm(agent: Agent, from?: string): SafeHtml {
     <form method="POST" action="/agents/${agent.id}/run" data-run-form="${agent.id}">
       ${from ? html`<input type="hidden" name="from" value="${from}">` : html``}
       <h3 style="margin: 0 0 var(--space-3);">Run ${agent.id}</h3>
-      <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-4);">
-        Set input values for this run. Defaults are pre-filled.
-      </p>
+      <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-4);">Set input values for this run.</p>
       ${fields as unknown as SafeHtml[]}
       <div style="display: flex; gap: var(--space-2); justify-content: flex-end; margin-top: var(--space-3);">
         <button type="button" class="btn btn--ghost btn--sm" data-close-modal="1">Cancel</button>
@@ -376,27 +394,7 @@ function renderRunInputsForm(agent: Agent, from?: string): SafeHtml {
   `;
 }
 
-/**
- * Render the full "Variables" section in the main content area.
- * Shows existing agent inputs with defaults + descriptions in a table,
- * plus an inline form for editing defaults on existing inputs and
- * adding new ones. Editing POSTs to /agents/:id/inputs/update.
- *
- * Provisional: this section migrates into the dashboard revamp's
- * tabbed agent detail layout as its own tab.
- */
-function typeSelect(namePrefix: string, current: string): SafeHtml {
-  const opt = (val: string) => val === current
-    ? html`<option value="${val}" selected>${val}</option>`
-    : html`<option value="${val}">${val}</option>`;
-  return html`
-    <select name="${namePrefix}" style="padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs);">
-      ${opt('string')}${opt('number')}${opt('boolean')}${opt('enum')}
-    </select>
-  `;
-}
-
-function renderInputDefaultsSection(agent: Agent): SafeHtml {
+function renderVariablesEditor(agent: Agent): SafeHtml {
   const inputs = Object.entries(agent.inputs ?? {});
   const FIELD = 'padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs);';
 
@@ -405,156 +403,48 @@ function renderInputDefaultsSection(agent: Agent): SafeHtml {
     const desc = spec.description ?? '';
     return html`
       <tr>
-        <td class="mono">${name}
-          <input type="hidden" name="inputName[]" value="${name}">
-        </td>
+        <td class="mono">${name}<input type="hidden" name="inputName[]" value="${name}"></td>
         <td>${typeSelect(`type_${name}`, spec.type)}</td>
-        <td>
-          <input type="text" name="default_${name}" value="${defVal}"
-            placeholder="(none)"
-            style="${FIELD} font-family: var(--font-mono); width: 10rem;">
-        </td>
-        <td>
-          <input type="text" name="description_${name}" value="${desc}"
-            placeholder="(none)"
-            style="${FIELD} width: 14rem;">
-        </td>
+        <td><input type="text" name="default_${name}" value="${defVal}" placeholder="(none)" style="${FIELD} font-family: var(--font-mono); width: 10rem;"></td>
+        <td><input type="text" name="description_${name}" value="${desc}" placeholder="(none)" style="${FIELD} width: 14rem;"></td>
       </tr>
     `;
   });
 
-  // Inline "new row" at the bottom of the table — no separate toggle needed.
   const newRow = html`
     <tr style="border-top: 2px solid var(--color-border);">
-      <td>
-        <input type="text" name="newInputName" placeholder="NEW_VAR" pattern="[A-Z_][A-Z0-9_]*"
-          style="${FIELD} font-family: var(--font-mono); width: 10rem;">
-      </td>
-      <td>
-        <select name="newInputType" style="${FIELD}">
-          <option value="string">string</option>
-          <option value="number">number</option>
-          <option value="boolean">boolean</option>
-          <option value="enum">enum</option>
-        </select>
-      </td>
-      <td>
-        <input type="text" name="newInputDefault" placeholder="default"
-          style="${FIELD} font-family: var(--font-mono); width: 10rem;">
-      </td>
-      <td>
-        <input type="text" name="newInputDescription" placeholder="description"
-          style="${FIELD} width: 14rem;">
-      </td>
+      <td><input type="text" name="newInputName" placeholder="NEW_VAR" pattern="[A-Z_][A-Z0-9_]*" style="${FIELD} font-family: var(--font-mono); width: 10rem;"></td>
+      <td><select name="newInputType" style="${FIELD}"><option value="string">string</option><option value="number">number</option><option value="boolean">boolean</option><option value="enum">enum</option></select></td>
+      <td><input type="text" name="newInputDefault" placeholder="default" style="${FIELD} font-family: var(--font-mono); width: 10rem;"></td>
+      <td><input type="text" name="newInputDescription" placeholder="description" style="${FIELD} width: 14rem;"></td>
     </tr>
   `;
 
   return html`
-    <section id="variables">
-      <h2>Variables</h2>
-      <p class="dim" style="font-size: var(--font-size-xs); margin-bottom: var(--space-3);">
-        Agent-level inputs referenced as <code>$NAME</code> in shell or <code>{{inputs.NAME}}</code> in prompts.
-        Defaults fill in when no <code>--input</code> value is supplied at run time.
-        Fill in the bottom row to add a new variable. Save creates a new version.
-      </p>
-      <form method="POST" action="/agents/${agent.id}/inputs/update">
-        <table class="table" style="font-size: var(--font-size-xs); margin-bottom: var(--space-3);">
-          <thead>
-            <tr><th>Name</th><th>Type</th><th>Default</th><th>Description</th></tr>
-          </thead>
-          <tbody>
-            ${inputRows as unknown as SafeHtml[]}
-            ${newRow}
-          </tbody>
-        </table>
-        <div style="display: flex; gap: var(--space-2); justify-content: flex-end;">
-          <button type="submit" class="btn btn--primary btn--sm">Save variables</button>
-        </div>
-      </form>
-    </section>
+    <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-3);">
+      Agent-level inputs. Referenced as <code>$NAME</code> in shell or <code>{{inputs.NAME}}</code> in prompts.
+    </p>
+    <form method="POST" action="/agents/${agent.id}/inputs/update">
+      <table class="table" style="font-size: var(--font-size-xs); margin-bottom: var(--space-3);">
+        <thead><tr><th>Name</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
+        <tbody>${inputRows as unknown as SafeHtml[]}${newRow}</tbody>
+      </table>
+      <div style="display: flex; gap: var(--space-2); justify-content: flex-end;">
+        <button type="submit" class="btn btn--primary btn--sm">Save variables</button>
+      </div>
+    </form>
   `;
 }
 
-/**
- * Render the agent-level inputs section in the inspector sidebar.
- * Shows declared inputs with their type, default, and description.
- * Links to #variables for full editing.
- */
-function renderInputsSection(agent: Agent): SafeHtml {
-  const inputs = Object.entries(agent.inputs ?? {});
-  if (inputs.length === 0) {
-    return html`
-      <section class="inspector__section">
-        <h4>Variables</h4>
-        <span class="dim" style="font-size: var(--font-size-xs);">No agent inputs declared.</span>
-        <div style="margin-top: var(--space-2);">
-          <a class="dim" href="#variables" style="font-size: var(--font-size-xs);">+ Add input</a>
-        </div>
-      </section>
-    `;
-  }
+// ── Small helpers ────────────────────────────────────────────────────────
 
-  const rows = inputs.map(([name, spec]) => {
-    const defVal = spec.default !== undefined ? String(spec.default) : '';
-    const typeBadge = html`<span class="badge badge--muted" style="font-size: 9px;">${spec.type}</span>`;
-    return html`
-      <div style="display: flex; align-items: baseline; gap: var(--space-2); font-size: var(--font-size-xs); padding: var(--space-1) 0; border-bottom: 1px solid var(--color-border);">
-        <code style="flex: 0 0 auto;">${name}</code>
-        ${typeBadge}
-        <span class="dim" style="margin-left: auto; text-align: right;">
-          ${defVal ? defVal : spec.required !== false ? 'required' : 'optional'}
-        </span>
-      </div>
-    `;
-  });
-
-  return html`
-    <section class="inspector__section">
-      <h4>Variables</h4>
-      <div>${rows as unknown as SafeHtml[]}</div>
-      <div style="margin-top: var(--space-2);">
-        <a class="dim" href="#variables" style="font-size: var(--font-size-xs);">Edit defaults</a>
-      </div>
-    </section>
-  `;
-}
-
-/**
- * Collect the unique tools this agent's nodes reference and render them
- * as a sidebar section. Derives from the DAG — no separate store query.
- * Shows which tools the agent depends on at a glance.
- */
-function renderToolsSection(agent: Agent): SafeHtml {
-  const toolIds = new Set<string>();
-  for (const node of agent.nodes) {
-    if (node.tool) {
-      toolIds.add(node.tool);
-    } else {
-      // v0.15 nodes without an explicit tool: show their implicit tool.
-      toolIds.add(node.type === 'shell' ? 'shell-exec' : 'claude-code');
-    }
-  }
-  if (toolIds.size === 0) return html``;
-
-  const badges = [...toolIds].sort().map((id) => html`
-    <a href="/tools/${id}" class="badge badge--muted" style="text-decoration: none;">${id}</a>
-  `);
-
-  return html`
-    <section class="inspector__section">
-      <h4>Tools</h4>
-      <div style="display:flex; gap:var(--space-2); flex-wrap:wrap;">
-        ${badges as unknown as SafeHtml[]}
-      </div>
-    </section>
-  `;
+function typeSelect(namePrefix: string, current: string): SafeHtml {
+  const opt = (val: string) => val === current ? html`<option value="${val}" selected>${val}</option>` : html`<option value="${val}">${val}</option>`;
+  return html`<select name="${namePrefix}" style="padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs);">${opt('string')}${opt('number')}${opt('boolean')}${opt('enum')}</select>`;
 }
 
 function vStatusBadge(status: string): SafeHtml {
-  const kind = status === 'active' ? 'badge--ok'
-    : status === 'paused' ? 'badge--warn'
-    : status === 'archived' ? 'badge--muted'
-    : 'badge--info';
+  const kind = status === 'active' ? 'badge--ok' : status === 'paused' ? 'badge--warn' : status === 'archived' ? 'badge--muted' : 'badge--info';
   return html`<span class="badge ${kind}">${status}</span>`;
 }
 
@@ -594,7 +484,6 @@ function renderModelOptions(provider?: string, currentModel?: string): SafeHtml 
     const sel = m.id === effective ? unsafeHtml(' selected') : unsafeHtml('');
     return html`<option value="${m.id}" title="${m.desc}"${sel}>${m.label}</option>`;
   });
-  // If the current model isn't in the list, add it as a custom entry.
   if (effective && !models.some((m) => m.id === effective)) {
     options.push(html`<option value="${effective}" selected>${effective}</option>`);
   }
@@ -604,5 +493,19 @@ function renderModelOptions(provider?: string, currentModel?: string): SafeHtml 
 function oneLine(text: string, max = 120): string {
   const collapsed = text.replace(/\s+/g, ' ').trim();
   if (collapsed.length <= max) return collapsed;
-  return collapsed.slice(0, max - 1) + '…';
+  return collapsed.slice(0, max - 1) + '\u2026';
+}
+
+// ── Legacy export (backward compat for the route) ────────────────────────
+
+/** @deprecated Use renderAgentOverview directly */
+export async function renderAgentDetailV2(args: {
+  agent: Agent;
+  recentRuns: Run[];
+  secretsStore: SecretsStore;
+  flash?: { kind: 'error' | 'info' | 'ok'; message: string };
+  back?: PageHeaderBack;
+  from?: string;
+}): Promise<string> {
+  return renderAgentOverview({ ...args, activeTab: 'overview' });
 }

--- a/packages/dashboard/src/views/agents-list.ts
+++ b/packages/dashboard/src/views/agents-list.ts
@@ -17,17 +17,18 @@ export interface HomeStats {
 }
 
 export interface AgentsListInput {
-  /** v1 YAML-loaded single-node agents, after removing any that were
-   *  superseded by a v2 DAG with the same id. */
   v1: AgentDefinition[];
-  /** v2 DAG agents from AgentStore. */
   v2: Agent[];
-  /** Recent runs (across all agents), used to look up last-run-per-agent. */
   recentRuns: Run[];
-  /** Overview stats for the tiles row. */
   stats: HomeStats;
-  /** Count of agents that invoke each agent (keyed by agent id). */
   invokerCounts?: Map<string, number>;
+  /** Current filter state from query params. */
+  filter?: {
+    status?: string;
+    source?: string;
+    q?: string;
+    sort?: string;
+  };
 }
 
 export function renderAgentsList(input: AgentsListInput): string {
@@ -59,6 +60,8 @@ export function renderAgentsList(input: AgentsListInput): string {
     })}
 
     ${empty ? renderEmptyState() : renderStatStrip(input.stats)}
+
+    ${!empty ? renderFilterBar(input.filter) : html``}
 
     ${hasV2 ? html`
       <div class="agent-grid">
@@ -105,6 +108,38 @@ export function renderAgentsList(input: AgentsListInput): string {
   `;
 
   return render(layout({ title: 'Agents', activeNav: 'agents' }, body));
+}
+
+function renderFilterBar(filter?: { status?: string; source?: string; q?: string; sort?: string }): SafeHtml {
+  const f = filter ?? {};
+  const selIf = (val: string, current?: string) => val === current ? ' selected' : '';
+  return html`
+    <form method="GET" action="/agents" class="filters" style="display: flex; gap: var(--space-3); align-items: center; flex-wrap: wrap; margin-bottom: var(--space-4);">
+      <input type="text" name="q" value="${f.q ?? ''}" placeholder="Search agents..."
+        style="padding: var(--space-1) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm); font-family: var(--font-mono); width: 16rem;">
+      <select name="status" style="padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm);">
+        ${html`<option value="">All statuses</option>
+        <option value="active"${selIf('active', f.status)}>active</option>
+        <option value="paused"${selIf('paused', f.status)}>paused</option>
+        <option value="draft"${selIf('draft', f.status)}>draft</option>
+        <option value="archived"${selIf('archived', f.status)}>archived</option>`}
+      </select>
+      <select name="source" style="padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm);">
+        ${html`<option value="">All sources</option>
+        <option value="local"${selIf('local', f.source)}>local</option>
+        <option value="examples"${selIf('examples', f.source)}>examples</option>
+        <option value="community"${selIf('community', f.source)}>community</option>`}
+      </select>
+      <select name="sort" style="padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm);">
+        ${html`<option value="name"${selIf('name', f.sort)}>Sort: name</option>
+        <option value="status"${selIf('status', f.sort)}>Sort: status</option>
+        <option value="recent"${selIf('recent', f.sort)}>Sort: recently run</option>
+        <option value="starred"${selIf('starred', f.sort)}>Sort: starred first</option>`}
+      </select>
+      <button type="submit" class="btn btn--sm">Filter</button>
+      ${(f.q || f.status || f.source || f.sort) ? html`<a href="/agents" class="dim" style="font-size: var(--font-size-xs);">Reset</a>` : html``}
+    </form>
+  `;
 }
 
 function renderStatStrip(s: HomeStats): SafeHtml {

--- a/packages/dashboard/src/views/agents-list.ts
+++ b/packages/dashboard/src/views/agents-list.ts
@@ -22,20 +22,23 @@ export interface AgentsListInput {
   recentRuns: Run[];
   stats: HomeStats;
   invokerCounts?: Map<string, number>;
-  /** Current filter state from query params. */
   filter?: {
     status?: string;
     source?: string;
     q?: string;
     sort?: string;
   };
+  /** Pagination. */
+  limit: number;
+  offset: number;
+  /** Total v2 count before pagination (after filtering). */
+  total: number;
 }
 
 export function renderAgentsList(input: AgentsListInput): string {
   const hasV2 = input.v2.length > 0;
   const hasV1 = input.v1.length > 0;
-  const v1Count = input.v1.length;
-  const totalVisible = input.v2.length + v1Count;
+  const { limit, offset, total } = input;
 
   // Build a `lastRun` index keyed by agent id / v1 name. Uses whatever the
   // caller passed in `recentRuns`; we assume that list is sorted newest-first
@@ -71,10 +74,12 @@ export function renderAgentsList(input: AgentsListInput): string {
 
     ${renderV1Block(input.v1, hasV2)}
 
+    ${total > limit ? renderAgentPager(input) : html``}
+
     ${empty ? html`` : html`
       <footer style="margin-top: var(--space-8); text-align: center;">
         <p class="dim">
-          ${String(totalVisible)} agent${totalVisible === 1 ? '' : 's'} visible \u00b7
+          ${String(total)} agent${total === 1 ? '' : 's'} total \u00b7
           <a href="/help">CLI reference</a> \u00b7
           <a href="/help/tutorial">Tutorial</a>
         </p>
@@ -140,6 +145,35 @@ function renderFilterBar(filter?: { status?: string; source?: string; q?: string
       ${(f.q || f.status || f.source || f.sort) ? html`<a href="/agents" class="dim" style="font-size: var(--font-size-xs);">Reset</a>` : html``}
     </form>
   `;
+}
+
+function renderAgentPager(input: AgentsListInput): SafeHtml {
+  const { limit, offset, total, filter: f } = input;
+  const showingStart = Math.min(offset + 1, total);
+  const showingEnd = Math.min(offset + limit, total);
+  const prevOffset = Math.max(0, offset - limit);
+  const nextOffset = offset + limit;
+  return html`
+    <div class="pager">
+      <div>Showing ${String(showingStart)}\u2013${String(showingEnd)} of ${String(total)}</div>
+      <div>
+        ${offset > 0 ? html`<a href="${agentBuildUrl(f, limit, prevOffset)}">\u2190 Prev</a>` : html`<span class="dim">\u2190 Prev</span>`}
+        ${nextOffset < total ? html`<a href="${agentBuildUrl(f, limit, nextOffset)}">Next \u2192</a>` : html`<span class="dim">Next \u2192</span>`}
+      </div>
+    </div>
+  `;
+}
+
+function agentBuildUrl(f: AgentsListInput['filter'], limit: number, offset: number): string {
+  const params = new URLSearchParams();
+  if (f?.status) params.set('status', f.status);
+  if (f?.source) params.set('source', f.source);
+  if (f?.q) params.set('q', f.q);
+  if (f?.sort && f.sort !== 'name') params.set('sort', f.sort);
+  if (limit !== 12) params.set('limit', String(limit));
+  if (offset !== 0) params.set('offset', String(offset));
+  const qs = params.toString();
+  return qs ? `/agents?${qs}` : '/agents';
 }
 
 function renderStatStrip(s: HomeStats): SafeHtml {

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -318,7 +318,7 @@ function renderProgressIndicator(e: NodeExecutionRecord): SafeHtml {
  */
 function renderNodeCards(execs: NodeExecutionRecord[], runId?: string, canReplay?: boolean): SafeHtml {
   const cards = execs.map((e) => {
-    const shouldOpen = e.status === 'failed' || e.error !== undefined;
+    const shouldOpen = e.status === 'completed' || e.status === 'failed' || e.error !== undefined;
     const openAttr = shouldOpen ? unsafeHtml(' open') : unsafeHtml('');
     const duration = formatDuration(e.startedAt, e.completedAt);
     const exitLabel = formatExitCode(e.exitCode);

--- a/packages/dashboard/src/views/tools-list.ts
+++ b/packages/dashboard/src/views/tools-list.ts
@@ -7,8 +7,12 @@ export function renderToolsList(args: {
   builtins: ToolDefinition[];
   userTools: ToolDefinition[];
   filter?: { q?: string; type?: string };
+  limit?: number;
+  offset?: number;
 }): string {
   const f = args.filter ?? {};
+  const limit = args.limit ?? 12;
+  const offset = args.offset ?? 0;
   let builtins = args.builtins;
   let userTools = args.userTools;
 
@@ -24,7 +28,12 @@ export function renderToolsList(args: {
     userTools = userTools.filter((t) => t.implementation.type === f.type);
   }
 
-  const total = builtins.length + userTools.length;
+  // Combine for pagination, then slice.
+  const allTools = [...builtins.map((t) => ({ tool: t, section: 'builtin' as const })), ...userTools.map((t) => ({ tool: t, section: 'user' as const }))];
+  const total = allTools.length;
+  const paged = allTools.slice(offset, offset + limit);
+  builtins = paged.filter((t) => t.section === 'builtin').map((t) => t.tool);
+  userTools = paged.filter((t) => t.section === 'user').map((t) => t.tool);
 
   const filterBar = html`
     <form method="GET" action="/tools" class="filters" style="display: flex; gap: var(--space-3); align-items: center; flex-wrap: wrap; margin-bottom: var(--space-4);">
@@ -72,6 +81,8 @@ export function renderToolsList(args: {
       </section>
     ` : html``}
 
+    ${total > limit ? toolPager(f, limit, offset, total) : html``}
+
     <footer style="margin-top: var(--space-8); text-align: center;">
       <p class="dim">${String(total)} tool${total === 1 ? '' : 's'} ${f.q || f.type ? 'matching' : 'available'}</p>
     </footer>
@@ -110,4 +121,30 @@ function renderToolCard(t: ToolDefinition): SafeHtml {
       </div>
     </article>
   `;
+}
+
+function toolPager(f: { q?: string; type?: string }, limit: number, offset: number, total: number): SafeHtml {
+  const start = Math.min(offset + 1, total);
+  const end = Math.min(offset + limit, total);
+  const prev = Math.max(0, offset - limit);
+  const next = offset + limit;
+  return html`
+    <div class="pager">
+      <div>Showing ${String(start)}\u2013${String(end)} of ${String(total)}</div>
+      <div>
+        ${offset > 0 ? html`<a href="${toolBuildUrl(f, limit, prev)}">\u2190 Prev</a>` : html`<span class="dim">\u2190 Prev</span>`}
+        ${next < total ? html`<a href="${toolBuildUrl(f, limit, next)}">Next \u2192</a>` : html`<span class="dim">Next \u2192</span>`}
+      </div>
+    </div>
+  `;
+}
+
+function toolBuildUrl(f: { q?: string; type?: string }, limit: number, offset: number): string {
+  const params = new URLSearchParams();
+  if (f.q) params.set('q', f.q);
+  if (f.type) params.set('type', f.type);
+  if (limit !== 12) params.set('limit', String(limit));
+  if (offset !== 0) params.set('offset', String(offset));
+  const qs = params.toString();
+  return qs ? `/tools?${qs}` : '/tools';
 }

--- a/packages/dashboard/src/views/tools-list.ts
+++ b/packages/dashboard/src/views/tools-list.ts
@@ -6,18 +6,51 @@ import { pageHeader } from './page-header.js';
 export function renderToolsList(args: {
   builtins: ToolDefinition[];
   userTools: ToolDefinition[];
+  filter?: { q?: string; type?: string };
 }): string {
-  const { builtins, userTools } = args;
+  const f = args.filter ?? {};
+  let builtins = args.builtins;
+  let userTools = args.userTools;
+
+  // Apply search filter.
+  if (f.q) {
+    const q = f.q.toLowerCase();
+    builtins = builtins.filter((t) => t.id.toLowerCase().includes(q) || (t.description ?? '').toLowerCase().includes(q));
+    userTools = userTools.filter((t) => t.id.toLowerCase().includes(q) || (t.description ?? '').toLowerCase().includes(q));
+  }
+  // Apply type filter.
+  if (f.type) {
+    builtins = builtins.filter((t) => t.implementation.type === f.type);
+    userTools = userTools.filter((t) => t.implementation.type === f.type);
+  }
+
   const total = builtins.length + userTools.length;
+
+  const filterBar = html`
+    <form method="GET" action="/tools" class="filters" style="display: flex; gap: var(--space-3); align-items: center; flex-wrap: wrap; margin-bottom: var(--space-4);">
+      <input type="text" name="q" value="${f.q ?? ''}" placeholder="Search tools..."
+        style="padding: var(--space-1) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm); font-family: var(--font-mono); width: 16rem;">
+      <select name="type" style="padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm);">
+        <option value="">All types</option>
+        <option value="shell"${f.type === 'shell' ? ' selected' : ''}>shell</option>
+        <option value="claude-code"${f.type === 'claude-code' ? ' selected' : ''}>claude-code</option>
+        <option value="builtin"${f.type === 'builtin' ? ' selected' : ''}>builtin</option>
+      </select>
+      <button type="submit" class="btn btn--sm">Filter</button>
+      ${(f.q || f.type) ? html`<a href="/tools" class="dim" style="font-size: var(--font-size-xs);">Reset</a>` : html``}
+    </form>
+  `;
 
   const body = html`
     ${pageHeader({ title: 'Tools' })}
 
+    ${filterBar}
+
     ${total === 0 ? html`
       <div class="settings-empty">
-        <h3 style="margin-top: 0;">No tools yet</h3>
-        <p class="dim">Tools are named, reusable units of work that agent nodes invoke.<br>
-          9 built-in tools ship with sua. Create your own in <code>tools/</code>.</p>
+        <h3 style="margin-top: 0;">No tools found</h3>
+        <p class="dim">${f.q || f.type ? 'No tools match your filters.' : 'Tools are named, reusable units of work that agent nodes invoke.'}</p>
+        ${f.q || f.type ? html`<a href="/tools" class="btn btn--sm">Reset filters</a>` : html``}
       </div>
     ` : html``}
 
@@ -40,7 +73,7 @@ export function renderToolsList(args: {
     ` : html``}
 
     <footer style="margin-top: var(--space-8); text-align: center;">
-      <p class="dim">${String(total)} tool${total === 1 ? '' : 's'} available</p>
+      <p class="dim">${String(total)} tool${total === 1 ? '' : 's'} ${f.q || f.type ? 'matching' : 'available'}</p>
     </footer>
   `;
 


### PR DESCRIPTION
## Summary

- Replaces the dense 2-column layout (main content + inspector sidebar) with a clean 5-tab interface
- **Overview**: DAG viz, quick stats, tools, suggest improvements, recent runs
- **Nodes**: node table with edit/delete/add, secrets by node
- **Config**: status, LLM defaults, variables editor, secrets manager
- **Runs**: full run history for this agent
- **YAML**: existing YAML editor with tab strip
- Inspector sidebar removed entirely (7 sections distributed into tabs)
- All redirects updated to target the appropriate tab
- Net -117 lines (simpler, not more complex)

## Test plan

- [x] `npx tsc --build` clean
- [x] `npx vitest run` — 564 tests pass
- [ ] `/agents/:id` shows Overview tab with DAG + stats
- [ ] `/agents/:id/nodes` shows node table with edit/delete
- [ ] `/agents/:id/config` shows LLM, variables, secrets, status
- [ ] `/agents/:id/runs` shows run history
- [ ] `/agents/:id/yaml` shows YAML editor with tab strip
- [ ] Config saves redirect back to Config tab
- [ ] Tab strip highlights active tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)