### PR TITLE
feat: output widget editor on agent config page

### DIFF
--- a/packages/dashboard/src/routes/agent-inputs.ts
+++ b/packages/dashboard/src/routes/agent-inputs.ts
@@ -1,5 +1,5 @@
 import { Router, type Request, type Response } from 'express';
-import type { AgentInputSpec } from '@some-useful-agents/core';
+import type { AgentInputSpec, OutputWidgetSchema, OutputWidgetType, WidgetFieldType } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 import { mergeNewInput } from './agent-nodes.js';
 
@@ -126,5 +126,80 @@ agentInputsRouter.post('/agents/:name/inputs/update', (req: Request, res: Respon
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/config?flash=${encodeURIComponent(`Save failed: ${msg}`)}#variables`);
+  }
+});
+
+// ── Output widget update ────────────────────────────────────────────────
+
+const VALID_WIDGET_TYPES = new Set<string>(['dashboard', 'key-value', 'diff-apply', 'raw']);
+const VALID_FIELD_TYPES = new Set<string>(['text', 'code', 'badge', 'action', 'metric', 'stat', 'preview']);
+
+agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
+  const agent = ctx.agentStore.getAgent(name);
+  if (!agent) {
+    res.status(404).redirect(303, '/agents');
+    return;
+  }
+
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const action = typeof body.action === 'string' ? body.action : 'save';
+
+  // Remove widget.
+  if (action === 'remove') {
+    try {
+      ctx.agentStore.createNewVersion(
+        agent.id,
+        { ...agent, outputWidget: undefined },
+        'dashboard',
+        'Removed output widget via dashboard',
+      );
+      res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/config?flash=${encodeURIComponent('Output widget removed.')}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/config?flash=${encodeURIComponent(`Failed: ${msg}`)}`);
+    }
+    return;
+  }
+
+  // Save widget.
+  const widgetType = typeof body.widgetType === 'string' ? body.widgetType : 'raw';
+  if (!VALID_WIDGET_TYPES.has(widgetType)) {
+    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/config?flash=${encodeURIComponent('Invalid widget type.')}`);
+    return;
+  }
+
+  // Collect fields from the form (fieldName_0, fieldLabel_0, fieldType_0, etc.).
+  const fields: OutputWidgetSchema['fields'] = [];
+  for (let i = 0; i < 50; i++) {
+    const fieldName = body[`fieldName_${i}`];
+    const fieldLabel = body[`fieldLabel_${i}`];
+    const fieldType = body[`fieldType_${i}`];
+    if (typeof fieldName !== 'string' || !fieldName.trim()) continue;
+    const ft = typeof fieldType === 'string' && VALID_FIELD_TYPES.has(fieldType) ? fieldType : 'text';
+    fields.push({
+      name: fieldName.trim(),
+      ...(typeof fieldLabel === 'string' && fieldLabel.trim() ? { label: fieldLabel.trim() } : {}),
+      type: ft as WidgetFieldType,
+    });
+  }
+
+  const outputWidget: OutputWidgetSchema = {
+    type: widgetType as OutputWidgetType,
+    fields,
+  };
+
+  try {
+    ctx.agentStore.createNewVersion(
+      agent.id,
+      { ...agent, outputWidget },
+      'dashboard',
+      'Updated output widget via dashboard',
+    );
+    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/config?flash=${encodeURIComponent('Output widget saved. New version created.')}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/config?flash=${encodeURIComponent(`Save failed: ${msg}`)}`);
   }
 });

--- a/packages/dashboard/src/views/agent-detail-helpers.ts
+++ b/packages/dashboard/src/views/agent-detail-helpers.ts
@@ -3,7 +3,7 @@
  * Extracted from agent-detail-v2.ts.
  */
 
-import type { Agent } from '@some-useful-agents/core';
+import type { Agent, OutputWidgetType, WidgetFieldType } from '@some-useful-agents/core';
 import { html, unsafeHtml, type SafeHtml } from './html.js';
 
 // ── Run inputs form ─────────────────────────────────────────────────────
@@ -118,6 +118,78 @@ export function renderVariablesEditor(agent: Agent): SafeHtml {
         <button type="submit" class="btn btn--primary btn--sm">Save variables</button>
       </div>
     </form>
+  `;
+}
+
+// ── Output widget editor ────────────────────────────────────────────────
+
+const WIDGET_TYPES: OutputWidgetType[] = ['dashboard', 'key-value', 'diff-apply', 'raw'];
+const FIELD_TYPES: WidgetFieldType[] = ['text', 'code', 'badge', 'metric', 'stat', 'preview', 'action'];
+
+function widgetTypeSelect(current: string): string {
+  const opts = WIDGET_TYPES.map((t) =>
+    `<option value="${t}"${t === current ? ' selected' : ''}>${t}</option>`
+  ).join('');
+  return `<select name="widgetType" style="padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs);">${opts}</select>`;
+}
+
+function fieldTypeSelect(name: string, current: string): string {
+  const opts = FIELD_TYPES.map((t) =>
+    `<option value="${t}"${t === current ? ' selected' : ''}>${t}</option>`
+  ).join('');
+  return `<select name="${name}" style="padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs);">${opts}</select>`;
+}
+
+export function renderOutputWidgetEditor(agent: Agent): SafeHtml {
+  const widget = agent.outputWidget;
+  const FIELD = 'padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs);';
+
+  const fieldRows = (widget?.fields ?? []).map((f, i) => unsafeHtml(`
+    <tr>
+      <td><input type="text" name="fieldName_${i}" value="${f.name}" style="${FIELD} font-family: var(--font-mono); width: 8rem;"></td>
+      <td><input type="text" name="fieldLabel_${i}" value="${f.label ?? ''}" placeholder="${f.name}" style="${FIELD} width: 8rem;"></td>
+      <td>${fieldTypeSelect(`fieldType_${i}`, f.type)}</td>
+      <td><button type="button" class="btn btn--ghost btn--sm" style="padding: 2px 6px; font-size: var(--font-size-xs); color: var(--color-err);" onclick="this.closest('tr').remove();">\u00D7</button></td>
+    </tr>
+  `));
+
+  return html`
+    <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-3);">
+      Controls how run output renders on the agent detail page. Use <code>preview</code> type for file paths (renders HTML/images inline).
+    </p>
+    <form method="POST" action="/agents/${agent.id}/output-widget/update">
+      <div style="display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-3);">
+        <label style="font-size: var(--font-size-xs); color: var(--color-text-muted); font-weight: var(--weight-medium);">Widget type</label>
+        ${unsafeHtml(widgetTypeSelect(widget?.type ?? 'raw'))}
+      </div>
+      <table class="table" style="font-size: var(--font-size-xs); margin-bottom: var(--space-3);">
+        <thead><tr><th>Field name</th><th>Label</th><th>Type</th><th></th></tr></thead>
+        <tbody id="widget-fields">
+          ${fieldRows as unknown as SafeHtml[]}
+        </tbody>
+      </table>
+      <div style="display: flex; gap: var(--space-2); justify-content: space-between; align-items: center;">
+        <button type="button" class="btn btn--ghost btn--sm" id="add-widget-field-btn">+ Add field</button>
+        <div style="display: flex; gap: var(--space-2);">
+          ${widget ? html`<button type="submit" name="action" value="remove" class="btn btn--ghost btn--sm" style="color: var(--color-err);">Remove widget</button>` : html``}
+          <button type="submit" name="action" value="save" class="btn btn--primary btn--sm">Save widget</button>
+        </div>
+      </div>
+    </form>
+    ${unsafeHtml(`<script>
+      document.getElementById('add-widget-field-btn')?.addEventListener('click', function() {
+        var tbody = document.getElementById('widget-fields');
+        var idx = tbody.rows.length;
+        var tr = document.createElement('tr');
+        var typeOpts = ${JSON.stringify(FIELD_TYPES)}.map(function(t) { return '<option value="' + t + '">' + t + '</option>'; }).join('');
+        tr.innerHTML =
+          '<td><input type="text" name="fieldName_' + idx + '" placeholder="field_name" style="padding:var(--space-1) var(--space-2);border:1px solid var(--color-border-strong);border-radius:var(--radius-sm);font-size:var(--font-size-xs);font-family:var(--font-mono);width:8rem;"></td>' +
+          '<td><input type="text" name="fieldLabel_' + idx + '" placeholder="Label" style="padding:var(--space-1) var(--space-2);border:1px solid var(--color-border-strong);border-radius:var(--radius-sm);font-size:var(--font-size-xs);width:8rem;"></td>' +
+          '<td><select name="fieldType_' + idx + '" style="padding:var(--space-1) var(--space-2);border:1px solid var(--color-border-strong);border-radius:var(--radius-sm);font-size:var(--font-size-xs);">' + typeOpts + '</select></td>' +
+          '<td><button type="button" class="btn btn--ghost btn--sm" style="padding:2px 6px;font-size:var(--font-size-xs);color:var(--color-err);" onclick="this.closest(\\'tr\\').remove();">\\u00D7</button></td>';
+        tbody.appendChild(tr);
+      });
+    </script>`)}
   `;
 }
 

--- a/packages/dashboard/src/views/agent-detail-v2.ts
+++ b/packages/dashboard/src/views/agent-detail-v2.ts
@@ -19,6 +19,7 @@ import { renderOutputWidget } from './output-widgets.js';
 import {
   renderRunInputsForm,
   renderVariablesEditor,
+  renderOutputWidgetEditor,
   vStatusBadge,
   statusOption,
   providerOption,
@@ -335,6 +336,12 @@ export async function renderAgentConfig(args: AgentDetailArgs): Promise<string> 
     <section class="card" style="margin-bottom: var(--space-6);">
       <h3 style="margin: 0 0 var(--space-3);">Variables</h3>
       ${renderVariablesEditor(agent)}
+    </section>
+
+    <!-- Output Widget -->
+    <section class="card" style="margin-bottom: var(--space-6);">
+      <h3 style="margin: 0 0 var(--space-3);">Output Widget</h3>
+      ${renderOutputWidgetEditor(agent)}
     </section>
 
     <!-- Secrets -->


### PR DESCRIPTION
## Summary

New "Output Widget" section on the agent Config tab, below Variables:

- **Widget type picker**: dropdown with dashboard, key-value, diff-apply, raw
- **Field table**: editable rows with name (mono input), label, and type dropdown
- **Type dropdown** includes all 7 types: text, code, badge, metric, stat, preview, action
- **Add/remove fields**: "+ Add field" button appends a row, × button removes one
- **Remove widget**: red button to clear the entire outputWidget
- **Saves as new version** via `POST /agents/:name/output-widget/update`

This is part A of the widget editor plan. For part B, run suggest improvements on graphics-creator with focus "change output_path to type preview" to fix it immediately.

## Test plan

- [x] 607 tests pass
- [ ] Agent Config tab shows "Output Widget" section
- [ ] Add fields, set types (including `preview`), save → widget appears on Overview
- [ ] Remove widget → "Output widget" section on Overview disappears
- [ ] Existing agents with widgets: fields pre-populated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)