### PR TITLE
feat: run detail layout — DAG+widget side-by-side, filterable nodes

### DIFF
--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -178,8 +178,8 @@ main.main--wide {
   margin-top: var(--space-3);
 }
 
-/* Run detail 2-column grid — DAG left, node inspector right.
- * Falls back to single column on narrow viewports. */
+/* Run detail 2-column grid — DAG left, result/widget right.
+ * Node execution is full-width below. Falls back to single column on narrow viewports. */
 .run-detail-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -198,6 +198,13 @@ main.main--wide {
   top: var(--space-4);
 }
 
+.run-detail-grid__result {
+  max-height: 80vh;
+  overflow-y: auto;
+  padding-right: var(--space-2);
+}
+
+/* Legacy: kept for backward compat with agent detail split-screen */
 .run-detail-grid__inspector {
   max-height: 80vh;
   overflow-y: auto;

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -5,6 +5,7 @@ import { SUGGEST_IMPROVEMENTS_JS } from './suggest-improvements.js.js';
 import { PULSE_LAYOUT_JS } from './pulse-layout.js.js';
 import { BUILD_FROM_GOAL_JS } from './build-from-goal.js.js';
 import { OUTPUT_WIDGET_ACTIONS_JS } from './output-widget-actions.js.js';
+import { RUN_DETAIL_FILTER_JS } from './run-detail-filter.js.js';
 import { footer } from './footer.js';
 
 export interface LayoutOptions {
@@ -62,7 +63,7 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
   ${body}
 </main>
 ${footer()}
-<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + BUILD_FROM_GOAL_JS + OUTPUT_WIDGET_ACTIONS_JS)}</script>
+<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + BUILD_FROM_GOAL_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS)}</script>
 </body>
 </html>`;
 }

--- a/packages/dashboard/src/views/run-detail-filter.js.ts
+++ b/packages/dashboard/src/views/run-detail-filter.js.ts
@@ -1,0 +1,46 @@
+/**
+ * Run detail node execution filter JS.
+ * Search across node id + stdout/stderr text, filter by status.
+ *
+ * Inlined via layout.ts.
+ */
+export const RUN_DETAIL_FILTER_JS = `
+  // ── Run detail node filter ─────────────────────────────────────────
+  (function () {
+    var searchInput = document.querySelector('.run-detail-nodes__search');
+    var statusSelect = document.querySelector('.run-detail-nodes__status-filter');
+    if (!searchInput && !statusSelect) return;
+
+    function filterNodes() {
+      var query = searchInput ? searchInput.value.toLowerCase() : '';
+      var status = statusSelect ? statusSelect.value : '';
+      var cards = document.querySelectorAll('.run-node[data-node-id]');
+
+      for (var i = 0; i < cards.length; i++) {
+        var card = cards[i];
+        var nodeId = card.getAttribute('data-node-id') || '';
+        var nodeStatus = card.getAttribute('data-node-status') || '';
+
+        // Status filter.
+        if (status && nodeStatus !== status) {
+          card.style.display = 'none';
+          continue;
+        }
+
+        // Text search: match against node id and card text content.
+        if (query) {
+          var text = nodeId.toLowerCase() + ' ' + (card.textContent || '').toLowerCase();
+          if (text.indexOf(query) === -1) {
+            card.style.display = 'none';
+            continue;
+          }
+        }
+
+        card.style.display = '';
+      }
+    }
+
+    if (searchInput) searchInput.addEventListener('input', filterNodes);
+    if (statusSelect) statusSelect.addEventListener('change', filterNodes);
+  })();
+`;

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -131,20 +131,41 @@ export function renderRunDetail(opts: RunDetailOptions): string {
       ` : html``}
 
       ${isDagRun ? html`
+        <!-- Top: DAG + Result side-by-side -->
         <div class="run-detail-grid">
           <div class="run-detail-grid__dag">
             ${dagSection}
             ${canReplay ? renderReplayFallback(run, agent!) : html``}
           </div>
-          <div class="run-detail-grid__inspector">
-            <h2 style="margin-top: 0;">Node execution</h2>
-            <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-3);">Click a node in the DAG to see its output.</p>
-            ${renderNodeCards(nodeExecutions!, run.id, canReplay)}
+          <div class="run-detail-grid__result">
+            <h2 style="margin-top: 0;">Result</h2>
+            ${!inProgress && run.result
+              ? (agent?.outputWidget
+                  ? renderOutputWidget(agent.outputWidget, run.result, agent.id) ?? outputFrame(run.result)
+                  : outputFrame(run.result))
+              : inProgress
+                ? html`<p class="dim" style="font-size: var(--font-size-xs);">Run in progress...</p>`
+                : html`<p class="dim" style="font-size: var(--font-size-xs);">No output yet.</p>`}
           </div>
         </div>
-        ${!inProgress && run.result && agent?.outputWidget
-          ? html`<section style="margin-top: var(--space-6);"><h2>Result</h2>${renderOutputWidget(agent.outputWidget, run.result, agent.id) ?? outputFrame(run.result)}</section>`
-          : html``}
+
+        <!-- Bottom: Node execution (full width, searchable) -->
+        <section class="run-detail-nodes" style="margin-top: var(--space-6);">
+          <div style="display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-3); flex-wrap: wrap;">
+            <h2 style="margin: 0;">Node execution</h2>
+            <input type="text" class="run-detail-nodes__search" placeholder="Search nodes..."
+              style="padding: var(--space-1) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs); font-family: var(--font-mono); background: var(--color-surface); color: var(--color-text); flex: 1; min-width: 120px; max-width: 280px;">
+            <select class="run-detail-nodes__status-filter"
+              style="padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs); background: var(--color-surface); color: var(--color-text);">
+              <option value="">All statuses</option>
+              <option value="completed">Completed</option>
+              <option value="failed">Failed</option>
+              <option value="running">Running</option>
+              <option value="skipped">Skipped</option>
+            </select>
+          </div>
+          ${renderNodeCards(nodeExecutions!, run.id, canReplay)}
+        </section>
       ` : html`
         <h2>Output</h2>
         ${run.result
@@ -351,7 +372,7 @@ function renderNodeCards(execs: NodeExecutionRecord[], runId?: string, canReplay
     }
 
     return html`
-      <details class="run-node" id="node-${e.nodeId}"${openAttr}>
+      <details class="run-node" id="node-${e.nodeId}" data-node-id="${e.nodeId}" data-node-status="${e.status}"${openAttr}>
         <summary class="run-node__header">
           <span class="run-node__id">${e.nodeId}</span>
           ${statusBadge(e.status)}


### PR DESCRIPTION
## Summary

Restructures the run detail page to mirror the agent overview layout:

- **Top row (2-column):** DAG on left, result widget (or raw output) on right
- **Bottom (full-width):** Node execution panel with search input + status filter dropdown
- Search matches node id, stdout, stderr, variables, and error text
- Status dropdown filters by completed/failed/running/skipped
- Responsive: stacks to single column on narrow screens

## Test plan

- [x] 573 tests pass
- [ ] Manual: run api-monitor, verify DAG left + widget right layout
- [ ] Manual: run a multi-node agent, search for a node by name
- [ ] Manual: filter by "failed" status
- [ ] Manual: verify responsive stacking on narrow viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)