### PR TITLE
feat(core): plumb dashboardBaseUrl through executor for notify run links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ docker-volumes/
 # Local plans
 .plans/
 
+# Claude Code session state (worktrees from subagent isolation, etc.)
+.claude/
+
 # gstack security reports (local-only, not committed)
 .gstack/
 

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { startDashboardServer } from '@some-useful-agents/dashboard';
-import { loadConfig, getAgentDirs, getDbPath, getSecretsPath, getVariablesPath, getRetentionDays } from '../config.js';
+import { loadConfig, getAgentDirs, getDbPath, getSecretsPath, getVariablesPath, getRetentionDays, getDashboardBaseUrl } from '../config.js';
 import * as ui from '../ui.js';
 
 function collectName(value: string, previous: string[]): string[] {
@@ -58,6 +58,7 @@ of scope for this release — wrap in launchd / systemd if you need it.
         variablesPath: getVariablesPath(config),
         retentionDays: getRetentionDays(config),
         allowUntrustedShell: new Set(options.allowUntrustedShell),
+        dashboardBaseUrl: getDashboardBaseUrl(config),
       });
     } catch (err) {
       ui.fail((err as Error).message);

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -20,7 +20,7 @@ import {
 } from '@some-useful-agents/core';
 import { readFileSync, readdirSync, existsSync, statSync, mkdirSync } from 'node:fs';
 import { dirname, join, extname } from 'node:path';
-import { loadConfig, getAgentDirs, getDbPath, getSecretsPath } from '../config.js';
+import { loadConfig, getAgentDirs, getDbPath, getSecretsPath, getDashboardBaseUrl } from '../config.js';
 import * as ui from '../ui.js';
 
 /**
@@ -304,6 +304,7 @@ workflowCommand
           runStore: stores.runs,
           secretsStore,
           allowUntrustedShell: new Set(options.allowUntrustedShell),
+          dashboardBaseUrl: getDashboardBaseUrl(config),
         },
       );
       if (run.status === 'completed') {
@@ -458,6 +459,7 @@ workflowCommand
           runStore: stores.runs,
           secretsStore,
           allowUntrustedShell: new Set(options.allowUntrustedShell),
+          dashboardBaseUrl: getDashboardBaseUrl(config),
         },
       );
       if (replay.status === 'completed') {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -7,6 +7,14 @@ export interface SuaConfig {
   dataDir: string;
   /** Default port the dashboard binds to. CLI --port still wins per-invocation. */
   dashboardPort?: number;
+  /**
+   * Base URL the dashboard is reachable at, used to build clickable run
+   * links inside notify handler payloads (Slack, etc). Defaults to
+   * `http://127.0.0.1:<dashboardPort>`. Override when the dashboard is
+   * behind a reverse proxy or bound to a non-loopback host that the
+   * notify destination needs to reach.
+   */
+  dashboardBaseUrl?: string;
   mcpPort: number;
   temporalAddress?: string;
   temporalNamespace?: string;
@@ -117,4 +125,9 @@ export function getDaemonLogRotateBytes(config: SuaConfig): number {
 
 export function getDashboardPort(config: SuaConfig): number {
   return config.dashboardPort ?? 3000;
+}
+
+export function getDashboardBaseUrl(config: SuaConfig): string {
+  if (config.dashboardBaseUrl) return config.dashboardBaseUrl.replace(/\/$/, '');
+  return `http://127.0.0.1:${getDashboardPort(config)}`;
 }

--- a/packages/core/src/dag-executor.test.ts
+++ b/packages/core/src/dag-executor.test.ts
@@ -1594,4 +1594,38 @@ describe('executeAgentDag — notify dispatch', () => {
     expect(run.error).toMatch(/Failed at node/);
     expect(warn).toHaveBeenCalled();
   });
+
+  it('threads dashboardBaseUrl through to the slack handler payload', async () => {
+    type SlackPayload = { blocks?: { text?: { text: string } }[] };
+    let capturedBody: SlackPayload = {};
+    const fetchMock = async (_url: string | URL | Request, init?: RequestInit) => {
+      capturedBody = JSON.parse(String(init?.body ?? '{}')) as SlackPayload;
+      return { ok: true, status: 200 } as unknown as Response;
+    };
+    const secrets = new MemorySecretsStore();
+    secrets.set('SLACK_HOOK', 'https://hooks.slack.com/services/T/B/X');
+    const agent = makeAgent({
+      nodes: [{ id: 'main', type: 'shell', command: 'false' }],
+      notify: {
+        on: ['failure'],
+        secrets: ['SLACK_HOOK'],
+        handlers: [{ type: 'slack', webhook_secret: 'SLACK_HOOK' }],
+      },
+    });
+    await executeAgentDag(
+      agent,
+      { triggeredBy: 'cli' },
+      {
+        runStore,
+        secretsStore: secrets,
+        spawnNode: cannedSpawner({ main: { exitCode: 1, error: 'boom' } }),
+        notifyFetch: fetchMock as unknown as typeof fetch,
+        notifyLogger: { warn: () => {} },
+        dashboardBaseUrl: 'https://my-host:3000',
+      },
+    );
+    const text = capturedBody.blocks?.[0]?.text?.text ?? '';
+    expect(text).toContain('https://my-host:3000/runs/');
+    expect(text).toContain('Open run in dashboard');
+  });
 });

--- a/packages/dashboard/src/context.ts
+++ b/packages/dashboard/src/context.ts
@@ -84,6 +84,13 @@ export interface DashboardContext {
    * heartbeat file and report scheduler status.
    */
   dataDir: string;
+  /**
+   * Public base URL the dashboard is reachable at, e.g. `http://127.0.0.1:3000`.
+   * Used to build clickable run links inside notify handler payloads. Built
+   * once at startup from `dashboardBaseUrl` opts (or `http://<host>:<port>`
+   * fallback) and threaded into the DAG executor on run-now / replay.
+   */
+  dashboardBaseUrl: string;
 }
 
 /**

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -87,6 +87,7 @@ command: echo from-the-internet
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
     dataDir: dir,
+    dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };
 
   return { app: buildDashboardApp(ctx), ctx };

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -57,6 +57,12 @@ export interface StartDashboardOptions {
   allowUntrustedShell?: Set<string>;
   /** Run-history retention in days (shown on /settings/general). Defaults to 30. */
   retentionDays?: number;
+  /**
+   * Public base URL the dashboard is reachable at. Used to build clickable
+   * run links inside notify handler payloads (Slack, etc). Falls back to
+   * `http://<host>:<port>` if unset.
+   */
+  dashboardBaseUrl?: string;
   /** Optional SecretsStore override (tests). */
   secretsStore?: SecretsStore;
   /** Optional LocalProvider override (tests). */
@@ -249,6 +255,7 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     allowUntrustedShell: opts.allowUntrustedShell ?? new Set(),
     activeRuns: new Map(),
     dataDir: dirname(opts.dbPath),
+    dashboardBaseUrl: (opts.dashboardBaseUrl ?? `http://${host}:${opts.port}`).replace(/\/$/, ''),
   };
 
   const app = buildDashboardApp(ctx);

--- a/packages/dashboard/src/routes/run-mutations.ts
+++ b/packages/dashboard/src/routes/run-mutations.ts
@@ -160,6 +160,7 @@ runMutationsRouter.post('/runs/:id/replay', async (req: Request, res: Response) 
       runStore: ctx.runStore,
       secretsStore: ctx.secretsStore,
       allowUntrustedShell: ctx.allowUntrustedShell,
+      dashboardBaseUrl: ctx.dashboardBaseUrl,
     },
   );
 

--- a/packages/dashboard/src/routes/run-now.ts
+++ b/packages/dashboard/src/routes/run-now.ts
@@ -65,6 +65,7 @@ runNowRouter.post('/agents/:name/run', async (req: Request, res: Response) => {
         variablesStore: ctx.variablesStore,
         toolStore: ctx.toolStore,
         allowUntrustedShell: ctx.allowUntrustedShell,
+        dashboardBaseUrl: ctx.dashboardBaseUrl,
       },
     );
 


### PR DESCRIPTION
## Summary

PR #151's notify dispatcher already supports a run-link in Slack Block Kit messages — the slack handler builds \`<base/runs/<id>|Open run in dashboard>\` when \`dashboardBaseUrl\` is on the dispatch context. PR #151 just never wired that field from any of the four sites that call \`executeAgentDag\`, so the link never rendered in practice.

This is the PR-A follow-up I called out in PR #151's body. End-to-end plumbing:

## Changes

- **Config** — new optional \`dashboardBaseUrl?: string\` field on \`SuaConfig\` with a \`getDashboardBaseUrl()\` helper. Falls back to \`http://127.0.0.1:<dashboardPort>\` (mirrors the existing \`dashboardPort\` shape from #155). Set this when the dashboard is behind a reverse proxy or bound to a non-loopback host that the notify destination needs to reach.
- **CLI** — \`sua workflow run\` and \`sua workflow replay\` now pass \`getDashboardBaseUrl(config)\` into \`executeAgentDag\` deps.
- **Dashboard** — \`startDashboardServer\` accepts an optional \`dashboardBaseUrl\` (CLI's \`sua dashboard start\` passes it from config; tests can override). Stored on \`DashboardContext\` (default \`http://<host>:<port>\` if not supplied). Run-now and replay routes thread \`ctx.dashboardBaseUrl\` into executor deps.
- **Test** — new dag-executor integration test asserts the slack handler payload contains the expected \`<host>/runs/<id>|Open run in dashboard\` markdown link when \`dashboardBaseUrl\` is set on deps.
- **\`.gitignore\`** — adds \`.claude/\` so subagent worktree directories from earlier sessions can't accidentally get committed.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm test\` green (731 / 731, +1 new)
- [x] \`npm run build\` clean
- [ ] Manual: agent with \`notify: { on: [failure], handlers: [{ type: slack, webhook_secret: ... }] }\` → fail → confirm Slack message includes a clickable "Open run in dashboard" link that opens the run page.
- [ ] Manual: set \`"dashboardBaseUrl": "https://my-dash.example.com"\` in \`sua.config.json\` → verify the link in the Slack message uses that base instead of \`127.0.0.1\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)