### PR TITLE
feat(core): notify field with slack/file/webhook handlers

### DIFF
--- a/packages/core/src/agent-store.ts
+++ b/packages/core/src/agent-store.ts
@@ -346,6 +346,7 @@ export class AgentStore {
     if (agent.inputs) dag.inputs = agent.inputs;
     if (agent.signal) dag.signal = agent.signal;
     if (agent.outputWidget) dag.outputWidget = agent.outputWidget;
+    if (agent.notify) dag.notify = agent.notify;
     if (agent.author !== undefined) dag.author = agent.author;
     if (agent.tags) dag.tags = agent.tags;
     return dag;
@@ -383,6 +384,7 @@ export class AgentStore {
       nodes: dag.nodes,
       signal: dag.signal,
       outputWidget: dag.outputWidget,
+      notify: dag.notify,
       author: dag.author,
       tags: dag.tags,
     };

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -174,6 +174,48 @@ export const agentV2Schema = z.object({
     { message: 'Signal must declare either "format" (v1) or "template" (v2).' },
   ).optional(),
 
+  notify: z.object({
+    on: z.array(z.enum(['failure', 'success', 'always'])).min(1, 'notify.on must list at least one trigger'),
+    secrets: z.array(z.string().regex(SECRET_NAME_RE, 'Secret names must be UPPERCASE_WITH_UNDERSCORES')).optional(),
+    handlers: z.array(z.discriminatedUnion('type', [
+      z.object({
+        type: z.literal('slack'),
+        webhook_secret: z.string().regex(SECRET_NAME_RE, 'webhook_secret must be UPPERCASE_WITH_UNDERSCORES'),
+        channel: z.string().optional(),
+        mention: z.string().optional(),
+      }),
+      z.object({
+        type: z.literal('file'),
+        path: z.string().min(1),
+        append: z.boolean().optional(),
+      }),
+      z.object({
+        type: z.literal('webhook'),
+        url: z.string().url(),
+        method: z.enum(['POST', 'PUT']).optional(),
+        headers_secret: z.string().regex(SECRET_NAME_RE, 'headers_secret must be UPPERCASE_WITH_UNDERSCORES').optional(),
+      }),
+    ])).min(1, 'notify.handlers must list at least one handler'),
+  }).superRefine((data, ctx) => {
+    // Cross-check: every handler that names a secret must declare it in
+    // notify.secrets. Mirrors the node-level rule that secrets must be
+    // declared per consumer; keeps audits simple.
+    const declared = new Set(data.secrets ?? []);
+    for (let i = 0; i < data.handlers.length; i++) {
+      const h = data.handlers[i];
+      const needed = h.type === 'slack' ? h.webhook_secret
+        : h.type === 'webhook' ? h.headers_secret
+        : undefined;
+      if (needed && !declared.has(needed)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['handlers', i],
+          message: `Handler references secret "${needed}" but it isn't listed in notify.secrets.`,
+        });
+      }
+    }
+  }).optional(),
+
   outputWidget: z.object({
     type: z.enum(['diff-apply', 'key-value', 'raw', 'dashboard']),
     fields: z.array(z.object({

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -253,6 +253,12 @@ export interface Agent {
    */
   outputWidget?: import('./output-widget-types.js').OutputWidgetSchema;
 
+  /**
+   * Notification handlers fired after a run commits (success / failure /
+   * always). See notify-dispatcher.ts for handler semantics.
+   */
+  notify?: import('./notify-dispatcher.js').NotifyConfig;
+
   // Metadata
   author?: string;
   tags?: string[];
@@ -342,6 +348,7 @@ export interface AgentVersionDag {
   nodes: AgentNode[];
   signal?: AgentSignal;
   outputWidget?: import('./output-widget-types.js').OutputWidgetSchema;
+  notify?: import('./notify-dispatcher.js').NotifyConfig;
   author?: string;
   tags?: string[];
 }

--- a/packages/core/src/agent-yaml.ts
+++ b/packages/core/src/agent-yaml.ts
@@ -86,6 +86,7 @@ function parsedToAgent(p: AgentV2Parsed): Agent {
     nodes,
     ...(p.signal && { signal: p.signal }),
     ...(p.outputWidget && { outputWidget: p.outputWidget }),
+    ...(p.notify && { notify: p.notify as Agent['notify'] }),
     ...(p.author !== undefined && { author: p.author }),
     ...(p.tags && { tags: p.tags }),
   };
@@ -105,6 +106,7 @@ const AGENT_KEY_ORDER = [
   'nodes',
   'signal',
   'outputWidget',
+  'notify',
   'author', 'tags',
 ] as const;
 

--- a/packages/core/src/dag-executor.test.ts
+++ b/packages/core/src/dag-executor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -1514,5 +1514,84 @@ describe('executeAgentDag — MCP server disabled gate', () => {
     expect(ne.errorCategory).toBe('setup');
     expect(ne.error).toMatch(/disabled-svr.*disabled/);
     toolStore.close();
+  });
+});
+
+describe('executeAgentDag — notify dispatch', () => {
+  it('fires notify handlers after the run row commits, on failure', async () => {
+    const captured: { agentId?: string; runId?: string; status?: string } = {};
+    const fetchMock = async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? '{}'));
+      captured.agentId = body.agent;
+      captured.runId = body.run_id;
+      captured.status = body.status;
+      return { ok: true, status: 200 } as unknown as Response;
+    };
+    const agent = makeAgent({
+      nodes: [{ id: 'main', type: 'shell', command: 'false' }],
+      notify: {
+        on: ['failure'],
+        handlers: [{ type: 'webhook', url: 'https://example.com/hook' }],
+      },
+    });
+    const run = await executeAgentDag(
+      agent,
+      { triggeredBy: 'cli' },
+      {
+        runStore,
+        spawnNode: cannedSpawner({ main: { exitCode: 1, error: 'boom' } }),
+        notifyFetch: fetchMock as unknown as typeof fetch,
+        notifyLogger: { warn: () => {} },
+      },
+    );
+    expect(run.status).toBe('failed');
+    expect(captured.runId).toBe(run.id);
+    expect(captured.agentId).toBe(agent.id);
+    expect(captured.status).toBe('failed');
+  });
+
+  it('does not fire when on: [failure] and run completed', async () => {
+    const fetchMock = vi.fn();
+    const agent = makeAgent({
+      notify: {
+        on: ['failure'],
+        handlers: [{ type: 'webhook', url: 'https://example.com/hook' }],
+      },
+    });
+    await executeAgentDag(
+      agent,
+      { triggeredBy: 'cli' },
+      {
+        runStore,
+        spawnNode: cannedSpawner({ main: { exitCode: 0, result: 'ok' } }),
+        notifyFetch: fetchMock as unknown as typeof fetch,
+        notifyLogger: { warn: () => {} },
+      },
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('handler exception does not affect the run result', async () => {
+    const fetchMock = async () => { throw new Error('network down'); };
+    const warn = vi.fn();
+    const agent = makeAgent({
+      notify: {
+        on: ['failure'],
+        handlers: [{ type: 'webhook', url: 'https://example.com/hook' }],
+      },
+    });
+    const run = await executeAgentDag(
+      agent,
+      { triggeredBy: 'cli' },
+      {
+        runStore,
+        spawnNode: cannedSpawner({ main: { exitCode: 1, error: 'boom' } }),
+        notifyFetch: fetchMock as unknown as typeof fetch,
+        notifyLogger: { warn },
+      },
+    );
+    expect(run.status).toBe('failed');
+    expect(run.error).toMatch(/Failed at node/);
+    expect(warn).toHaveBeenCalled();
   });
 });

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -36,6 +36,7 @@ import { UntrustedCommunityShellError } from './agent-executor.js';
 import { buildNodeEnv, buildUpstreamSnapshot, filterEnvForLog } from './node-env.js';
 import { type SpawnResult, type SpawnNodeFn, type SpawnProgress, spawnNodeReal } from './node-spawner.js';
 import { resolveToolId, resolveToolInputs } from './tool-dispatch.js';
+import { dispatchNotify, type NotifyLogger } from './notify-dispatcher.js';
 import {
   executeControlFlowNode,
   executeAgentInvokeNode,
@@ -83,6 +84,19 @@ export interface DagExecutorDeps {
    * Production uses the default (real spawn via `executeNodeReal`).
    */
   spawnNode?: SpawnNodeFn;
+  /**
+   * Optional dashboard URL prefix used by the notify dispatcher to embed
+   * a "view run in dashboard" link in Slack messages. When absent, the
+   * link is omitted; the notify still fires.
+   */
+  dashboardBaseUrl?: string;
+  /**
+   * Optional fetch override used by the notify dispatcher's slack/webhook
+   * handlers. Tests inject a mock; production uses global fetch.
+   */
+  notifyFetch?: typeof fetch;
+  /** Logger for notify handler failures. Defaults to console.warn. */
+  notifyLogger?: NotifyLogger;
 }
 
 export interface DagExecuteOptions {
@@ -778,6 +792,30 @@ export async function executeAgentDag(
 
   const run = deps.runStore.getRun(runId);
   if (!run) throw new Error(`Run ${runId} vanished from store after write`);
+
+  // Notify dispatch fires AFTER the run row is committed. Wrapped so any
+  // dispatcher exception can never bubble into the run path — the run
+  // result is final by this point.
+  if (agent.notify) {
+    try {
+      await dispatchNotify(agent.notify, {
+        agent,
+        run,
+        secretsStore: deps.secretsStore,
+        variablesStore: deps.variablesStore,
+        dashboardBaseUrl: deps.dashboardBaseUrl,
+        fetchImpl: deps.notifyFetch,
+        logger: deps.notifyLogger,
+      });
+    } catch (err) {
+      // Defense-in-depth: dispatchNotify catches handler errors itself.
+      // This catches anything truly unexpected (e.g. secretsStore.getAll
+      // rejecting in a way the dispatcher's try/catch missed).
+      const logger = deps.notifyLogger ?? { warn: (m: string) => console.warn(`[notify] ${m}`) };
+      logger.warn(`dispatch failed: ${(err as Error).message}`);
+    }
+  }
+
   return run;
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -66,6 +66,18 @@ export { parseMcpServersBlob, type ParsedMcpBlob } from './mcp-config-parse.js';
 export { VariablesStore, looksLikeSensitive, type Variable } from './variables-store.js';
 
 export {
+  dispatchNotify,
+  buildSlackBlocks,
+  type NotifyConfig,
+  type NotifyTrigger,
+  type NotifyHandlerConfig,
+  type SlackHandlerConfig,
+  type FileHandlerConfig,
+  type WebhookHandlerConfig,
+  type DispatchNotifyOptions,
+  type NotifyLogger,
+} from './notify-dispatcher.js';
+export {
   executeAgentDag,
   topologicalSort,
   resolveUpstreamTemplate,

--- a/packages/core/src/notify-dispatcher.test.ts
+++ b/packages/core/src/notify-dispatcher.test.ts
@@ -1,0 +1,351 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  dispatchNotify,
+  buildSlackBlocks,
+  type NotifyConfig,
+} from './notify-dispatcher.js';
+import { MemorySecretsStore } from './secrets-store.js';
+import type { Agent } from './agent-v2-types.js';
+import type { Run } from './types.js';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'sua-notify-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: 'test-agent',
+    name: 'Test Agent',
+    status: 'active',
+    source: 'local',
+    mcp: false,
+    version: 1,
+    nodes: [{ id: 'main', type: 'shell', command: 'echo hi' }],
+    ...overrides,
+  };
+}
+
+function makeRun(overrides: Partial<Run> = {}): Run {
+  return {
+    id: 'run-123',
+    agentName: 'test-agent',
+    status: 'failed',
+    startedAt: '2026-04-28T16:00:00Z',
+    completedAt: '2026-04-28T16:00:05Z',
+    error: 'something exploded',
+    triggeredBy: 'cli',
+    ...overrides,
+  };
+}
+
+const silentLogger = { warn: () => {} };
+
+describe('dispatchNotify trigger matching', () => {
+  it('fires on failure when on: [failure] and run failed', async () => {
+    const notify: NotifyConfig = {
+      on: ['failure'],
+      handlers: [{ type: 'file', path: 'log.jsonl' }],
+    };
+    const result = await dispatchNotify(notify, {
+      agent: makeAgent(),
+      run: makeRun({ status: 'failed' }),
+      cwd: dir,
+      logger: silentLogger,
+    });
+    expect(result.fired).toBe(1);
+    expect(result.succeeded).toBe(1);
+    expect(existsSync(join(dir, 'log.jsonl'))).toBe(true);
+  });
+
+  it('does NOT fire on success when on: [failure]', async () => {
+    const notify: NotifyConfig = {
+      on: ['failure'],
+      handlers: [{ type: 'file', path: 'log.jsonl' }],
+    };
+    const result = await dispatchNotify(notify, {
+      agent: makeAgent(),
+      run: makeRun({ status: 'completed' }),
+      cwd: dir,
+      logger: silentLogger,
+    });
+    expect(result.fired).toBe(0);
+    expect(existsSync(join(dir, 'log.jsonl'))).toBe(false);
+  });
+
+  it('fires on success when on: [success] and run completed', async () => {
+    const notify: NotifyConfig = {
+      on: ['success'],
+      handlers: [{ type: 'file', path: 'log.jsonl' }],
+    };
+    const result = await dispatchNotify(notify, {
+      agent: makeAgent(),
+      run: makeRun({ status: 'completed' }),
+      cwd: dir,
+      logger: silentLogger,
+    });
+    expect(result.fired).toBe(1);
+  });
+
+  it('always fires on terminal status when on: [always]', async () => {
+    const notify: NotifyConfig = {
+      on: ['always'],
+      handlers: [{ type: 'file', path: 'log.jsonl' }],
+    };
+    for (const status of ['completed', 'failed', 'cancelled'] as const) {
+      const result = await dispatchNotify(notify, {
+        agent: makeAgent(),
+        run: makeRun({ status }),
+        cwd: dir,
+        logger: silentLogger,
+      });
+      expect(result.fired).toBe(1);
+    }
+  });
+});
+
+describe('file handler', () => {
+  it('writes a JSON line with the run payload', async () => {
+    const notify: NotifyConfig = {
+      on: ['failure'],
+      handlers: [{ type: 'file', path: 'failures.log' }],
+    };
+    await dispatchNotify(notify, {
+      agent: makeAgent(),
+      run: makeRun(),
+      cwd: dir,
+      logger: silentLogger,
+    });
+    const contents = readFileSync(join(dir, 'failures.log'), 'utf-8');
+    expect(contents.endsWith('\n')).toBe(true);
+    const parsed = JSON.parse(contents.trim());
+    expect(parsed.agent).toBe('test-agent');
+    expect(parsed.run_id).toBe('run-123');
+    expect(parsed.status).toBe('failed');
+    expect(parsed.error).toBe('something exploded');
+  });
+
+  it('appends across calls when append is true (default)', async () => {
+    const notify: NotifyConfig = {
+      on: ['always'],
+      handlers: [{ type: 'file', path: 'log.jsonl' }],
+    };
+    await dispatchNotify(notify, { agent: makeAgent(), run: makeRun({ id: 'r1' }), cwd: dir, logger: silentLogger });
+    await dispatchNotify(notify, { agent: makeAgent(), run: makeRun({ id: 'r2', status: 'completed', error: undefined }), cwd: dir, logger: silentLogger });
+    const lines = readFileSync(join(dir, 'log.jsonl'), 'utf-8').trim().split('\n');
+    expect(lines.length).toBe(2);
+    expect(JSON.parse(lines[0]).run_id).toBe('r1');
+    expect(JSON.parse(lines[1]).run_id).toBe('r2');
+  });
+
+  it('rejects path traversal', async () => {
+    const notify: NotifyConfig = {
+      on: ['failure'],
+      handlers: [{ type: 'file', path: '../escape.log' }],
+    };
+    const warn = vi.fn();
+    const result = await dispatchNotify(notify, {
+      agent: makeAgent(),
+      run: makeRun(),
+      cwd: dir,
+      logger: { warn },
+    });
+    expect(result.fired).toBe(1);
+    expect(result.succeeded).toBe(0);
+    expect(warn).toHaveBeenCalled();
+    expect(warn.mock.calls[0][0]).toMatch(/escapes the working directory/);
+  });
+});
+
+describe('webhook handler', () => {
+  it('POSTs JSON body with run payload', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    const notify: NotifyConfig = {
+      on: ['failure'],
+      handlers: [{ type: 'webhook', url: 'https://example.com/hook' }],
+    };
+    await dispatchNotify(notify, {
+      agent: makeAgent(),
+      run: makeRun(),
+      cwd: dir,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      logger: silentLogger,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://example.com/hook');
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body);
+    expect(body.agent).toBe('test-agent');
+    expect(body.run_id).toBe('run-123');
+    expect(body.status).toBe('failed');
+    expect(body.error).toBe('something exploded');
+  });
+
+  it('injects Bearer token from headers_secret', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    const secretsStore = new MemorySecretsStore();
+    await secretsStore.set('WEBHOOK_TOKEN', 'sekret-value');
+    const notify: NotifyConfig = {
+      on: ['failure'],
+      secrets: ['WEBHOOK_TOKEN'],
+      handlers: [{ type: 'webhook', url: 'https://example.com/hook', headers_secret: 'WEBHOOK_TOKEN' }],
+    };
+    await dispatchNotify(notify, {
+      agent: makeAgent(),
+      run: makeRun(),
+      cwd: dir,
+      secretsStore,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      logger: silentLogger,
+    });
+    const init = fetchMock.mock.calls[0][1];
+    expect(init.headers.Authorization).toBe('Bearer sekret-value');
+  });
+
+  it('rejects bad URLs via assertSafeUrl', async () => {
+    const fetchMock = vi.fn();
+    const warn = vi.fn();
+    const notify: NotifyConfig = {
+      on: ['failure'],
+      handlers: [{ type: 'webhook', url: 'http://127.0.0.1/hook' }],
+    };
+    const result = await dispatchNotify(notify, {
+      agent: makeAgent(),
+      run: makeRun(),
+      cwd: dir,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      logger: { warn },
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.succeeded).toBe(0);
+    expect(warn).toHaveBeenCalled();
+    expect(warn.mock.calls[0][0]).toMatch(/private|reserved|Blocked/i);
+  });
+
+  it('logs a warn on non-2xx response and does not throw', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+    const warn = vi.fn();
+    const notify: NotifyConfig = {
+      on: ['failure'],
+      handlers: [{ type: 'webhook', url: 'https://example.com/hook' }],
+    };
+    const result = await dispatchNotify(notify, {
+      agent: makeAgent(),
+      run: makeRun(),
+      cwd: dir,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      logger: { warn },
+    });
+    expect(result.succeeded).toBe(0);
+    expect(warn.mock.calls[0][0]).toMatch(/503/);
+  });
+});
+
+describe('slack handler', () => {
+  it('builds Block Kit payload with agent id, run id, status, error tail, dashboard link', () => {
+    const out = buildSlackBlocks(
+      makeAgent(),
+      makeRun(),
+      { channel: '#alerts', mention: '@oncall', dashboardBaseUrl: 'https://dash.local' },
+    );
+    expect(out.channel).toBe('#alerts');
+    expect(out.blocks.length).toBeGreaterThan(0);
+    const block = out.blocks[0] as { type: string; text: { type: string; text: string } };
+    expect(block.type).toBe('section');
+    expect(block.text.type).toBe('mrkdwn');
+    expect(block.text.text).toContain('test-agent');
+    expect(block.text.text).toContain('run-123');
+    expect(block.text.text).toContain('failed');
+    expect(block.text.text).toContain('something exploded');
+    expect(block.text.text).toContain('https://dash.local/runs/run-123');
+    expect(block.text.text).toContain('@oncall');
+  });
+
+  it('truncates error to last 200 chars', () => {
+    const longErr = 'X'.repeat(500) + 'TAIL';
+    const out = buildSlackBlocks(makeAgent(), makeRun({ error: longErr }), {});
+    const block = out.blocks[0] as { text: { text: string } };
+    expect(block.text.text).toContain('TAIL');
+    expect(block.text.text).not.toContain('X'.repeat(300));
+  });
+
+  it('POSTs to slack webhook when handler fires', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    const secretsStore = new MemorySecretsStore();
+    await secretsStore.set('SLACK_WEBHOOK', 'https://hooks.slack.com/services/T/B/X');
+    const notify: NotifyConfig = {
+      on: ['failure'],
+      secrets: ['SLACK_WEBHOOK'],
+      handlers: [{ type: 'slack', webhook_secret: 'SLACK_WEBHOOK', channel: '#alerts' }],
+    };
+    await dispatchNotify(notify, {
+      agent: makeAgent(),
+      run: makeRun(),
+      cwd: dir,
+      secretsStore,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      logger: silentLogger,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://hooks.slack.com/services/T/B/X');
+    const body = JSON.parse(init.body);
+    expect(body.channel).toBe('#alerts');
+    expect(Array.isArray(body.blocks)).toBe(true);
+  });
+
+  it('warns when the webhook secret is missing from the store', async () => {
+    const fetchMock = vi.fn();
+    const warn = vi.fn();
+    const notify: NotifyConfig = {
+      on: ['failure'],
+      secrets: ['SLACK_WEBHOOK'],
+      handlers: [{ type: 'slack', webhook_secret: 'SLACK_WEBHOOK' }],
+    };
+    const result = await dispatchNotify(notify, {
+      agent: makeAgent(),
+      run: makeRun(),
+      cwd: dir,
+      secretsStore: new MemorySecretsStore(),
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      logger: { warn },
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.succeeded).toBe(0);
+    expect(warn.mock.calls[0][0]).toMatch(/SLACK_WEBHOOK/);
+  });
+});
+
+describe('handler isolation', () => {
+  it('one handler failing does not crash the dispatcher or block other handlers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    const warn = vi.fn();
+    const notify: NotifyConfig = {
+      on: ['failure'],
+      handlers: [
+        { type: 'file', path: '../escape.log' },
+        { type: 'webhook', url: 'https://example.com/hook' },
+      ],
+    };
+    const result = await dispatchNotify(notify, {
+      agent: makeAgent(),
+      run: makeRun(),
+      cwd: dir,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      logger: { warn },
+    });
+    expect(result.fired).toBe(2);
+    expect(result.succeeded).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/notify-dispatcher.ts
+++ b/packages/core/src/notify-dispatcher.ts
@@ -1,0 +1,306 @@
+/**
+ * Notify dispatcher — fires user-declared handlers (slack / file / webhook)
+ * after a DAG run commits its final state. Called from `dag-executor.ts`
+ * with the finalised Run row in hand.
+ *
+ * Trigger conditions:
+ *   - `on: ['failure']` — run.status === 'failed'
+ *   - `on: ['success']` — run.status === 'completed'
+ *   - `on: ['always']`  — any terminal status (also 'cancelled')
+ *
+ * Reliability:
+ *   - Handlers run in parallel.
+ *   - Handler exceptions are caught + logged; they NEVER bubble into the
+ *     run path. A broken Slack webhook should not turn a successful run
+ *     into a failed one.
+ *
+ * Secrets:
+ *   - Secrets are env-var-only at the node level (see `node-env.ts`). Notify
+ *     config doesn't see node env, so we resolve declared `notify.secrets:`
+ *     against `secretsStore.getAll()` here, the same shape `node-env.ts`
+ *     uses.
+ *
+ * Templating:
+ *   - String fields (channel, path, url, mention) accept `{{vars.X}}`
+ *     substitution via the global variables store. `{{upstream.X.result}}`
+ *     is NOT supported — the dispatcher fires once per run, not per node,
+ *     and binding it to a single upstream's output is ambiguous.
+ */
+
+import { resolve } from 'node:path';
+import { appendFileSync, writeFileSync } from 'node:fs';
+import type { Agent } from './agent-v2-types.js';
+import type { Run } from './types.js';
+import type { SecretsStore } from './secrets-store.js';
+import type { VariablesStore } from './variables-store.js';
+import { assertSafeUrl } from './builtin-tools.js';
+import { resolveVarsTemplate } from './node-templates.js';
+
+export type NotifyTrigger = 'failure' | 'success' | 'always';
+
+export interface SlackHandlerConfig {
+  type: 'slack';
+  /** Name of the secret holding the Slack incoming webhook URL. */
+  webhook_secret: string;
+  channel?: string;
+  mention?: string;
+}
+
+export interface FileHandlerConfig {
+  type: 'file';
+  /** Path relative to the working directory; absolute paths are allowed
+   *  only if they resolve inside cwd. Path traversal is rejected. */
+  path: string;
+  /** When true (default), append. When false, overwrite each notify. */
+  append?: boolean;
+}
+
+export interface WebhookHandlerConfig {
+  type: 'webhook';
+  url: string;
+  method?: 'POST' | 'PUT';
+  /** Name of the secret holding a Bearer token; injected as
+   *  `Authorization: Bearer <secret>` if present. */
+  headers_secret?: string;
+}
+
+export type NotifyHandlerConfig =
+  | SlackHandlerConfig
+  | FileHandlerConfig
+  | WebhookHandlerConfig;
+
+export interface NotifyConfig {
+  on: NotifyTrigger[];
+  secrets?: string[];
+  handlers: NotifyHandlerConfig[];
+}
+
+export interface NotifyLogger {
+  warn(message: string): void;
+}
+
+const defaultLogger: NotifyLogger = {
+  warn(msg) {
+    // eslint-disable-next-line no-console
+    console.warn(`[notify] ${msg}`);
+  },
+};
+
+export interface DispatchNotifyOptions {
+  agent: Agent;
+  run: Run;
+  secretsStore?: SecretsStore;
+  variablesStore?: VariablesStore;
+  /** Project-cwd for the file handler's path-traversal guard. Defaults to process.cwd(). */
+  cwd?: string;
+  /** Optional URL prefix for dashboard run links inside Slack messages. */
+  dashboardBaseUrl?: string;
+  /** Injection point for tests. Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Injection point for tests; defaults to console.warn. */
+  logger?: NotifyLogger;
+}
+
+/**
+ * Fire all handlers in `notify` whose trigger condition matches the run's
+ * final status. Returns the count of handlers that ran successfully — useful
+ * for tests; the dag-executor ignores it.
+ *
+ * Never throws; handler errors are caught and logged.
+ */
+export async function dispatchNotify(
+  notify: NotifyConfig,
+  opts: DispatchNotifyOptions,
+): Promise<{ fired: number; succeeded: number }> {
+  const logger = opts.logger ?? defaultLogger;
+  if (!shouldFire(notify.on, opts.run.status)) {
+    return { fired: 0, succeeded: 0 };
+  }
+
+  // Resolve declared secrets up-front. If the store is locked / a secret
+  // is missing, we still fire handlers that don't need it; broken handlers
+  // log and continue. This matches the "never break the run" contract.
+  const secrets: Record<string, string> = {};
+  if (notify.secrets && notify.secrets.length > 0 && opts.secretsStore) {
+    try {
+      const all = await opts.secretsStore.getAll();
+      for (const name of notify.secrets) {
+        if (name in all) secrets[name] = all[name];
+      }
+    } catch (err) {
+      logger.warn(`failed to read secrets: ${(err as Error).message}`);
+    }
+  }
+
+  const vars = opts.variablesStore?.getAll() ?? {};
+
+  const results = await Promise.all(
+    notify.handlers.map(async (handler) => {
+      try {
+        await runHandler(handler, { ...opts, secrets, vars, logger });
+        return true;
+      } catch (err) {
+        logger.warn(`handler ${handler.type} failed: ${(err as Error).message}`);
+        return false;
+      }
+    }),
+  );
+
+  return {
+    fired: results.length,
+    succeeded: results.filter(Boolean).length,
+  };
+}
+
+function shouldFire(triggers: NotifyTrigger[], status: Run['status']): boolean {
+  if (triggers.includes('always')) return status !== 'pending' && status !== 'running';
+  if (triggers.includes('failure') && status === 'failed') return true;
+  if (triggers.includes('success') && status === 'completed') return true;
+  return false;
+}
+
+interface HandlerContext extends DispatchNotifyOptions {
+  secrets: Record<string, string>;
+  vars: Record<string, string>;
+  logger: NotifyLogger;
+}
+
+async function runHandler(handler: NotifyHandlerConfig, ctx: HandlerContext): Promise<void> {
+  switch (handler.type) {
+    case 'slack':
+      return slackHandler(handler, ctx);
+    case 'file':
+      return fileHandler(handler, ctx);
+    case 'webhook':
+      return webhookHandler(handler, ctx);
+    default: {
+      const exhaustive: never = handler;
+      throw new Error(`Unknown notify handler type: ${JSON.stringify(exhaustive)}`);
+    }
+  }
+}
+
+// ── Slack ──────────────────────────────────────────────────────────────
+
+export function buildSlackBlocks(
+  agent: Agent,
+  run: Run,
+  opts: { mention?: string; channel?: string; dashboardBaseUrl?: string },
+): { text: string; blocks: unknown[]; channel?: string } {
+  const statusEmoji =
+    run.status === 'failed' ? ':x:' :
+    run.status === 'completed' ? ':white_check_mark:' :
+    run.status === 'cancelled' ? ':no_entry_sign:' :
+    ':information_source:';
+  const headline = `${statusEmoji} *${agent.name ?? agent.id}* — ${run.status}`;
+  const errTail = run.error ? run.error.slice(-200) : '';
+  const lines: string[] = [
+    headline,
+    `agent: \`${agent.id}\`  run: \`${run.id}\``,
+  ];
+  if (run.startedAt) lines.push(`started: ${run.startedAt}`);
+  if (run.completedAt) lines.push(`completed: ${run.completedAt}`);
+  if (errTail) lines.push(`error: \`${errTail}\``);
+  if (opts.dashboardBaseUrl) {
+    const base = opts.dashboardBaseUrl.replace(/\/$/, '');
+    lines.push(`<${base}/runs/${encodeURIComponent(run.id)}|Open run in dashboard>`);
+  }
+  const text = (opts.mention ? `${opts.mention}\n` : '') + lines.join('\n');
+
+  const blocks: unknown[] = [
+    { type: 'section', text: { type: 'mrkdwn', text } },
+  ];
+
+  return {
+    text: stripMarkdown(text),
+    blocks,
+    ...(opts.channel ? { channel: opts.channel } : {}),
+  };
+}
+
+function stripMarkdown(text: string): string {
+  return text.replace(/[*_`<>]/g, '');
+}
+
+async function slackHandler(handler: SlackHandlerConfig, ctx: HandlerContext): Promise<void> {
+  const url = ctx.secrets[handler.webhook_secret];
+  if (!url) {
+    throw new Error(`secret "${handler.webhook_secret}" not declared in notify.secrets or not present in store`);
+  }
+  await assertSafeUrl(url);
+
+  const channel = handler.channel ? resolveVarsTemplate(handler.channel, ctx.vars) : undefined;
+  const mention = handler.mention ? resolveVarsTemplate(handler.mention, ctx.vars) : undefined;
+
+  const payload = buildSlackBlocks(ctx.agent, ctx.run, {
+    channel,
+    mention,
+    dashboardBaseUrl: ctx.dashboardBaseUrl,
+  });
+
+  const fetchFn = ctx.fetchImpl ?? fetch;
+  const res = await fetchFn(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    throw new Error(`slack webhook returned ${res.status}`);
+  }
+}
+
+// ── File ───────────────────────────────────────────────────────────────
+
+async function fileHandler(handler: FileHandlerConfig, ctx: HandlerContext): Promise<void> {
+  const cwd = resolve(ctx.cwd ?? process.cwd());
+  const rawPath = resolveVarsTemplate(handler.path, ctx.vars);
+  const filePath = resolve(cwd, rawPath);
+  if (!filePath.startsWith(cwd + '/') && filePath !== cwd) {
+    throw new Error(`Path "${rawPath}" escapes the working directory.`);
+  }
+  const append = handler.append !== false;
+  const line = JSON.stringify(notifyPayload(ctx.agent, ctx.run)) + '\n';
+  if (append) {
+    appendFileSync(filePath, line, 'utf-8');
+  } else {
+    writeFileSync(filePath, line, 'utf-8');
+  }
+}
+
+// ── Webhook ────────────────────────────────────────────────────────────
+
+async function webhookHandler(handler: WebhookHandlerConfig, ctx: HandlerContext): Promise<void> {
+  const url = resolveVarsTemplate(handler.url, ctx.vars);
+  await assertSafeUrl(url);
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (handler.headers_secret) {
+    const token = ctx.secrets[handler.headers_secret];
+    if (!token) {
+      throw new Error(`secret "${handler.headers_secret}" not declared in notify.secrets or not present in store`);
+    }
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  const fetchFn = ctx.fetchImpl ?? fetch;
+  const res = await fetchFn(url, {
+    method: handler.method ?? 'POST',
+    headers,
+    body: JSON.stringify(notifyPayload(ctx.agent, ctx.run)),
+  });
+  if (!res.ok) {
+    throw new Error(`webhook returned ${res.status}`);
+  }
+}
+
+// ── Payload shape ──────────────────────────────────────────────────────
+
+function notifyPayload(agent: Agent, run: Run): Record<string, unknown> {
+  return {
+    agent: agent.id,
+    run_id: run.id,
+    status: run.status,
+    started_at: run.startedAt,
+    completed_at: run.completedAt,
+    ...(run.error ? { error: run.error } : {}),
+    ...(run.result !== undefined ? { output: run.result } : {}),
+  };
+}

--- a/packages/dashboard/src/routes/agent-inputs.ts
+++ b/packages/dashboard/src/routes/agent-inputs.ts
@@ -1,11 +1,11 @@
 import { Router, type Request, type Response } from 'express';
-import type { AgentInputSpec, OutputWidgetSchema, OutputWidgetType, WidgetFieldType } from '@some-useful-agents/core';
+import type { AgentInputSpec, OutputWidgetSchema, OutputWidgetType, WidgetFieldType, NotifyConfig } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 import { mergeNewInput, parseEnumValues } from './agent-nodes.js';
 import { renderOutputWidget } from '../views/output-widgets.js';
 import { synthPreviewOutput, type FieldType } from '../views/output-widget-help.js';
 import { render } from '../views/html.js';
-import { sanitizeHtml, getTemplateGenerator } from '@some-useful-agents/core';
+import { sanitizeHtml, getTemplateGenerator, agentV2Schema } from '@some-useful-agents/core';
 
 export const agentInputsRouter: Router = Router();
 
@@ -381,5 +381,85 @@ agentInputsRouter.post('/agents/:name/output-widget/generate', async (req: Reque
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     res.status(502).type('text/plain').send(`Generation failed: ${msg}`);
+  }
+});
+
+// ── Notify update ───────────────────────────────────────────────────────
+
+/**
+ * POST /agents/:name/notify/update — save or remove the notify block.
+ * Body: action='save'|'remove', notify=<JSON string of notify config>.
+ * Validates by re-parsing the agent through agentV2Schema (so any zod
+ * issue surfaces as the same kind of error the YAML importer raises).
+ */
+agentInputsRouter.post('/agents/:name/notify/update', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
+  const agent = ctx.agentStore.getAgent(name);
+  if (!agent) {
+    res.status(404).redirect(303, '/agents');
+    return;
+  }
+
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const action = typeof body.action === 'string' ? body.action : 'save';
+  const flashBase = `/agents/${encodeURIComponent(agent.id)}/config`;
+
+  if (action === 'remove') {
+    try {
+      ctx.agentStore.createNewVersion(
+        agent.id,
+        { ...agent, notify: undefined },
+        'dashboard',
+        'Removed notify via dashboard',
+      );
+      res.redirect(303, `${flashBase}?flash=${encodeURIComponent('Notify removed.')}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      res.redirect(303, `${flashBase}?flash=${encodeURIComponent(`Failed: ${msg}`)}`);
+    }
+    return;
+  }
+
+  const raw = typeof body.notify === 'string' ? body.notify.trim() : '';
+  if (!raw) {
+    res.redirect(303, `${flashBase}?flash=${encodeURIComponent('Notify body is empty.')}`);
+    return;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `${flashBase}?flash=${encodeURIComponent(`Invalid JSON: ${msg}`)}`);
+    return;
+  }
+
+  // Reuse the agent-v2 zod schema by re-validating the whole agent — this
+  // ensures notify cross-checks (e.g. handler secrets must be declared)
+  // run identically to the YAML import path.
+  const candidate = { ...agent, notify: parsed };
+  const result = agentV2Schema.safeParse(candidate);
+  if (!result.success) {
+    const summary = result.error.issues
+      .filter((i) => i.path[0] === 'notify')
+      .map((i) => `${i.path.join('.')}: ${i.message}`)
+      .join('; ') || result.error.issues[0]?.message || 'Invalid notify config.';
+    res.redirect(303, `${flashBase}?flash=${encodeURIComponent(`Validation failed: ${summary}`)}`);
+    return;
+  }
+
+  try {
+    ctx.agentStore.createNewVersion(
+      agent.id,
+      { ...agent, notify: parsed as NotifyConfig },
+      'dashboard',
+      'Updated notify via dashboard',
+    );
+    res.redirect(303, `${flashBase}?flash=${encodeURIComponent('Notify saved. New version created.')}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `${flashBase}?flash=${encodeURIComponent(`Save failed: ${msg}`)}`);
   }
 });

--- a/packages/dashboard/src/views/agent-detail-helpers.ts
+++ b/packages/dashboard/src/views/agent-detail-helpers.ts
@@ -529,6 +529,47 @@ function fieldTypeSelectWithTooltip(name: string, current: string, _widgetType: 
   return `<select name="${name}" title="${tip}" style="padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs);">${opts}</select>`;
 }
 
+// ── Notify editor ────────────────────────────────────────────────────────
+
+/**
+ * Renders the notify-handlers editor on the agent's Config tab.
+ *
+ * UX is intentionally simple — a single textarea with the JSON for the
+ * `notify:` block. The schema is small enough that a structured form
+ * would be more clicks than typing it. Save round-trips through the
+ * agent-v2 schema, so any error surfaces inline as a flash.
+ */
+export function renderNotifyEditor(agent: Agent): SafeHtml {
+  const FIELD = 'padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs); font-family: var(--font-mono); width: 100%;';
+  const current = agent.notify ? JSON.stringify(agent.notify, null, 2) : '';
+  const placeholder = JSON.stringify({
+    on: ['failure'],
+    secrets: ['SLACK_WEBHOOK'],
+    handlers: [
+      { type: 'slack', webhook_secret: 'SLACK_WEBHOOK', channel: '#alerts' },
+      { type: 'file', path: 'logs/failures.jsonl' },
+    ],
+  }, null, 2);
+
+  return html`
+    <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-3);">
+      Fires after every run commits. Handlers run in parallel; a broken handler
+      logs and is skipped — it never fails the run.
+    </p>
+    <form method="POST" action="/agents/${agent.id}/notify/update">
+      <textarea name="notify" rows="14" placeholder="${placeholder}" style="${FIELD}">${current}</textarea>
+      <p class="dim" style="font-size: var(--font-size-xs); margin: var(--space-2) 0;">
+        JSON shape mirrors the YAML <code>notify:</code> block. Trigger: <code>failure</code>, <code>success</code>, or <code>always</code>.
+        Secrets must be declared in <code>secrets:</code> and set via <a href="/settings/secrets">Settings → Secrets</a>.
+      </p>
+      <div style="display: flex; gap: var(--space-2); justify-content: flex-end;">
+        ${agent.notify ? html`<button type="submit" name="action" value="remove" class="btn btn--ghost btn--sm" style="color: var(--color-err);">Remove notify</button>` : html``}
+        <button type="submit" name="action" value="save" class="btn btn--primary btn--sm">Save notify</button>
+      </div>
+    </form>
+  `;
+}
+
 // ── Small helpers ────────────────────────────────────────────────────────
 
 export function typeSelect(namePrefix: string, current: string): SafeHtml {

--- a/packages/dashboard/src/views/agent-detail-v2.ts
+++ b/packages/dashboard/src/views/agent-detail-v2.ts
@@ -20,6 +20,7 @@ import {
   renderRunInputsForm,
   renderVariablesEditor,
   renderOutputWidgetEditor,
+  renderNotifyEditor,
   vStatusBadge,
   statusOption,
   providerOption,
@@ -344,6 +345,12 @@ export async function renderAgentConfig(args: AgentDetailArgs): Promise<string> 
     <section class="card" style="margin-bottom: var(--space-6);">
       <h3 style="margin: 0 0 var(--space-3);">Output Widget</h3>
       ${renderOutputWidgetEditor(agent)}
+    </section>
+
+    <!-- Notify -->
+    <section class="card" style="margin-bottom: var(--space-6);">
+      <h3 style="margin: 0 0 var(--space-3);">Notify</h3>
+      ${renderNotifyEditor(agent)}
     </section>
 
     <!-- Secrets -->


### PR DESCRIPTION
## Summary

Adds an optional `notify:` block to the agent-v2 schema. After a DAG run commits its final state, the executor dispatches user-declared handlers when the run's status matches the configured trigger (`failure | success | always`).

- New `notify-dispatcher.ts`: three handlers (Slack Block Kit, append-file, generic webhook) running in parallel and isolated — a broken Slack webhook can never turn a successful run into a failed one.
- URLs gated by existing `assertSafeUrl` (SSRF guard); file paths gated by the same cwd-escape check the `file-write` builtin uses; secrets resolved from `secretsStore` the same way nodes resolve declared secrets.
- Schema: secrets are referenced by name in handlers and declared once in `notify.secrets`. `{{secrets.X}}` templates do not exist in this codebase, so the original plan's template approach was corrected to a per-handler `webhook_secret` / `headers_secret` field plus a top-level `secrets:` list, with a zod cross-check that every referenced name is declared.
- Dashboard agent config gets a JSON-textarea `renderNotifyEditor` and a `POST /agents/:name/notify/update` route, mirroring the existing widget editor pattern.

## Tests

- 16 dispatcher tests (trigger matching, all three handlers, isolation, SSRF guard, secret resolution, Slack Block Kit shape).
- 3 dag-executor integration tests (fires on failure, doesn't fire on success, handler exception doesn't fail the run).
- 683 / 683 total (+19 new).

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` green
- [x] `npm run build` clean
- [ ] Manual: agent with `notify: { on: [failure], handlers: [{ type: file, path: \"logs/test.log\" }] }` writes to log on failure
- [ ] Manual: Slack webhook handler against a test channel renders the Block Kit message
- [ ] Manual: webhook handler POSTs the expected JSON shape

## Notes

- Dashboard link in Slack messages depends on a `dashboardBaseUrl` field added to `DagExecutorDeps` (not `SuaConfig`). When absent, the link is omitted. One-line wiring follow-up at whichever CLI command instantiates the executor.
- Email handler intentionally not in this PR (needs SMTP/API integration). Defer until Slack proves the pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)