### PR TITLE
feat: dot-path extraction in upstream templates

### DIFF
--- a/packages/core/src/agent-v2-schema.test.ts
+++ b/packages/core/src/agent-v2-schema.test.ts
@@ -238,6 +238,11 @@ describe('extractUpstreamReferences', () => {
 
   it('ignores malformed references', () => {
     expect([...extractUpstreamReferences('{{upstream.a}}')]).toEqual([]);
-    expect([...extractUpstreamReferences('{{upstream.a.other}}')]).toEqual([]);
+  });
+
+  it('extracts dot-path field references', () => {
+    expect([...extractUpstreamReferences('{{upstream.a.headline}}')]).toEqual(['a']);
+    expect([...extractUpstreamReferences('{{upstream.write-draft.graphic_type}}')]).toEqual(['write-draft']);
+    expect([...extractUpstreamReferences('{{upstream.a.data.nested.field}}')]).toEqual(['a']);
   });
 });

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -28,8 +28,13 @@ const INPUT_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
  * Match `{{upstream.<nodeId>.result}}` anywhere in a string. Captures the
  * node id so we can cross-check against the declared node set.
  */
-const UPSTREAM_REF_RE = /\{\{upstream\.([a-z0-9][a-z0-9_-]*)\.result\}\}/g;
+/** Matches both {{upstream.nodeId.result}} and {{upstream.nodeId.fieldPath}} */
+const UPSTREAM_REF_RE = /\{\{upstream\.([a-z0-9][a-z0-9_-]*)\.([a-zA-Z0-9_.]+)\}\}/g;
 
+/**
+ * Extract upstream node IDs referenced in template text.
+ * Supports both {{upstream.<id>.result}} and {{upstream.<id>.<field>}}.
+ */
 export function extractUpstreamReferences(text: string): Set<string> {
   const out = new Set<string>();
   for (const m of text.matchAll(UPSTREAM_REF_RE)) {
@@ -314,14 +319,14 @@ export const agentV2Schema = z.object({
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             path: basePath,
-            message: `Template references {{upstream.${ref}.result}} but "${ref}" is not a node in this agent.`,
+            message: `Template references upstream node "${ref}" but "${ref}" is not a node in this agent.`,
           });
         } else if (!deps.has(ref)) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             path: basePath,
             message:
-              `Template references {{upstream.${ref}.result}} but "${node.id}" does not declare ` +
+              `Template references upstream node "${ref}" but "${node.id}" does not declare ` +
               `"${ref}" in its dependsOn list. Add "${ref}" to dependsOn so the executor knows the order.`,
           });
         }

--- a/packages/core/src/discovery-catalog.ts
+++ b/packages/core/src/discovery-catalog.ts
@@ -38,7 +38,11 @@ const NODE_TYPES = `
 - branch: Merge node. Collects outputs from multiple dependsOn upstreams into { merged, count }.
 - end: Terminate flow cleanly. Optional endMessage.
 - break: Exit loop iteration early. Optional endMessage.
-- Edge conditions: Any node can have onlyIf: { upstream, field, equals/notEquals/exists } to conditionally skip.`.trim();
+- Edge conditions: Any node can have onlyIf: { upstream, field, equals/notEquals/exists } to conditionally skip.
+UPSTREAM DATA FLOW:
+- Shell nodes: $UPSTREAM_<NODEID>_RESULT env var (full output). Field extraction: pipe through jq.
+- Claude-code nodes: {{upstream.<nodeId>.result}} (full output) OR {{upstream.<nodeId>.<field>}} (JSON dot-path extraction).
+  Example: {{upstream.fetch.headline}} extracts the "headline" field from fetch's JSON output.`.trim();
 
 const OUTPUT_WIDGETS = `
 ## OUTPUT WIDGET TYPES (outputWidget: in agent YAML)

--- a/packages/core/src/node-templates.ts
+++ b/packages/core/src/node-templates.ts
@@ -1,29 +1,56 @@
 /**
- * Template resolution for `{{upstream.<id>.result}}` and `{{vars.<NAME>}}`
- * tokens in node prompts and env values. Extracted from dag-executor.ts.
+ * Template resolution for `{{upstream.<id>.result}}`, `{{upstream.<id>.<field>}}`,
+ * and `{{vars.<NAME>}}` tokens in node prompts and env values.
+ * Extracted from dag-executor.ts.
  */
 
-import { extractUpstreamReferences } from './agent-v2-schema.js';
-
 /**
- * Substitute `{{upstream.<id>.result}}` tokens in a text blob. Deliberately
- * kept tiny and greedy — we rely on schema-time validation to guarantee
- * every reference resolves.
+ * Substitute upstream templates in a text blob. Supports:
+ *   - {{upstream.<id>.result}} — full raw output (original behavior)
+ *   - {{upstream.<id>.<field>}} — dot-path extraction from JSON output
+ *
+ * When a field path (not "result") is used, the resolver tries to parse the
+ * upstream output as JSON and extract the field. Falls back to empty string
+ * if the output isn't JSON or the field doesn't exist.
  */
 export function resolveUpstreamTemplate(text: string, snapshot: Record<string, string>): string {
   if (!text.includes('{{upstream.')) return text;
-  const refs = extractUpstreamReferences(text);
-  let out = text;
-  for (const id of refs) {
-    const value = snapshot[id] ?? '';
-    // Escape {{ in the substituted value so the inputs resolver that runs
-    // afterwards can't re-expand it as a second template layer. Same
-    // defense the v1 chain-resolver ships (chain-resolver.ts:120-125).
-    const safe = value.replace(/\{\{/g, '{ {');
-    // Use a simple literal replace; the ref format is fixed.
-    out = out.split(`{{upstream.${id}.result}}`).join(safe);
+
+  // Match all {{upstream.nodeId.path}} references.
+  const REF_RE = /\{\{upstream\.([a-z0-9][a-z0-9_-]*)\.([a-zA-Z0-9_.]+)\}\}/g;
+
+  return text.replace(REF_RE, (_match, nodeId: string, fieldPath: string) => {
+    const raw = snapshot[nodeId] ?? '';
+    const safe = (v: string) => v.replace(/\{\{/g, '{ {');
+
+    // {{upstream.X.result}} — return full output (backward compat).
+    if (fieldPath === 'result') return safe(raw);
+
+    // Try JSON dot-path extraction.
+    try {
+      const parsed = JSON.parse(raw);
+      if (typeof parsed === 'object' && parsed !== null) {
+        const value = dotGet(parsed, fieldPath);
+        if (value !== undefined) {
+          return safe(typeof value === 'string' ? value : JSON.stringify(value));
+        }
+      }
+    } catch { /* not JSON, fall through */ }
+
+    // Fallback: return empty string (field not found).
+    return '';
+  });
+}
+
+/** Walk a dot-path into a nested object. */
+function dotGet(obj: unknown, path: string): unknown {
+  const parts = path.split('.');
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (current === null || current === undefined) return undefined;
+    current = (current as Record<string, unknown>)[part];
   }
-  return out;
+  return current;
 }
 
 /**


### PR DESCRIPTION
## Summary

`{{upstream.nodeId.field}}` now extracts a specific field from the upstream node's JSON output. Previously only `{{upstream.nodeId.result}}` worked (returning the full raw output).

This fixes agents like graphics-creator that reference specific JSON fields from upstream nodes (e.g. `{{upstream.write-draft.headline}}`).

- Updated regex in agent-v2-schema.ts to match any dot-path, not just `.result`
- Updated `resolveUpstreamTemplate` in node-templates.ts with `dotGet` JSON extraction
- Schema validation still requires the referenced node to be in `dependsOn`
- Falls back to empty string if upstream output isn't JSON or field doesn't exist
- Updated discovery catalog to document the syntax

## Test plan

- [x] 607 tests pass (1 new test for dot-path extraction)
- [ ] Run graphics-creator agent — `render-graphic` node should now receive actual values for `{{upstream.write-draft.headline}}` etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)