### PR TITLE
feat(cli): sua daemon — detached background services

### DIFF
--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -12,6 +12,7 @@ import {
   getServiceStatus,
   spawnService,
   stopService,
+  waitForServiceSettle,
 } from '../daemon-supervisor.js';
 import * as ui from '../ui.js';
 
@@ -22,13 +23,13 @@ daemonCommand
   .command('start')
   .description('Start configured services as detached subprocesses')
   .option('--service <name>', 'Start only this service (repeatable)', collectService, [] as ServiceName[])
-  .action((opts: { service: ServiceName[] }) => {
+  .action(async (opts: { service: ServiceName[] }) => {
     const config = loadConfig();
     const dataDir = resolve(config.dataDir);
     const services = opts.service.length > 0 ? opts.service : getDaemonServices(config);
     const suaBin = process.argv[1];
 
-    const started: string[] = [];
+    const spawned: { name: ServiceName; pid: number; logPath: string }[] = [];
     const skipped: string[] = [];
     const failed: { name: string; reason: string }[] = [];
 
@@ -40,7 +41,7 @@ daemonCommand
           env: process.env,
           logRotateBytes: getDaemonLogRotateBytes(config),
         });
-        started.push(`${name} (pid ${result.pid}) → ${result.logPath}`);
+        spawned.push(result);
       } catch (err) {
         const msg = (err as Error).message;
         if (/already running/.test(msg)) {
@@ -48,6 +49,25 @@ daemonCommand
         } else {
           failed.push({ name, reason: msg });
         }
+      }
+    }
+
+    // Settle: wait long enough for the children to either bind their port,
+    // hit their preflight, or crash. Then re-check liveness so users see
+    // "crashed → check log" instead of a misleading "started" line.
+    const settled = await Promise.all(
+      spawned.map((s) => waitForServiceSettle(dataDir, s.name).then((status) => ({ ...s, status }))),
+    );
+    const started: string[] = [];
+    const crashed: { name: ServiceName; logPath: string }[] = [];
+    for (const { name, pid, logPath, status } of settled) {
+      if (status.state === 'running') {
+        started.push(`${name} (pid ${pid}) → ${logPath}`);
+      } else {
+        crashed.push({ name, logPath });
+        // Clear the stale pid so the next `daemon start` doesn't think it's
+        // an "already running" instance.
+        stopService(dataDir, name);
       }
     }
 
@@ -59,11 +79,18 @@ daemonCommand
       ui.section('Already running');
       for (const line of skipped) console.log(`  ${chalk.yellow('•')} ${line}`);
     }
-    if (failed.length > 0) {
-      ui.section('Failed');
-      for (const { name, reason } of failed) console.log(`  ${chalk.red('✖')} ${name}: ${reason}`);
-      process.exit(1);
+    if (crashed.length > 0) {
+      ui.section('Crashed on startup');
+      for (const { name, logPath } of crashed) {
+        console.log(`  ${chalk.red('✖')} ${name} — see ${logPath}`);
+      }
     }
+    if (failed.length > 0) {
+      ui.section('Failed to spawn');
+      for (const { name, reason } of failed) console.log(`  ${chalk.red('✖')} ${name}: ${reason}`);
+    }
+
+    if (failed.length > 0 || crashed.length > 0) process.exit(1);
 
     if (started.length === 0 && skipped.length === 0) {
       ui.warn('No services configured. Set `daemon.services` in sua.config.json or pass --service.');
@@ -115,6 +142,7 @@ daemonCommand
     await new Promise((r) => setTimeout(r, 250));
 
     const suaBin = process.argv[1];
+    const spawned: { name: ServiceName; pid: number; logPath: string }[] = [];
     const failures: { name: string; reason: string }[] = [];
     for (const name of services) {
       try {
@@ -124,11 +152,24 @@ daemonCommand
           env: process.env,
           logRotateBytes: getDaemonLogRotateBytes(config),
         });
-        ui.ok(`${name} restarted (pid ${result.pid})`);
+        spawned.push(result);
       } catch (err) {
         failures.push({ name, reason: (err as Error).message });
       }
     }
+
+    const settled = await Promise.all(
+      spawned.map((s) => waitForServiceSettle(dataDir, s.name).then((status) => ({ ...s, status }))),
+    );
+    for (const { name, pid, logPath, status } of settled) {
+      if (status.state === 'running') {
+        ui.ok(`${name} restarted (pid ${pid})`);
+      } else {
+        failures.push({ name, reason: `crashed on startup — see ${logPath}` });
+        stopService(dataDir, name);
+      }
+    }
+
     if (failures.length > 0) {
       ui.section('Failed');
       for (const { name, reason } of failures) ui.fail(`${name}: ${reason}`);

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -1,0 +1,213 @@
+import { resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { Command } from 'commander';
+import chalk from 'chalk';
+import Table from 'cli-table3';
+import { getSchedulerStatus } from '@some-useful-agents/core';
+import { loadConfig, getDaemonServices, getDaemonLogRotateBytes } from '../config.js';
+import {
+  ALL_SERVICES,
+  type ServiceName,
+  daemonPaths,
+  getServiceStatus,
+  spawnService,
+  stopService,
+} from '../daemon-supervisor.js';
+import * as ui from '../ui.js';
+
+export const daemonCommand = new Command('daemon')
+  .description('Run sua services (schedule, dashboard, mcp) as detached background processes');
+
+daemonCommand
+  .command('start')
+  .description('Start configured services as detached subprocesses')
+  .option('--service <name>', 'Start only this service (repeatable)', collectService, [] as ServiceName[])
+  .action((opts: { service: ServiceName[] }) => {
+    const config = loadConfig();
+    const dataDir = resolve(config.dataDir);
+    const services = opts.service.length > 0 ? opts.service : getDaemonServices(config);
+    const suaBin = process.argv[1];
+
+    const started: string[] = [];
+    const skipped: string[] = [];
+    const failed: { name: string; reason: string }[] = [];
+
+    for (const name of services) {
+      try {
+        const result = spawnService(dataDir, name, {
+          suaBin,
+          cwd: process.cwd(),
+          env: process.env,
+          logRotateBytes: getDaemonLogRotateBytes(config),
+        });
+        started.push(`${name} (pid ${result.pid}) → ${result.logPath}`);
+      } catch (err) {
+        const msg = (err as Error).message;
+        if (/already running/.test(msg)) {
+          skipped.push(`${name}: ${msg}`);
+        } else {
+          failed.push({ name, reason: msg });
+        }
+      }
+    }
+
+    if (started.length > 0) {
+      ui.section('Started');
+      for (const line of started) console.log(`  ${chalk.green('✔')} ${line}`);
+    }
+    if (skipped.length > 0) {
+      ui.section('Already running');
+      for (const line of skipped) console.log(`  ${chalk.yellow('•')} ${line}`);
+    }
+    if (failed.length > 0) {
+      ui.section('Failed');
+      for (const { name, reason } of failed) console.log(`  ${chalk.red('✖')} ${name}: ${reason}`);
+      process.exit(1);
+    }
+
+    if (started.length === 0 && skipped.length === 0) {
+      ui.warn('No services configured. Set `daemon.services` in sua.config.json or pass --service.');
+    }
+  });
+
+daemonCommand
+  .command('stop')
+  .description('SIGTERM running services')
+  .option('--service <name>', 'Stop only this service (repeatable)', collectService, [] as ServiceName[])
+  .action((opts: { service: ServiceName[] }) => {
+    const config = loadConfig();
+    const dataDir = resolve(config.dataDir);
+    const services = opts.service.length > 0 ? opts.service : getDaemonServices(config);
+
+    const stopped: string[] = [];
+    const notRunning: string[] = [];
+
+    for (const name of services) {
+      const result = stopService(dataDir, name);
+      if (result.signalled) {
+        stopped.push(`${name} (pid ${result.pid})`);
+      } else {
+        notRunning.push(name);
+      }
+    }
+
+    if (stopped.length > 0) {
+      ui.section('Stopped');
+      for (const line of stopped) console.log(`  ${chalk.green('✔')} ${line}`);
+    }
+    if (notRunning.length > 0) {
+      ui.section('Not running');
+      for (const name of notRunning) console.log(`  ${chalk.dim('•')} ${name}`);
+    }
+  });
+
+daemonCommand
+  .command('restart')
+  .description('Stop then start the configured services')
+  .option('--service <name>', 'Restart only this service (repeatable)', collectService, [] as ServiceName[])
+  .action(async (opts: { service: ServiceName[] }) => {
+    const config = loadConfig();
+    const dataDir = resolve(config.dataDir);
+    const services = opts.service.length > 0 ? opts.service : getDaemonServices(config);
+
+    for (const name of services) stopService(dataDir, name);
+    // Brief pause so SIGTERM is received before respawn.
+    await new Promise((r) => setTimeout(r, 250));
+
+    const suaBin = process.argv[1];
+    const failures: { name: string; reason: string }[] = [];
+    for (const name of services) {
+      try {
+        const result = spawnService(dataDir, name, {
+          suaBin,
+          cwd: process.cwd(),
+          env: process.env,
+          logRotateBytes: getDaemonLogRotateBytes(config),
+        });
+        ui.ok(`${name} restarted (pid ${result.pid})`);
+      } catch (err) {
+        failures.push({ name, reason: (err as Error).message });
+      }
+    }
+    if (failures.length > 0) {
+      ui.section('Failed');
+      for (const { name, reason } of failures) ui.fail(`${name}: ${reason}`);
+      process.exit(1);
+    }
+  });
+
+daemonCommand
+  .command('status')
+  .description('Show pid + heartbeat health for each managed service')
+  .action(() => {
+    const config = loadConfig();
+    const dataDir = resolve(config.dataDir);
+
+    const table = new Table({
+      head: [chalk.bold('Service'), chalk.bold('State'), chalk.bold('PID'), chalk.bold('Detail')],
+    });
+
+    for (const name of ALL_SERVICES) {
+      const status = getServiceStatus(dataDir, name);
+      let stateLabel: string;
+      switch (status.state) {
+        case 'running': stateLabel = chalk.green('running'); break;
+        case 'stale':   stateLabel = chalk.red('stale (pid dead)'); break;
+        default:        stateLabel = chalk.dim('stopped'); break;
+      }
+
+      let detail = '';
+      if (name === 'schedule' && status.state === 'running') {
+        const { status: schedStatus, heartbeat } = getSchedulerStatus(dataDir);
+        if (schedStatus === 'running' && heartbeat) {
+          detail = `heartbeat fresh, ${heartbeat.agents.length} agent${heartbeat.agents.length === 1 ? '' : 's'}`;
+        } else if (schedStatus === 'stale') {
+          detail = chalk.yellow('heartbeat stale');
+        } else {
+          detail = chalk.yellow('no heartbeat yet');
+        }
+      }
+
+      table.push([name, stateLabel, status.pid?.toString() ?? '—', detail]);
+    }
+
+    ui.section('Daemon services');
+    console.log(table.toString());
+    console.log(ui.dim(`Logs: ${daemonPaths(dataDir).logsDir}\n`));
+  });
+
+daemonCommand
+  .command('logs')
+  .description('Print the tail of a service log')
+  .argument('<service>', 'schedule | dashboard | mcp')
+  .option('-n, --lines <count>', 'Number of trailing lines to show', '50')
+  .action((service: string, opts: { lines: string }) => {
+    if (!ALL_SERVICES.includes(service as ServiceName)) {
+      ui.fail(`Unknown service "${service}". Expected one of: ${ALL_SERVICES.join(', ')}.`);
+      process.exit(1);
+    }
+    const config = loadConfig();
+    const dataDir = resolve(config.dataDir);
+    const path = daemonPaths(dataDir).logPath(service as ServiceName);
+
+    if (!existsSync(path)) {
+      ui.warn(`No log yet at ${path}.`);
+      return;
+    }
+    const n = Math.max(1, parseInt(opts.lines, 10) || 50);
+    // Read up to last 256 KB to keep memory bounded; sufficient for n<=1000.
+    const cap = 256 * 1024;
+    const fd = readFileSync(path);
+    const slice = fd.subarray(Math.max(0, fd.length - cap));
+    const lines = slice.toString('utf-8').split('\n');
+    const tail = lines.slice(Math.max(0, lines.length - n - 1)).join('\n');
+    process.stdout.write(tail);
+    if (!tail.endsWith('\n')) process.stdout.write('\n');
+  });
+
+function collectService(value: string, previous: ServiceName[]): ServiceName[] {
+  if (!ALL_SERVICES.includes(value as ServiceName)) {
+    throw new Error(`Unknown service "${value}". Expected one of: ${ALL_SERVICES.join(', ')}.`);
+  }
+  return [...previous, value as ServiceName];
+}

--- a/packages/cli/src/commands/schedule.ts
+++ b/packages/cli/src/commands/schedule.ts
@@ -241,20 +241,27 @@ scheduleCommand
     }
 
     if (entries.length === 0) {
-      ui.warn('No agents have a schedule. Add `schedule: "<cron>"` to an agent YAML and restart.');
-      runStore.close();
-      await provider.shutdown();
-      return;
+      ui.warn(
+        'No agents have a schedule. Idling — restart the scheduler after adding ' +
+          '`schedule: "<cron>"` to an agent YAML.',
+      );
     }
 
-    const bannerLines = entries.map(
-      ({ agent, schedule }) => `${agent.name.padEnd(24)} ${cronToHuman(schedule)}`,
-    );
+    const bannerLines = entries.length > 0
+      ? entries.map(({ agent, schedule }) => `${agent.name.padEnd(24)} ${cronToHuman(schedule)}`)
+      : ['idle — no scheduled agents'];
     ui.banner(`Scheduler running (${entries.length} agent${entries.length === 1 ? '' : 's'})`, bannerLines);
     console.log(ui.dim('Press Ctrl+C to stop.\n'));
 
+    // When there are no scheduled entries the scheduler holds no internal
+    // timers, so the event loop would exit immediately. Keep a low-frequency
+    // tick so the supervised process stays alive (and keeps writing the
+    // heartbeat) until the user adds a schedule and restarts it.
+    const idleKeepAlive = entries.length === 0 ? setInterval(() => {}, 60_000) : null;
+
     const shutdown = async () => {
       console.log('\nShutting down scheduler...');
+      if (idleKeepAlive) clearInterval(idleKeepAlive);
       scheduler.stop();
       runStore.close();
       await provider.shutdown();

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -16,6 +16,16 @@ export interface SuaConfig {
    * ambient leak surface.
    */
   runRetentionDays?: number;
+  /**
+   * `sua daemon` settings. Controls which services are managed by default
+   * and how aggressively per-service logs are rotated.
+   */
+  daemon?: {
+    /** Services started by `sua daemon start` (with no --service flag). */
+    services?: ('schedule' | 'dashboard' | 'mcp')[];
+    /** Rotate log when it exceeds this many bytes (rotate-on-start). */
+    logRotateBytes?: number;
+  };
 }
 
 const DEFAULT_CONFIG: SuaConfig = {
@@ -27,6 +37,10 @@ const DEFAULT_CONFIG: SuaConfig = {
   temporalNamespace: 'default',
   temporalTaskQueue: 'sua-agents',
   runRetentionDays: 30,
+  daemon: {
+    services: ['schedule', 'dashboard'],
+    logRotateBytes: 10 * 1024 * 1024,
+  },
 };
 
 export function loadConfig(): SuaConfig {
@@ -88,4 +102,12 @@ export function getVariablesPath(config: SuaConfig): string {
 
 export function getRetentionDays(config: SuaConfig): number {
   return config.runRetentionDays ?? 30;
+}
+
+export function getDaemonServices(config: SuaConfig): ('schedule' | 'dashboard' | 'mcp')[] {
+  return config.daemon?.services ?? ['schedule', 'dashboard'];
+}
+
+export function getDaemonLogRotateBytes(config: SuaConfig): number {
+  return config.daemon?.logRotateBytes ?? 10 * 1024 * 1024;
 }

--- a/packages/cli/src/daemon-supervisor.test.ts
+++ b/packages/cli/src/daemon-supervisor.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  ALL_SERVICES,
+  daemonPaths,
+  ensureDaemonDirs,
+  getServiceStatus,
+  isProcessAlive,
+  readServicePid,
+  rotateLog,
+  spawnService,
+  stopService,
+} from './daemon-supervisor.js';
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), 'sua-daemon-test-'));
+});
+
+afterEach(() => {
+  // Best-effort cleanup; ignore if any spawned subprocess holds files.
+  try { rmSync(dataDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('daemonPaths', () => {
+  it('places pid + logs under <dataDir>/daemon', () => {
+    const paths = daemonPaths(dataDir);
+    expect(paths.baseDir).toBe(join(dataDir, 'daemon'));
+    expect(paths.logsDir).toBe(join(dataDir, 'daemon', 'logs'));
+    expect(paths.pidPath('schedule')).toBe(join(dataDir, 'daemon', 'schedule.pid'));
+    expect(paths.logPath('mcp')).toBe(join(dataDir, 'daemon', 'logs', 'mcp.log'));
+  });
+
+  it('exposes the canonical service list', () => {
+    expect(ALL_SERVICES).toEqual(['schedule', 'dashboard', 'mcp']);
+  });
+});
+
+describe('ensureDaemonDirs', () => {
+  it('creates baseDir and logsDir', () => {
+    const paths = ensureDaemonDirs(dataDir);
+    expect(existsSync(paths.baseDir)).toBe(true);
+    expect(existsSync(paths.logsDir)).toBe(true);
+  });
+});
+
+describe('readServicePid', () => {
+  it('returns null when no pid file exists', () => {
+    expect(readServicePid(dataDir, 'schedule')).toBeNull();
+  });
+
+  it('reads a recorded pid', () => {
+    const paths = ensureDaemonDirs(dataDir);
+    writeFileSync(paths.pidPath('schedule'), '12345\n');
+    expect(readServicePid(dataDir, 'schedule')).toBe(12345);
+  });
+
+  it('returns null for malformed pid files', () => {
+    const paths = ensureDaemonDirs(dataDir);
+    writeFileSync(paths.pidPath('schedule'), 'not-a-pid\n');
+    expect(readServicePid(dataDir, 'schedule')).toBeNull();
+  });
+});
+
+describe('isProcessAlive', () => {
+  it('reports the current process as alive', () => {
+    expect(isProcessAlive(process.pid)).toBe(true);
+  });
+
+  it('reports a clearly dead pid as dead', () => {
+    // Pick a high pid extremely unlikely to be live in test environments.
+    expect(isProcessAlive(99999999)).toBe(false);
+  });
+});
+
+describe('rotateLog', () => {
+  it('does nothing when the log is below cap', () => {
+    const paths = ensureDaemonDirs(dataDir);
+    const log = paths.logPath('mcp');
+    writeFileSync(log, 'small');
+    rotateLog(log, 1024);
+    expect(existsSync(log)).toBe(true);
+    expect(existsSync(`${log}.1`)).toBe(false);
+  });
+
+  it('rotates when over cap', () => {
+    const paths = ensureDaemonDirs(dataDir);
+    const log = paths.logPath('mcp');
+    writeFileSync(log, 'x'.repeat(2048));
+    rotateLog(log, 1024);
+    expect(existsSync(log)).toBe(false);
+    expect(existsSync(`${log}.1`)).toBe(true);
+    expect(statSync(`${log}.1`).size).toBe(2048);
+  });
+
+  it('drops a prior rotated copy on subsequent rotation', () => {
+    const paths = ensureDaemonDirs(dataDir);
+    const log = paths.logPath('mcp');
+    writeFileSync(`${log}.1`, 'old');
+    writeFileSync(log, 'x'.repeat(2048));
+    rotateLog(log, 1024);
+    expect(readFileSync(`${log}.1`, 'utf-8').length).toBe(2048);
+  });
+
+  it('is a no-op when the log does not exist', () => {
+    const paths = daemonPaths(dataDir);
+    expect(() => rotateLog(paths.logPath('mcp'), 1024)).not.toThrow();
+  });
+});
+
+describe('getServiceStatus', () => {
+  it('returns stopped when no pid file exists', () => {
+    const status = getServiceStatus(dataDir, 'schedule');
+    expect(status.state).toBe('stopped');
+    expect(status.pid).toBeUndefined();
+  });
+
+  it('returns running when the pid is alive (using current process pid)', () => {
+    const paths = ensureDaemonDirs(dataDir);
+    writeFileSync(paths.pidPath('schedule'), `${process.pid}\n`);
+    const status = getServiceStatus(dataDir, 'schedule');
+    expect(status.state).toBe('running');
+    expect(status.pid).toBe(process.pid);
+  });
+
+  it('returns stale when the recorded pid is dead', () => {
+    const paths = ensureDaemonDirs(dataDir);
+    writeFileSync(paths.pidPath('schedule'), '99999999\n');
+    const status = getServiceStatus(dataDir, 'schedule');
+    expect(status.state).toBe('stale');
+  });
+});
+
+describe('spawnService + stopService', () => {
+  it('spawns a detached child, records its pid, and stops it cleanly', async () => {
+    // Spawn `node -e "..."` masquerading as a service. We bypass SERVICE_ARGV
+    // by substituting suaBin with a script path, and then post-write the pid
+    // ourselves to test stop semantics. Since spawnService re-executes `sua`,
+    // we use a different tactic: directly verify the lifecycle via a fake
+    // pid that we know is alive (current process), then via stopService.
+    const paths = ensureDaemonDirs(dataDir);
+    // Simulate "service running" by writing the test pid (the test process
+    // itself). stopService will refuse to actually kill it (we'd kill the
+    // test runner!), so we use a child-spawned `sleep` instead.
+    const { spawn } = await import('node:child_process');
+    const child = spawn('node', ['-e', 'setTimeout(() => {}, 60000)'], {
+      detached: true,
+      stdio: 'ignore',
+    });
+    child.unref();
+    expect(typeof child.pid).toBe('number');
+    writeFileSync(paths.pidPath('schedule'), `${child.pid}\n`);
+
+    expect(getServiceStatus(dataDir, 'schedule').state).toBe('running');
+
+    const result = stopService(dataDir, 'schedule');
+    expect(result.signalled).toBe(true);
+    expect(result.pid).toBe(child.pid);
+    expect(existsSync(paths.pidPath('schedule'))).toBe(false);
+
+    // Wait briefly for the SIGTERM to take effect.
+    await new Promise((r) => setTimeout(r, 100));
+    expect(isProcessAlive(child.pid!)).toBe(false);
+  });
+
+  it('refuses to spawn when a live pid is already recorded', () => {
+    const paths = ensureDaemonDirs(dataDir);
+    writeFileSync(paths.pidPath('schedule'), `${process.pid}\n`);
+    expect(() =>
+      spawnService(dataDir, 'schedule', {
+        suaBin: '/nonexistent/sua',
+        cwd: process.cwd(),
+        env: process.env,
+      }),
+    ).toThrow(/already running/);
+  });
+
+  it('clears a stale pid file before spawning', () => {
+    const paths = ensureDaemonDirs(dataDir);
+    writeFileSync(paths.pidPath('schedule'), '99999999\n');
+    // Stale pid present. Calling spawnService should clear it; we use a
+    // bogus suaBin so the spawn itself fails after the clear, but we assert
+    // the pid file no longer points at the dead pid before the failure.
+    try {
+      spawnService(dataDir, 'schedule', {
+        suaBin: '/nonexistent/sua',
+        cwd: process.cwd(),
+        env: process.env,
+      });
+    } catch {
+      /* expected — spawn proceeds but the executed script doesn't exist;
+         child may still exit with an error, that's fine. */
+    }
+    // After spawn, the pid file should reference whatever child was started
+    // (or be absent if spawn failed). Either way, it must not be 99999999.
+    const newPid = readServicePid(dataDir, 'schedule');
+    expect(newPid).not.toBe(99999999);
+  });
+});

--- a/packages/cli/src/daemon-supervisor.test.ts
+++ b/packages/cli/src/daemon-supervisor.test.ts
@@ -12,6 +12,7 @@ import {
   rotateLog,
   spawnService,
   stopService,
+  waitForServiceSettle,
 } from './daemon-supervisor.js';
 
 let dataDir: string;
@@ -164,6 +165,30 @@ describe('spawnService + stopService', () => {
     // Wait briefly for the SIGTERM to take effect.
     await new Promise((r) => setTimeout(r, 100));
     expect(isProcessAlive(child.pid!)).toBe(false);
+  });
+
+  it('waitForServiceSettle returns running when the recorded pid stays alive', async () => {
+    const paths = ensureDaemonDirs(dataDir);
+    writeFileSync(paths.pidPath('schedule'), `${process.pid}\n`);
+    const status = await waitForServiceSettle(dataDir, 'schedule', 50);
+    expect(status.state).toBe('running');
+  });
+
+  it('waitForServiceSettle reports stale when the child dies during the settle window', async () => {
+    const { spawn } = await import('node:child_process');
+    // Spawn a child that exits after 20ms — we settle for 100ms, so it's
+    // dead by the time we check.
+    const child = spawn('node', ['-e', 'setTimeout(() => process.exit(0), 20)'], {
+      detached: true,
+      stdio: 'ignore',
+    });
+    child.unref();
+    const paths = ensureDaemonDirs(dataDir);
+    writeFileSync(paths.pidPath('mcp'), `${child.pid}\n`);
+
+    const status = await waitForServiceSettle(dataDir, 'mcp', 100);
+    expect(status.state).toBe('stale');
+    expect(status.pid).toBe(child.pid);
   });
 
   it('refuses to spawn when a live pid is already recorded', () => {

--- a/packages/cli/src/daemon-supervisor.ts
+++ b/packages/cli/src/daemon-supervisor.ts
@@ -204,3 +204,18 @@ export function getServiceStatus(dataDir: string, name: ServiceName): ServiceSta
   // PID file points at a dead process.
   return { name, state: 'stale', pid, logPath: paths.logPath(name) };
 }
+
+/**
+ * After spawnService returns, the child may still die on startup (port
+ * conflict, missing config, secrets preflight failure). Wait briefly and
+ * report whether the recorded pid is still alive. Returns the final
+ * ServiceStatus so callers can surface the log path on crash.
+ */
+export async function waitForServiceSettle(
+  dataDir: string,
+  name: ServiceName,
+  settleMs = 750,
+): Promise<ServiceStatus> {
+  await new Promise((r) => setTimeout(r, settleMs));
+  return getServiceStatus(dataDir, name);
+}

--- a/packages/cli/src/daemon-supervisor.ts
+++ b/packages/cli/src/daemon-supervisor.ts
@@ -1,0 +1,206 @@
+/**
+ * Daemon supervisor: spawn/stop/status for `sua daemon`-managed services.
+ *
+ * Each service (schedule, dashboard, mcp) is invoked by re-executing the
+ * current `sua` binary with the corresponding subcommand as a detached
+ * subprocess. PIDs and rotated logs live under `<dataDir>/daemon/`.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+
+export type ServiceName = 'schedule' | 'dashboard' | 'mcp';
+
+export const ALL_SERVICES: readonly ServiceName[] = ['schedule', 'dashboard', 'mcp'] as const;
+
+export interface SpawnedService {
+  name: ServiceName;
+  pid: number;
+  logPath: string;
+}
+
+export interface ServiceStatus {
+  name: ServiceName;
+  state: 'running' | 'stopped' | 'stale';
+  pid?: number;
+  logPath: string;
+}
+
+export interface DaemonPaths {
+  baseDir: string;   // <dataDir>/daemon
+  logsDir: string;   // <dataDir>/daemon/logs
+  pidPath: (name: ServiceName) => string;
+  logPath: (name: ServiceName) => string;
+}
+
+const DEFAULT_LOG_ROTATE_BYTES = 10 * 1024 * 1024; // 10 MB
+
+export function daemonPaths(dataDir: string): DaemonPaths {
+  const baseDir = join(dataDir, 'daemon');
+  const logsDir = join(baseDir, 'logs');
+  return {
+    baseDir,
+    logsDir,
+    pidPath: (name) => join(baseDir, `${name}.pid`),
+    logPath: (name) => join(logsDir, `${name}.log`),
+  };
+}
+
+export function ensureDaemonDirs(dataDir: string): DaemonPaths {
+  const paths = daemonPaths(dataDir);
+  mkdirSync(paths.logsDir, { recursive: true });
+  return paths;
+}
+
+// ── PID helpers ─────────────────────────────────────────────────────────
+
+export function readServicePid(dataDir: string, name: ServiceName): number | null {
+  const path = daemonPaths(dataDir).pidPath(name);
+  if (!existsSync(path)) return null;
+  try {
+    const pid = parseInt(readFileSync(path, 'utf-8').trim(), 10);
+    return Number.isFinite(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function writePid(path: string, pid: number): void {
+  writeFileSync(path, String(pid) + '\n');
+}
+
+function clearPid(path: string): void {
+  try { unlinkSync(path); } catch { /* already gone */ }
+}
+
+// ── Log rotation (rotate-on-start) ──────────────────────────────────────
+
+/**
+ * Rotate the log if it's over the size cap. Renames `<svc>.log` → `<svc>.log.1`,
+ * dropping any prior `.log.1`. Simple, no gzip — keeps last 1.
+ */
+export function rotateLog(logPath: string, capBytes: number): void {
+  if (!existsSync(logPath)) return;
+  let size = 0;
+  try {
+    size = statSync(logPath).size;
+  } catch {
+    return;
+  }
+  if (size <= capBytes) return;
+  const rotated = `${logPath}.1`;
+  try { unlinkSync(rotated); } catch { /* ignore */ }
+  try { renameSync(logPath, rotated); } catch { /* best effort */ }
+}
+
+// ── Spawn / stop ────────────────────────────────────────────────────────
+
+export interface SpawnOptions {
+  /** Binary path of the `sua` CLI (typically `process.argv[1]`). */
+  suaBin: string;
+  /** Working directory for the child (typically `process.cwd()`). */
+  cwd: string;
+  /** Environment variables to pass through (typically `process.env`). */
+  env: NodeJS.ProcessEnv;
+  /** Log rotation threshold in bytes. */
+  logRotateBytes?: number;
+  /** Per-service extra args. */
+  extraArgs?: Partial<Record<ServiceName, string[]>>;
+}
+
+const SERVICE_ARGV: Record<ServiceName, string[]> = {
+  schedule: ['schedule', 'start'],
+  dashboard: ['dashboard', 'start'],
+  mcp: ['mcp', 'start'],
+};
+
+/**
+ * Spawn a service as a detached subprocess. Refuses if a live PID is already
+ * recorded for the service. Returns the spawned PID + log path on success.
+ */
+export function spawnService(
+  dataDir: string,
+  name: ServiceName,
+  options: SpawnOptions,
+): SpawnedService {
+  const paths = ensureDaemonDirs(dataDir);
+  const existingPid = readServicePid(dataDir, name);
+  if (existingPid !== null && isProcessAlive(existingPid)) {
+    throw new Error(`Service "${name}" is already running (PID ${existingPid}).`);
+  }
+  // Stale PID — clear it.
+  if (existingPid !== null) clearPid(paths.pidPath(name));
+
+  const logPath = paths.logPath(name);
+  rotateLog(logPath, options.logRotateBytes ?? DEFAULT_LOG_ROTATE_BYTES);
+  // Open log in append mode so subsequent writes accumulate across restarts.
+  const logFd = openSync(logPath, 'a');
+
+  const args = [options.suaBin, ...SERVICE_ARGV[name], ...(options.extraArgs?.[name] ?? [])];
+  const child = spawn(process.execPath, args, {
+    cwd: options.cwd,
+    env: options.env,
+    detached: true,
+    stdio: ['ignore', logFd, logFd],
+  });
+  child.unref();
+
+  if (typeof child.pid !== 'number') {
+    throw new Error(`Failed to spawn service "${name}" — no PID assigned.`);
+  }
+  writePid(paths.pidPath(name), child.pid);
+  return { name, pid: child.pid, logPath };
+}
+
+/**
+ * Stop a service by SIGTERM-ing its recorded PID. Cleans up the PID file
+ * regardless of outcome. Returns true if a process was alive and signalled.
+ */
+export function stopService(dataDir: string, name: ServiceName): { signalled: boolean; pid?: number } {
+  const paths = daemonPaths(dataDir);
+  const pid = readServicePid(dataDir, name);
+  if (pid === null) return { signalled: false };
+  let signalled = false;
+  if (isProcessAlive(pid)) {
+    try {
+      process.kill(pid, 'SIGTERM');
+      signalled = true;
+    } catch {
+      signalled = false;
+    }
+  }
+  clearPid(paths.pidPath(name));
+  return { signalled, pid };
+}
+
+export function getServiceStatus(dataDir: string, name: ServiceName): ServiceStatus {
+  const paths = daemonPaths(dataDir);
+  const pid = readServicePid(dataDir, name);
+  if (pid === null) {
+    return { name, state: 'stopped', logPath: paths.logPath(name) };
+  }
+  if (isProcessAlive(pid)) {
+    return { name, state: 'running', pid, logPath: paths.logPath(name) };
+  }
+  // PID file points at a dead process.
+  return { name, state: 'stale', pid, logPath: paths.logPath(name) };
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,6 +24,7 @@ import { workerCommand } from './commands/worker.js';
 import { scheduleCommand } from './commands/schedule.js';
 import { tutorialCommand } from './commands/tutorial.js';
 import { dashboardCommand } from './commands/dashboard.js';
+import { daemonCommand } from './commands/daemon.js';
 import { workflowCommand } from './commands/workflow.js';
 import { toolCommand } from './commands/tool.js';
 import { examplesCommand } from './commands/examples.js';
@@ -52,6 +53,7 @@ Examples:
   $ sua agent run weather --input ZIP=94110      Supply a declared input
   $ sua agent list                               See everything runnable
   $ sua schedule start                           Fire scheduled agents on cron
+  $ sua daemon start                             Run schedule + dashboard as detached background services
   $ sua mcp start                                Start the MCP server on 127.0.0.1:3003
   $ sua doctor --security                        Audit security posture
 
@@ -87,6 +89,7 @@ program.addCommand(workerCommand);
 program.addCommand(scheduleCommand);
 program.addCommand(tutorialCommand);
 program.addCommand(dashboardCommand);
+program.addCommand(daemonCommand);
 program.addCommand(workflowCommand);
 program.addCommand(toolCommand);
 program.addCommand(examplesCommand);

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -258,8 +258,15 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     );
   }
 
-  const server = await new Promise<Server>((resolve) => {
-    const s = app.listen(opts.port, host, () => resolve(s));
+  const server = await new Promise<Server>((resolve, reject) => {
+    const s = app.listen(opts.port, host, () => {
+      s.removeListener('error', reject);
+      resolve(s);
+    });
+    // Without this, EADDRINUSE (and other listen failures) emit on the
+    // server but never reach the awaiter — the promise hangs and the
+    // caller prints its banner against a server that didn't actually bind.
+    s.once('error', (err) => reject(err));
   });
 
   const authUrl = `http://${host}:${opts.port}/auth#token=${token}`;


### PR DESCRIPTION
## Summary

Adds `sua daemon` so schedule + dashboard + (optional) MCP keep running after the terminal closes. Closes the "schedules don't fire when the terminal closes" gap from the v0.19 Theme B plan.

- New `daemon-supervisor` module: spawn/stop/status helpers, log rotate-on-start, pid-alive detection (signal 0), single-instance guard.
- New `commands/daemon.ts` exposing `start | stop | restart | status | logs`. `--service <name>` filter; `daemon status` surfaces the existing scheduler heartbeat.
- Optional `daemon.services` + `daemon.logRotateBytes` in `sua.config.json`, defaulting to `[schedule, dashboard]` at 10 MB.
- 18 new unit tests covering paths, rotation, pid lifecycle, spawn refusal on a live pid, stop semantics with a real child process.

PIDs and logs live under `<dataDir>/daemon/` (per-project), reusing the existing scheduler heartbeat at `<dataDir>/scheduler-heartbeat.json` for health checks. Detached subprocesses re-invoke `process.argv[1]` (the `sua` CLI) with the corresponding verb.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` green (682 / 682, +18 new)
- [x] `npm run build` clean
- [x] Smoke: `sua daemon --help` and `sua daemon status` render correctly
- [ ] Manual: `sua daemon start && sua daemon status`, close terminal, reopen, status still green
- [ ] Manual: `sua daemon stop` cleans up all pid files
- [ ] Manual: rotate-on-start triggers when log > cap

## Out of scope (deferred to v0.20+)

- launchd / systemd unit file generation
- gzip of rotated logs (currently keep-last-1, no compression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)