### PR TITLE
feat: include failed run errors in suggest improvements + pre-fill run inputs

### DIFF
--- a/packages/dashboard/src/routes/agents.ts
+++ b/packages/dashboard/src/routes/agents.ts
@@ -320,7 +320,24 @@ async function buildTabArgs(req: Request, ctx: ReturnType<typeof getContext>, na
   const { rows } = ctx.runStore.queryRuns({
     agentName: agent.id, limit: 50, offset: 0, statuses: [] as RunStatus[],
   });
-  return { agent, recentRuns: rows, secretsStore: ctx.secretsStore, flash, back, from: fromParam };
+
+  // Extract previous run's agent-level inputs for the Run Now modal.
+  let previousInputs: Record<string, string> | undefined;
+  if (rows.length > 0 && agent.inputs) {
+    try {
+      const execs = ctx.runStore.listNodeExecutions(rows[0].id);
+      if (execs.length > 0 && execs[0].inputsJson) {
+        const allEnv = JSON.parse(execs[0].inputsJson) as Record<string, string>;
+        const inputNames = new Set(Object.keys(agent.inputs));
+        previousInputs = {};
+        for (const [k, v] of Object.entries(allEnv)) {
+          if (inputNames.has(k) && v !== '') previousInputs[k] = v;
+        }
+      }
+    } catch { /* no node executions yet */ }
+  }
+
+  return { agent, recentRuns: rows, secretsStore: ctx.secretsStore, flash, back, from: fromParam, previousInputs };
 }
 
 agentsRouter.get('/agents/:name/nodes', async (req: Request, res: Response) => {

--- a/packages/dashboard/src/routes/run-now-build.ts
+++ b/packages/dashboard/src/routes/run-now-build.ts
@@ -173,15 +173,51 @@ buildRouter.post('/agents/:name/analyze', async (req: Request, res: Response) =>
   const focus = typeof body.focus === 'string' ? body.focus.trim() : '';
   const targetYaml = exportAgent(target);
 
-  // Fetch the most recent completed run for this agent so the analyzer
-  // can consider real execution output (errors, timeouts, etc.).
+  // Fetch the most recent runs (completed AND failed) so the analyzer
+  // can consider real execution output, errors, and timeouts.
   let lastRunOutput = '';
   try {
-    const recent = ctx.runStore.listRuns({ agentName: name, status: 'completed', limit: 1 });
-    if (recent.length > 0 && recent[0].result) {
-      const raw = recent[0].result;
-      // Cap at 2000 chars to keep the prompt focused.
+    // Try completed first.
+    const completed = ctx.runStore.listRuns({ agentName: name, status: 'completed', limit: 1 });
+    if (completed.length > 0 && completed[0].result) {
+      const raw = completed[0].result;
       lastRunOutput = raw.length > 2000 ? raw.slice(0, 2000) + '\n...(truncated)' : raw;
+    }
+
+    // Also check for recent failed runs — include the error so the
+    // analyzer can diagnose what went wrong without the user pasting it.
+    const failed = ctx.runStore.listRuns({ agentName: name, status: 'failed', limit: 1 });
+    if (failed.length > 0) {
+      const f = failed[0];
+      const failedAt = f.completedAt ?? f.startedAt;
+      const completedAt = completed[0]?.completedAt ?? '';
+      // Include if the failure is more recent than the last success.
+      if (!completedAt || failedAt > completedAt) {
+        const errorInfo = [
+          `\n\nMOST RECENT RUN FAILED (${f.id.slice(0, 8)}):`,
+          f.error ? `Error: ${f.error}` : '',
+          f.result ? `Output: ${f.result.slice(0, 1000)}` : '',
+        ].filter(Boolean).join('\n');
+        lastRunOutput += errorInfo;
+
+        // Also include per-node errors from the failed run.
+        try {
+          const execs = ctx.runStore.listNodeExecutions(f.id);
+          const failedNodes = execs.filter((e) => e.status === 'failed');
+          if (failedNodes.length > 0) {
+            lastRunOutput += '\n\nFailed nodes:';
+            for (const e of failedNodes) {
+              lastRunOutput += `\n- ${e.nodeId}: ${e.error ?? 'no error message'}`;
+              if (e.result) lastRunOutput += ` | output: ${e.result.slice(0, 200)}`;
+            }
+          }
+        } catch { /* node executions might not exist */ }
+      }
+    }
+
+    // Cap total size.
+    if (lastRunOutput.length > 3000) {
+      lastRunOutput = lastRunOutput.slice(0, 3000) + '\n...(truncated)';
     }
   } catch { /* run store may not have runs yet */ }
 

--- a/packages/dashboard/src/views/agent-detail-helpers.ts
+++ b/packages/dashboard/src/views/agent-detail-helpers.ts
@@ -8,7 +8,7 @@ import { html, unsafeHtml, type SafeHtml } from './html.js';
 
 // ── Run inputs form ─────────────────────────────────────────────────────
 
-export function renderRunInputsForm(agent: Agent, from?: string): SafeHtml {
+export function renderRunInputsForm(agent: Agent, from?: string, previousInputs?: Record<string, string>): SafeHtml {
   const inputs = Object.entries(agent.inputs ?? {});
   const FIELD = 'padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm); font-family: var(--font-mono); width: 100%;';
 
@@ -23,7 +23,9 @@ export function renderRunInputsForm(agent: Agent, from?: string): SafeHtml {
   }
 
   const fields = inputs.map(([name, spec]) => {
-    const defVal = spec.default !== undefined ? String(spec.default) : '';
+    // Previous run's value takes priority over spec default.
+    const prevVal = previousInputs?.[name];
+    const defVal = prevVal !== undefined ? prevVal : (spec.default !== undefined ? String(spec.default) : '');
     const reqLabel = spec.required !== false && spec.default === undefined
       ? html`<span style="color: var(--color-err); font-size: var(--font-size-xs);">required</span>`
       : html`<span class="dim" style="font-size: var(--font-size-xs);">optional</span>`;

--- a/packages/dashboard/src/views/agent-detail-v2.ts
+++ b/packages/dashboard/src/views/agent-detail-v2.ts
@@ -39,6 +39,8 @@ export interface AgentDetailArgs {
   back?: PageHeaderBack;
   from?: string;
   activeTab: AgentTab;
+  /** Previous run's agent-level inputs, for pre-filling the Run Now modal. */
+  previousInputs?: Record<string, string>;
 }
 
 // ── Tab strip ────────────────────────────────────────────────────────────
@@ -112,7 +114,7 @@ function agentPageShell(args: AgentDetailArgs, content: SafeHtml): string {
     <div id="run-modal" class="modal-backdrop">
       <div class="modal" style="max-width: 500px;">
         <div id="run-modal-content">
-          ${renderRunInputsForm(agent, from)}
+          ${renderRunInputsForm(agent, from, args.previousInputs)}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Two improvements:

**Suggest improvements includes failed run errors:**
- Now fetches failed runs (not just completed) and includes error text, per-node failure details, and output in the LAST_RUN_OUTPUT sent to the analyzer
- If the most recent run failed, its errors are appended automatically — no more manual error pasting

**Run Now modal pre-fills from previous run:**
- Input values default to whatever was used in the most recent run
- Previous values take priority over spec defaults
- Works for all input types (text, enum, boolean)

## Test plan

- [x] 607 tests pass
- [ ] Run an agent, fail it, click "Suggest improvements" → analyzer sees the error text
- [ ] Run an agent with inputs, then click "Run now" again → inputs pre-filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)