### PR TITLE
fix: pass toolStore + variablesStore to run-now executor

### DIFF
--- a/packages/dashboard/src/routes/run-now.ts
+++ b/packages/dashboard/src/routes/run-now.ts
@@ -62,6 +62,8 @@ runNowRouter.post('/agents/:name/run', async (req: Request, res: Response) => {
       {
         runStore: ctx.runStore,
         secretsStore: ctx.secretsStore,
+        variablesStore: ctx.variablesStore,
+        toolStore: ctx.toolStore,
         allowUntrustedShell: ctx.allowUntrustedShell,
       },
     );


### PR DESCRIPTION
## Summary

The "Run now" button called `executeAgentDag` without `toolStore` or `variablesStore` in the deps object. This meant:

- **User-defined tools** (like `modern-graphics`) couldn't be resolved — the executor fell through to the legacy path and tried `npx modern-graphics`, failing with npm 404
- **Global variables** weren't injected into agent nodes

Two-line fix: add `toolStore: ctx.toolStore` and `variablesStore: ctx.variablesStore` to the deps.

## Test plan

- [x] 607 tests pass
- [ ] Run graphics-creator → render node invokes modern-graphics tool via Docker
- [ ] Global variables ($MODERN_GRAPHICS_IMAGE, $GRAPHICS_OUTPUT_DIR) resolve in tool command

🤖 Generated with [Claude Code](https://claude.com/claude-code)