### PR TITLE
feat: auto-fix YAML errors + Fix with AI button

### DIFF
--- a/packages/dashboard/src/routes/run-now-build.ts
+++ b/packages/dashboard/src/routes/run-now-build.ts
@@ -18,6 +18,80 @@ export const buildRouter: Router = Router();
 const ANALYZER_AGENT_ID = 'agent-analyzer';
 const BUILDER_AGENT_ID = 'agent-builder';
 
+// ── Auto-fix common LLM YAML mistakes ──────────────────────────────────
+
+function autoFixYaml(yaml: string): string {
+  try {
+    const raw = parseRawYaml(yaml);
+    if (!raw || typeof raw !== 'object') return yaml;
+    let changed = false;
+
+    // Fix 1: {{inputs.X}} → $X in shell node commands.
+    if (raw.nodes && Array.isArray(raw.nodes)) {
+      for (const n of raw.nodes) {
+        if (n.type === 'shell' && typeof n.command === 'string') {
+          const fixed = n.command.replace(
+            /\{\{inputs\.([A-Z_][A-Z0-9_]*)\}\}/g,
+            (_: string, name: string) => '$' + name,
+          );
+          if (fixed !== n.command) { n.command = fixed; changed = true; }
+        }
+      }
+    }
+
+    // Fix 2: inputs as array → object.
+    if (Array.isArray(raw.inputs)) {
+      const obj: Record<string, unknown> = {};
+      for (const item of raw.inputs) {
+        if (typeof item === 'object' && item !== null && item.name) {
+          const name = String(item.name).toUpperCase();
+          const { name: _n, ...rest } = item;
+          obj[name] = rest;
+          changed = true;
+        }
+      }
+      if (Object.keys(obj).length > 0) {
+        raw.inputs = obj;
+      }
+    }
+
+    // Fix 3: lowercase input names → UPPERCASE.
+    if (raw.inputs && typeof raw.inputs === 'object' && !Array.isArray(raw.inputs)) {
+      const fixed: Record<string, unknown> = {};
+      for (const [key, val] of Object.entries(raw.inputs)) {
+        const upper = key.toUpperCase();
+        if (upper !== key) changed = true;
+        fixed[upper] = val;
+      }
+      if (changed) raw.inputs = fixed;
+    }
+
+    // Fix 4: enum inputs missing values array.
+    if (raw.inputs && typeof raw.inputs === 'object' && !Array.isArray(raw.inputs)) {
+      for (const [_key, spec] of Object.entries(raw.inputs)) {
+        if (typeof spec === 'object' && spec !== null) {
+          const s = spec as Record<string, unknown>;
+          if (s.type === 'enum' && !Array.isArray(s.values)) {
+            if (s.default && typeof s.default === 'string') {
+              s.values = [s.default];
+              changed = true;
+            }
+          }
+        }
+      }
+    }
+
+    // Fix 5: source: "examples" or "community" → "local".
+    if (raw.source && raw.source !== 'local') {
+      raw.source = 'local';
+      changed = true;
+    }
+
+    if (changed) return stringifyRawYaml(raw, { lineWidth: 0 });
+  } catch { /* if raw parse fails, return as-is */ }
+  return yaml;
+}
+
 /**
  * Format a list of tool definitions into a human-readable catalog string
  * for injection into the builder agent prompt.
@@ -219,23 +293,7 @@ buildRouter.get('/agents/:name/analyze/:runId', (req: Request, res: Response) =>
   let suggestedYaml = extract('yaml') || undefined;
   let yamlError: string | undefined;
   if (suggestedYaml && suggestedYaml.length > 10) {
-    // Fix {{inputs.X}} → $X in shell node commands (analyzer LLM gets this wrong often).
-    try {
-      const raw = parseRawYaml(suggestedYaml);
-      if (raw?.nodes && Array.isArray(raw.nodes)) {
-        let changed = false;
-        for (const n of raw.nodes) {
-          if (n.type === 'shell' && typeof n.command === 'string') {
-            const fixed = n.command.replace(
-              /\{\{inputs\.([A-Z_][A-Z0-9_]*)\}\}/g,
-              (_: string, name: string) => '$' + name,
-            );
-            if (fixed !== n.command) { n.command = fixed; changed = true; }
-          }
-        }
-        if (changed) suggestedYaml = stringifyRawYaml(raw, { lineWidth: 0 });
-      }
-    } catch { /* let the real parser report the error */ }
+    suggestedYaml = autoFixYaml(suggestedYaml);
     try { parseAgent(suggestedYaml); } catch (e) { yamlError = e instanceof Error ? e.message : String(e); }
   }
 
@@ -252,6 +310,117 @@ buildRouter.get('/agents/:name/analyze/:runId', (req: Request, res: Response) =>
     yamlError,
     currentYaml,
   });
+});
+
+// ── YAML auto-fix via LLM ───────────────────────────────────────────────
+
+/**
+ * POST /agents/:name/analyze/fix-yaml — send broken YAML + error to Claude
+ * for a fix attempt. Returns { yaml, yamlError? } synchronously (waits for
+ * the LLM response, ~10-30s).
+ */
+buildRouter.post('/agents/:name/analyze/fix-yaml', async (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const brokenYaml = typeof body.yaml === 'string' ? body.yaml : '';
+  const error = typeof body.error === 'string' ? body.error : '';
+
+  if (!brokenYaml || !error) {
+    res.json({ ok: false, error: 'Missing yaml or error fields.' });
+    return;
+  }
+
+  // Build a one-shot fix agent inline (no YAML file needed).
+  const fixAgent = {
+    id: '_yaml-fixer',
+    name: 'YAML Fixer',
+    description: 'Fix YAML validation errors',
+    status: 'active' as const,
+    source: 'local' as const,
+    version: 1,
+    nodes: [{
+      id: 'fix',
+      type: 'claude-code' as const,
+      prompt: `IMPORTANT: Respond with ONLY the fixed YAML. No explanation, no XML tags, no markdown code fences. Just the raw YAML text.
+
+Fix this sua agent YAML so it passes schema validation.
+
+VALIDATION ERROR:
+${error}
+
+BROKEN YAML:
+${brokenYaml}
+
+Rules:
+- Input names: UPPERCASE_WITH_UNDERSCORES
+- inputs: must be an object/map, not an array
+- enum inputs: must have a non-empty values array
+- Shell nodes: use $ENV_VARS for inputs, never double-brace templates
+- Claude-code nodes: use double-brace inputs.NAME syntax in prompts
+- conditional nodes: must have conditionalConfig with a predicate
+- switch nodes: must have switchConfig with field + cases
+- outputWidget.type: one of dashboard, key-value, diff-apply, raw
+- outputWidget.fields[].type: one of text, code, badge, action, metric, stat
+- source: must be "local"
+- Keep the same agent id ("${name}")
+
+Output ONLY the complete fixed YAML. Nothing else.`,
+      maxTurns: 1,
+      timeout: 60,
+    }],
+  };
+
+  try {
+    const run = await executeAgentDag(
+      fixAgent,
+      { triggeredBy: 'dashboard', inputs: {} },
+      {
+        runStore: ctx.runStore,
+        secretsStore: ctx.secretsStore,
+        variablesStore: ctx.variablesStore,
+      },
+    );
+
+    // Wait for completion.
+    const maxWait = 65_000;
+    const pollInterval = 1_000;
+    const startTime = Date.now();
+    let result = ctx.runStore.getRun(run.id);
+
+    while (result && (result.status === 'running' || result.status === 'pending') && Date.now() - startTime < maxWait) {
+      await new Promise((r) => setTimeout(r, pollInterval));
+      result = ctx.runStore.getRun(run.id);
+    }
+
+    if (!result?.result) {
+      res.json({ ok: false, error: 'Fix attempt timed out or produced no output.' });
+      return;
+    }
+
+    // Clean up the result — strip markdown fences, XML tags, etc.
+    let fixedYaml = result.result
+      .replace(/^```ya?ml?\n?/i, '')
+      .replace(/\n?```\s*$/, '')
+      .replace(/<yaml>\n?/gi, '')
+      .replace(/\n?<\/yaml>/gi, '')
+      .trim();
+
+    // Apply auto-fixers.
+    fixedYaml = autoFixYaml(fixedYaml);
+
+    // Validate.
+    let fixError: string | undefined;
+    try {
+      parseAgent(fixedYaml);
+    } catch (e) {
+      fixError = e instanceof Error ? e.message : String(e);
+    }
+
+    res.json({ ok: true, yaml: fixedYaml, yamlError: fixError });
+  } catch (err) {
+    res.json({ ok: false, error: (err as Error).message });
+  }
 });
 
 // ── Agent Builder (goal-driven wizard) ─────────────────────────────────

--- a/packages/dashboard/src/views/suggest-improvements.js.ts
+++ b/packages/dashboard/src/views/suggest-improvements.js.ts
@@ -62,18 +62,51 @@ export const SUGGEST_IMPROVEMENTS_JS = `
       }
       if (data.yamlError) {
         h += '<div class="flash flash--error" style="margin-bottom:var(--space-3);font-size:var(--font-size-xs);">' +
-          '<strong>Suggested YAML has validation errors:</strong> ' + esc(data.yamlError) +
-          '<br>Click "Edit YAML" to fix manually.</div>';
+          '<strong>YAML validation error:</strong> ' + esc(data.yamlError) + '</div>';
       }
       h += '<div style="display:flex;gap:var(--space-2);justify-content:flex-end;flex-wrap:wrap;">';
       if (data.yaml && !data.yamlError) {
         h += '<button type="button" class="btn btn--primary btn--sm" id="sg-apply-now">Apply now</button>';
         h += '<button type="button" class="btn btn--ghost btn--sm" id="sg-review">Review first</button>';
-      } else if (data.yaml) {
-        h += '<button type="button" class="btn btn--primary btn--sm" id="sg-review">Edit YAML to fix</button>';
+      } else if (data.yaml && data.yamlError) {
+        h += '<button type="button" class="btn btn--primary btn--sm" id="sg-fix-ai">Fix with AI</button>';
+        h += '<button type="button" class="btn btn--ghost btn--sm" id="sg-review">Edit manually</button>';
       }
       h += '<button type="button" class="btn btn--ghost btn--sm" id="sg-dismiss">Dismiss</button></div>';
       content.innerHTML = h;
+
+      // "Fix with AI" — send broken YAML + error to Claude for another fix attempt.
+      var fixBtn = document.getElementById('sg-fix-ai');
+      if (fixBtn && data.yaml && data.yamlError) fixBtn.addEventListener('click', function () {
+        fixBtn.disabled = true;
+        fixBtn.textContent = 'Fixing...';
+        fetch('/agents/' + encodeURIComponent(agentId) + '/analyze/fix-yaml', {
+          method: 'POST', credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ yaml: data.yaml, error: data.yamlError }),
+        })
+        .then(function (r) { return r.json(); })
+        .then(function (result) {
+          if (result.ok && result.yaml) {
+            data.yaml = result.yaml;
+            data.yamlError = result.yamlError || undefined;
+            renderResult(data);
+          } else {
+            fixBtn.disabled = false;
+            fixBtn.textContent = 'Fix with AI';
+            var err = document.createElement('div');
+            err.className = 'flash flash--error';
+            err.style.cssText = 'margin-top:var(--space-2);font-size:var(--font-size-xs);';
+            err.textContent = 'Fix attempt failed: ' + (result.error || 'Unknown error');
+            fixBtn.parentNode.appendChild(err);
+          }
+        })
+        .catch(function () {
+          fixBtn.disabled = false;
+          fixBtn.textContent = 'Fix with AI';
+        });
+      });
+
       // "Apply now" — save the YAML directly without opening the editor.
       var an = document.getElementById('sg-apply-now');
       if (an && data.yaml) an.addEventListener('click', function () {
@@ -82,7 +115,7 @@ export const SUGGEST_IMPROVEMENTS_JS = `
         var t = document.createElement('textarea'); t.name = 'yaml'; t.value = data.yaml; t.style.display = 'none';
         f.appendChild(t); document.body.appendChild(f); f.submit();
       });
-      // "Review first" — open the YAML editor pre-filled.
+      // "Review first" / "Edit manually" — open the YAML editor pre-filled.
       var rv = document.getElementById('sg-review');
       if (rv && data.yaml) rv.addEventListener('click', function () {
         var f = document.createElement('form'); f.method = 'POST';


### PR DESCRIPTION
## Summary

Three layers of YAML error recovery in the suggest improvements flow:

1. **Auto-fixers** (instant, server-side): `autoFixYaml()` handles 5 common LLM mistakes before validation even runs:
   - `{{inputs.X}}` → `$X` in shell commands
   - `inputs` as array → object
   - lowercase input names → UPPERCASE
   - enum inputs missing `values` array
   - `source: "examples"` → `"local"`

2. **"Fix with AI" button**: When errors remain, the modal shows "Fix with AI" instead of "Edit YAML to fix". Sends broken YAML + error to `POST /agents/:name/analyze/fix-yaml` which runs a one-shot Claude fix agent (~10-30s). Auto-fixers run on the result too. On success, the modal re-renders with "Apply now".

3. **Manual fallback**: "Edit manually" still opens the raw YAML editor.

## Test plan

- [x] 606 tests pass
- [ ] Suggest improvements on an agent → if YAML has errors, see "Fix with AI" + "Edit manually" buttons
- [ ] Click "Fix with AI" → button shows "Fixing..." → on success, diff updates and "Apply now" appears
- [ ] Auto-fixers: create an agent with lowercase inputs → suggest improvements → auto-fixed to UPPERCASE

🤖 Generated with [Claude Code](https://claude.com/claude-code)