### PR TITLE
fix: auto-repair broken template syntax from escaped braces

### DIFF
--- a/packages/dashboard/src/routes/run-now-build.ts
+++ b/packages/dashboard/src/routes/run-now-build.ts
@@ -87,7 +87,23 @@ function autoFixYaml(yaml: string): string {
       changed = true;
     }
 
-    // Fix 6: conditional nodes missing conditionalConfig — add a default.
+    // Fix 6: repair broken template syntax in claude-code prompts.
+    // The escape function in resolveUpstreamTemplate converts {{ to { {
+    // to prevent re-expansion. If an LLM or round-trip saves this escaped
+    // form, fix it back so templates resolve at runtime.
+    if (raw.nodes && Array.isArray(raw.nodes)) {
+      for (const n of raw.nodes) {
+        if (n.type === 'claude-code' && typeof n.prompt === 'string') {
+          const fixed = n.prompt
+            .replace(/\{ \{upstream\./g, '{{upstream.')
+            .replace(/\{ \{inputs\./g, '{{inputs.')
+            .replace(/\{ \{vars\./g, '{{vars.');
+          if (fixed !== n.prompt) { n.prompt = fixed; changed = true; }
+        }
+      }
+    }
+
+    // Fix 7: conditional nodes missing conditionalConfig — add a default.
     if (raw.nodes && Array.isArray(raw.nodes)) {
       for (const n of raw.nodes) {
         if (n.type === 'conditional' && !n.conditionalConfig) {


### PR DESCRIPTION
## Summary

The template resolver escapes `{{` to `{ {` in substituted values to prevent re-expansion. When the suggest improvements AI round-trips YAML through the analyzer, this escaped form gets saved permanently to the agent YAML, breaking all template resolution.

The graphics-creator agent hit this: prompts had `{ {upstream.validate-draft.headline}}` instead of `{{upstream.validate-draft.headline}}`, so Claude received literal placeholder text instead of actual values.

New auto-fix #6: detects and repairs `{ {upstream.`, `{ {inputs.`, `{ {vars.` back to correct double-brace syntax in claude-code node prompts.

## Test plan

- [x] 607 tests pass
- [ ] Run suggest improvements on an agent → apply → templates still work
- [ ] graphics-creator: re-run suggest improvements to fix the stored broken templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)