### PR TITLE
fix: preserve all agent fields (outputWidget, signal, etc.) on save

### DIFF
--- a/packages/dashboard/src/routes/agent-inputs.ts
+++ b/packages/dashboard/src/routes/agent-inputs.ts
@@ -118,19 +118,7 @@ agentInputsRouter.post('/agents/:name/inputs/update', (req: Request, res: Respon
   try {
     ctx.agentStore.createNewVersion(
       agent.id,
-      {
-        id: agent.id,
-        name: agent.name,
-        description: agent.description,
-        status: agent.status,
-        schedule: agent.schedule,
-        source: agent.source,
-        mcp: agent.mcp,
-        nodes: agent.nodes,
-        inputs: merged && Object.keys(merged).length > 0 ? merged : undefined,
-        author: agent.author,
-        tags: agent.tags,
-      },
+      { ...agent, inputs: merged && Object.keys(merged).length > 0 ? merged : undefined },
       'dashboard',
       'Updated input defaults via dashboard',
     );

--- a/packages/dashboard/src/routes/agent-nodes.ts
+++ b/packages/dashboard/src/routes/agent-nodes.ts
@@ -131,16 +131,7 @@ agentNodesRouter.post('/agents/:name/add-node', (req: Request, res: Response) =>
 
   try {
     ctx.agentStore.upsertAgent(
-      {
-        id: agent.id,
-        name: agent.name,
-        description: agent.description,
-        status: agent.status,
-        schedule: agent.schedule,
-        source: agent.source,
-        mcp: agent.mcp,
-        nodes: [...agent.nodes, newNode],
-      },
+      { ...agent, nodes: [...agent.nodes, newNode] },
       'dashboard',
       `Added node "${values.id}" via dashboard`,
     );
@@ -254,19 +245,7 @@ agentNodesRouter.post('/agents/:name/nodes/:nodeId/edit', (req: Request, res: Re
   try {
     ctx.agentStore.createNewVersion(
       agent.id,
-      {
-        id: agent.id,
-        name: agent.name,
-        description: agent.description,
-        status: agent.status,
-        schedule: agent.schedule,
-        source: agent.source,
-        mcp: agent.mcp,
-        nodes: updatedNodes,
-        inputs: mergeNewInput(agent.inputs, body),
-        author: agent.author,
-        tags: agent.tags,
-      },
+      { ...agent, nodes: updatedNodes, inputs: mergeNewInput(agent.inputs, body) },
       'dashboard',
       `Edited node "${nodeId}"`,
     );
@@ -315,19 +294,7 @@ agentNodesRouter.post('/agents/:name/nodes/:nodeId/delete', (req: Request, res: 
   try {
     ctx.agentStore.createNewVersion(
       agent.id,
-      {
-        id: agent.id,
-        name: agent.name,
-        description: agent.description,
-        status: agent.status,
-        schedule: agent.schedule,
-        source: agent.source,
-        mcp: agent.mcp,
-        nodes: updatedNodes,
-        inputs: agent.inputs,
-        author: agent.author,
-        tags: agent.tags,
-      },
+      { ...agent, nodes: updatedNodes },
       'dashboard',
       `Deleted node "${nodeId}"`,
     );

--- a/packages/dashboard/src/routes/versions.ts
+++ b/packages/dashboard/src/routes/versions.ts
@@ -93,19 +93,7 @@ versionsRouter.post('/agents/:id/rollback', (req: Request, res: Response) => {
     // the DAG, so they carry over unchanged on rollback).
     ctx.agentStore.createNewVersion(
       id,
-      {
-        id: agent.id,
-        name: agent.name,
-        description: agent.description,
-        status: agent.status,
-        schedule: agent.schedule,
-        source: agent.source,
-        mcp: agent.mcp,
-        nodes: targetVersion.dag.nodes,
-        inputs: targetVersion.dag.inputs,
-        author: targetVersion.dag.author,
-        tags: targetVersion.dag.tags,
-      },
+      { ...agent, ...targetVersion.dag },
       'dashboard',
       `Rollback to v${target}`,
     );


### PR DESCRIPTION
## Summary

All agent save paths manually constructed the agent object by listing individual fields, and forgot `outputWidget`, `signal`, or both:

| Route | Action | Was missing |
|-------|--------|-------------|
| `POST /agents/:name/add-node` | Add a node | outputWidget, signal, inputs, tags |
| `POST /agents/:name/nodes/:id/edit` | Edit a node | outputWidget, signal |
| `POST /agents/:name/nodes/:id/delete` | Delete a node | outputWidget, signal |
| `POST /agents/:name/inputs/update` | Update inputs | outputWidget, signal |
| `POST /agents/:name/versions/:v/rollback` | Rollback version | outputWidget, signal |

Now all paths use `{ ...agent, <changed fields> }` so every field is preserved. 5 insertions, 62 deletions — less code, more correct.

This was the root cause of outputWidget being wiped after suggest improvements applied changes.

## Test plan

- [x] 607 tests pass
- [ ] Apply suggest improvements with outputWidget → widget survives on agent detail page
- [ ] Edit a node → outputWidget and signal still present
- [ ] Delete a node → same
- [ ] Rollback to a prior version → outputWidget preserved if it was in that version

🤖 Generated with [Claude Code](https://claude.com/claude-code)