### PR TITLE
fix: persist outputWidget when saving from YAML editor

### DIFF
--- a/packages/dashboard/src/routes/agent-nodes.ts
+++ b/packages/dashboard/src/routes/agent-nodes.ts
@@ -459,6 +459,7 @@ agentNodesRouter.post('/agents/:name/yaml', (req: Request, res: Response) => {
         nodes: parsed.nodes,
         inputs: parsed.inputs,
         signal: parsed.signal,
+        outputWidget: parsed.outputWidget,
         author: parsed.author,
         tags: parsed.tags,
       },


### PR DESCRIPTION
## Summary

- The YAML save route (`POST /agents/:name/yaml`) passed all agent fields to `createNewVersion` except `outputWidget`
- When the suggest-improvements analyzer generated an `outputWidget` schema and the user clicked "Apply now", the widget was silently dropped
- One-line fix: add `outputWidget: parsed.outputWidget` to the save payload

## Test plan

- [x] 600 tests pass
- [ ] Use suggest improvements on an agent, ask for OpenUI output widget, click "Apply now", verify the widget appears on the agent detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)