### PR TITLE
chore: release v0.16.1 (README updates)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @some-useful-agents/cli
 
+## 0.16.1
+
+### Patch Changes
+
+- **docs: update READMEs for v0.16 features.**
+
+  All package READMEs updated to reflect Pulse, build-from-goal, tabbed agent detail, filtering/pagination, LLM defaults, and security improvements.
+
+- Updated dependencies
+  - @some-useful-agents/core@0.16.1
+  - @some-useful-agents/dashboard@0.16.1
+  - @some-useful-agents/mcp-server@0.16.1
+  - @some-useful-agents/temporal-provider@0.16.1
+
 ## 0.16.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@some-useful-agents/cli",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "CLI for some-useful-agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @some-useful-agents/core
 
+## 0.16.1
+
+### Patch Changes
+
+- **docs: update READMEs for v0.16 features.**
+
+  All package READMEs updated to reflect Pulse, build-from-goal, tabbed agent detail, filtering/pagination, LLM defaults, and security improvements.
+
 ## 0.16.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@some-useful-agents/core",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Core types, schemas, and utilities for some-useful-agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/dashboard/CHANGELOG.md
+++ b/packages/dashboard/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @some-useful-agents/dashboard
 
+## 0.16.1
+
+### Patch Changes
+
+- **docs: update READMEs for v0.16 features.**
+
+  All package READMEs updated to reflect Pulse, build-from-goal, tabbed agent detail, filtering/pagination, LLM defaults, and security improvements.
+
+- Updated dependencies
+  - @some-useful-agents/core@0.16.1
+
 ## 0.16.0
 
 ### Minor Changes

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@some-useful-agents/dashboard",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Web dashboard for some-useful-agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @some-useful-agents/mcp-server
 
+## 0.16.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @some-useful-agents/core@0.16.1
+
 ## 0.16.0
 
 ### Patch Changes

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@some-useful-agents/mcp-server",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "MCP server for some-useful-agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/temporal-provider/CHANGELOG.md
+++ b/packages/temporal-provider/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @some-useful-agents/temporal-provider
 
+## 0.16.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @some-useful-agents/core@0.16.1
+
 ## 0.16.0
 
 ### Patch Changes

--- a/packages/temporal-provider/package.json
+++ b/packages/temporal-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@some-useful-agents/temporal-provider",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Temporal workflow provider for some-useful-agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Patch release to publish updated READMEs to npm. The v0.16.0 publish went out before the README updates (PR #113) were merged. npm renders the README from the package at publish time, so a new version is needed.

No code changes. Only version bump + changelog entries.

## Test plan
- [ ] Merge → approve environment gate → verify READMEs on npmjs.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)