### PR TITLE
chore: add changesets for v0.18 → v0.19 work (release-staging only)

### DIFF
--- a/.changeset/agent-install.md
+++ b/.changeset/agent-install.md
@@ -1,0 +1,19 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+`sua agent install <url>` — fetch + validate + import an agent over HTTPS.
+
+End-to-end install flow for sharing agents. The CLI verb fetches a YAML, validates against `agentV2Schema`, and writes through the same `upsertAgent` path that `sua workflow import-yaml` uses (DB-backed). The dashboard ships a paste / preview / confirm form at `/agents/install`, mirroring the v0.18 MCP import idiom.
+
+- `core/registry`: GitHub `/blob/<branch>/<path>` URLs are normalized to `raw.githubusercontent.com`; `gist.github.com/<user>/<id>` is resolved via the `/raw` redirect; plain HTTPS passes through. Size cap (256 KB) and 10-second timeout. URL gated by `assertSafeUrl` before fetch — link-local and loopback hosts are blocked.
+- CLI accepts `--from-gist`, `--auth-header "Bearer ..."` for private fetches (never persisted), `--yes` for non-interactive runs (refuses overwrite without `--force`), and `--force` to upgrade an existing id. ID-collision diff prompt shows declared inputs / secrets / mcp / schedule before confirming.
+- Trust model: install never auto-runs. `source` is always set to `local` regardless of what the YAML declares — the installer takes ownership. Community-host allowlist is deferred until a trusted host actually exists.
+- Dashboard `/agents/install` — three-step paste/preview/confirm form. Same `Authorization` header support as the CLI; never persisted.
+- A `vitest.config.ts` resolve alias is added so cross-package tests resolve workspace packages to source TS without a rebuild step.
+
+Pairs with the source-on-upgrade fix that ensures the installer-takes-ownership invariant holds across upgrades, not just initial installs.

--- a/.changeset/agent-source-upgrade-fix.md
+++ b/.changeset/agent-source-upgrade-fix.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Fix `sua agent install` not propagating `source: local` when upgrading an existing agent.
+
+The install path explicitly built its upsert payload with `source: 'local'` to honor its installer-takes-ownership contract, but both branches of `upsertAgent` (metadata-only update when DAG unchanged, new-version creation when DAG differs) called `updateAgentMeta` with a patch that omitted `source`, and `updateAgentMeta`'s type signature didn't accept it either. So an existing row with `source: 'examples'` would stay `examples` even after `sua agent install --force`, quietly violating the documented contract.
+
+`updateAgentMeta` now accepts `source` and writes it. Both `upsertAgent` paths pass `agent.source` through. New test in `AgentStore.upsertAgent` covers source change across both upsert paths (identical DAG → metadata-only update; differing DAG → new version).
+
+Initial installs of new agents were unaffected — `createAgent` honored `agent.source` directly. Only upgrades hit the bug.

--- a/.changeset/daemon-supervisor.md
+++ b/.changeset/daemon-supervisor.md
@@ -1,0 +1,19 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+`sua daemon` — run schedule, dashboard, and (optional) MCP as detached background services.
+
+New top-level CLI verb with `start | stop | restart | status | logs` subcommands. PIDs and rotated logs live under `<dataDir>/daemon/`; existing scheduler heartbeat is reused for health detail. Detached subprocesses re-invoke the local `sua` binary with the corresponding verb so config and env propagate cleanly.
+
+- `sua daemon start` spawns the configured services, waits for them to settle, then reports per-service `started` / `crashed on startup` (with log path) / `already running`. Children that crash are caught by a post-spawn liveness check, not silently presented as running.
+- `sua daemon status` shows pid + scheduler heartbeat + a clickable URL column for services that bind a port. URLs render as OSC 8 hyperlinks in TTY-aware terminals; non-TTY contexts (pipes, file redirects) emit plain text. Dashboard URL embeds `/auth#token=<token>` so a click in a fresh browser completes the auth handshake without bouncing through a sign-in page.
+- New optional `daemon` config block: `services` (default `[schedule, dashboard]`), `logRotateBytes` (default 10 MB), plus separate `dashboardPort` (default 3000) and `dashboardBaseUrl` (default loopback) fields. Daemon now passes `--port` through to `dashboard start` and `mcp start` so configured ports actually take effect under supervision.
+- The scheduler now idles instead of exiting when zero agents have a `schedule:` field, so the daemon can supervise a dashboard-only project without the schedule slot flickering "stale (pid dead)".
+- Dashboard `startDashboardServer` rejects its listen promise on `'error'` events (e.g. EADDRINUSE) instead of hanging — the previous behavior left the daemon thinking the dashboard was running while it never bound.
+
+Closes the "schedules don't fire when the terminal closes" gap from the v0.19 operationalization plan.

--- a/.changeset/dashboard-base-url-wiring.md
+++ b/.changeset/dashboard-base-url-wiring.md
@@ -1,0 +1,18 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Notify Slack messages now include a clickable run link.
+
+The notify dispatcher already supported a run-link in Slack Block Kit messages — the slack handler builds `<base/runs/<id>|Open run in dashboard>` when `dashboardBaseUrl` is on the dispatch context. Earlier release just never wired that field from any of the four sites that call `executeAgentDag`, so the link never rendered in practice.
+
+End-to-end plumbing in this release:
+
+- New optional `dashboardBaseUrl?: string` field on `SuaConfig` plus a `getDashboardBaseUrl()` helper that falls back to `http://127.0.0.1:<dashboardPort>`. Override when the dashboard is behind a reverse proxy or bound to a non-loopback host that the notify destination needs to reach.
+- `sua workflow run` and `sua workflow replay` pass the resolved base URL into executor deps.
+- `startDashboardServer` accepts an optional `dashboardBaseUrl` (CLI passes it from config; tests can override). Stored on `DashboardContext` (default `http://<host>:<port>` if not supplied). Run-now and replay routes thread `ctx.dashboardBaseUrl` into executor deps.
+- Integration test asserts the slack handler payload contains the expected dashboard link when `dashboardBaseUrl` is set on deps.

--- a/.changeset/gitignore-claude-worktrees.md
+++ b/.changeset/gitignore-claude-worktrees.md
@@ -1,0 +1,11 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Add `.claude/` to `.gitignore` so subagent worktree directories from Claude Code sessions can't accidentally land in commits as embedded git repositories.
+
+No runtime impact; repo-hygiene only.

--- a/.changeset/notify-handlers.md
+++ b/.changeset/notify-handlers.md
@@ -1,0 +1,21 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+`notify:` field on agent v2 — fire user-declared handlers on run failure / success / always.
+
+After a DAG run commits its final state, the executor dispatches handlers in parallel and isolated. A broken Slack webhook can never turn a successful run into a failed one — handler exceptions are caught, logged via the existing logger, and never propagate back into the run.
+
+Three builtin handler types:
+
+- **slack** — POSTs a Block Kit message to a Slack incoming webhook URL stored as a secret. Headline (status emoji + agent name + status), agent id / run id / start+complete timestamps, last 200 chars of error if failed, and (when `dashboardBaseUrl` is configured) a clickable link back to the run page. Optional `mention` and `channel` fields.
+- **file** — appends a JSON line per fire to a project-cwd-scoped path. Reuses the file-write builtin's path-traversal guard.
+- **webhook** — generic `POST` with body `{ agent, run_id, status, started_at, completed_at, error?, output? }`. Optional secret-backed `Authorization` header. URL gated by the existing `assertSafeUrl` SSRF guard.
+
+Schema corrects the original plan's assumption that `{{secrets.X}}` templates work in handler config: secrets in this codebase are env-var-only at the node level, so notify config declares its own `secrets:` list and the dispatcher resolves values from the secrets store. A zod cross-check rejects handlers that reference an undeclared secret. `{{vars.X}}` template substitution works in string fields like `channel`, `path`, and `url` via the existing template helpers.
+
+Dashboard agent config gets a JSON-textarea editor for the notify block and a `POST /agents/:name/notify/update` route alongside the existing widget editor pattern. Email handler intentionally not in this release — defer until Slack proves the pattern.

--- a/.changeset/runs-pagination-fix.md
+++ b/.changeset/runs-pagination-fix.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Fix `/runs` page-size links rendering raw `<a>` HTML as escaped text.
+
+The page-size selector in the runs list footer was building anchor tags as plain strings concatenated with `.join(' ')`, then interpolating into a `html\`...\`` template tag — which escapes string values. The result was visible literal `<a href="...">25</a>` text instead of clickable links.
+
+Switched to the same SafeHtml-fragment pattern the agents-list and tools-list pagers already use, so each link is a `html\`...\`` template literal that the renderer treats as trusted markup.


### PR DESCRIPTION
## Summary

Authors changesets retroactively for the eight feature/fix PRs merged since v0.18. **This does not cut a release** — it just stages the changeset entries so the changesets bot has something to assemble whenever you decide to release v0.19.

Seven entries (one PR rolled into another to avoid duplication):

| Changeset | PR(s) | Bump |
|---|---|---|
| daemon-supervisor | #150 + #155 (rolled in — daemon polish) | minor |
| notify-handlers | #151 | minor |
| agent-install | #152 | minor |
| dashboard-base-url-wiring | #157 | minor |
| daemon-supervisor (already covers daemon URL column / dashboardPort / auth-token link) | #155 | (folded above) |
| runs-pagination-fix | #153 | patch |
| agent-source-upgrade-fix | #154 | patch |
| gitignore-claude-worktrees | from #157 | patch |

ROADMAP doc updates (#156 RBAC, #158 outcome-driven flows) intentionally skip changesets — no version impact.

## Why fold #155 into the daemon-supervisor changeset

#155 is daemon-shaped polish (URL column, dashboardPort config, OSC 8 hyperlinks, auth-token link, child-crash detection follow-up). For the v0.19 release notes, all of it lives under "the daemon" story. A single changeset entry reads better than two.

## Versioning

Workspace is in a fixed group, so all five packages bump together. Five minors + three patches → the next release is a minor bump (0.18 → 0.19) when you cut it.

## Test plan

- [x] No code changes; \`.changeset/*.md\` only.
- [ ] After merge: changesets bot opens (or updates) the release PR with v0.19 staged. Don't merge that release PR until you're ready to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)