### PR TITLE
feat: Pulse Phase 2 + theme system

### DIFF
--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -150,13 +150,14 @@ export const agentV2Schema = z.object({
     title: z.string().min(1),
     icon: z.string().optional(),
     // v2 template system
-    template: z.enum(['metric', 'time-series', 'text-headline', 'text-image', 'image', 'table', 'status', 'media', 'widget']).optional(),
+    template: z.enum(['metric', 'time-series', 'text-headline', 'text-image', 'image', 'table', 'status', 'media', 'widget', 'comparison', 'key-value', 'story', 'funnel']).optional(),
     mapping: z.record(z.string()).optional(),
     // v1 (deprecated, still accepted)
     format: z.enum(['text', 'number', 'table', 'json', 'chart']).optional(),
     field: z.string().optional(),
     refresh: z.string().optional(),
     size: z.enum(['1x1', '2x1', '1x2', '2x2']).optional(),
+    accent: z.enum(['teal', 'blue', 'green', 'orange', 'red', 'purple']).optional(),
     hidden: z.boolean().optional(),
     thresholds: z.array(z.object({
       above: z.number().optional(),

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -271,7 +271,13 @@ export type SignalTemplate =
   | 'table'
   | 'status'
   | 'media'
-  | 'widget';
+  | 'widget'
+  | 'comparison'
+  | 'key-value'
+  | 'story'
+  | 'funnel';
+
+export type SignalAccent = 'teal' | 'blue' | 'green' | 'orange' | 'red' | 'purple';
 
 export interface AgentSignal {
   title: string;
@@ -292,6 +298,8 @@ export interface AgentSignal {
   refresh?: string;
   /** Grid tile size on the Pulse board (default: "1x1"). */
   size?: '1x1' | '2x1' | '1x2' | '2x2';
+  /** Accent color for tile border and value tinting. */
+  accent?: SignalAccent;
   /** Hidden from Pulse dashboard. Toggle via the tile's visibility button. */
   hidden?: boolean;
   /** Conditional palette thresholds for metric tiles. Evaluated top-to-bottom, first match wins. */

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -1166,3 +1166,187 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
   background: rgba(251,191,36,0.08);
   border-color: var(--color-warning);
 }
+
+/* -- Accent colors (signal.accent) -- */
+.pulse-tile[data-accent="teal"]   { border-left: 4px solid #2dd4bf; }
+.pulse-tile[data-accent="blue"]   { border-left: 4px solid #60a5fa; }
+.pulse-tile[data-accent="green"]  { border-left: 4px solid #4ade80; }
+.pulse-tile[data-accent="orange"] { border-left: 4px solid #fb923c; }
+.pulse-tile[data-accent="red"]    { border-left: 4px solid #f87171; }
+.pulse-tile[data-accent="purple"] { border-left: 4px solid #a78bfa; }
+
+.pulse-tile[data-accent="teal"]   .pulse-tile__value { color: #2dd4bf; }
+.pulse-tile[data-accent="blue"]   .pulse-tile__value { color: #60a5fa; }
+.pulse-tile[data-accent="green"]  .pulse-tile__value { color: #4ade80; }
+.pulse-tile[data-accent="orange"] .pulse-tile__value { color: #fb923c; }
+.pulse-tile[data-accent="red"]    .pulse-tile__value { color: #f87171; }
+.pulse-tile[data-accent="purple"] .pulse-tile__value { color: #a78bfa; }
+
+.pulse-tile[data-accent="teal"]   .pulse-tile__trend { color: #2dd4bf; }
+.pulse-tile[data-accent="blue"]   .pulse-tile__trend { color: #60a5fa; }
+.pulse-tile[data-accent="green"]  .pulse-tile__trend { color: #4ade80; }
+.pulse-tile[data-accent="orange"] .pulse-tile__trend { color: #fb923c; }
+.pulse-tile[data-accent="red"]    .pulse-tile__trend { color: #f87171; }
+.pulse-tile[data-accent="purple"] .pulse-tile__trend { color: #a78bfa; }
+
+.pulse-tile[data-accent="teal"]   .pulse-tile__sparkline polyline { stroke: #2dd4bf; }
+.pulse-tile[data-accent="blue"]   .pulse-tile__sparkline polyline { stroke: #60a5fa; }
+.pulse-tile[data-accent="green"]  .pulse-tile__sparkline polyline { stroke: #4ade80; }
+.pulse-tile[data-accent="orange"] .pulse-tile__sparkline polyline { stroke: #fb923c; }
+.pulse-tile[data-accent="red"]    .pulse-tile__sparkline polyline { stroke: #f87171; }
+.pulse-tile[data-accent="purple"] .pulse-tile__sparkline polyline { stroke: #a78bfa; }
+
+.pulse-tile[data-accent="teal"]   .pulse-tile__status-dot { background: #2dd4bf; }
+.pulse-tile[data-accent="blue"]   .pulse-tile__status-dot { background: #60a5fa; }
+.pulse-tile[data-accent="green"]  .pulse-tile__status-dot { background: #4ade80; }
+.pulse-tile[data-accent="orange"] .pulse-tile__status-dot { background: #fb923c; }
+.pulse-tile[data-accent="red"]    .pulse-tile__status-dot { background: #f87171; }
+.pulse-tile[data-accent="purple"] .pulse-tile__status-dot { background: #a78bfa; }
+
+/* -- Configure tile button -- */
+.pulse-tile__configure-btn {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  padding: 0 var(--space-1);
+  line-height: 1;
+  opacity: 0;
+  transition: opacity 100ms ease;
+}
+.pulse-tile:hover .pulse-tile__configure-btn { opacity: 0.7; }
+.pulse-tile__configure-btn:hover { opacity: 1 !important; color: var(--color-primary); }
+
+/* -- Configure modal -- */
+.pulse-configure-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(2px);
+}
+.pulse-configure-modal__content {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  width: min(520px, 90vw);
+  max-height: 80vh;
+  overflow-y: auto;
+  padding: var(--space-5);
+}
+.pulse-configure-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-4);
+}
+.pulse-configure-modal__close {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: 1.25rem;
+  padding: var(--space-1);
+  line-height: 1;
+}
+.pulse-configure-modal__close:hover { color: var(--color-text); }
+.pulse-configure-modal__section {
+  margin-bottom: var(--space-4);
+}
+.pulse-configure-modal__label {
+  display: block;
+  font-size: var(--font-size-xs);
+  font-weight: var(--weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-1);
+}
+.pulse-configure-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-border);
+}
+
+/* -- Template picker grid -- */
+.pulse-configure-modal__templates {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+  gap: var(--space-2);
+}
+.pulse-configure-modal__tpl-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: var(--space-2);
+  background: var(--color-surface-raised);
+  border: 2px solid transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: border-color 100ms ease;
+}
+.pulse-configure-modal__tpl-card:hover {
+  border-color: var(--color-border);
+}
+.pulse-configure-modal__tpl-card.is-active {
+  border-color: var(--color-primary);
+  background: rgba(45, 212, 191, 0.08);
+}
+.pulse-configure-modal__tpl-icon {
+  font-size: 1.25rem;
+}
+.pulse-configure-modal__tpl-name {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+  text-align: center;
+}
+
+/* -- Theme picker grid (Settings > Appearance) -- */
+.theme-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: var(--space-3);
+}
+.theme-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  background: var(--color-surface-raised);
+  border: 2px solid transparent;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: border-color 100ms ease;
+}
+.theme-card:hover {
+  border-color: var(--color-border-strong);
+}
+.theme-card.is-active {
+  border-color: var(--color-primary);
+}
+.theme-card__preview {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  border-radius: var(--radius-sm);
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.theme-card__name {
+  font-size: var(--font-size-xs);
+  font-weight: var(--weight-semibold);
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}

--- a/packages/dashboard/src/assets/themes.css
+++ b/packages/dashboard/src/assets/themes.css
@@ -1,0 +1,70 @@
+/*
+ * Widget themes — CSS custom property overrides scoped to
+ * [data-widget-theme="X"]. Can be applied at body, container, or tile level.
+ * CSS cascade handles precedence: tile > container > body > tokens.css.
+ *
+ * Default = no overrides (uses tokens.css dark mode).
+ * Light = uses tokens.css [data-theme="light"].
+ */
+
+/* ── Warm ── */
+/* Amber accent, stone backgrounds, softer corners. */
+[data-widget-theme="warm"] {
+  --color-primary: #f59e0b;
+  --color-primary-hover: #d97706;
+  --color-primary-soft: rgba(245, 158, 11, 0.1);
+  --color-bg: #1c1917;
+  --color-surface: #292524;
+  --color-surface-raised: #44403c;
+  --color-border: #57534e;
+  --color-border-strong: #78716c;
+  --color-text: #fafaf9;
+  --color-text-muted: #d6d3d1;
+  --color-text-subtle: #a8a29e;
+  --radius-sm: 8px;
+  --radius-md: 16px;
+  --radius-lg: 20px;
+  --shadow-focus: 0 0 0 3px rgba(245, 158, 11, 0.25);
+}
+
+/* ── Minimal ── */
+/* No borders, no shadows, flat design. Clean and focused. */
+[data-widget-theme="minimal"] {
+  --color-primary: #a3a3a3;
+  --color-primary-hover: #d4d4d4;
+  --color-primary-soft: rgba(163, 163, 163, 0.08);
+  --color-border: transparent;
+  --color-border-strong: rgba(255, 255, 255, 0.06);
+  --shadow-sm: none;
+  --shadow-md: none;
+  --shadow-focus: 0 0 0 2px rgba(163, 163, 163, 0.3);
+  --radius-sm: 0;
+  --radius-md: 0;
+  --radius-lg: 0;
+}
+
+/* ── Neon ── */
+/* Purple accent, true black background, vivid status colors. */
+[data-widget-theme="neon"] {
+  --color-primary: #a855f7;
+  --color-primary-hover: #c084fc;
+  --color-primary-soft: rgba(168, 85, 247, 0.12);
+  --color-bg: #0a0a0a;
+  --color-surface: #171717;
+  --color-surface-raised: #262626;
+  --color-border: #333333;
+  --color-border-strong: #444444;
+  --color-text: #fafafa;
+  --color-text-muted: #a3a3a3;
+  --color-text-subtle: #737373;
+  --color-ok: #22d3ee;
+  --color-ok-soft: rgba(34, 211, 238, 0.1);
+  --color-err: #fb7185;
+  --color-err-soft: rgba(251, 113, 133, 0.1);
+  --color-warn: #fbbf24;
+  --color-info: #818cf8;
+  --color-info-soft: rgba(129, 140, 248, 0.1);
+  --shadow-sm: 0 1px 3px rgb(0 0 0 / 0.4);
+  --shadow-md: 0 4px 12px rgb(0 0 0 / 0.5);
+  --shadow-focus: 0 0 0 3px rgba(168, 85, 247, 0.3);
+}

--- a/packages/dashboard/src/routes/pulse.ts
+++ b/packages/dashboard/src/routes/pulse.ts
@@ -1,10 +1,11 @@
 import { Router, type Request, type Response } from 'express';
-import { parseAgent, type Agent, type AgentSignal, type Run } from '@some-useful-agents/core';
+import { parseAgent, type Agent, type AgentSignal, type SignalTemplate, type SignalAccent, type Run } from '@some-useful-agents/core';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { getContext } from '../context.js';
-import { renderPulsePage, type PulseTile } from '../views/pulse.js';
-import { normalizeSignal, extractMappedValues } from '../views/pulse-templates.js';
+import { renderPulsePage, tileWrap, type PulseTile } from '../views/pulse.js';
+import { renderTile } from '../views/pulse-renderers.js';
+import { normalizeSignal, extractMappedValues, TEMPLATE_REGISTRY } from '../views/pulse-templates.js';
 
 export const pulseRouter: Router = Router();
 
@@ -46,7 +47,29 @@ function buildTile(agent: Agent & { signal: AgentSignal }, ctx: ReturnType<typeo
 
   const { mapping } = normalizeSignal(signal);
   const slots = extractMappedValues(lastRun, mapping, outputsJson);
-  return { agent, signal, lastRun, slots };
+
+  // Discover output field keys for the configure modal.
+  const outputFields: string[] = [];
+  const fieldSet = new Set<string>();
+  if (outputsJson) {
+    try {
+      const parsed = JSON.parse(outputsJson);
+      if (typeof parsed === 'object' && parsed !== null) {
+        for (const k of Object.keys(parsed)) fieldSet.add(k);
+      }
+    } catch { /* ignore */ }
+  }
+  if (lastRun?.result) {
+    try {
+      const parsed = JSON.parse(lastRun.result);
+      if (typeof parsed === 'object' && parsed !== null) {
+        for (const k of Object.keys(parsed)) fieldSet.add(k);
+      }
+    } catch { /* not JSON */ }
+  }
+  outputFields.push(...Array.from(fieldSet).sort());
+
+  return { agent, signal, lastRun, slots, outputFields };
 }
 
 // ── Virtual system tiles ─────────────────────────────────────────────────
@@ -173,4 +196,82 @@ pulseRouter.post('/agents/:id/signal/toggle', (req: Request, res: Response) => {
   } catch {
     res.redirect(303, '/pulse');
   }
+});
+
+// ── Update signal config ────────────────────────────────────────────────
+
+pulseRouter.post('/agents/:id/signal', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const agent = ctx.agentStore.getAgent(id);
+  if (!agent) {
+    res.redirect(303, '/pulse');
+    return;
+  }
+
+  const body = req.body as Record<string, string>;
+  const template = body.template as SignalTemplate | undefined;
+  const accent = body.accent as SignalAccent | undefined;
+  const title = body.title?.trim();
+  const icon = body.icon?.trim();
+  const size = body.size as AgentSignal['size'] | undefined;
+  const refresh = body.refresh?.trim();
+
+  // Validate template exists in registry.
+  if (template && !TEMPLATE_REGISTRY[template]) {
+    res.redirect(303, '/pulse');
+    return;
+  }
+
+  // Parse mapping from JSON string.
+  let mapping: Record<string, string> | undefined;
+  if (body.mapping) {
+    try {
+      mapping = JSON.parse(body.mapping);
+    } catch {
+      res.redirect(303, '/pulse');
+      return;
+    }
+  }
+
+  const signal: AgentSignal = {
+    ...(agent.signal ?? { title: agent.id }),
+    ...(title ? { title } : {}),
+    ...(icon !== undefined ? { icon: icon || undefined } : {}),
+    ...(template ? { template } : {}),
+    ...(mapping ? { mapping } : {}),
+    ...(accent ? { accent } : {}),
+    ...(size ? { size } : {}),
+    ...(refresh !== undefined ? { refresh: refresh || undefined } : {}),
+  };
+
+  try {
+    const updated = { ...agent, signal };
+    ctx.agentStore.upsertAgent(updated, 'dashboard', `Update signal config via Pulse`);
+    res.redirect(303, '/pulse');
+  } catch {
+    res.redirect(303, '/pulse');
+  }
+});
+
+// ── Tile fragment (for auto-refresh polling) ────────────────────────────
+
+pulseRouter.get('/pulse/tile/:id', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+
+  // System tiles.
+  if (id.startsWith('_system-')) {
+    const systemTiles = buildSystemTiles(ctx);
+    const tile = systemTiles.find((t) => t.agent.id === id);
+    if (!tile) { res.status(404).send('Tile not found'); return; }
+    res.type('html').send(renderTile(tile, tileWrap).toString());
+    return;
+  }
+
+  // Agent tiles.
+  const agent = ctx.agentStore.getAgent(id);
+  if (!agent || !agent.signal) { res.status(404).send('Tile not found'); return; }
+  const tile = buildTile(agent as Agent & { signal: AgentSignal }, ctx);
+  res.type('html').send(renderTile(tile, tileWrap).toString());
 });

--- a/packages/dashboard/src/routes/settings.ts
+++ b/packages/dashboard/src/routes/settings.ts
@@ -5,6 +5,7 @@ import { renderSettingsShell } from '../views/settings-shell.js';
 import { renderSettingsSecrets } from '../views/settings-secrets.js';
 import { renderSettingsVariables } from '../views/settings-variables.js';
 import { renderSettingsGeneral } from '../views/settings-general.js';
+import { renderSettingsAppearance } from '../views/settings-appearance.js';
 import { getContext, type DashboardContext } from '../context.js';
 import { SESSION_COOKIE } from '../auth-middleware.js';
 
@@ -241,6 +242,12 @@ settingsRouter.get('/settings/integrations', (req: Request, res: Response) => {
     </div>
   `;
   res.type('html').send(renderSettingsShell({ active: 'integrations', body, flash }));
+});
+
+settingsRouter.get('/settings/appearance', (req: Request, res: Response) => {
+  const { flash } = readQueryBanners(req);
+  const body = renderSettingsAppearance();
+  res.type('html').send(renderSettingsShell({ active: 'appearance', body, flash }));
 });
 
 settingsRouter.get('/settings/general', (req: Request, res: Response) => {

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -7,6 +7,8 @@ import { HOME_LAYOUT_JS } from './home-layout.js.js';
 import { BUILD_FROM_GOAL_JS } from './build-from-goal.js.js';
 import { OUTPUT_WIDGET_ACTIONS_JS } from './output-widget-actions.js.js';
 import { RUN_DETAIL_FILTER_JS } from './run-detail-filter.js.js';
+import { PULSE_CONFIGURE_JS } from './pulse-configure.js.js';
+import { PULSE_REFRESH_JS } from './pulse-refresh.js.js';
 import { footer } from './footer.js';
 
 export interface LayoutOptions {
@@ -40,11 +42,13 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="/assets/dashboard.css">
+<link rel="stylesheet" href="/assets/themes.css">
 <script>
 (function(){var t=localStorage.getItem('sua-theme');if(t==='light')document.documentElement.setAttribute('data-theme','light');})();
 </script>
 </head>
 <body class="app">
+<script>(function(){var w=localStorage.getItem('sua-widget-theme');if(w&&w!=='default'&&w!=='light')document.body.setAttribute('data-widget-theme',w);})();</script>
 <header class="topbar">
   <a class="topbar__brand" href="/">sua</a>
   <nav class="topbar__nav">
@@ -64,7 +68,7 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
   ${body}
 </main>
 ${footer()}
-<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + HOME_LAYOUT_JS + BUILD_FROM_GOAL_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS)}</script>
+<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + HOME_LAYOUT_JS + BUILD_FROM_GOAL_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS)}</script>
 </body>
 </html>`;
 }

--- a/packages/dashboard/src/views/pulse-configure.js.ts
+++ b/packages/dashboard/src/views/pulse-configure.js.ts
@@ -1,0 +1,259 @@
+/**
+ * Pulse configure tile modal: template picker, mapping form, metadata fields.
+ * Opens when the gear icon is clicked on a non-system tile.
+ */
+export const PULSE_CONFIGURE_JS = `
+  (function () {
+    var modal = null;
+    var registry = null;
+    var currentAgentId = null;
+    var currentConfig = null;
+    var currentOutputFields = [];
+
+    function getRegistry() {
+      if (registry) return registry;
+      var el = document.getElementById('pulse-template-registry');
+      if (!el) return {};
+      try { registry = JSON.parse(el.textContent || '{}'); } catch { registry = {}; }
+      return registry;
+    }
+
+    function ensureModal() {
+      if (modal) return;
+      modal = document.createElement('div');
+      modal.className = 'pulse-configure-modal';
+      modal.style.display = 'none';
+      modal.addEventListener('click', function (e) {
+        if (e.target === modal) closeModal();
+      });
+      document.body.appendChild(modal);
+    }
+
+    function closeModal() {
+      if (modal) modal.style.display = 'none';
+      currentAgentId = null;
+      currentConfig = null;
+    }
+
+    function openModal(agentId, config, outputFields) {
+      ensureModal();
+      currentAgentId = agentId;
+      currentConfig = config;
+      currentOutputFields = outputFields || [];
+
+      var reg = getRegistry();
+      var selectedTemplate = config.template || 'metric';
+
+      modal.innerHTML = '<div class="pulse-configure-modal__content">' +
+        '<div class="pulse-configure-modal__header">' +
+          '<h3 style="margin: 0;">Configure tile</h3>' +
+          '<button type="button" class="pulse-configure-modal__close" title="Close">\\u00D7</button>' +
+        '</div>' +
+        '<form method="POST" action="/agents/' + encodeURIComponent(agentId) + '/signal" class="pulse-configure-modal__form">' +
+          '<div class="pulse-configure-modal__section">' +
+            '<label class="pulse-configure-modal__label">Template</label>' +
+            '<div class="pulse-configure-modal__templates" id="cfg-template-grid"></div>' +
+          '</div>' +
+          '<div class="pulse-configure-modal__section">' +
+            '<label class="pulse-configure-modal__label">Title</label>' +
+            '<input type="text" name="title" value="' + esc(config.title || '') + '" class="input" style="width: 100%;">' +
+          '</div>' +
+          '<div class="pulse-configure-modal__section" style="display: flex; gap: var(--space-3);">' +
+            '<div style="flex: 1;">' +
+              '<label class="pulse-configure-modal__label">Icon</label>' +
+              '<input type="text" name="icon" value="' + esc(config.icon || '') + '" class="input" style="width: 100%;" placeholder="emoji or symbol">' +
+            '</div>' +
+            '<div style="flex: 1;">' +
+              '<label class="pulse-configure-modal__label">Size</label>' +
+              '<select name="size" class="input" style="width: 100%;">' +
+                '<option value="1x1"' + (config.size === '1x1' ? ' selected' : '') + '>1\\u00D71</option>' +
+                '<option value="2x1"' + (config.size === '2x1' ? ' selected' : '') + '>2\\u00D71 (wide)</option>' +
+                '<option value="1x2"' + (config.size === '1x2' ? ' selected' : '') + '>1\\u00D72 (tall)</option>' +
+                '<option value="2x2"' + (config.size === '2x2' ? ' selected' : '') + '>2\\u00D72 (large)</option>' +
+              '</select>' +
+            '</div>' +
+          '</div>' +
+          '<div class="pulse-configure-modal__section" style="display: flex; gap: var(--space-3);">' +
+            '<div style="flex: 1;">' +
+              '<label class="pulse-configure-modal__label">Accent</label>' +
+              '<select name="accent" class="input" style="width: 100%;">' +
+                '<option value=""' + (!config.accent ? ' selected' : '') + '>None</option>' +
+                '<option value="teal"' + (config.accent === 'teal' ? ' selected' : '') + '>Teal</option>' +
+                '<option value="blue"' + (config.accent === 'blue' ? ' selected' : '') + '>Blue</option>' +
+                '<option value="green"' + (config.accent === 'green' ? ' selected' : '') + '>Green</option>' +
+                '<option value="orange"' + (config.accent === 'orange' ? ' selected' : '') + '>Orange</option>' +
+                '<option value="red"' + (config.accent === 'red' ? ' selected' : '') + '>Red</option>' +
+                '<option value="purple"' + (config.accent === 'purple' ? ' selected' : '') + '>Purple</option>' +
+              '</select>' +
+            '</div>' +
+            '<div style="flex: 1;">' +
+              '<label class="pulse-configure-modal__label">Refresh</label>' +
+              '<input type="text" name="refresh" value="' + esc(config.refresh || '') + '" class="input" style="width: 100%;" placeholder="e.g. 5m, 1h">' +
+            '</div>' +
+          '</div>' +
+          '<div class="pulse-configure-modal__section">' +
+            '<label class="pulse-configure-modal__label">Field mapping</label>' +
+            '<div id="cfg-mapping-form"></div>' +
+          '</div>' +
+          '<input type="hidden" name="template" id="cfg-template-value" value="' + esc(selectedTemplate) + '">' +
+          '<input type="hidden" name="mapping" id="cfg-mapping-value" value="">' +
+          '<div class="pulse-configure-modal__footer">' +
+            '<button type="button" class="btn btn--ghost btn--sm" onclick="this.closest(\\'.pulse-configure-modal\\').style.display=\\'none\\'">Cancel</button>' +
+            '<button type="submit" class="btn btn--primary btn--sm">Save</button>' +
+          '</div>' +
+        '</form>' +
+      '</div>';
+
+      // Close button
+      modal.querySelector('.pulse-configure-modal__close').addEventListener('click', closeModal);
+
+      // Build template picker grid
+      var grid = document.getElementById('cfg-template-grid');
+      var templateNames = Object.keys(reg);
+      for (var i = 0; i < templateNames.length; i++) {
+        var t = reg[templateNames[i]];
+        var card = document.createElement('button');
+        card.type = 'button';
+        card.className = 'pulse-configure-modal__tpl-card' + (t.name === selectedTemplate ? ' is-active' : '');
+        card.setAttribute('data-template', t.name);
+        card.innerHTML = '<span class="pulse-configure-modal__tpl-icon">' + (t.icon || '') + '</span>' +
+          '<span class="pulse-configure-modal__tpl-name">' + esc(t.displayName) + '</span>';
+        card.title = t.description || '';
+        card.addEventListener('click', (function (name) {
+          return function () {
+            document.getElementById('cfg-template-value').value = name;
+            var cards = grid.querySelectorAll('.pulse-configure-modal__tpl-card');
+            for (var j = 0; j < cards.length; j++) cards[j].classList.remove('is-active');
+            this.classList.add('is-active');
+            renderMappingForm(name);
+          };
+        })(t.name));
+        grid.appendChild(card);
+      }
+
+      // Initial mapping form
+      renderMappingForm(selectedTemplate);
+
+      // Serialize mapping on submit
+      modal.querySelector('form').addEventListener('submit', function () {
+        var mappingObj = {};
+        var rows = document.querySelectorAll('#cfg-mapping-form .cfg-mapping-row');
+        for (var r = 0; r < rows.length; r++) {
+          var slotName = rows[r].getAttribute('data-slot');
+          var select = rows[r].querySelector('select');
+          var literalInput = rows[r].querySelector('.cfg-literal-input');
+          if (select && select.value === '__literal__' && literalInput) {
+            mappingObj[slotName] = literalInput.value;
+          } else if (select) {
+            mappingObj[slotName] = select.value;
+          }
+        }
+        document.getElementById('cfg-mapping-value').value = JSON.stringify(mappingObj);
+      });
+
+      modal.style.display = 'flex';
+    }
+
+    function renderMappingForm(templateName) {
+      var reg = getRegistry();
+      var tpl = reg[templateName];
+      var container = document.getElementById('cfg-mapping-form');
+      if (!container || !tpl) return;
+      container.innerHTML = '';
+
+      var currentMapping = currentConfig.mapping || {};
+
+      if (tpl.slots.length === 0) {
+        container.innerHTML = '<p style="font-size: var(--font-size-xs); color: var(--color-text-muted);">This template has no configurable slots.</p>';
+        return;
+      }
+
+      for (var i = 0; i < tpl.slots.length; i++) {
+        var slot = tpl.slots[i];
+        var row = document.createElement('div');
+        row.className = 'cfg-mapping-row';
+        row.setAttribute('data-slot', slot.name);
+
+        var label = document.createElement('label');
+        label.style.cssText = 'font-size: var(--font-size-xs); color: var(--color-text-muted); display: block; margin-bottom: 2px;';
+        label.textContent = slot.label + (slot.required ? ' *' : '');
+        row.appendChild(label);
+
+        var select = document.createElement('select');
+        select.className = 'input';
+        select.style.cssText = 'width: 100%; margin-bottom: var(--space-2);';
+
+        // Add output field options
+        var currentVal = currentMapping[slot.name] || '';
+        var hasFieldMatch = false;
+
+        for (var f = 0; f < currentOutputFields.length; f++) {
+          var opt = document.createElement('option');
+          opt.value = currentOutputFields[f];
+          opt.textContent = currentOutputFields[f];
+          if (currentVal === currentOutputFields[f]) {
+            opt.selected = true;
+            hasFieldMatch = true;
+          }
+          select.appendChild(opt);
+        }
+
+        // "result" option (raw output)
+        var resultOpt = document.createElement('option');
+        resultOpt.value = 'result';
+        resultOpt.textContent = 'result (raw output)';
+        if (currentVal === 'result') { resultOpt.selected = true; hasFieldMatch = true; }
+        select.appendChild(resultOpt);
+
+        // Literal option
+        var litOpt = document.createElement('option');
+        litOpt.value = '__literal__';
+        litOpt.textContent = 'Literal value...';
+        if (currentVal && !hasFieldMatch) { litOpt.selected = true; }
+        select.appendChild(litOpt);
+
+        row.appendChild(select);
+
+        // Literal input (shown when literal is selected)
+        var litInput = document.createElement('input');
+        litInput.type = 'text';
+        litInput.className = 'input cfg-literal-input';
+        litInput.style.cssText = 'width: 100%; margin-bottom: var(--space-2);';
+        litInput.placeholder = 'Enter literal value';
+        litInput.value = (!hasFieldMatch && currentVal) ? currentVal : '';
+        litInput.style.display = (!hasFieldMatch && currentVal) ? '' : 'none';
+        row.appendChild(litInput);
+
+        select.addEventListener('change', (function (input) {
+          return function () {
+            input.style.display = this.value === '__literal__' ? '' : 'none';
+          };
+        })(litInput));
+
+        container.appendChild(row);
+      }
+    }
+
+    function esc(s) {
+      return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    }
+
+    // Click handler for gear buttons
+    document.addEventListener('click', function (e) {
+      var btn = e.target.closest ? e.target.closest('.pulse-tile__configure-btn') : null;
+      if (!btn) return;
+      var agentId = btn.getAttribute('data-tile-id');
+      if (!agentId) return;
+
+      var header = btn.closest('.pulse-tile__header');
+      if (!header) return;
+
+      var config = {};
+      var outputFields = [];
+      try { config = JSON.parse(header.getAttribute('data-signal-config') || '{}'); } catch {}
+      try { outputFields = JSON.parse(header.getAttribute('data-output-fields') || '[]'); } catch {}
+
+      openModal(agentId, config, outputFields);
+    });
+  })();
+`;

--- a/packages/dashboard/src/views/pulse-refresh.js.ts
+++ b/packages/dashboard/src/views/pulse-refresh.js.ts
@@ -1,0 +1,89 @@
+/**
+ * Pulse auto-refresh: polls tile fragment endpoints at each tile's
+ * declared refresh interval and replaces the tile's innerHTML.
+ */
+export const PULSE_REFRESH_JS = `
+  (function () {
+    var REFRESH_INTERVALS = {
+      '5m': 300000,
+      '10m': 600000,
+      '15m': 900000,
+      '30m': 1800000,
+      '1h': 3600000,
+      '2h': 7200000,
+      '4h': 14400000,
+      '12h': 43200000,
+      '24h': 86400000,
+    };
+
+    function parseRefresh(val) {
+      if (!val) return 0;
+      val = val.trim().toLowerCase();
+      if (REFRESH_INTERVALS[val]) return REFRESH_INTERVALS[val];
+      // Parse Nm or Nh patterns.
+      var match = val.match(/^(\\d+)(m|h|s)$/);
+      if (match) {
+        var n = parseInt(match[1], 10);
+        if (match[2] === 's') return n * 1000;
+        if (match[2] === 'm') return n * 60000;
+        if (match[2] === 'h') return n * 3600000;
+      }
+      return 0;
+    }
+
+    function scheduleRefresh(tile) {
+      var agentId = tile.getAttribute('data-agent-id');
+      if (!agentId) return;
+
+      var header = tile.querySelector('.pulse-tile__header');
+      if (!header) return;
+
+      var config = {};
+      try { config = JSON.parse(header.getAttribute('data-signal-config') || '{}'); } catch {}
+      var interval = parseRefresh(config.refresh);
+      if (interval < 30000) return; // Don't poll faster than 30s.
+
+      setTimeout(function refresh() {
+        tile.style.opacity = '0.7';
+        fetch('/pulse/tile/' + encodeURIComponent(agentId))
+          .then(function (r) { return r.ok ? r.text() : null; })
+          .then(function (html) {
+            if (html) {
+              // Create a temp container, parse the fragment, and replace the tile.
+              var temp = document.createElement('div');
+              temp.innerHTML = html;
+              var newTile = temp.firstElementChild;
+              if (newTile && tile.parentNode) {
+                // Preserve layout state (palette, collapsed, size).
+                var palette = tile.getAttribute('data-palette');
+                if (palette) newTile.setAttribute('data-palette', palette);
+                if (tile.classList.contains('pulse-tile--collapsed')) newTile.classList.add('pulse-tile--collapsed');
+                var gridCol = tile.style.gridColumn;
+                var gridRow = tile.style.gridRow;
+                if (gridCol) newTile.style.gridColumn = gridCol;
+                if (gridRow) newTile.style.gridRow = gridRow;
+
+                tile.parentNode.replaceChild(newTile, tile);
+                tile = newTile;
+                // Re-schedule on the new tile element.
+                scheduleRefresh(tile);
+              }
+            } else {
+              tile.style.opacity = '1';
+              setTimeout(refresh, interval);
+            }
+          })
+          .catch(function () {
+            tile.style.opacity = '1';
+            setTimeout(refresh, interval);
+          });
+      }, interval);
+    }
+
+    // Schedule refresh for all tiles with a refresh interval.
+    var tiles = document.querySelectorAll('.pulse-tile[data-agent-id]');
+    for (var i = 0; i < tiles.length; i++) {
+      scheduleRefresh(tiles[i]);
+    }
+  })();
+`;

--- a/packages/dashboard/src/views/pulse-renderers.ts
+++ b/packages/dashboard/src/views/pulse-renderers.ts
@@ -180,6 +180,147 @@ function renderMedia(tile: PulseTile, wrap: TileWrapFn): SafeHtml {
   `);
 }
 
+// ── Phase 2 renderers ───────────────────────────────────────────────────
+
+function renderComparison(tile: PulseTile, wrap: TileWrapFn): SafeHtml {
+  const ll = tile.slots.left_label ? String(tile.slots.left_label) : 'A';
+  const lv = tile.slots.left_value !== undefined ? stringify(tile.slots.left_value) : '--';
+  const rl = tile.slots.right_label ? String(tile.slots.right_label) : 'B';
+  const rv = tile.slots.right_value !== undefined ? stringify(tile.slots.right_value) : '--';
+  const title = tile.slots.title ? String(tile.slots.title) : '';
+
+  // Color-code: if both values are numeric, green the higher one.
+  const ln = Number(lv), rn = Number(rv);
+  const leftColor = !isNaN(ln) && !isNaN(rn) && ln > rn ? 'color: var(--color-ok);' : '';
+  const rightColor = !isNaN(ln) && !isNaN(rn) && rn > ln ? 'color: var(--color-ok);' : '';
+
+  return wrap(tile, html`
+    ${title ? html`<div style="font-size: var(--font-size-xs); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: var(--space-2);">${title}</div>` : html``}
+    <div style="display: flex; align-items: center; gap: var(--space-3); flex: 1;">
+      <div style="flex: 1; text-align: center;">
+        <div style="font-size: var(--font-size-xs); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em; font-family: var(--font-mono);">${ll}</div>
+        <div style="font-size: 1.5rem; font-weight: var(--weight-bold); font-family: var(--font-mono); line-height: 1.2; margin-top: 2px; ${leftColor}">${lv}</div>
+      </div>
+      <div style="font-size: var(--font-size-xs); color: var(--color-text-subtle); font-weight: var(--weight-semibold);">vs</div>
+      <div style="flex: 1; text-align: center;">
+        <div style="font-size: var(--font-size-xs); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em; font-family: var(--font-mono);">${rl}</div>
+        <div style="font-size: 1.5rem; font-weight: var(--weight-bold); font-family: var(--font-mono); line-height: 1.2; margin-top: 2px; ${rightColor}">${rv}</div>
+      </div>
+    </div>
+  `);
+}
+
+function renderKeyValueGrid(tile: PulseTile, wrap: TileWrapFn): SafeHtml {
+  const title = tile.slots.title ? String(tile.slots.title) : '';
+  let pairs: Array<{ label: string; value: string }> = [];
+
+  const raw = tile.slots.pairs;
+  if (Array.isArray(raw)) {
+    pairs = raw.map((p) => {
+      if (typeof p === 'object' && p !== null) {
+        const obj = p as Record<string, unknown>;
+        return { label: String(obj.label ?? obj.key ?? ''), value: stringify(obj.value ?? '') };
+      }
+      return { label: '', value: stringify(p) };
+    });
+  } else if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        pairs = parsed.map((p: Record<string, unknown>) => ({
+          label: String(p.label ?? p.key ?? ''),
+          value: stringify(p.value ?? ''),
+        }));
+      }
+    } catch { /* not JSON */ }
+  }
+
+  if (pairs.length === 0) {
+    return wrap(tile, html`<p class="dim" style="font-size: var(--font-size-xs);">No data</p>`);
+  }
+
+  const cols = Math.min(pairs.length, 3);
+  const cells = pairs.map((p) => html`
+    <div style="text-align: center; padding: var(--space-2);">
+      <div style="font-size: var(--font-size-xs); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em; font-family: var(--font-mono);">${p.label}</div>
+      <div style="font-size: var(--font-size-sm); font-weight: var(--weight-semibold); font-family: var(--font-mono); margin-top: 2px;">${p.value}</div>
+    </div>
+  `);
+
+  return wrap(tile, html`
+    ${title ? html`<div style="font-size: var(--font-size-xs); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: var(--space-2);">${title}</div>` : html``}
+    <div style="display: grid; grid-template-columns: repeat(${String(cols)}, 1fr); gap: var(--space-1); background: var(--color-surface-raised); border-radius: var(--radius-sm); padding: var(--space-2);">
+      ${cells as unknown as SafeHtml[]}
+    </div>
+  `);
+}
+
+function renderStory(tile: PulseTile, wrap: TileWrapFn): SafeHtml {
+  const whatChanged = tile.slots.what_changed ? String(tile.slots.what_changed) : '';
+  const timePeriod = tile.slots.time_period ? String(tile.slots.time_period) : '';
+  const whatItMeans = tile.slots.what_it_means ? String(tile.slots.what_it_means) : '';
+
+  return wrap(tile, html`
+    <div style="display: flex; flex-direction: column; gap: var(--space-2); flex: 1;">
+      ${whatChanged ? html`<div style="font-size: var(--font-size-sm); font-weight: var(--weight-bold); line-height: 1.4;">${whatChanged}</div>` : html``}
+      ${timePeriod ? html`<div><span class="badge badge--muted" style="font-size: 10px;">${timePeriod}</span></div>` : html``}
+      ${whatItMeans ? html`<div style="font-size: var(--font-size-xs); color: var(--color-text-muted); line-height: 1.5;">${whatItMeans}</div>` : html``}
+    </div>
+  `);
+}
+
+function renderFunnel(tile: PulseTile, wrap: TileWrapFn): SafeHtml {
+  let stages: Array<{ label: string; value: number; color?: string }> = [];
+
+  const raw = tile.slots.stages;
+  if (Array.isArray(raw)) {
+    stages = raw.map((s) => {
+      if (typeof s === 'object' && s !== null) {
+        const obj = s as Record<string, unknown>;
+        return { label: String(obj.label ?? ''), value: Number(obj.value ?? 0), color: obj.color ? String(obj.color) : undefined };
+      }
+      return { label: String(s), value: 0 };
+    });
+  } else if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        stages = parsed.map((s: Record<string, unknown>) => ({
+          label: String(s.label ?? ''),
+          value: Number(s.value ?? 0),
+          color: s.color ? String(s.color) : undefined,
+        }));
+      }
+    } catch { /* not JSON */ }
+  }
+
+  if (stages.length === 0) {
+    return wrap(tile, html`<p class="dim" style="font-size: var(--font-size-xs);">No stages</p>`);
+  }
+
+  const maxVal = Math.max(...stages.map((s) => s.value), 1);
+  const defaultColors = ['#2dd4bf', '#60a5fa', '#a78bfa', '#fb923c', '#f87171', '#fbbf24'];
+
+  const bars = stages.map((s, i) => {
+    const pct = Math.max(20, (s.value / maxVal) * 100); // min 20% width for label visibility
+    const color = s.color ?? defaultColors[i % defaultColors.length];
+    return html`
+      <div style="display: flex; align-items: center; gap: var(--space-2);">
+        <div style="width: ${String(Math.round(pct))}%; background: ${color}; border-radius: var(--radius-sm); padding: 4px var(--space-2); font-size: 10px; font-family: var(--font-mono); color: #fff; font-weight: var(--weight-semibold); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+          ${s.label}
+        </div>
+        <span style="font-size: var(--font-size-xs); font-family: var(--font-mono); color: var(--color-text-muted); white-space: nowrap;">${String(s.value)}</span>
+      </div>
+    `;
+  });
+
+  return wrap(tile, html`
+    <div style="display: flex; flex-direction: column; gap: var(--space-1); flex: 1;">
+      ${bars as unknown as SafeHtml[]}
+    </div>
+  `);
+}
+
 // ── Dispatcher ───────────────────────────────────────────────────────────
 
 export function renderTile(tile: PulseTile, wrap: TileWrapFn): SafeHtml {
@@ -194,6 +335,10 @@ export function renderTile(tile: PulseTile, wrap: TileWrapFn): SafeHtml {
     case 'text-image': return renderTextImage(tile, wrap);
     case 'media': return renderMedia(tile, wrap);
     case 'widget': return renderWidgetTile(tile, wrap);
+    case 'comparison': return renderComparison(tile, wrap);
+    case 'key-value': return renderKeyValueGrid(tile, wrap);
+    case 'story': return renderStory(tile, wrap);
+    case 'funnel': return renderFunnel(tile, wrap);
     default: return renderTextHeadline(tile, wrap);
   }
 }

--- a/packages/dashboard/src/views/pulse-templates.ts
+++ b/packages/dashboard/src/views/pulse-templates.ts
@@ -126,6 +126,53 @@ export const TEMPLATE_REGISTRY: Record<string, TemplateDefinition> = {
     slots: [],
     defaultSize: '2x1',
   },
+  comparison: {
+    name: 'comparison',
+    displayName: 'Comparison',
+    description: 'Side-by-side A vs B comparison',
+    icon: '\u2194',
+    slots: [
+      { name: 'left_label', label: 'Left label', required: true, type: 'string' },
+      { name: 'left_value', label: 'Left value', required: true, type: 'string' },
+      { name: 'right_label', label: 'Right label', required: true, type: 'string' },
+      { name: 'right_value', label: 'Right value', required: true, type: 'string' },
+      { name: 'title', label: 'Title', required: false, type: 'string' },
+    ],
+    defaultSize: '2x1',
+  },
+  'key-value': {
+    name: 'key-value',
+    displayName: 'Key-Value Grid',
+    description: 'Stats grid with multiple labeled values',
+    icon: '\u2261',
+    slots: [
+      { name: 'pairs', label: 'Key-value pairs', required: true, type: 'array' },
+      { name: 'title', label: 'Title', required: false, type: 'string' },
+    ],
+    defaultSize: '2x1',
+  },
+  story: {
+    name: 'story',
+    displayName: 'Story',
+    description: 'Data-driven narrative with headline and context',
+    icon: '\u270D',
+    slots: [
+      { name: 'what_changed', label: 'What changed', required: true, type: 'string' },
+      { name: 'time_period', label: 'Time period', required: false, type: 'string' },
+      { name: 'what_it_means', label: 'What it means', required: false, type: 'string' },
+    ],
+    defaultSize: '2x1',
+  },
+  funnel: {
+    name: 'funnel',
+    displayName: 'Funnel',
+    description: 'Conversion funnel with stacked bars',
+    icon: '\u25BD',
+    slots: [
+      { name: 'stages', label: 'Funnel stages', required: true, type: 'array' },
+    ],
+    defaultSize: '1x2',
+  },
 };
 
 // ── Backward compatibility ───────────────────────────────────────────────

--- a/packages/dashboard/src/views/pulse-types.ts
+++ b/packages/dashboard/src/views/pulse-types.ts
@@ -11,6 +11,8 @@ export interface PulseTile {
   signal: AgentSignal;
   lastRun?: Run;
   slots: Record<string, unknown>;
+  /** Keys available in the last run's output (for configure modal field picker). */
+  outputFields?: string[];
 }
 
 export interface PulsePageInput {

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -11,7 +11,7 @@ import type { Agent, AgentSignal, Run, SignalTemplate } from '@some-useful-agent
 import { html, render, unsafeHtml, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { formatAge } from './components.js';
-import { normalizeSignal } from './pulse-templates.js';
+import { normalizeSignal, TEMPLATE_REGISTRY } from './pulse-templates.js';
 import { esc } from './pulse-helpers.js';
 import { renderTile } from './pulse-renderers.js';
 export type { PulseTile, PulsePageInput, TileWrapFn } from './pulse-types.js';
@@ -27,8 +27,11 @@ export function tileWrap(tile: PulseTile, content: SafeHtml): SafeHtml {
   const paletteAttr = autoPalette && autoPalette !== 'default'
     ? ` data-auto-palette="${autoPalette}"`
     : '';
+  const accentAttr = tile.signal.accent
+    ? ` data-accent="${esc(tile.signal.accent)}"`
+    : '';
   return unsafeHtml(
-    `<div class="pulse-tile ${sizeClass(sizeAttr)}" data-agent-id="${esc(tile.agent.id)}" data-tile-size="${esc(sizeAttr)}"${paletteAttr}>` +
+    `<div class="pulse-tile ${sizeClass(sizeAttr)}" data-agent-id="${esc(tile.agent.id)}" data-tile-size="${esc(sizeAttr)}"${paletteAttr}${accentAttr}>` +
     tileHeader(tile, isSystem).toString() +
     content.toString() +
     (isSystem ? '' : tileFooter(tile).toString()) +
@@ -70,14 +73,32 @@ function sizeClass(size: string): string {
 
 function tileHeader(tile: PulseTile, isSystem: boolean): SafeHtml {
   const icon = tile.signal.icon ?? '';
+  const { template, mapping } = normalizeSignal(tile.signal);
+  // Embed signal config as data attributes for the configure modal JS.
+  const signalData = JSON.stringify({
+    template,
+    mapping,
+    title: tile.signal.title,
+    icon: tile.signal.icon ?? '',
+    size: tile.signal.size ?? '1x1',
+    accent: tile.signal.accent ?? '',
+    refresh: tile.signal.refresh ?? '',
+  });
+  const outputFieldsJson = JSON.stringify(tile.outputFields ?? []);
+
   return html`
-    <div class="pulse-tile__header">
+    <div class="pulse-tile__header"
+      data-signal-config="${signalData}"
+      data-output-fields="${outputFieldsJson}">
       <button type="button" class="pulse-tile__collapse" data-tile-id="${tile.agent.id}" title="Collapse/expand">\u25BC</button>
       <div style="display: flex; align-items: center; gap: var(--space-2); flex: 1; cursor: pointer;" data-tile-id="${tile.agent.id}" data-collapse-trigger>
         ${icon ? html`<span class="pulse-tile__icon">${icon}</span>` : html``}
         <span class="pulse-tile__title">${tile.signal.title}</span>
       </div>
       <div style="display: flex; gap: var(--space-1); align-items: center;">
+        ${isSystem ? html`` : html`
+          <button type="button" class="pulse-tile__configure-btn" data-tile-id="${tile.agent.id}" title="Configure tile">\u2699</button>
+        `}
         <button type="button" class="pulse-tile__palette-btn" data-tile-id="${tile.agent.id}" title="Change palette">\u25CF</button>
         ${isSystem ? html`` : html`
           <form method="POST" action="/agents/${tile.agent.id}/signal/toggle" style="margin: 0;">
@@ -154,6 +175,7 @@ export function renderPulsePage(input: PulsePageInput): string {
     ` : html``}
 
     ${unsafeHtml(`<script type="application/json" id="pulse-tile-data">${JSON.stringify({ allTileIds, systemTileIds })}</script>`)}
+    ${unsafeHtml(`<script type="application/json" id="pulse-template-registry">${JSON.stringify(TEMPLATE_REGISTRY)}</script>`)}
   `;
 
   return render(layout({ title: 'Pulse', activeNav: 'pulse' }, body));

--- a/packages/dashboard/src/views/settings-appearance.ts
+++ b/packages/dashboard/src/views/settings-appearance.ts
@@ -1,0 +1,84 @@
+/**
+ * Settings > Appearance: theme picker grid.
+ */
+
+import { html, unsafeHtml, type SafeHtml } from './html.js';
+import { THEMES } from './themes.js';
+
+export function renderSettingsAppearance(): SafeHtml {
+  const cards = THEMES.map((t) => {
+    return html`
+      <button type="button" class="theme-card" data-theme-id="${t.id}" title="${t.description}">
+        <div class="theme-card__preview" style="background: ${t.preview.bg};">
+          <div style="background: ${t.preview.surface}; border-radius: 4px; padding: 6px 8px; margin-bottom: 4px;">
+            <div style="width: 40px; height: 4px; background: ${t.preview.accent}; border-radius: 2px; margin-bottom: 4px;"></div>
+            <div style="width: 60px; height: 3px; background: ${t.preview.text}; border-radius: 2px; opacity: 0.5;"></div>
+          </div>
+          <div style="display: flex; gap: 4px;">
+            <div style="flex: 1; background: ${t.preview.surface}; border-radius: 3px; height: 16px;"></div>
+            <div style="flex: 1; background: ${t.preview.surface}; border-radius: 3px; height: 16px;"></div>
+          </div>
+        </div>
+        <span class="theme-card__name">${t.name}</span>
+      </button>
+    `;
+  });
+
+  return html`
+    <div>
+      <h2 style="margin-top: 0; margin-bottom: var(--space-2);">Theme</h2>
+      <p style="font-size: var(--font-size-sm); color: var(--color-text-muted); margin-bottom: var(--space-4);">
+        Choose a visual theme for the dashboard. Applies to all widget surfaces (Pulse, Home).
+        Stored in your browser.
+      </p>
+
+      <div class="theme-grid">
+        ${cards as unknown as SafeHtml[]}
+      </div>
+
+      <p style="font-size: var(--font-size-xs); color: var(--color-text-subtle); margin-top: var(--space-4);">
+        The light/dark toggle in the top bar is separate from widget themes.
+        Widget themes override widget colors only.
+      </p>
+    </div>
+
+    ${unsafeHtml(`<script>
+      (function () {
+        var THEME_KEY = 'sua-widget-theme';
+        var current = localStorage.getItem(THEME_KEY) || 'default';
+
+        // Mark the active card.
+        var cards = document.querySelectorAll('.theme-card');
+        for (var i = 0; i < cards.length; i++) {
+          if (cards[i].getAttribute('data-theme-id') === current) {
+            cards[i].classList.add('is-active');
+          }
+          cards[i].addEventListener('click', function () {
+            var id = this.getAttribute('data-theme-id');
+            // Store theme.
+            if (id === 'default') {
+              localStorage.removeItem(THEME_KEY);
+              document.body.removeAttribute('data-widget-theme');
+            } else if (id === 'light') {
+              // Light theme uses the existing data-theme="light" system.
+              localStorage.setItem(THEME_KEY, 'light');
+              document.documentElement.setAttribute('data-theme', 'light');
+              localStorage.setItem('sua-theme', 'light');
+              document.body.removeAttribute('data-widget-theme');
+            } else {
+              localStorage.setItem(THEME_KEY, id);
+              document.body.setAttribute('data-widget-theme', id);
+              // Revert to dark base for non-light themes.
+              document.documentElement.removeAttribute('data-theme');
+              localStorage.setItem('sua-theme', 'dark');
+            }
+            // Update active state.
+            var all = document.querySelectorAll('.theme-card');
+            for (var j = 0; j < all.length; j++) all[j].classList.remove('is-active');
+            this.classList.add('is-active');
+          });
+        }
+      })();
+    </script>`)}
+  `;
+}

--- a/packages/dashboard/src/views/settings-shell.ts
+++ b/packages/dashboard/src/views/settings-shell.ts
@@ -2,7 +2,7 @@ import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
 
-export type SettingsTab = 'secrets' | 'variables' | 'integrations' | 'general';
+export type SettingsTab = 'secrets' | 'variables' | 'integrations' | 'appearance' | 'general';
 
 export interface SettingsShellArgs {
   active: SettingsTab;
@@ -26,6 +26,7 @@ export function renderSettingsShell(args: SettingsShellArgs): string {
       ${tab('secrets', 'Secrets')}
       ${tab('variables', 'Variables')}
       ${tab('integrations', 'Integrations')}
+      ${tab('appearance', 'Appearance')}
       ${tab('general', 'General')}
     </nav>
     <div class="settings-shell">

--- a/packages/dashboard/src/views/themes.ts
+++ b/packages/dashboard/src/views/themes.ts
@@ -1,0 +1,44 @@
+/**
+ * Widget theme definitions. Each theme is a set of CSS custom property
+ * overrides applied via data-widget-theme attribute.
+ */
+
+export interface WidgetTheme {
+  id: string;
+  name: string;
+  description: string;
+  preview: { bg: string; surface: string; accent: string; text: string };
+}
+
+export const THEMES: WidgetTheme[] = [
+  {
+    id: 'default',
+    name: 'Default',
+    description: 'Dark mode with teal accent',
+    preview: { bg: '#1a1918', surface: '#242220', accent: '#2dd4bf', text: '#e7e5e4' },
+  },
+  {
+    id: 'light',
+    name: 'Light',
+    description: 'Clean light mode',
+    preview: { bg: '#faf9f7', surface: '#ffffff', accent: '#0f766e', text: '#1c1917' },
+  },
+  {
+    id: 'warm',
+    name: 'Warm',
+    description: 'Amber accent, stone backgrounds',
+    preview: { bg: '#1c1917', surface: '#292524', accent: '#f59e0b', text: '#fafaf9' },
+  },
+  {
+    id: 'minimal',
+    name: 'Minimal',
+    description: 'No borders, no shadows, flat',
+    preview: { bg: '#1a1918', surface: '#242220', accent: '#a3a3a3', text: '#e7e5e4' },
+  },
+  {
+    id: 'neon',
+    name: 'Neon',
+    description: 'Purple accent, true black',
+    preview: { bg: '#0a0a0a', surface: '#171717', accent: '#a855f7', text: '#fafafa' },
+  },
+];


### PR DESCRIPTION
## Summary

- **4 new Pulse templates**: comparison (A vs B with color-coded winner), key-value grid (stats), story (narrative with headline/badge/body), funnel (stacked bars with color gradient)
- **Accent colors**: 6-color palette applied to tile borders, values, sparklines, status dots via `signal.accent` field
- **Configure tile modal**: gear icon on tiles opens modal with template picker, field mapping form (discovers output fields from last run), title/icon/size/accent/refresh editors
- **Auto-refresh**: tiles with `signal.refresh` get polled via `GET /pulse/tile/:agentId` fragment endpoint, preserves layout state across refreshes
- **Theme system**: 5 themes (Default, Light, Warm, Minimal, Neon) at Settings > Appearance, applied via CSS custom property overrides, persists in localStorage

## Test plan

- [x] `npx tsc --build` passes
- [x] 600 tests pass across 35 files
- [ ] Visual: verify comparison, key-value, story, funnel templates render correctly
- [ ] Visual: verify accent colors apply to tile borders and values
- [ ] Visual: click gear icon on a tile, verify modal opens with template picker
- [ ] Visual: save from modal, verify signal config persists (new agent version)
- [ ] Visual: set `refresh: "1m"` on a tile, verify it auto-refreshes
- [ ] Visual: go to Settings > Appearance, pick each theme, verify colors change
- [ ] Visual: theme persists across page loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)