### PR TITLE
feat: node & widget discovery catalog + richer dashboard

### DIFF
--- a/agents/examples/agent-analyzer.yaml
+++ b/agents/examples/agent-analyzer.yaml
@@ -22,6 +22,11 @@ inputs:
     required: false
     default: ""
     description: Output from the agent's most recent completed run. Injected automatically by the dashboard.
+  DISCOVERY_CATALOG:
+    type: string
+    required: false
+    default: ""
+    description: Node types, signal templates, output widgets, available agents, and patterns. Injected at analysis time.
 
 nodes:
   - id: analyze
@@ -44,38 +49,17 @@ nodes:
       - Opportunities to split or merge nodes for clarity
       - Unused or redundant dependencies between nodes
       - Prompt improvements for claude-code nodes
-      - Missing or improvable outputWidget declarations (see below)
+      - Missing or improvable outputWidget declarations
+      - Whether the agent would benefit from control-flow nodes (conditional, switch, loop, agent-invoke)
+      - Whether a richer signal template would better showcase the output on Pulse
+      - Whether existing agents could be invoked as sub-agents via agent-invoke or loop nodes
 
-      OUTPUT WIDGETS (outputWidget):
-      Agents can declare an outputWidget that controls how their run output
-      renders on the dashboard. If the agent produces structured output (JSON
-      or XML-tagged fields), suggest adding an outputWidget. Available types:
+      NODE & WIDGET DISCOVERY CATALOG:
+      {{inputs.DISCOVERY_CATALOG}}
 
-      - dashboard: Hero metric + stats grid + text. Best for monitoring data.
-        Field types: metric (big number), stat (grid card), badge (colored pill), text.
-      - key-value: Labeled pairs in a definition list. Good for config/status reports.
-        Field types: text, code (monospace), badge.
-      - diff-apply: Classification badge + summary + diff + action buttons.
-        Good for analysis/review agents. Field types: text, code, badge.
-        Supports actions: [{ id, label, method: POST, endpoint, payloadField }].
-      - raw: Sectioned output with labeled fields. Fallback for mixed content.
-
-      Example outputWidget for a monitoring agent:
-        outputWidget:
-          type: dashboard
-          fields:
-            - name: status
-              label: Status
-              type: badge
-            - name: value
-              label: Value
-              type: metric
-            - name: details
-              label: Details
-              type: text
-
-      Only suggest outputWidget when the agent produces structured output.
-      Shell agents outputting plain text don't benefit from widgets.
+      Use the catalog above to suggest appropriate signal templates, output widgets,
+      control-flow patterns, and sub-agent invocations. Always suggest both signal:
+      and outputWidget: when the agent produces structured output.
 
       {{inputs.FOCUS}}
 

--- a/agents/examples/agent-builder.yaml
+++ b/agents/examples/agent-builder.yaml
@@ -23,6 +23,11 @@ inputs:
     required: false
     default: ""
     description: Dynamically injected tool catalog. Populated by the dashboard at build time.
+  DISCOVERY_CATALOG:
+    type: string
+    required: false
+    default: ""
+    description: Node types, signal templates, output widgets, available agents, and architecture patterns. Injected at build time.
 
 nodes:
   - id: design
@@ -41,43 +46,16 @@ nodes:
       AVAILABLE TOOLS (use these as node types or tool references):
       {{inputs.AVAILABLE_TOOLS}}
 
-      SIGNAL BLOCK (always include a signal block so the agent shows on the Pulse dashboard):
-      Every agent MUST include a signal: block. Pick the best template for the output:
-      - metric: Big number display. Slots: value (required), label, unit. Best for: counts, percentages, latency.
-      - text-headline: Headline + body text. Slots: headline (required), body. Best for: summaries, jokes, greetings.
-      - table: Data table. Slots: rows (required, array), columns. Best for: search results, listings.
-      - status: Colored dot + label. Slots: status (required: healthy/degraded/down), label, message. Best for: health checks, monitors.
-      - media: Image or video player. Slots: url (required), title, caption. Best for: generated images, screenshots.
-      - time-series: Sparkline chart. Slots: values (required, array of numbers), current, label. Best for: trends.
-      - text-image: Text alongside an image. Slots: text (required), imageUrl (required). Best for: cards with thumbnails.
-      - image: Full image. Slots: imageUrl (required), alt. Best for: generated visuals.
+      NODE & WIDGET DISCOVERY CATALOG:
+      {{inputs.DISCOVERY_CATALOG}}
 
+      SIGNAL BLOCK:
+      Every agent MUST include a signal: block. Pick the best template from the catalog above.
       The mapping maps dot-paths from the agent's structured output to template slots.
       Use "result" to reference the full raw output. Use literal strings for static labels.
-
-      Example signal blocks:
-        signal:
-          title: API Latency
-          icon: "\u26A1"
-          format: number
-          template: metric
-          mapping:
-            value: latency_ms
-            label: API Latency
-            unit: ms
-
-        signal:
-          title: Daily Summary
-          icon: "\U0001F4CA"
-          format: text
-          template: text-headline
-          mapping:
-            headline: Daily Summary
-            body: result
-          size: 2x1
-
-      The format: field is a universal output hint (text/number/table/json/chart).
-      The template: field selects the Pulse display. Always include both.
+      Always include both format: (text/number/table/json/chart) and template: fields.
+      Always include outputWidget: when the agent produces structured JSON output.
+      For agent-invoke and loop nodes, use agents listed in AVAILABLE AGENTS above.
 
       DESIGN GUIDELINES:
       - Start simple. Prefer fewer nodes that do more over many tiny nodes.
@@ -106,45 +84,12 @@ nodes:
       - switch nodes must have switchConfig with field + cases.
       - source: must be "local" (not "examples" or "community").
 
-      EXAMPLE PATTERNS:
-
-      Simple single-node (shell):
-        nodes:
-          - id: main
-            type: shell
-            command: curl -s https://api.example.com/data | jq '.items'
-            timeout: 30
-
-      Two-step pipeline (fetch + analyze):
-        nodes:
-          - id: fetch
-            type: shell
-            command: curl -s "$TARGET_URL"
-            timeout: 30
-          - id: analyze
-            type: claude-code
-            prompt: |
-              Analyze this data and summarize the key findings:
-              $UPSTREAM_FETCH_RESULT
-            dependsOn: [fetch]
-            maxTurns: 1
-            timeout: 60
-
-      Multi-step with conditional:
-        nodes:
-          - id: fetch
-            type: shell
-            command: curl -s "$API_URL"
-          - id: check
-            type: conditional
-            dependsOn: [fetch]
-            conditionalConfig:
-              predicate: { field: status, equals: 200 }
-          - id: process
-            type: shell
-            command: echo "Processing $UPSTREAM_FETCH_RESULT"
-            dependsOn: [check]
-            onlyIf: { upstream: check, field: matched, equals: true }
+      ARCHITECTURE PATTERNS:
+      Use the patterns from the discovery catalog above. Key tips:
+      - Conditional Router: use conditional node + onlyIf edge conditions for branching.
+      - Loop + Invoke: use loop node with loopConfig to process arrays via sub-agents.
+      - Self-Correcting: validate LLM output with a shell node, fix with onlyIf on failure.
+      - Always consider whether the goal benefits from control-flow nodes (conditional, switch, loop).
 
       Respond in EXACTLY this format:
       <yaml>

--- a/agents/examples/api-monitor.yaml
+++ b/agents/examples/api-monitor.yaml
@@ -27,6 +27,7 @@ signal:
     label: API Monitor
     message: message
   refresh: 5m
+  accent: green
 
 outputWidget:
   type: dashboard

--- a/agents/examples/daily-joke.yaml
+++ b/agents/examples/daily-joke.yaml
@@ -15,6 +15,8 @@ signal:
     headline: Joke of the Day
     body: result
   refresh: 24h
+  size: 2x1
+  accent: purple
 nodes:
   - id: fetch
     type: shell

--- a/agents/examples/daily-summary.yaml
+++ b/agents/examples/daily-summary.yaml
@@ -9,12 +9,14 @@ source: examples
 signal:
   title: Today's Activity
   icon: "\uD83D\uDCCA"
-  template: text-headline
+  template: story
   mapping:
-    headline: Today's Activity
-    body: result
+    what_changed: agents
+    time_period: Today
+    what_it_means: result
   refresh: 1h
   size: 2x1
+  accent: blue
 
 outputWidget:
   type: dashboard

--- a/agents/examples/git-activity.yaml
+++ b/agents/examples/git-activity.yaml
@@ -17,6 +17,7 @@ signal:
     label: Commits (7 days)
   refresh: 1h
   size: 2x1
+  accent: teal
 
 outputWidget:
   type: dashboard

--- a/agents/examples/hello.yaml
+++ b/agents/examples/hello.yaml
@@ -13,6 +13,7 @@ signal:
   mapping:
     headline: Hello
     body: result
+  accent: teal
 nodes:
   - id: greet
     type: shell

--- a/agents/examples/system-health.yaml
+++ b/agents/examples/system-health.yaml
@@ -17,6 +17,12 @@ signal:
     unit: "%"
   refresh: 1h
   size: 1x1
+  accent: green
+  thresholds:
+    - above: 90
+      palette: accent-red
+    - above: 70
+      palette: accent-orange
 
 outputWidget:
   type: dashboard

--- a/packages/core/src/discovery-catalog.test.ts
+++ b/packages/core/src/discovery-catalog.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { buildDiscoveryCatalog, type TemplateDef } from './discovery-catalog.js';
+import type { Agent } from './agent-v2-types.js';
+
+const MOCK_REGISTRY: Record<string, TemplateDef> = {
+  metric: {
+    name: 'metric',
+    displayName: 'Metric',
+    slots: [
+      { name: 'value', required: true, type: 'number' },
+      { name: 'label', required: false, type: 'string' },
+    ],
+    defaultSize: '1x1',
+  },
+  status: {
+    name: 'status',
+    displayName: 'Status',
+    slots: [
+      { name: 'status', required: true, type: 'string' },
+    ],
+    defaultSize: '1x1',
+  },
+  widget: {
+    name: 'widget',
+    displayName: 'Output Widget',
+    slots: [],
+    defaultSize: '2x1',
+  },
+};
+
+const MOCK_AGENTS: Agent[] = [
+  {
+    id: 'api-monitor',
+    name: 'API Monitor',
+    description: 'Monitor API endpoints',
+    status: 'active',
+    version: 1,
+    nodes: [],
+    inputs: { TARGET_URL: { type: 'string', required: true }, TIMEOUT: { type: 'number' } },
+  } as unknown as Agent,
+  {
+    id: 'agent-builder',
+    name: 'Agent Builder',
+    description: 'Builds agents',
+    status: 'active',
+    source: 'examples',
+    version: 1,
+    nodes: [],
+  } as unknown as Agent,
+];
+
+describe('buildDiscoveryCatalog', () => {
+  it('includes all sections', () => {
+    const catalog = buildDiscoveryCatalog({
+      agents: MOCK_AGENTS,
+      tools: [],
+      templateRegistry: MOCK_REGISTRY,
+    });
+
+    expect(catalog).toContain('## NODE TYPES');
+    expect(catalog).toContain('## SIGNAL TEMPLATES');
+    expect(catalog).toContain('## OUTPUT WIDGET TYPES');
+    expect(catalog).toContain('## AVAILABLE AGENTS');
+    expect(catalog).toContain('## ARCHITECTURE PATTERNS');
+    expect(catalog).toContain('## WIDGET & SIGNAL DESIGN');
+  });
+
+  it('lists node types', () => {
+    const catalog = buildDiscoveryCatalog({ agents: [], tools: [], templateRegistry: {} });
+    expect(catalog).toContain('- shell:');
+    expect(catalog).toContain('- claude-code:');
+    expect(catalog).toContain('- conditional:');
+    expect(catalog).toContain('- loop:');
+    expect(catalog).toContain('- agent-invoke:');
+    expect(catalog).toContain('- branch:');
+    expect(catalog).toContain('- end:');
+    expect(catalog).toContain('- break:');
+  });
+
+  it('builds signal templates from registry', () => {
+    const catalog = buildDiscoveryCatalog({
+      agents: [],
+      tools: [],
+      templateRegistry: MOCK_REGISTRY,
+    });
+
+    expect(catalog).toContain('- metric (1x1): Metric. Required: value(number).');
+    expect(catalog).toContain('- status (1x1): Status. Required: status(string).');
+    // widget meta-template should be filtered out
+    expect(catalog).not.toContain('Output Widget');
+  });
+
+  it('lists available agents excluding builder/analyzer', () => {
+    const catalog = buildDiscoveryCatalog({
+      agents: MOCK_AGENTS,
+      tools: [],
+      templateRegistry: {},
+    });
+
+    expect(catalog).toContain('- api-monitor:');
+    expect(catalog).toContain('Inputs: TARGET_URL, TIMEOUT.');
+    expect(catalog).not.toContain('agent-builder');
+  });
+
+  it('stays under 4000 chars with typical data', () => {
+    const catalog = buildDiscoveryCatalog({
+      agents: MOCK_AGENTS,
+      tools: [],
+      templateRegistry: MOCK_REGISTRY,
+    });
+
+    expect(catalog.length).toBeLessThan(4000);
+  });
+
+  it('handles empty agents gracefully', () => {
+    const catalog = buildDiscoveryCatalog({
+      agents: [],
+      tools: [],
+      templateRegistry: MOCK_REGISTRY,
+    });
+
+    expect(catalog).toContain('No agents available yet.');
+  });
+});

--- a/packages/core/src/discovery-catalog.ts
+++ b/packages/core/src/discovery-catalog.ts
@@ -1,0 +1,117 @@
+/**
+ * Discovery catalog builder. Assembles a concise text catalog of node types,
+ * signal templates, output widgets, available agents, and architecture patterns
+ * for injection into the agent-builder and agent-analyzer LLM prompts.
+ *
+ * Built at runtime from live data (stores, registries) so it stays current
+ * as tools and agents change.
+ */
+
+import type { Agent } from './agent-v2-types.js';
+import type { ToolDefinition } from './tool-types.js';
+
+export interface TemplateDef {
+  name: string;
+  displayName: string;
+  slots: Array<{ name: string; required: boolean; type: string }>;
+  defaultSize: string;
+}
+
+export interface DiscoveryCatalogOptions {
+  agents: Agent[];
+  tools: ToolDefinition[];
+  templateRegistry: Record<string, TemplateDef>;
+}
+
+const EXCLUDED_AGENT_IDS = new Set(['agent-builder', 'agent-analyzer']);
+
+// ── Static content ──────────────────────────────────────────────────────
+
+const NODE_TYPES = `
+## NODE TYPES
+- shell: Run a shell command. Fields: command (required).
+- claude-code: Multi-turn LLM. Fields: prompt (required), maxTurns (optional).
+- conditional: Gate on upstream field. Needs conditionalConfig: { predicate: { field, equals/notEquals/exists } }. Outputs { matched, value }.
+- switch: Multi-way branch on field value. Needs switchConfig: { field, cases: { caseName: matchValue } }. Outputs { case, value }.
+- loop: Iterate over array, invoke sub-agent per item. Needs loopConfig: { over: "fieldName", agentId: "agent-id", maxIterations? }. Injects ITEM + ITEM_INDEX.
+- agent-invoke: Call another agent as a node. Needs agentInvokeConfig: { agentId, inputMapping?: { INPUT_NAME: "upstream.nodeId.field" } }.
+- branch: Merge node. Collects outputs from multiple dependsOn upstreams into { merged, count }.
+- end: Terminate flow cleanly. Optional endMessage.
+- break: Exit loop iteration early. Optional endMessage.
+- Edge conditions: Any node can have onlyIf: { upstream, field, equals/notEquals/exists } to conditionally skip.`.trim();
+
+const OUTPUT_WIDGETS = `
+## OUTPUT WIDGET TYPES (outputWidget: in agent YAML)
+Use when the agent produces structured JSON. The widget renders on the agent detail page.
+- dashboard: Hero metric + stats grid. Field types: metric (big number), stat (compact label+value), badge (pill), text.
+- key-value: Labeled pairs as definition list. Field types: text, code, badge.
+- diff-apply: Review/analysis with actions. Field types: text, code, badge. Supports actions (buttons that POST).
+- raw: Sectioned fallback for mixed content. Field types: text, code.
+Field type tips: Use metric for the single most important number. Use stat for supporting numbers. Use badge for status/category.`.trim();
+
+const PATTERNS = `
+## ARCHITECTURE PATTERNS
+1. API Monitor: shell(curl) → signal(status + thresholds). Single node, schedule: "*/5 * * * *".
+2. Data Pipeline: shell(fetch) → claude-code(analyze) → shell(output). Use dependsOn chaining.
+3. Conditional Router: shell(classify) → conditional(check predicate) → shell(path-a, onlyIf: matched) + shell(path-b, onlyIf: !matched) → branch(merge).
+4. Loop + Invoke: shell(read-source) → loop(over: "items", agentId: "processor-agent") → shell(compile-results).
+5. Self-Correcting: claude-code(generate) → shell(validate) → claude-code(fix, onlyIf: validation failed).
+6. Scheduled Digest: shell(gather-data) → claude-code(summarize). schedule: "0 8 * * *". Use story or text-headline template.`.trim();
+
+const WIDGET_GUIDANCE = `
+## WIDGET & SIGNAL DESIGN
+- Always include BOTH signal: (for Pulse tiles) AND outputWidget: (for agent detail) when output is structured JSON.
+- Signal template and outputWidget type are independent. Signal controls the Pulse tile. Widget controls the run detail view.
+- Use size: "2x1" for templates with body text (text-headline, story, table, comparison).
+- Use accent color to group related agents visually (teal, blue, green, orange, red, purple).
+- Use thresholds on metric tiles to auto-color: thresholds: [{ above: 90, palette: accent-red }, { above: 50, palette: accent-orange }].
+- Map JSON output fields precisely. Avoid mapping to "result" when the agent outputs structured JSON with named fields.
+- For dashboard widgets: put the most important number as type: metric, supporting stats as type: stat, categories as type: badge.`.trim();
+
+// ── Dynamic builders ────────────────────────────────────────────────────
+
+function buildTemplateSection(registry: Record<string, TemplateDef>): string {
+  const lines = Object.values(registry)
+    .filter((t) => t.name !== 'widget') // meta-template, not user-facing
+    .map((t) => {
+      const required = t.slots.filter((s) => s.required).map((s) => `${s.name}(${s.type})`);
+      const optional = t.slots.filter((s) => !s.required).map((s) => s.name);
+      const reqStr = required.length > 0 ? `Required: ${required.join(', ')}.` : 'No required slots.';
+      const optStr = optional.length > 0 ? `Optional: ${optional.join(', ')}.` : '';
+      return `- ${t.name} (${t.defaultSize}): ${t.displayName}. ${reqStr}${optStr ? ' ' + optStr : ''}`;
+    });
+  return `## SIGNAL TEMPLATES (signal.template in agent YAML)\n${lines.join('\n')}`;
+}
+
+function buildAgentsSection(agents: Agent[]): string {
+  const eligible = agents
+    .filter((a) => a.status === 'active' && !EXCLUDED_AGENT_IDS.has(a.id))
+    .slice(0, 20); // cap to keep catalog lean
+
+  if (eligible.length === 0) {
+    return '## AVAILABLE AGENTS (for agent-invoke / loop nodes)\nNo agents available yet.';
+  }
+
+  const lines = eligible.map((a) => {
+    const inputNames = a.inputs ? Object.keys(a.inputs).join(', ') : '';
+    const inputStr = inputNames ? ` Inputs: ${inputNames}.` : '';
+    return `- ${a.id}: ${a.description ?? a.name}.${inputStr}`;
+  });
+
+  return `## AVAILABLE AGENTS (for agent-invoke / loop nodes)\n${lines.join('\n')}`;
+}
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+export function buildDiscoveryCatalog(opts: DiscoveryCatalogOptions): string {
+  const sections = [
+    NODE_TYPES,
+    buildTemplateSection(opts.templateRegistry),
+    OUTPUT_WIDGETS,
+    buildAgentsSection(opts.agents),
+    PATTERNS,
+    WIDGET_GUIDANCE,
+  ];
+
+  return sections.join('\n\n');
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export * from './cron-validator.js';
 export * from './cron-human.js';
 export * from './scheduler-heartbeat.js';
 export * from './scheduler-catchup.js';
+export * from './discovery-catalog.js';
 export * from './llm-invoker.js';
 export * from './fs-utils.js';
 export * from './mcp-token.js';

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -1366,6 +1366,83 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
   text-align: center;
 }
 
+/* -- Template hint (description + layout preview) -- */
+.cfg-template-hint {
+  margin-top: var(--space-2);
+}
+.cfg-template-hint__inner {
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-3);
+}
+.cfg-template-hint__desc {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-2);
+}
+.cfg-template-hint__layout {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-text-subtle);
+  margin: 0;
+  line-height: 1.4;
+  white-space: pre;
+}
+
+/* -- Form divider -- */
+.cfg-divider {
+  border: none;
+  border-top: 1px solid var(--color-border);
+  margin: var(--space-4) 0;
+}
+
+/* -- Mapping form rows -- */
+.cfg-mapping-row {
+  margin-bottom: var(--space-3);
+}
+.cfg-mapping-label {
+  display: block;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  margin-bottom: 4px;
+  font-weight: var(--weight-medium);
+}
+.cfg-slot-type {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--color-text-subtle);
+  background: var(--color-surface-raised);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+.cfg-mapping-select {
+  width: 100%;
+  margin-bottom: var(--space-1);
+}
+.cfg-literal-input {
+  width: 100%;
+}
+
+/* -- Suggested template badge -- */
+.cfg-suggested-badge {
+  font-size: 8px;
+  font-weight: var(--weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-primary);
+  position: absolute;
+  top: 2px;
+  right: 4px;
+}
+.pulse-configure-modal__tpl-card.is-suggested {
+  position: relative;
+  border-color: rgba(45, 212, 191, 0.3);
+}
+.pulse-configure-modal__tpl-card {
+  position: relative;
+}
+
 /* -- Theme picker grid (Settings > Appearance) -- */
 .theme-grid {
   display: grid;

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -1229,6 +1229,36 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
 .pulse-tile[data-accent="red"]    .pulse-tile__status-dot { background: #f87171; }
 .pulse-tile[data-accent="purple"] .pulse-tile__status-dot { background: #a78bfa; }
 
+/* -- Visual polish: accent glow on metric values -- */
+.pulse-tile[data-accent] .pulse-tile__value {
+  text-shadow: 0 0 20px currentColor;
+}
+
+/* -- Status dot pulse animation for "running" states -- */
+.pulse-tile__status-dot--healthy {
+  animation: status-pulse 2s ease-in-out infinite;
+}
+@keyframes status-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+/* -- Story tile pull-quote style -- */
+.pulse-tile .pulse-tile__body--md blockquote,
+.pulse-tile .story-what-changed {
+  border-left: 3px solid var(--color-primary);
+  padding-left: var(--space-3);
+  font-style: italic;
+}
+
+/* -- Comparison divider -- */
+.pulse-tile .comparison-divider {
+  width: 1px;
+  background: var(--color-border);
+  align-self: stretch;
+  margin: var(--space-2) 0;
+}
+
 /* -- Configure tile button -- */
 .pulse-tile__configure-btn {
   background: none;

--- a/packages/dashboard/src/routes/run-now-build.ts
+++ b/packages/dashboard/src/routes/run-now-build.ts
@@ -6,7 +6,8 @@
  */
 
 import { Router, type Request, type Response } from 'express';
-import { executeAgentDag, exportAgent, listBuiltinTools, parseAgent, type RunStatus, type ToolDefinition } from '@some-useful-agents/core';
+import { executeAgentDag, exportAgent, listBuiltinTools, parseAgent, buildDiscoveryCatalog, type RunStatus, type ToolDefinition } from '@some-useful-agents/core';
+import { TEMPLATE_REGISTRY } from '../views/pulse-templates.js';
 import { parse as parseRawYaml, stringify as stringifyRawYaml } from 'yaml';
 import { readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
@@ -81,6 +82,16 @@ buildRouter.post('/agents/:name/analyze', async (req: Request, res: Response) =>
 
   // Fire-and-forget: start the analyzer but don't await it.
   // Return the runId immediately so the client can poll.
+  // Build discovery catalog for the analyzer.
+  const aBuiltins = listBuiltinTools();
+  let aUserTools: ToolDefinition[] = [];
+  try { if (ctx.toolStore) aUserTools = ctx.toolStore.listTools(); } catch {}
+  const discoveryCatalog = buildDiscoveryCatalog({
+    agents: ctx.agentStore.listAgents(),
+    tools: [...aBuiltins, ...aUserTools],
+    templateRegistry: TEMPLATE_REGISTRY,
+  });
+
   const runPromise = executeAgentDag(
     analyzer,
     {
@@ -89,6 +100,7 @@ buildRouter.post('/agents/:name/analyze', async (req: Request, res: Response) =>
         AGENT_YAML: targetYaml,
         ...(focus ? { FOCUS: `Focus your analysis on: ${focus}` } : {}),
         ...(lastRunOutput ? { LAST_RUN_OUTPUT: lastRunOutput } : {}),
+        DISCOVERY_CATALOG: discoveryCatalog,
       },
     },
     {
@@ -282,6 +294,11 @@ buildRouter.post('/agents/build', async (req: Request, res: Response) => {
     if (ctx.toolStore) userTools = ctx.toolStore.listTools();
   } catch { /* store not available */ }
   const catalog = formatToolCatalog([...builtins, ...userTools]);
+  const discoveryCatalog = buildDiscoveryCatalog({
+    agents: ctx.agentStore.listAgents(),
+    tools: [...builtins, ...userTools],
+    templateRegistry: TEMPLATE_REGISTRY,
+  });
 
   const runPromise = executeAgentDag(
     builder,
@@ -291,6 +308,7 @@ buildRouter.post('/agents/build', async (req: Request, res: Response) => {
         GOAL: goal,
         ...(focus ? { FOCUS: `Constraints: ${focus}` } : {}),
         AVAILABLE_TOOLS: catalog,
+        DISCOVERY_CATALOG: discoveryCatalog,
       },
     },
     {

--- a/packages/dashboard/src/views/pulse-configure.js.ts
+++ b/packages/dashboard/src/views/pulse-configure.js.ts
@@ -10,6 +10,32 @@ export const PULSE_CONFIGURE_JS = `
     var currentConfig = null;
     var currentOutputFields = [];
 
+    var ACCENT_COLORS = {
+      '': '#6b7280',
+      teal: '#2dd4bf',
+      blue: '#60a5fa',
+      green: '#4ade80',
+      orange: '#fb923c',
+      red: '#f87171',
+      purple: '#a78bfa',
+    };
+
+    // Layout hint per template — shows how the template arranges data.
+    var LAYOUT_HINTS = {
+      'metric': '\\u250C\\u2500\\u2500\\u2500\\u2500\\u2500\\u2500\\u2500\\u2500\\u2510\\n\\u2502  42ms   \\u2502\\n\\u2502  label  \\u2502\\n\\u2514\\u2500\\u2500\\u2500\\u2500\\u2500\\u2500\\u2500\\u2500\\u2518',
+      'time-series': 'Sparkline chart + current value',
+      'text-headline': 'Bold headline\\nBody text below',
+      'table': 'Column headers\\nRow 1  Row 2  Row 3',
+      'status': '\\u25CF healthy \\u2014 message',
+      'comparison': 'Left value  vs  Right value',
+      'key-value': 'Label: Value\\nLabel: Value\\nLabel: Value',
+      'story': 'What changed (bold)\\nTime period (badge)\\nWhat it means (body)',
+      'funnel': '\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588 Stage 1\\n\\u2588\\u2588\\u2588\\u2588\\u2588\\u2588 Stage 2\\n\\u2588\\u2588\\u2588\\u2588 Stage 3',
+      'media': 'Image/video player + caption',
+      'text-image': 'Text alongside image',
+      'image': 'Full image display',
+    };
+
     function getRegistry() {
       if (registry) return registry;
       var el = document.getElementById('pulse-template-registry');
@@ -35,6 +61,17 @@ export const PULSE_CONFIGURE_JS = `
       currentConfig = null;
     }
 
+    function accentSwatch(value, label, selected) {
+      var color = ACCENT_COLORS[value] || '#6b7280';
+      var border = selected ? '2px solid var(--color-primary)' : '2px solid transparent';
+      return '<button type="button" class="cfg-accent-btn" data-accent="' + esc(value) + '" ' +
+        'style="display:inline-flex;align-items:center;gap:6px;padding:4px 10px;border-radius:var(--radius-sm);border:' + border + ';background:var(--color-surface-raised);cursor:pointer;" ' +
+        'title="' + esc(label) + '">' +
+        '<span style="display:inline-block;width:12px;height:12px;border-radius:50%;background:' + color + ';"></span>' +
+        '<span style="font-size:var(--font-size-xs);">' + esc(label) + '</span>' +
+        '</button>';
+    }
+
     function openModal(agentId, config, outputFields) {
       ensureModal();
       currentAgentId = agentId;
@@ -43,6 +80,13 @@ export const PULSE_CONFIGURE_JS = `
 
       var reg = getRegistry();
       var selectedTemplate = config.template || 'metric';
+      var currentAccent = config.accent || '';
+
+      var accentSwatches = '';
+      var accentEntries = [['', 'None'], ['teal', 'Teal'], ['blue', 'Blue'], ['green', 'Green'], ['orange', 'Orange'], ['red', 'Red'], ['purple', 'Purple']];
+      for (var a = 0; a < accentEntries.length; a++) {
+        accentSwatches += accentSwatch(accentEntries[a][0], accentEntries[a][1], accentEntries[a][0] === currentAccent);
+      }
 
       modal.innerHTML = '<div class="pulse-configure-modal__content">' +
         '<div class="pulse-configure-modal__header">' +
@@ -50,20 +94,29 @@ export const PULSE_CONFIGURE_JS = `
           '<button type="button" class="pulse-configure-modal__close" title="Close">\\u00D7</button>' +
         '</div>' +
         '<form method="POST" action="/agents/' + encodeURIComponent(agentId) + '/signal" class="pulse-configure-modal__form">' +
+
+          // Template picker
           '<div class="pulse-configure-modal__section">' +
             '<label class="pulse-configure-modal__label">Template</label>' +
             '<div class="pulse-configure-modal__templates" id="cfg-template-grid"></div>' +
+            '<div id="cfg-template-hint" class="cfg-template-hint"></div>' +
           '</div>' +
+
+          '<hr class="cfg-divider">' +
+
+          // Title
           '<div class="pulse-configure-modal__section">' +
             '<label class="pulse-configure-modal__label">Title</label>' +
             '<input type="text" name="title" value="' + esc(config.title || '') + '" class="input" style="width: 100%;">' +
           '</div>' +
-          '<div class="pulse-configure-modal__section" style="display: flex; gap: var(--space-3);">' +
-            '<div style="flex: 1;">' +
+
+          // Icon + Size row
+          '<div class="pulse-configure-modal__section" style="display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-4);">' +
+            '<div>' +
               '<label class="pulse-configure-modal__label">Icon</label>' +
               '<input type="text" name="icon" value="' + esc(config.icon || '') + '" class="input" style="width: 100%;" placeholder="emoji or symbol">' +
             '</div>' +
-            '<div style="flex: 1;">' +
+            '<div>' +
               '<label class="pulse-configure-modal__label">Size</label>' +
               '<select name="size" class="input" style="width: 100%;">' +
                 '<option value="1x1"' + (config.size === '1x1' ? ' selected' : '') + '>1\\u00D71</option>' +
@@ -73,30 +126,34 @@ export const PULSE_CONFIGURE_JS = `
               '</select>' +
             '</div>' +
           '</div>' +
-          '<div class="pulse-configure-modal__section" style="display: flex; gap: var(--space-3);">' +
-            '<div style="flex: 1;">' +
-              '<label class="pulse-configure-modal__label">Accent</label>' +
-              '<select name="accent" class="input" style="width: 100%;">' +
-                '<option value=""' + (!config.accent ? ' selected' : '') + '>None</option>' +
-                '<option value="teal"' + (config.accent === 'teal' ? ' selected' : '') + '>Teal</option>' +
-                '<option value="blue"' + (config.accent === 'blue' ? ' selected' : '') + '>Blue</option>' +
-                '<option value="green"' + (config.accent === 'green' ? ' selected' : '') + '>Green</option>' +
-                '<option value="orange"' + (config.accent === 'orange' ? ' selected' : '') + '>Orange</option>' +
-                '<option value="red"' + (config.accent === 'red' ? ' selected' : '') + '>Red</option>' +
-                '<option value="purple"' + (config.accent === 'purple' ? ' selected' : '') + '>Purple</option>' +
-              '</select>' +
+
+          // Accent
+          '<div class="pulse-configure-modal__section">' +
+            '<label class="pulse-configure-modal__label">Accent</label>' +
+            '<div style="display: flex; flex-wrap: wrap; gap: var(--space-2);" id="cfg-accent-row">' +
+              accentSwatches +
             '</div>' +
-            '<div style="flex: 1;">' +
-              '<label class="pulse-configure-modal__label">Refresh</label>' +
-              '<input type="text" name="refresh" value="' + esc(config.refresh || '') + '" class="input" style="width: 100%;" placeholder="e.g. 5m, 1h">' +
-            '</div>' +
+            '<input type="hidden" name="accent" id="cfg-accent-value" value="' + esc(currentAccent) + '">' +
           '</div>' +
+
+          // Refresh
+          '<div class="pulse-configure-modal__section">' +
+            '<label class="pulse-configure-modal__label">Auto-refresh</label>' +
+            '<input type="text" name="refresh" value="' + esc(config.refresh || '') + '" class="input" style="width: 100%;" placeholder="e.g. 5m, 1h, 24h (leave empty to disable)">' +
+          '</div>' +
+
+          '<hr class="cfg-divider">' +
+
+          // Field mapping
           '<div class="pulse-configure-modal__section">' +
             '<label class="pulse-configure-modal__label">Field mapping</label>' +
+            '<p style="font-size:var(--font-size-xs);color:var(--color-text-subtle);margin:0 0 var(--space-2);">Map your agent\\u2019s output fields to the template\\u2019s display slots.</p>' +
             '<div id="cfg-mapping-form"></div>' +
           '</div>' +
+
           '<input type="hidden" name="template" id="cfg-template-value" value="' + esc(selectedTemplate) + '">' +
           '<input type="hidden" name="mapping" id="cfg-mapping-value" value="">' +
+
           '<div class="pulse-configure-modal__footer">' +
             '<button type="button" class="btn btn--ghost btn--sm" onclick="this.closest(\\'.pulse-configure-modal\\').style.display=\\'none\\'">Cancel</button>' +
             '<button type="submit" class="btn btn--primary btn--sm">Save</button>' +
@@ -107,17 +164,51 @@ export const PULSE_CONFIGURE_JS = `
       // Close button
       modal.querySelector('.pulse-configure-modal__close').addEventListener('click', closeModal);
 
+      // Accent swatch click
+      var accentBtns = modal.querySelectorAll('.cfg-accent-btn');
+      for (var ab = 0; ab < accentBtns.length; ab++) {
+        accentBtns[ab].addEventListener('click', function () {
+          var val = this.getAttribute('data-accent');
+          document.getElementById('cfg-accent-value').value = val;
+          var all = modal.querySelectorAll('.cfg-accent-btn');
+          for (var j = 0; j < all.length; j++) all[j].style.border = '2px solid transparent';
+          this.style.border = '2px solid var(--color-primary)';
+        });
+      }
+
+      // Score templates by how well they match the agent's output fields.
+      function scoreFit(tpl) {
+        if (!tpl.slots || tpl.slots.length === 0) return 0;
+        var requiredSlots = tpl.slots.filter(function(s) { return s.required; });
+        if (requiredSlots.length === 0) return 0;
+        var matched = 0;
+        for (var s = 0; s < requiredSlots.length; s++) {
+          if (currentOutputFields.indexOf(requiredSlots[s].name) !== -1) matched++;
+        }
+        return matched / requiredSlots.length;
+      }
+
       // Build template picker grid
       var grid = document.getElementById('cfg-template-grid');
       var templateNames = Object.keys(reg);
+      // Find best-fit template for "Suggested" badge.
+      var bestFitName = '';
+      var bestFitScore = 0;
+      for (var b = 0; b < templateNames.length; b++) {
+        var score = scoreFit(reg[templateNames[b]]);
+        if (score > bestFitScore) { bestFitScore = score; bestFitName = templateNames[b]; }
+      }
+
       for (var i = 0; i < templateNames.length; i++) {
         var t = reg[templateNames[i]];
+        var isSuggested = t.name === bestFitName && bestFitScore > 0;
         var card = document.createElement('button');
         card.type = 'button';
-        card.className = 'pulse-configure-modal__tpl-card' + (t.name === selectedTemplate ? ' is-active' : '');
+        card.className = 'pulse-configure-modal__tpl-card' + (t.name === selectedTemplate ? ' is-active' : '') + (isSuggested ? ' is-suggested' : '');
         card.setAttribute('data-template', t.name);
         card.innerHTML = '<span class="pulse-configure-modal__tpl-icon">' + (t.icon || '') + '</span>' +
-          '<span class="pulse-configure-modal__tpl-name">' + esc(t.displayName) + '</span>';
+          '<span class="pulse-configure-modal__tpl-name">' + esc(t.displayName) + '</span>' +
+          (isSuggested ? '<span class="cfg-suggested-badge">Suggested</span>' : '');
         card.title = t.description || '';
         card.addEventListener('click', (function (name) {
           return function () {
@@ -126,12 +217,14 @@ export const PULSE_CONFIGURE_JS = `
             for (var j = 0; j < cards.length; j++) cards[j].classList.remove('is-active');
             this.classList.add('is-active');
             renderMappingForm(name);
+            updateTemplateHint(name);
           };
         })(t.name));
         grid.appendChild(card);
       }
 
-      // Initial mapping form
+      // Initial template hint + mapping form
+      updateTemplateHint(selectedTemplate);
       renderMappingForm(selectedTemplate);
 
       // Serialize mapping on submit
@@ -152,6 +245,21 @@ export const PULSE_CONFIGURE_JS = `
       });
 
       modal.style.display = 'flex';
+    }
+
+    function updateTemplateHint(templateName) {
+      var hint = document.getElementById('cfg-template-hint');
+      if (!hint) return;
+      var reg = getRegistry();
+      var tpl = reg[templateName];
+      if (!tpl) { hint.innerHTML = ''; return; }
+
+      var layout = LAYOUT_HINTS[templateName] || tpl.description || '';
+      hint.innerHTML =
+        '<div class="cfg-template-hint__inner">' +
+          '<div class="cfg-template-hint__desc">' + esc(tpl.description) + '</div>' +
+          (layout ? '<pre class="cfg-template-hint__layout">' + esc(layout) + '</pre>' : '') +
+        '</div>';
     }
 
     function renderMappingForm(templateName) {
@@ -175,13 +283,13 @@ export const PULSE_CONFIGURE_JS = `
         row.setAttribute('data-slot', slot.name);
 
         var label = document.createElement('label');
-        label.style.cssText = 'font-size: var(--font-size-xs); color: var(--color-text-muted); display: block; margin-bottom: 2px;';
-        label.textContent = slot.label + (slot.required ? ' *' : '');
+        label.className = 'cfg-mapping-label';
+        label.innerHTML = esc(slot.label) + (slot.required ? ' <span style="color:var(--color-err);">*</span>' : '') +
+          ' <span class="cfg-slot-type">' + esc(slot.type) + '</span>';
         row.appendChild(label);
 
         var select = document.createElement('select');
-        select.className = 'input';
-        select.style.cssText = 'width: 100%; margin-bottom: var(--space-2);';
+        select.className = 'input cfg-mapping-select';
 
         // Add output field options
         var currentVal = currentMapping[slot.name] || '';
@@ -218,7 +326,6 @@ export const PULSE_CONFIGURE_JS = `
         var litInput = document.createElement('input');
         litInput.type = 'text';
         litInput.className = 'input cfg-literal-input';
-        litInput.style.cssText = 'width: 100%; margin-bottom: var(--space-2);';
         litInput.placeholder = 'Enter literal value';
         litInput.value = (!hasFieldMatch && currentVal) ? currentVal : '';
         litInput.style.display = (!hasFieldMatch && currentVal) ? '' : 'none';


### PR DESCRIPTION
## Summary

**Discovery catalog**: Runtime-built text catalog injected into the agent-builder and agent-analyzer LLM prompts. Replaces hardcoded template/pattern sections with dynamic, comprehensive knowledge of:
- All 9 node types (shell, claude-code, conditional, switch, loop, agent-invoke, branch, end, break) with config schemas
- All 13 signal templates with slots and default sizes
- All 4 output widget types with field type guidance
- Available agents for agent-invoke/loop nodes
- 6 architecture patterns (API monitor, data pipeline, conditional router, loop+invoke, self-correcting, scheduled digest)
- Widget design guidance (when to use each type, field type tips)

**Prompt updates**: Builder and analyzer prompts now consume the catalog, enabling Claude to suggest sophisticated multi-node DAGs with control flow, sub-agent invocation, and rich visual output.

**Richer examples**: 6 agents upgraded with accent colors, thresholds, and better signal templates so Pulse looks good out of the box.

**Visual polish**: Accent glow on metric values, pulsing healthy status dots, story pull-quote styling.

## Test plan

- [x] 606 tests pass (6 new for discovery catalog)
- [ ] "Build from goal" → "API health checker with retry" → produces conditional + retry pattern
- [ ] "Build from goal" → "Batch process URLs" → produces loop + agent-invoke pattern
- [ ] "Suggest improvements" on simple agent → suggests control flow + outputWidget
- [ ] Pulse page with example agents shows accent colors and visual polish

🤖 Generated with [Claude Code](https://claude.com/claude-code)