### PR TITLE
fix: bundle themes.css into dashboard.css

### DIFF
--- a/packages/dashboard/src/routes/assets.ts
+++ b/packages/dashboard/src/routes/assets.ts
@@ -63,7 +63,7 @@ function loadDashboardCss(): string {
   // Works from dist/routes/ (../assets) and from src/routes/ during tests
   // (../assets too). The copy-assets script keeps both in sync.
   const assetsDir = join(here, '..', 'assets');
-  const order = ['tokens.css', 'base.css', 'components.css', 'screens.css'];
+  const order = ['tokens.css', 'base.css', 'components.css', 'screens.css', 'themes.css'];
   return order
     .map((name) => {
       const path = join(assetsDir, name);

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -42,7 +42,6 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="/assets/dashboard.css">
-<link rel="stylesheet" href="/assets/themes.css">
 <script>
 (function(){var t=localStorage.getItem('sua-theme');if(t==='light')document.documentElement.setAttribute('data-theme','light');})();
 </script>


### PR DESCRIPTION
## Summary

- themes.css was linked as a separate `<link>` tag but the asset router only serves explicitly registered files (`dashboard.css`, `cytoscape.min.js`, `graph-render.js`), so it 404'd
- Added `themes.css` to the `dashboard.css` concatenation order in `assets.ts`
- Removed the broken separate `<link>` from `layout.ts`

This is why themes weren't applying after PR #124 merged.

## Test plan

- [x] 600 tests pass
- [ ] Rebuild, restart dashboard, verify themes load at Settings > Appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)