### PR TITLE
fix: redesign configure modal with DESIGN.md spacing

### DIFF
--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -1289,17 +1289,24 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
-  box-shadow: var(--shadow-lg);
-  width: min(520px, 90vw);
-  max-height: 80vh;
+  box-shadow: 0 8px 30px rgb(0 0 0 / 0.4);
+  width: min(560px, 92vw);
+  max-height: 85vh;
   overflow-y: auto;
-  padding: var(--space-5);
+  padding: var(--space-6) var(--space-8);
 }
 .pulse-configure-modal__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: var(--space-4);
+  margin-bottom: var(--space-6);
+  padding-bottom: var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+}
+.pulse-configure-modal__header h3 {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-lg);
+  font-weight: var(--weight-bold);
 }
 .pulse-configure-modal__close {
   background: none;
@@ -1307,105 +1314,134 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
   color: var(--color-text-muted);
   cursor: pointer;
   font-size: 1.25rem;
-  padding: var(--space-1);
+  padding: var(--space-2);
   line-height: 1;
+  border-radius: var(--radius-sm);
 }
-.pulse-configure-modal__close:hover { color: var(--color-text); }
+.pulse-configure-modal__close:hover {
+  color: var(--color-text);
+  background: var(--color-surface-raised);
+}
 .pulse-configure-modal__section {
-  margin-bottom: var(--space-4);
+  margin-bottom: var(--space-6);
 }
 .pulse-configure-modal__label {
   display: block;
   font-size: var(--font-size-xs);
   font-weight: var(--weight-semibold);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.08em;
   color: var(--color-text-muted);
-  margin-bottom: var(--space-1);
+  margin-bottom: var(--space-2);
+  font-family: var(--font-mono);
 }
 .pulse-configure-modal__footer {
   display: flex;
   justify-content: flex-end;
-  gap: var(--space-2);
-  padding-top: var(--space-3);
+  gap: var(--space-3);
+  padding-top: var(--space-6);
+  margin-top: var(--space-4);
   border-top: 1px solid var(--color-border);
 }
 
 /* -- Template picker grid -- */
 .pulse-configure-modal__templates {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(84px, 1fr));
   gap: var(--space-2);
 }
 .pulse-configure-modal__tpl-card {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   gap: 4px;
-  padding: var(--space-2);
+  padding: var(--space-3) var(--space-2);
   background: var(--color-surface-raised);
   border: 2px solid transparent;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: border-color 100ms ease;
+  transition: border-color 100ms ease, background 100ms ease;
+  min-height: 56px;
 }
 .pulse-configure-modal__tpl-card:hover {
-  border-color: var(--color-border);
+  border-color: var(--color-border-strong);
+  background: var(--color-surface);
 }
 .pulse-configure-modal__tpl-card.is-active {
   border-color: var(--color-primary);
-  background: rgba(45, 212, 191, 0.08);
+  background: var(--color-primary-soft);
 }
 .pulse-configure-modal__tpl-icon {
-  font-size: 1.25rem;
+  font-size: 1.125rem;
+  line-height: 1;
 }
 .pulse-configure-modal__tpl-name {
-  font-size: 10px;
+  font-size: 9px;
   font-family: var(--font-mono);
   color: var(--color-text-muted);
   text-align: center;
+  letter-spacing: 0.02em;
 }
 
 /* -- Template hint (description + layout preview) -- */
 .cfg-template-hint {
-  margin-top: var(--space-2);
+  margin-top: var(--space-3);
 }
 .cfg-template-hint__inner {
-  background: var(--color-surface-raised);
+  background: var(--color-bg);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  padding: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  display: flex;
+  gap: var(--space-4);
+  align-items: flex-start;
 }
 .cfg-template-hint__desc {
-  font-size: var(--font-size-xs);
+  font-size: var(--font-size-sm);
   color: var(--color-text-muted);
-  margin-bottom: var(--space-2);
+  line-height: var(--line-body);
+  flex: 1;
 }
 .cfg-template-hint__layout {
   font-family: var(--font-mono);
   font-size: 10px;
   color: var(--color-text-subtle);
   margin: 0;
-  line-height: 1.4;
+  line-height: 1.5;
   white-space: pre;
+  background: var(--color-surface-raised);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
 }
 
 /* -- Form divider -- */
 .cfg-divider {
   border: none;
   border-top: 1px solid var(--color-border);
-  margin: var(--space-4) 0;
+  margin: var(--space-6) 0;
 }
 
 /* -- Mapping form rows -- */
 .cfg-mapping-row {
-  margin-bottom: var(--space-3);
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+.cfg-mapping-row:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
 }
 .cfg-mapping-label {
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
   font-size: var(--font-size-xs);
   color: var(--color-text-muted);
-  margin-bottom: 4px;
+  margin-bottom: var(--space-2);
   font-weight: var(--weight-medium);
 }
 .cfg-slot-type {
@@ -1413,34 +1449,35 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
   font-size: 9px;
   color: var(--color-text-subtle);
   background: var(--color-surface-raised);
-  padding: 1px 4px;
+  padding: 2px 6px;
   border-radius: 3px;
+  border: 1px solid var(--color-border);
 }
 .cfg-mapping-select {
   width: 100%;
-  margin-bottom: var(--space-1);
+  margin-bottom: var(--space-2);
 }
 .cfg-literal-input {
   width: 100%;
+  margin-top: var(--space-1);
 }
 
 /* -- Suggested template badge -- */
 .cfg-suggested-badge {
-  font-size: 8px;
-  font-weight: var(--weight-semibold);
+  font-size: 7px;
+  font-weight: var(--weight-bold);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.06em;
   color: var(--color-primary);
   position: absolute;
-  top: 2px;
-  right: 4px;
+  bottom: 3px;
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
 }
 .pulse-configure-modal__tpl-card.is-suggested {
-  position: relative;
-  border-color: rgba(45, 212, 191, 0.3);
-}
-.pulse-configure-modal__tpl-card {
-  position: relative;
+  border-color: rgba(45, 212, 191, 0.4);
+  padding-bottom: var(--space-4);
 }
 
 /* -- Theme picker grid (Settings > Appearance) -- */


### PR DESCRIPTION
## Summary

The configure modal was cramped and hard to read. Redesigned following DESIGN.md principles (typography + whitespace do the work, comfortable density).

Changes:
- **Modal**: wider (560px), generous padding (24px/32px), header with bottom border
- **Template cards**: taller, better hover/active states using primary-soft
- **Template hint**: side-by-side layout (description left, ASCII preview right)
- **Sections**: separated by proper dividers with space-6 margins
- **Mapping rows**: each row separated by subtle border, type badges with border
- **Suggested badge**: centered at card bottom, smaller but bolder
- **Footer**: more breathing room above buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)