### PR TITLE
docs: update READMEs for v0.16.0 npm release

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Installed automatically by `sua init`. Manage with `sua examples install/remove/
 
 | Agent | What it teaches |
 |---|---|
-| `hello` | Your first agent — single shell node |
+| `hello` | Your first agent, single shell node |
 | `two-step-digest` | Chain nodes with `dependsOn` + upstream output passing |
 | `daily-greeting` | Cron scheduling (`schedule: "0 8 * * *"`) |
 | `parameterised-greet` | Agent inputs with defaults (`--input NAME=Greg`) |
@@ -45,6 +45,9 @@ Installed automatically by `sua init`. Manage with `sua examples install/remove/
 | `parameterised-greet-claude` | Claude Code companion (requires API key) |
 | `llm-tells-a-joke` | Configurable topic input + clean prompt design |
 | `agent-analyzer` | Self-correcting 3-node pipeline: analyze, validate, fix |
+| `agent-builder` | Goal-driven wizard, builds agents from plain language |
+| `system-health` | Disk/memory/CPU check with Pulse metric tile |
+| `daily-summary` | Activity summary with Pulse text-headline tile |
 
 ## CLI commands
 
@@ -111,14 +114,16 @@ sua schedule list                       # show scheduled agents
 
 ## Dashboard
 
-Start with `sua dashboard start`. Features:
+Start with `sua dashboard start`. Dark mode by default, JetBrains Mono, warm stone neutrals.
 
-- **Agents** — card grid, DAG visualization, click nodes for actions (edit, replay), per-node status, YAML editor, suggest improvements (AI analysis)
-- **Variables** — inline editing of agent input defaults and types, add/remove variables, global variables tab in Settings
-- **Run now** — modal with input fields for agents that declare inputs, pre-filled with defaults
-- **Tools** — browse all 9 built-in tools + user tools, inspect inputs/outputs
-- **Runs** — filter by agent/status, replay from any node with pre-flight validation, resolved variables panel with filter, real-time turn progress for multi-turn LLM nodes
-- **Settings** — secrets CRUD with copy-before-save modal, global variables CRUD, MCP token rotation, retention policy
+- **Pulse** — information radiator at `/pulse`. Signal tiles show agent output as live widgets. 9 display templates (metric, text-headline, table, status, time-series, image, text-image, media). Container layout with drag-and-drop reorder, edit mode, widget palette with auto-theming. System metric tiles replace the health strip. Markdown rendering, YouTube media player, tile collapse/expand.
+- **Build from goal** — describe what you want in plain language, the builder designs a complete agent YAML with nodes, tools, inputs, and a Pulse signal block.
+- **Agents** — card grid with filtering (status, source, search), sorting, pagination. 5-tab detail page: Overview (DAG viz, stats), Nodes (edit/delete/add), Config (LLM defaults, variables, secrets, status), Runs (history), YAML (editor).
+- **Suggest improvements** — AI-powered agent review with "Apply now" one-click save. Auto-fixes shell template mistakes. Available from failed run pages with the error pre-filled.
+- **LLM defaults** — agent-level provider (Claude/Codex) and model selection. Nodes inherit unless they override.
+- **Tools** — browse built-in + user tools with filtering and pagination
+- **Runs** — filter by agent/status, paginate, replay from any node, resolved variables panel, real-time turn progress for LLM nodes
+- **Settings** — secrets CRUD with passphrase unlock, global variables, MCP token rotation
 - **Tutorial** — 7-step guided walkthrough that scaffolds agents from the dashboard
 
 ## Flow control
@@ -154,11 +159,14 @@ Available node types: `conditional`, `switch`, `loop`, `agent-invoke`, `branch`,
 
 ## Security
 
-- **Secrets encrypted at rest** — scrypt N=2^17, passphrase-derived key
+- **Secrets encrypted at rest** — AES-256-GCM with scrypt KDF (OWASP 2024 params)
 - **3-layer redaction in run logs** — declared secrets, sensitive name patterns (TOKEN, KEY, PASS), known credential value patterns (GitHub PATs, AWS keys, JWTs)
-- **MCP binds localhost** — bearer token auth, loopback-only by default
+- **Path traversal protection** — file-read/file-write tools validate paths stay within the working directory
+- **Env-var injection deny-list** — agent inputs cannot override LD_PRELOAD, PATH, NODE_OPTIONS, or 25+ other sensitive env vars
+- **MCP binds localhost** — bearer token auth, loopback-only by default, timing-safe token comparison
 - **Community shell gate** — community agents require explicit `--allow-untrusted-shell`
-- **Dashboard CSRF defense** — Origin header check on all mutations
+- **Dashboard auth** — 3-layer (Host + Origin + cookie), HttpOnly SameSite=Strict cookies, 8-hour expiry
+- **CI/CD** — SHA-pinned GitHub Actions, npm Trusted Publishing via OIDC (no static NPM_TOKEN)
 - **Example agents vetted** — CI security check + execution test on every PR
 
 Full model: [docs/SECURITY.md](docs/SECURITY.md)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,10 +25,20 @@ sua dashboard start              # open the web dashboard
 - `sua tool` — list, show, validate
 - `sua examples` — install, remove, list
 - `sua secrets` — set, get, list, delete, migrate, check
+- `sua vars` — list, get, set, delete (global variables)
 - `sua mcp` — start, rotate-token, token
 - `sua schedule` — list, validate
 - `sua dashboard` — start
 - `sua init`, `sua doctor`, `sua tutorial`
+
+## v0.16.0 highlights
+
+- **Build from goal** — `sua dashboard start`, click "Build from goal", describe what you want. The builder designs a complete agent YAML with the right nodes, tools, and wiring.
+- **Pulse dashboard** — `/pulse` shows a live information radiator with signal tiles from your agents. 9 display templates, drag-and-drop layout, auto-theming.
+- **Agent-level LLM defaults** — set `provider: codex` and `model: o4-mini` at the agent level. Nodes inherit unless they override.
+- **Flow control** — conditional, switch, loop, agent-invoke, branch, end, break nodes.
+- **9 built-in tools** — shell-exec, claude-code, http-get/post, file-read/write, json-parse/path, template.
+- **13 example agents** — from hello world to conditional routing to AI-powered analysis.
 
 See the [main repo README](https://github.com/gregmeyer/some-useful-agents) for full documentation.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,15 +1,18 @@
 # @some-useful-agents/core
 
-Core library for some-useful-agents. Provides types, schemas, stores, the DAG executor, tool registry, secrets management, and template resolution.
+Core library for some-useful-agents. Types, schemas, stores, DAG executor, tool registry, secrets management, and template resolution.
 
 ## What's inside
 
-- **Agent types + Zod schemas** — `Agent`, `AgentNode`, `NodeType` (shell, claude-code, conditional, switch, loop, agent-invoke, branch, end, break)
-- **DAG executor** — topological walk with flow control, onlyIf conditional edges, nested agent-invoke, loop iteration
-- **Tool system** — 9 built-in tools + `ToolStore` for user-defined tools
-- **Stores** — `AgentStore`, `RunStore`, `ToolStore` (SQLite via `node:sqlite`)
-- **Secrets** — `EncryptedFileStore` with scrypt-derived key, passphrase + legacy-fallback modes
-- **Template resolution** — `{{upstream.X.result}}`, `{{inputs.NAME}}`, `$UPSTREAM_X_RESULT`
+- **Agent types + Zod schemas** — `Agent`, `AgentNode`, `AgentSignal`, `SignalTemplate`, `NodeType` (shell, claude-code, conditional, switch, loop, agent-invoke, branch, end, break)
+- **DAG executor** — topological walk with flow control, onlyIf conditional edges, nested agent-invoke, loop iteration, AbortSignal cancellation
+- **LlmSpawner** — multi-provider abstraction for Claude and Codex CLIs with stream-json progress tracking
+- **Tool system** — 9 built-in tools + `ToolStore` for user-defined tools, with path traversal protection on file-read/file-write
+- **Stores** — `AgentStore` (versioned DAGs), `RunStore` (paginated queries), `ToolStore` (SQLite via `node:sqlite`)
+- **Secrets** — `EncryptedFileStore` with AES-256-GCM, scrypt KDF (OWASP 2024 params), passphrase + legacy-fallback modes
+- **Template resolution** — `{{upstream.X.result}}`, `{{inputs.NAME}}`, `{{vars.NAME}}`, `$UPSTREAM_X_RESULT`
+- **Signal system** — `AgentSignal` with display templates (metric, text-headline, table, status, time-series, image, text-image, media) and field mapping for the Pulse dashboard
+- **Input security** — sensitive env-var deny-list prevents LD_PRELOAD/PATH/NODE_OPTIONS injection via agent inputs
 
 ## Install
 
@@ -21,6 +24,7 @@ npm install @some-useful-agents/core
 
 ```typescript
 import { AgentStore, RunStore, executeAgentDag, listBuiltinTools } from '@some-useful-agents/core';
+import type { Agent, AgentSignal, SignalTemplate } from '@some-useful-agents/core';
 ```
 
 See the [main repo README](https://github.com/gregmeyer/some-useful-agents) for full documentation.

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -1,15 +1,18 @@
 # @some-useful-agents/dashboard
 
-Web dashboard for some-useful-agents. Server-rendered HTML, no bundler, no framework.
+Web dashboard for some-useful-agents. Server-rendered HTML, no bundler, no framework. Dark mode by default, JetBrains Mono, warm stone neutrals.
 
 ## Features
 
-- **Agents** — card grid, DAG visualization, click-to-replay, per-node action dialogs
-- **Tools** — browse built-in + user tools, inspect inputs/outputs
-- **Runs** — filter, paginate, nested run linking, replay from any node
-- **Settings** — secrets CRUD with passphrase unlock, MCP token rotation
-- **Tutorial** — 7-step guided walkthrough with inline scaffold actions
-- **Template palette** — autocomplete for `$` and `{{` in node command/prompt editors
+- **Pulse** — information radiator at `/pulse`. Signal tiles show agent output as live widgets. 9 display templates (metric, text-headline, table, status, time-series, image, text-image, media). Container layout with drag-and-drop, edit mode, widget palette, auto-theming by template type. Conditional color thresholds. System metric tiles (runs today, failure rate, avg duration, agents). Markdown rendering, YouTube media player, tile collapse/expand.
+- **Agents** — card grid with filtering (status, source, search), sorting (name, status, recent, starred), pagination. 5-tab detail page: Overview (DAG viz, stats), Nodes (edit/delete/add), Config (LLM defaults, variables, secrets, status), Runs (history), YAML (editor).
+- **Build from goal** — describe what you want in plain language. The builder wizard designs a complete agent YAML with the right nodes, tools, inputs, and signal block.
+- **Suggest improvements** — AI-powered agent review. "Apply now" saves directly, auto-fixes shell template mistakes. Available from failed run pages with the error pre-filled.
+- **Tools** — browse built-in + user tools with filtering and pagination
+- **Runs** — filter by agent/status, paginate, replay from any node, resolved variables panel, real-time turn progress for LLM nodes
+- **Settings** — secrets CRUD with passphrase unlock, global variables, MCP token rotation
+- **LLM defaults** — agent-level provider (Claude/Codex) and model selection with dropdown UI
+- **Design system** — DESIGN.md source of truth. Dark mode default, JetBrains Mono headings, warm stone neutrals, teal accent.
 
 ## Start
 


### PR DESCRIPTION
## Summary

Updates all 4 READMEs (root + cli + core + dashboard) to reflect v0.16.0 features before npm publish. These render on npmjs.com package pages.

Key additions:
- Pulse information radiator
- Build from goal wizard
- 5-tab agent detail layout
- Filtering/sorting/pagination
- LLM defaults (provider/model)
- Security protections (path traversal, env-var deny-list)
- 13 example agents

## Test plan
- [ ] Merge, then re-trigger release workflow for npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)