### PR TITLE
feat: page size selector, widget links, persist outputWidget

### DIFF
--- a/packages/dashboard/src/routes/agent-nodes.ts
+++ b/packages/dashboard/src/routes/agent-nodes.ts
@@ -459,6 +459,7 @@ agentNodesRouter.post('/agents/:name/yaml', (req: Request, res: Response) => {
         nodes: parsed.nodes,
         inputs: parsed.inputs,
         signal: parsed.signal,
+        outputWidget: parsed.outputWidget,
         author: parsed.author,
         tags: parsed.tags,
       },

--- a/packages/dashboard/src/views/agents-list.ts
+++ b/packages/dashboard/src/views/agents-list.ts
@@ -74,7 +74,7 @@ export function renderAgentsList(input: AgentsListInput): string {
 
     ${renderV1Block(input.v1, hasV2)}
 
-    ${total > limit ? renderAgentPager(input) : html``}
+    ${total > 0 ? renderAgentPager(input) : html``}
 
     ${empty ? html`` : html`
       <footer style="margin-top: var(--space-8); text-align: center;">
@@ -153,10 +153,21 @@ function renderAgentPager(input: AgentsListInput): SafeHtml {
   const showingEnd = Math.min(offset + limit, total);
   const prevOffset = Math.max(0, offset - limit);
   const nextOffset = offset + limit;
+  const sizes = [12, 24, 48, 100];
+  const sizeLinks = sizes.map((s) => {
+    const url = agentBuildUrl(f, s, 0);
+    const bold = s === limit ? ' style="font-weight: var(--weight-bold); color: var(--color-text);"' : '';
+    return `<a href="${url}"${bold}>${s}</a>`;
+  }).join(' ');
+
   return html`
     <div class="pager">
       <div>Showing ${String(showingStart)}\u2013${String(showingEnd)} of ${String(total)}</div>
-      <div>
+      <div style="display: flex; align-items: center; gap: var(--space-3);">
+        <span style="display: flex; align-items: center; gap: var(--space-1); font-size: var(--font-size-xs); color: var(--color-text-muted);">
+          Show: ${sizeLinks}
+        </span>
+        <span style="color: var(--color-border);">|</span>
         ${offset > 0 ? html`<a href="${agentBuildUrl(f, limit, prevOffset)}">\u2190 Prev</a>` : html`<span class="dim">\u2190 Prev</span>`}
         ${nextOffset < total ? html`<a href="${agentBuildUrl(f, limit, nextOffset)}">Next \u2192</a>` : html`<span class="dim">Next \u2192</span>`}
       </div>

--- a/packages/dashboard/src/views/home-widgets.ts
+++ b/packages/dashboard/src/views/home-widgets.ts
@@ -107,31 +107,26 @@ function buildInFlight(data: HomeWidgetData): SystemWidget {
     };
   }
 
-  const fields: OutputWidgetSchema['fields'] = [
-    { name: 'count', label: 'In flight', type: 'metric' },
-  ];
-  const outputObj: Record<string, string> = { count: String(inFlightRuns.length) };
-
-  // Add each running agent as a text field (up to 5).
-  for (const r of inFlightRuns.slice(0, 5)) {
-    const key = `run_${r.id.slice(0, 8)}`;
-    fields.push({ name: key, label: r.agentName, type: 'text' });
-    outputObj[key] = formatAge(r.startedAt).toString();
-  }
-  if (inFlightRuns.length > 5) {
-    fields.push({ name: 'more', label: 'More', type: 'text' });
-    outputObj.more = `+${String(inFlightRuns.length - 5)} more`;
-  }
-
-  const schema: OutputWidgetSchema = { type: 'key-value', fields };
-  const output = JSON.stringify(outputObj);
-  const widgetHtml = renderOutputWidget(schema, output, '_home-in-flight');
+  const rows = inFlightRuns.slice(0, 5).map((r) => html`
+    <div style="display: flex; align-items: center; gap: var(--space-2); padding: var(--space-2) 0; border-bottom: 1px solid var(--color-border);">
+      <div class="spinner" style="width: 10px; height: 10px; border-width: 2px; flex-shrink: 0;"></div>
+      <a href="/agents/${r.agentName}" class="mono" style="font-size: var(--font-size-xs); font-weight: var(--weight-semibold);">${r.agentName}</a>
+      <a href="/runs/${r.id}" style="font-size: 10px; color: var(--color-text-subtle); margin-left: auto;">${formatAge(r.startedAt)}</a>
+    </div>
+  `);
 
   return {
     id: '_home-in-flight',
     title: 'In Flight',
     icon: '\u{1F680}',
-    html: widgetHtml ?? html`<p class="dim">No data</p>`,
+    html: html`
+      <div style="text-align: center; margin-bottom: var(--space-2);">
+        <div style="font-size: 1.5rem; font-weight: var(--weight-bold); font-family: var(--font-mono);">${String(inFlightRuns.length)}</div>
+        <div style="font-size: var(--font-size-xs); color: var(--color-text-muted);">In flight</div>
+      </div>
+      ${rows as unknown as SafeHtml[]}
+      ${inFlightRuns.length > 5 ? html`<div style="font-size: 10px; color: var(--color-text-subtle); padding-top: var(--space-1);">+${String(inFlightRuns.length - 5)} more</div>` : html``}
+    `,
   };
 }
 

--- a/packages/dashboard/src/views/runs-list.ts
+++ b/packages/dashboard/src/views/runs-list.ts
@@ -120,13 +120,23 @@ export function renderRunsList(opts: RunsListOptions): string {
       </table>
     `;
 
+  const runSizes = [25, 50, 100];
+  const runSizeLinks = runSizes.map((s) => {
+    const url = buildUrl(filter, s, 0);
+    const bold = s === limit ? ' style="font-weight: var(--weight-bold); color: var(--color-text);"' : '';
+    return `<a href="${url}"${bold}>${s}</a>`;
+  }).join(' ');
+
   const pager = total > 0 ? html`
     <div class="pager">
-      <div>Showing ${String(showingStart)}–${String(showingEnd)} of ${String(total)}</div>
-      <div>
-        ${offset > 0 ? html`<a href="${buildUrl(filter, limit, prevOffset)}">← Prev</a>` : html`<span class="dim">← Prev</span>`}
-        ${' '}
-        ${nextOffset < total ? html`<a href="${buildUrl(filter, limit, nextOffset)}">Next →</a>` : html`<span class="dim">Next →</span>`}
+      <div>Showing ${String(showingStart)}\u2013${String(showingEnd)} of ${String(total)}</div>
+      <div style="display: flex; align-items: center; gap: var(--space-3);">
+        <span style="display: flex; align-items: center; gap: var(--space-1); font-size: var(--font-size-xs); color: var(--color-text-muted);">
+          Show: ${runSizeLinks}
+        </span>
+        <span style="color: var(--color-border);">|</span>
+        ${offset > 0 ? html`<a href="${buildUrl(filter, limit, prevOffset)}">\u2190 Prev</a>` : html`<span class="dim">\u2190 Prev</span>`}
+        ${nextOffset < total ? html`<a href="${buildUrl(filter, limit, nextOffset)}">Next \u2192</a>` : html`<span class="dim">Next \u2192</span>`}
       </div>
     </div>
   ` : html``;

--- a/packages/dashboard/src/views/tools-list.ts
+++ b/packages/dashboard/src/views/tools-list.ts
@@ -81,7 +81,7 @@ export function renderToolsList(args: {
       </section>
     ` : html``}
 
-    ${total > limit ? toolPager(f, limit, offset, total) : html``}
+    ${total > 0 ? toolPager(f, limit, offset, total) : html``}
 
     <footer style="margin-top: var(--space-8); text-align: center;">
       <p class="dim">${String(total)} tool${total === 1 ? '' : 's'} ${f.q || f.type ? 'matching' : 'available'}</p>
@@ -128,10 +128,22 @@ function toolPager(f: { q?: string; type?: string }, limit: number, offset: numb
   const end = Math.min(offset + limit, total);
   const prev = Math.max(0, offset - limit);
   const next = offset + limit;
+
+  const sizes = [12, 24, 48, 100];
+  const sizeLinks = sizes.map((s) => {
+    const url = toolBuildUrl(f, s, 0);
+    const bold = s === limit ? ' style="font-weight: var(--weight-bold); color: var(--color-text);"' : '';
+    return `<a href="${url}"${bold}>${s}</a>`;
+  }).join(' ');
+
   return html`
     <div class="pager">
       <div>Showing ${String(start)}\u2013${String(end)} of ${String(total)}</div>
-      <div>
+      <div style="display: flex; align-items: center; gap: var(--space-3);">
+        <span style="display: flex; align-items: center; gap: var(--space-1); font-size: var(--font-size-xs); color: var(--color-text-muted);">
+          Show: ${sizeLinks}
+        </span>
+        <span style="color: var(--color-border);">|</span>
         ${offset > 0 ? html`<a href="${toolBuildUrl(f, limit, prev)}">\u2190 Prev</a>` : html`<span class="dim">\u2190 Prev</span>`}
         ${next < total ? html`<a href="${toolBuildUrl(f, limit, next)}">Next \u2192</a>` : html`<span class="dim">Next \u2192</span>`}
       </div>


### PR DESCRIPTION
## Summary

- **Page size selector** on /agents (12 24 48 100), /runs (25 50 100), and /tools (12 24 48 100). Pager always visible when items exist, not gated by total > limit.
- **In-flight widget links**: agent names link to `/agents/:id`, run ages link to `/runs/:id` (was plain text)
- **Persist outputWidget**: `POST /agents/:name/yaml` now passes `outputWidget` to `createNewVersion`. Previously suggest-improvements "Apply now" silently dropped it.

## Test plan

- [x] 600 tests pass
- [ ] /agents page shows "Show: 12 24 48 100" in pager
- [ ] /runs page shows "Show: 25 50 100" in pager
- [ ] /tools page shows "Show: 12 24 48 100" in pager
- [ ] Home page in-flight widget agent names are clickable links
- [ ] Suggest improvements → Apply now → outputWidget appears on agent detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)