### PR TITLE
feat: color-coded template palette groups

### DIFF
--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -536,6 +536,15 @@ main.main--wide {
 .template-palette__group:first-child {
   border-top: none;
 }
+.template-palette__group--upstream { color: #2dd4bf; }
+.template-palette__group--input   { color: #60a5fa; }
+.template-palette__group--var     { color: #4ade80; }
+.template-palette__group--secret  { color: #fb923c; }
+
+.template-palette__item--upstream { border-left: 2px solid #2dd4bf; }
+.template-palette__item--input   { border-left: 2px solid #60a5fa; }
+.template-palette__item--var     { border-left: 2px solid #4ade80; }
+.template-palette__item--secret  { border-left: 2px solid #fb923c; }
 
 .template-palette__empty {
   padding: var(--space-3);

--- a/packages/dashboard/src/views/template-palette.js.ts
+++ b/packages/dashboard/src/views/template-palette.js.ts
@@ -199,13 +199,13 @@ export const TEMPLATE_PALETTE_JS = `
           if (items[i].group !== lastGroup) {
             lastGroup = items[i].group;
             var sep = document.createElement('div');
-            sep.className = 'template-palette__group';
+            sep.className = 'template-palette__group template-palette__group--' + lastGroup;
             sep.textContent = GROUP_LABELS[lastGroup] || lastGroup;
             palette.appendChild(sep);
           }
 
           var row = document.createElement('div');
-          row.className = 'template-palette__item' + (i === selectedIndex ? ' is-selected' : '');
+          row.className = 'template-palette__item template-palette__item--' + items[i].group + (i === selectedIndex ? ' is-selected' : '');
           row.setAttribute('data-index', String(i));
           row.setAttribute('role', 'option');
 


### PR DESCRIPTION
## Summary

- Template palette autocomplete now shows color-coded left borders per group: upstream (teal), inputs (blue), variables (green), secrets (orange)
- Group header text matches the border color
- Makes it easy to distinguish variable sources at a glance when typing `$` or `{{`

## Test plan

- [x] 573 tests pass
- [ ] Manual: open node edit, type `$` in command textarea, verify palette shows colored groups
- [ ] Manual: type `{{` in prompt textarea, verify claude-mode groups are colored

🤖 Generated with [Claude Code](https://claude.com/claude-code)