### PR TITLE
feat: free-form draggable groups + add-group modal

### DIFF
--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -628,8 +628,34 @@ main.main--wide {
 /* ---------- Pulse ---------- */
 
 /* -- Containers -- */
+/* -- Canvas mode: free-form positioned containers -- */
+.pulse-canvas {
+  position: relative;
+  min-height: 600px;
+}
+.pulse-canvas .pulse-container:not(.pulse-container--positioned) {
+  /* Fallback: containers without positions still flow normally. */
+  position: relative;
+}
+
 .pulse-container {
   margin-bottom: var(--space-6);
+}
+.pulse-container--positioned {
+  position: absolute;
+  min-width: 280px;
+  margin-bottom: 0;
+}
+.pulse-container--dragging {
+  opacity: 0.85;
+  z-index: 50;
+  box-shadow: var(--shadow-md);
+}
+.pulse-edit-mode .pulse-container__header {
+  cursor: grab;
+}
+.pulse-edit-mode .pulse-container--dragging .pulse-container__header {
+  cursor: grabbing;
 }
 
 .pulse-container__header {

--- a/packages/dashboard/src/views/widget-layout.js.ts
+++ b/packages/dashboard/src/views/widget-layout.js.ts
@@ -313,21 +313,70 @@ export function widgetLayoutJS(config: WidgetLayoutConfig): string {
       setEditMode(editMode);
     });
 
-    // ── Add container ────────────────────────────────────────────────
+    // ── Add container (modal) ───────────────────────────────────────
+    var addGroupModal = null;
+    function showAddGroupModal() {
+      if (!addGroupModal) {
+        addGroupModal = document.createElement('div');
+        addGroupModal.className = 'pulse-configure-modal';
+        addGroupModal.addEventListener('click', function(e) {
+          if (e.target === addGroupModal) addGroupModal.style.display = 'none';
+        });
+        addGroupModal.innerHTML =
+          '<div class="pulse-configure-modal__content" style="max-width: 360px;">' +
+            '<div class="pulse-configure-modal__header">' +
+              '<h3 style="margin: 0;">New group</h3>' +
+              '<button type="button" class="pulse-configure-modal__close" title="Close">\\u00D7</button>' +
+            '</div>' +
+            '<div class="pulse-configure-modal__section">' +
+              '<label class="pulse-configure-modal__label">Group name</label>' +
+              '<input type="text" class="input" id="add-group-name-input" style="width: 100%;" placeholder="e.g. Monitoring" autofocus>' +
+            '</div>' +
+            '<div class="pulse-configure-modal__footer">' +
+              '<button type="button" class="btn btn--ghost btn--sm" id="add-group-cancel">Cancel</button>' +
+              '<button type="button" class="btn btn--primary btn--sm" id="add-group-confirm">Add group</button>' +
+            '</div>' +
+          '</div>';
+        document.body.appendChild(addGroupModal);
+
+        addGroupModal.querySelector('.pulse-configure-modal__close').addEventListener('click', function() {
+          addGroupModal.style.display = 'none';
+        });
+        document.getElementById('add-group-cancel').addEventListener('click', function() {
+          addGroupModal.style.display = 'none';
+        });
+        document.getElementById('add-group-confirm').addEventListener('click', function() {
+          var input = document.getElementById('add-group-name-input');
+          var name = input.value.trim();
+          if (!name) { input.focus(); return; }
+          var id = 'custom-' + Date.now();
+          layout.containers.push({ id: id, label: name, tiles: [] });
+          saveLayout(layout);
+          renderLayout();
+          restoreCollapsed();
+          restorePalettes();
+          applySizes();
+          setEditMode(editMode);
+          input.value = '';
+          addGroupModal.style.display = 'none';
+        });
+        document.getElementById('add-group-name-input').addEventListener('keydown', function(e) {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            document.getElementById('add-group-confirm').click();
+          }
+        });
+      }
+      addGroupModal.style.display = 'flex';
+      setTimeout(function() {
+        var input = document.getElementById('add-group-name-input');
+        if (input) { input.value = ''; input.focus(); }
+      }, 50);
+    }
+
     var addBtn = document.getElementById('${config.addContainerId}');
     if (addBtn) {
-      addBtn.addEventListener('click', function() {
-        var name = prompt('Group name:');
-        if (!name || !name.trim()) return;
-        var id = 'custom-' + Date.now();
-        layout.containers.push({ id: id, label: name.trim(), tiles: [] });
-        saveLayout(layout);
-        renderLayout();
-        restoreCollapsed();
-        restorePalettes();
-        applySizes();
-        setEditMode(editMode);
-      });
+      addBtn.addEventListener('click', showAddGroupModal);
     }
 
     // ── Palette cycling ──────────────────────────────────────────────

--- a/packages/dashboard/src/views/widget-layout.js.ts
+++ b/packages/dashboard/src/views/widget-layout.js.ts
@@ -125,16 +125,39 @@ export function widgetLayoutJS(config: WidgetLayoutConfig): string {
       }
     }
 
+    // Check if any container has a stored position (free-form mode).
+    function hasFreePositions() {
+      for (var ci = 0; ci < layout.containers.length; ci++) {
+        if (layout.containers[ci].x !== undefined) return true;
+      }
+      return false;
+    }
+
     // Re-render containers from layout.
     function renderLayout() {
       host.innerHTML = '';
+      var isFree = hasFreePositions();
+      if (isFree) {
+        host.classList.add('pulse-canvas');
+      } else {
+        host.classList.remove('pulse-canvas');
+      }
+
       for (var ci = 0; ci < layout.containers.length; ci++) {
         var c = layout.containers[ci];
         var section = document.createElement('section');
         section.className = 'pulse-container';
         section.setAttribute('data-container-id', c.id);
 
-        // Header.
+        // Apply free-form position if stored.
+        if (c.x !== undefined && c.y !== undefined) {
+          section.classList.add('pulse-container--positioned');
+          section.style.left = c.x + 'px';
+          section.style.top = c.y + 'px';
+          if (c.w) section.style.width = c.w + 'px';
+        }
+
+        // Header (draggable in edit mode).
         var header = document.createElement('div');
         header.className = 'pulse-container__header';
         var label = document.createElement('span');
@@ -197,6 +220,103 @@ export function widgetLayoutJS(config: WidgetLayoutConfig): string {
     }
 
     renderLayout();
+
+    // ── Container drag (free-form positioning) ──────────────────────
+    var containerDrag = null; // { el, containerId, startX, startY, origX, origY }
+
+    document.addEventListener('mousedown', function(e) {
+      if (!editMode) return;
+      var header = e.target.closest ? e.target.closest('.pulse-container__header') : null;
+      if (!header) return;
+      // Don't drag when clicking buttons or editable labels.
+      if (e.target.closest('.pulse-container__delete') || e.target.closest('.pulse-container__label')) return;
+
+      var container = header.closest('.pulse-container');
+      if (!container) return;
+      var containerId = container.getAttribute('data-container-id');
+      if (!containerId) return;
+
+      e.preventDefault();
+
+      // Get current position. If not yet positioned, compute from current offset.
+      var rect = container.getBoundingClientRect();
+      var hostRect = host.getBoundingClientRect();
+      var origX = container.classList.contains('pulse-container--positioned')
+        ? parseInt(container.style.left) || 0
+        : rect.left - hostRect.left;
+      var origY = container.classList.contains('pulse-container--positioned')
+        ? parseInt(container.style.top) || 0
+        : rect.top - hostRect.top;
+
+      containerDrag = {
+        el: container,
+        containerId: containerId,
+        startX: e.clientX,
+        startY: e.clientY,
+        origX: origX,
+        origY: origY,
+      };
+      container.classList.add('pulse-container--dragging');
+    });
+
+    document.addEventListener('mousemove', function(e) {
+      if (!containerDrag) return;
+      e.preventDefault();
+      var dx = e.clientX - containerDrag.startX;
+      var dy = e.clientY - containerDrag.startY;
+      var newX = Math.max(0, containerDrag.origX + dx);
+      var newY = Math.max(0, containerDrag.origY + dy);
+
+      containerDrag.el.style.left = newX + 'px';
+      containerDrag.el.style.top = newY + 'px';
+      containerDrag.el.classList.add('pulse-container--positioned');
+
+      // Switch host to canvas mode on first drag.
+      if (!host.classList.contains('pulse-canvas')) {
+        // Convert all containers to absolute positions before switching.
+        var sections = host.querySelectorAll('.pulse-container');
+        var hostRect = host.getBoundingClientRect();
+        for (var s = 0; s < sections.length; s++) {
+          if (sections[s] === containerDrag.el) continue;
+          if (!sections[s].classList.contains('pulse-container--positioned')) {
+            var r = sections[s].getBoundingClientRect();
+            sections[s].style.left = (r.left - hostRect.left) + 'px';
+            sections[s].style.top = (r.top - hostRect.top) + 'px';
+            sections[s].classList.add('pulse-container--positioned');
+          }
+        }
+        host.classList.add('pulse-canvas');
+      }
+    });
+
+    document.addEventListener('mouseup', function() {
+      if (!containerDrag) return;
+      containerDrag.el.classList.remove('pulse-container--dragging');
+
+      // Persist position to layout.
+      var cId = containerDrag.containerId;
+      for (var ci = 0; ci < layout.containers.length; ci++) {
+        if (layout.containers[ci].id === cId) {
+          layout.containers[ci].x = parseInt(containerDrag.el.style.left) || 0;
+          layout.containers[ci].y = parseInt(containerDrag.el.style.top) || 0;
+          break;
+        }
+      }
+      // Also persist all other containers' positions if they got converted.
+      var sections = host.querySelectorAll('.pulse-container--positioned');
+      for (var s = 0; s < sections.length; s++) {
+        var sId = sections[s].getAttribute('data-container-id');
+        for (var ci2 = 0; ci2 < layout.containers.length; ci2++) {
+          if (layout.containers[ci2].id === sId) {
+            layout.containers[ci2].x = parseInt(sections[s].style.left) || 0;
+            layout.containers[ci2].y = parseInt(sections[s].style.top) || 0;
+            break;
+          }
+        }
+      }
+      saveLayout(layout);
+      containerDrag = null;
+    });
 
     // ── Edit mode toggle ─────────────────────────────────────────────
     var editMode = false;


### PR DESCRIPTION
## Summary

- **Add-group modal**: Replaced `window.prompt()` with a styled modal for naming new groups. Matches the configure tile modal pattern. Enter key submits, click-outside closes.
- **Free-form draggable groups**: In edit mode, grab a group header bar and drag it to any position on the canvas. Groups auto-size to their widget content. Positions persist in localStorage. First drag converts the page from stacked to canvas mode.

Applies to both Pulse and Home page (shared widget-layout.js).

## Test plan

- [x] 600 tests pass
- [ ] Click "Edit layout", click "+ Add group", verify modal appears (not browser prompt)
- [ ] In edit mode, drag a group header to reposition it on the canvas
- [ ] Reload page, verify group positions persist
- [ ] Resize a widget inside a group, verify the group expands to fit

🤖 Generated with [Claude Code](https://claude.com/claude-code)