### PR TITLE
fix: move output-file behind requireAuth, fix iframe 401

### DIFF
--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -106,26 +106,18 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   // library code and a tiny bootstrap script.
   app.use(assetsRouter);
 
-  // Output files: served before requireAuth because iframes can't handle
-  // auth redirects. The route does its own cookie check inline. Also
-  // overrides X-Frame-Options to allow same-origin embedding.
+  // Everything below requires the session cookie.
+  app.use(requireAuth);
+
+  // Output files: behind requireAuth (so auth works properly), but
+  // removes X-Frame-Options so the preview iframe can embed content.
   app.use((req, res, next) => {
     if (req.path === '/output-file') {
-      // Inline auth: check the session cookie exists.
-      const cookies = req.headers.cookie ?? '';
-      if (!cookies.includes('sua_session=')) {
-        res.status(401).type('text/plain').send('Unauthorized');
-        return;
-      }
-      // Allow iframe embedding for output file previews.
       res.removeHeader('X-Frame-Options');
     }
     next();
   });
   app.use(outputFilesRouter);
-
-  // Everything below requires the session cookie.
-  app.use(requireAuth);
 
   // Home page with today's stats + recent activity (paginated).
   app.get('/', (req, res) => {


### PR DESCRIPTION
## Summary

PR #144 had a broken inline cookie check — it looked for `sua_session` but the actual cookie name is `sua_dashboard_session`. This caused 401 on all output-file requests, breaking the preview iframe.

Fix: put output-file route behind `requireAuth` (proper auth that actually works) and just remove `X-Frame-Options` for `/output-file` paths. The iframe shares the session cookie with the parent page so auth passes naturally.

5 insertions, 13 deletions — simpler and correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)