### PR TITLE
docs(roadmap): outcome-driven flows as future direction

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -128,6 +128,15 @@ on direction.
   attribution, and the MCP token model. Plan when there's a concrete
   multi-user use case driving it; until then, single-user is fine and the
   simpler surface is a feature, not a gap.
+- **Outcome-driven flows** — instead of hand-authoring a static DAG, the user
+  declares what they want (goal + success criteria + constraints) and a
+  built-in planner generates the flow at run time. After the run, an
+  evaluator checks the criteria; failures trigger a re-plan. Bridges the gap
+  between "I know what I want" and "I know the exact steps." Depends on tool
+  policies + a shared Claude API integration + dashboard revamp; sequence
+  those first. Plan: [`~/.claude/plans/outcome-driven-flows.md`](.) (local),
+  to be promoted to an in-repo plan or ADR when implementation gets
+  scheduled. ~3 weeks of focused work after dependencies.
 
 ## Explicitly rejected
 


### PR DESCRIPTION
## Summary

Adds an **Outcome-driven flows** entry to ROADMAP.md under *Maybe (6–12 months)*. Captures the design where users declare a goal + success criteria + constraints, and a built-in planner generates the DAG at run time. After the run, an evaluator checks each criterion; failures trigger a re-plan loop.

The full plan (Outcome type shape, planner/evaluator design, re-plan loop, constraint enforcement, ~3 week effort estimate) lives at \`~/.claude/plans/outcome-driven-flows.md\`. The roadmap entry summarizes it and notes the sequencing dependencies:

1. **Tool policies** — planner needs guardrails to respect.
2. **Claude API / AI-assist generalization** — planner *is* AI; share the integration AI-assist will use.
3. **Dashboard revamp** — outcome-driven agents need a different detail page.

This is a docs-only change; no code or schema changes. The local plan file will be promoted to an in-repo plan or ADR when implementation is scheduled.

## Test plan

- [x] No code changes; doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)