### PR TITLE
fix: don't filter output file allowlist by existence at startup

### DIFF
--- a/packages/dashboard/src/routes/output-files.ts
+++ b/packages/dashboard/src/routes/output-files.ts
@@ -46,9 +46,9 @@ let resolvedAllowed: string[] | null = null;
 
 function getAllowedDirs(): string[] {
   if (resolvedAllowed) return resolvedAllowed;
-  resolvedAllowed = DEFAULT_ALLOWED_DIRS
-    .map((d) => resolve(d))
-    .filter((d) => existsSync(d));
+  // Don't filter by existsSync — directories may be created by agents
+  // after the dashboard starts. Existence is checked at request time.
+  resolvedAllowed = DEFAULT_ALLOWED_DIRS.map((d) => resolve(d));
   return resolvedAllowed;
 }
 


### PR DESCRIPTION
## Summary

The `/output-file` allowlist was cached at startup with `existsSync` filter. If an agent creates its output directory on first run (e.g. `./graphics-output`), the directory doesn't exist when the dashboard starts, so it gets excluded. Later requests get 403 "File not in an allowed directory."

Fix: resolve paths without filtering by existence. The file existence check at request time (`existsSync(absPath)`) is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)