### PR TITLE
feat: file preview widget type + /output-file serving route

### DIFF
--- a/packages/core/src/discovery-catalog.ts
+++ b/packages/core/src/discovery-catalog.ts
@@ -50,8 +50,8 @@ Use when the agent produces structured JSON. The widget renders on the agent det
 - dashboard: Hero metric + stats grid. Field types: metric (big number), stat (compact label+value), badge (pill), text.
 - key-value: Labeled pairs as definition list. Field types: text, code, badge.
 - diff-apply: Review/analysis with actions. Field types: text, code, badge. Supports actions (buttons that POST).
-- raw: Sectioned fallback for mixed content. Field types: text, code.
-Field type tips: Use metric for the single most important number. Use stat for supporting numbers. Use badge for status/category.`.trim();
+- raw: Sectioned fallback for mixed content. Field types: text, code, preview.
+Field type tips: Use metric for the single most important number. Use stat for supporting numbers. Use badge for status/category. Use preview for file paths (renders HTML/images in a sandboxed iframe).`.trim();
 
 const PATTERNS = `
 ## ARCHITECTURE PATTERNS

--- a/packages/core/src/output-widget-schema.ts
+++ b/packages/core/src/output-widget-schema.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 export const widgetFieldSchema = z.object({
   name: z.string().min(1),
   label: z.string().optional(),
-  type: z.enum(['text', 'code', 'badge', 'action', 'metric', 'stat']),
+  type: z.enum(['text', 'code', 'badge', 'action', 'metric', 'stat', 'preview']),
 });
 
 export const widgetActionSchema = z.object({

--- a/packages/core/src/output-widget-types.ts
+++ b/packages/core/src/output-widget-types.ts
@@ -6,8 +6,9 @@
 
 /** Field type determines rendering: text is plain, code gets monospace+scroll,
  *  badge gets a colored pill, action renders a button, metric renders a big number,
- *  stat renders a compact label+value pair in a grid. */
-export type WidgetFieldType = 'text' | 'code' | 'badge' | 'action' | 'metric' | 'stat';
+ *  stat renders a compact label+value pair in a grid, preview renders a file
+ *  in a sandboxed iframe via the /output-file route. */
+export type WidgetFieldType = 'text' | 'code' | 'badge' | 'action' | 'metric' | 'stat' | 'preview';
 
 export interface WidgetField {
   /** Key in the structured output to extract this field from. */

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -32,6 +32,7 @@ import { buildRouter } from './routes/run-now-build.js';
 import { runMutationsRouter } from './routes/run-mutations.js';
 import { toolsRouter } from './routes/tools.js';
 import { assetsRouter } from './routes/assets.js';
+import { outputFilesRouter } from './routes/output-files.js';
 import { settingsRouter } from './routes/settings.js';
 import { helpRouter } from './routes/help.js';
 import { versionsRouter } from './routes/versions.js';
@@ -107,6 +108,9 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
 
   // Everything below requires the session cookie.
   app.use(requireAuth);
+
+  // Serve agent output files from allowlisted directories.
+  app.use(outputFilesRouter);
 
   // Home page with today's stats + recent activity (paginated).
   app.get('/', (req, res) => {

--- a/packages/dashboard/src/routes/output-files.ts
+++ b/packages/dashboard/src/routes/output-files.ts
@@ -1,0 +1,126 @@
+/**
+ * Serve agent output files from allowlisted directories.
+ * Used by the 'preview' widget field type to render HTML/image outputs inline.
+ *
+ * Security: only serves files from explicitly allowlisted directories.
+ * Path traversal is blocked by resolving to absolute paths and checking
+ * the resolved path starts with an allowed directory.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { resolve, extname } from 'node:path';
+
+export const outputFilesRouter: Router = Router();
+
+/** Default allowlisted directories for agent output files. */
+const DEFAULT_ALLOWED_DIRS = [
+  './graphics-output',
+  './output',
+  './agent-output',
+  '/tmp/graphics-output',
+  '/private/tmp/graphics-output',
+];
+
+const MIME_TYPES: Record<string, string> = {
+  '.html': 'text/html',
+  '.htm': 'text/html',
+  '.css': 'text/css',
+  '.js': 'application/javascript',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.pdf': 'application/pdf',
+  '.txt': 'text/plain',
+  '.md': 'text/plain',
+  '.csv': 'text/csv',
+};
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+let resolvedAllowed: string[] | null = null;
+
+function getAllowedDirs(): string[] {
+  if (resolvedAllowed) return resolvedAllowed;
+  resolvedAllowed = DEFAULT_ALLOWED_DIRS
+    .map((d) => resolve(d))
+    .filter((d) => existsSync(d));
+  return resolvedAllowed;
+}
+
+/**
+ * Add a directory to the allowlist at runtime (e.g. from agent config).
+ */
+export function addAllowedOutputDir(dir: string): void {
+  const abs = resolve(dir);
+  resolvedAllowed = null; // reset cache
+  if (!DEFAULT_ALLOWED_DIRS.includes(dir) && !DEFAULT_ALLOWED_DIRS.includes(abs)) {
+    DEFAULT_ALLOWED_DIRS.push(abs);
+  }
+}
+
+/**
+ * Check if a resolved file path is inside an allowed directory.
+ */
+function isAllowed(filePath: string): boolean {
+  const abs = resolve(filePath);
+  return getAllowedDirs().some((dir) => abs.startsWith(dir + '/') || abs === dir);
+}
+
+/**
+ * GET /output-file?path=<absolute-or-relative-path>
+ * Serves the file if it's inside an allowlisted directory.
+ */
+outputFilesRouter.get('/output-file', (req: Request, res: Response) => {
+  const rawPath = typeof req.query.path === 'string' ? req.query.path : '';
+
+  if (!rawPath) {
+    res.status(400).type('text/plain').send('Missing ?path= parameter');
+    return;
+  }
+
+  const absPath = resolve(rawPath);
+
+  // Security: check allowlist.
+  if (!isAllowed(absPath)) {
+    res.status(403).type('text/plain').send(
+      `File not in an allowed directory. Allowed: ${getAllowedDirs().join(', ')}`,
+    );
+    return;
+  }
+
+  // Check file exists and is a regular file.
+  if (!existsSync(absPath)) {
+    res.status(404).type('text/plain').send('File not found');
+    return;
+  }
+  const stat = statSync(absPath);
+  if (!stat.isFile()) {
+    res.status(400).type('text/plain').send('Not a file');
+    return;
+  }
+  if (stat.size > MAX_FILE_SIZE) {
+    res.status(413).type('text/plain').send('File too large (max 10MB)');
+    return;
+  }
+
+  const ext = extname(absPath).toLowerCase();
+  const contentType = MIME_TYPES[ext] ?? 'application/octet-stream';
+
+  try {
+    const content = readFileSync(absPath);
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    // Sandbox HTML files to prevent script execution in the dashboard context.
+    if (ext === '.html' || ext === '.htm') {
+      res.setHeader('Content-Security-Policy', "default-src 'none'; style-src 'unsafe-inline'; img-src data: https:;");
+    }
+    res.type(contentType).send(content);
+  } catch {
+    res.status(500).type('text/plain').send('Error reading file');
+  }
+});

--- a/packages/dashboard/src/views/output-widgets.ts
+++ b/packages/dashboard/src/views/output-widgets.ts
@@ -77,6 +77,40 @@ function extractFields(
 }
 
 /**
+ * Render a file preview iframe for a 'preview' field type. The value should
+ * be a file path that gets served via GET /output-file?path=<path>.
+ */
+function renderPreview(label: string, filePath: string): SafeHtml {
+  if (!filePath) return html`<p class="dim" style="font-size: var(--font-size-xs);">No file path</p>`;
+  const encodedPath = encodeURIComponent(filePath);
+  const lower = filePath.toLowerCase();
+  const isImage = /\.(png|jpe?g|gif|svg|webp|bmp)$/.test(lower);
+
+  const header = html`
+    <div style="display: flex; align-items: center; gap: var(--space-2); margin-bottom: var(--space-2);">
+      <h4 style="font-size: var(--font-size-xs); color: var(--color-text-muted); margin: 0;">${label}</h4>
+      <a href="/output-file?path=${encodedPath}" target="_blank" rel="noopener" style="font-size: var(--font-size-xs); color: var(--color-primary);">Open in tab \u2197</a>
+    </div>
+  `;
+
+  if (isImage) {
+    return html`
+      <section style="margin-bottom: var(--space-3);">
+        ${header}
+        <img src="/output-file?path=${encodedPath}" alt="${label}" style="max-width: 100%; border-radius: var(--radius-sm); border: 1px solid var(--color-border);" loading="lazy">
+      </section>
+    `;
+  }
+
+  return html`
+    <section style="margin-bottom: var(--space-3);">
+      ${header}
+      <iframe src="/output-file?path=${encodedPath}" sandbox="allow-same-origin" style="width: 100%; height: 400px; border: 1px solid var(--color-border); border-radius: var(--radius-sm); background: #fff;"></iframe>
+    </section>
+  `;
+}
+
+/**
  * Render a widget from an agent's outputWidget schema and run output.
  * Returns undefined if the schema type is unknown.
  */
@@ -194,6 +228,9 @@ function renderKeyValue(
     .map((f) => {
       const value = fields[f.name] ?? '';
       const label = f.label ?? f.name;
+      if (f.type === 'preview') {
+        return renderPreview(label, value);
+      }
       if (f.type === 'badge') {
         return html`<dt>${label}</dt><dd><span class="badge">${value}</span></dd>`;
       }
@@ -223,6 +260,9 @@ function renderRaw(
     .map((f) => {
       const value = fields[f.name] ?? '';
       const label = f.label ?? f.name;
+      if (f.type === 'preview') {
+        return renderPreview(label, value);
+      }
       if (f.type === 'code') {
         return html`
           <section style="margin-bottom: var(--space-3);">
@@ -297,6 +337,8 @@ function renderDashboard(
           <div style="font-size: var(--font-size-xs); color: var(--color-text-muted); margin-top: 2px;">${label}</div>
         </div>
       `);
+    } else if (f.type === 'preview') {
+      texts.push(renderPreview(label, value));
     } else {
       texts.push(html`
         <div style="font-size: var(--font-size-sm); color: var(--color-text-muted);">


### PR DESCRIPTION
## Summary

New `preview` widget field type that renders agent output files inline on the dashboard:

- **HTML files** → sandboxed iframe (400px, white background, CSP-locked)
- **Images** (png, jpg, gif, svg, webp) → `<img>` tag with lazy loading
- **"Open in tab"** link on every preview for full-screen viewing

### Route: `GET /output-file?path=<path>`

Serves files from **allowlisted directories only**:
- `./graphics-output`, `./output`, `./agent-output`
- `/tmp/graphics-output`, `/private/tmp/graphics-output`

Security:
- Resolves to absolute path, checks it starts with an allowed directory prefix
- `X-Content-Type-Options: nosniff`
- CSP sandbox on HTML: `default-src 'none'; style-src 'unsafe-inline'; img-src data: https:`
- 10MB max file size
- Requires auth (behind `requireAuth` middleware)

### Usage

In agent YAML `outputWidget`:
```yaml
outputWidget:
  type: raw
  fields:
    - name: output_path
      label: Generated Graphic
      type: preview
```

The `output_path` field value should be the file path produced by the agent.

## Test plan

- [x] 607 tests pass
- [ ] Run graphics-creator → update widget to use `type: preview` on output_path → see rendered HTML in iframe
- [ ] Agent producing an image → see inline image preview
- [ ] Try path traversal (`../../etc/passwd`) → get 403
- [ ] "Open in tab" link opens file in new browser tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)