### PR TITLE
fix(core): propagate source through upsertAgent on upgrade

### DIFF
--- a/packages/core/src/agent-store.test.ts
+++ b/packages/core/src/agent-store.test.ts
@@ -187,6 +187,27 @@ describe('AgentStore.upsertAgent', () => {
     expect(store.listVersions('hello')).toHaveLength(2);
     expect(store.getAgent('hello')!.nodes[0].command).toBe('echo changed');
   });
+
+  it('updates source on upgrade — installer-takes-ownership semantics', () => {
+    // Initial import as an example agent (e.g. shipped with sua).
+    store.upsertAgent(seed({ source: 'examples' }), 'import');
+    expect(store.getAgent('hello')!.source).toBe('examples');
+
+    // `sua agent install` re-imports the same id with source: 'local'
+    // (the installer takes ownership). The DAG might or might not differ;
+    // either path must propagate the new source.
+    // Path 1: identical DAG (metadata-only update).
+    store.upsertAgent(seed({ source: 'local' }), 'import');
+    expect(store.getAgent('hello')!.source).toBe('local');
+
+    // Path 2: differing DAG (new version row + metadata update).
+    store.upsertAgent(
+      seed({ source: 'community', nodes: [{ id: 'main', type: 'shell', command: 'echo new' }] }),
+      'import',
+    );
+    expect(store.getAgent('hello')!.source).toBe('community');
+    expect(store.getAgent('hello')!.version).toBe(2);
+  });
 });
 
 describe('AgentStore.updateAgentMeta', () => {

--- a/packages/core/src/agent-store.ts
+++ b/packages/core/src/agent-store.ts
@@ -163,6 +163,7 @@ export class AgentStore {
         status: agent.status,
         schedule: agent.schedule,
         mcp: agent.mcp,
+        source: agent.source,
       });
       return { ...agent, version: existing.version };
     }
@@ -201,7 +202,7 @@ export class AgentStore {
    */
   updateAgentMeta(
     id: string,
-    patch: Partial<Pick<Agent, 'name' | 'description' | 'status' | 'schedule' | 'mcp' | 'starred'>>,
+    patch: Partial<Pick<Agent, 'name' | 'description' | 'status' | 'schedule' | 'mcp' | 'starred' | 'source'>>,
   ): void {
     const fields: string[] = [];
     const values: SqlValue[] = [];
@@ -211,6 +212,7 @@ export class AgentStore {
     if (patch.schedule !== undefined) { fields.push('schedule = ?'); values.push(patch.schedule ?? null); }
     if (patch.mcp !== undefined) { fields.push('mcp = ?'); values.push(patch.mcp ? 1 : 0); }
     if (patch.starred !== undefined) { fields.push('starred = ?'); values.push(patch.starred ? 1 : 0); }
+    if (patch.source !== undefined) { fields.push('source = ?'); values.push(patch.source); }
     if (fields.length === 0) return;
     fields.push('updated_at = ?');
     values.push(new Date().toISOString());
@@ -248,6 +250,7 @@ export class AgentStore {
         status: agent.status,
         schedule: agent.schedule,
         mcp: agent.mcp,
+        source: agent.source,
       });
       this.db.prepare(`UPDATE agents SET current_version = ?, updated_at = ? WHERE id = ?`).run(nextVersion, now, id);
       this.db.exec('COMMIT');


### PR DESCRIPTION
## Summary

Found while end-to-end testing PR #152's `sua agent install <url>`. The install path explicitly sets `source: 'local'` to enforce its installer-takes-ownership contract, but the value was silently dropped on existing agents.

Both branches of `upsertAgent` (metadata-only update when DAG unchanged, and new-version creation when DAG differs) called `updateAgentMeta(...)` with a patch that omitted `source`, and `updateAgentMeta`'s type signature didn't accept it. So an agent that already lived in the DB as `source=examples` stayed `examples` even after `sua agent install --force` — quietly violating the documented contract.

Initial installs of new agents were unaffected (`createAgent` honors `agent.source` directly). Only upgrades hit the bug.

## Repro before fix

```
$ sua workflow list | grep daily-joke
│ daily-joke      │ active │ examples │ ...
$ sua agent install https://github.com/.../daily-joke.yaml --yes --force
✅  Upgraded daily-joke to version N
   source:   local (installer takes ownership)   ← printed but not actually written
$ sua workflow list | grep daily-joke
│ daily-joke      │ active │ examples │ ...      ← unchanged!
```

## After fix

```
$ sua workflow list | grep daily-joke
│ daily-joke      │ active │ local    │ ...      ← coerced as documented
```

## Changes

- `updateAgentMeta` accepts `source` in its patch type and writes it to the row when set.
- Both `upsertAgent` paths pass `agent.source` into `updateAgentMeta`.
- New test: `AgentStore.upsertAgent > updates source on upgrade` covers both paths (identical DAG → metadata-only update; differing DAG → new version).

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` green (730 / 730, +1 new test, 0 regressions)
- [x] `npm run build` clean
- [x] Manual e2e: install an existing `source=examples` agent via `sua agent install --force`; verify list shows `source=local` afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)