### PR TITLE
fix: loosen CSP on output-file HTML preview

### DIFF
--- a/packages/dashboard/src/routes/output-files.ts
+++ b/packages/dashboard/src/routes/output-files.ts
@@ -115,9 +115,14 @@ outputFilesRouter.get('/output-file', (req: Request, res: Response) => {
     const content = readFileSync(absPath);
     res.setHeader('Cache-Control', 'no-cache');
     res.setHeader('X-Content-Type-Options', 'nosniff');
-    // Sandbox HTML files to prevent script execution in the dashboard context.
+    // Allow HTML files to render with inline styles, fonts, and images.
+    // These are user-generated output files, not untrusted third-party content.
     if (ext === '.html' || ext === '.htm') {
-      res.setHeader('Content-Security-Policy', "default-src 'none'; style-src 'unsafe-inline'; img-src data: https:;");
+      res.setHeader('Content-Security-Policy',
+        "default-src 'none'; style-src 'unsafe-inline' https://fonts.googleapis.com; " +
+        "font-src https://fonts.gstatic.com; " +
+        "img-src data: https: http:; " +
+        "connect-src 'none'; script-src 'none';");
     }
     res.type(contentType).send(content);
   } catch {


### PR DESCRIPTION
## Summary

The preview iframe showed "This content is blocked" because the CSP on `/output-file` was `default-src 'none'`. Generated HTML graphics use Google Fonts, inline styles, and data URI images.

Updated CSP to allow fonts and images while keeping scripts blocked:
- `style-src: 'unsafe-inline' https://fonts.googleapis.com`
- `font-src: https://fonts.gstatic.com`
- `img-src: data: https: http:`
- `script-src: 'none'` (still no JS execution)
- `connect-src: 'none'` (no network requests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)