### PR TITLE
fix(dashboard): /agents list renders flash banners from mutation redirects

### DIFF
--- a/.changeset/agents-list-flash.md
+++ b/.changeset/agents-list-flash.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Fix `/agents` list page silently dropping flash banners.
+
+Mutation routes that redirect to `/agents?flash=...` (e.g. the new hard-delete from PR #162) had their messages dropped — the GET handler never read `req.query.flash` and `AgentsListInput` had no `flash` field, so the `layout()` call rendered without a banner. Users would delete an agent and see nothing change visually beyond the agent disappearing.
+
+Wires the `flash` end-to-end: route reads `req.query.flash` (kind=ok) and `req.query.error` (kind=error), `AgentsListInput` accepts the optional banner, and the layout renders it via the existing `flash--ok` / `flash--error` styles already used by `/runs`. Test added.
+
+Same pattern as `/runs` and the agent detail page already use; agents-list was the odd one out.

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -1038,6 +1038,17 @@ describe('Dashboard hard-delete (POST /agents/:name/delete)', () => {
     expect(res.status).toBe(303);
     expect(decodeURIComponent(res.headers.location)).toMatch(/not found/);
   });
+
+  it('GET /agents renders the flash banner when ?flash= is present', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .get('/agents?flash=Deleted%20%22something%22.')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('flash--ok');
+    expect(res.text).toContain('Deleted &quot;something&quot;.');
+  });
 });
 
 describe('Dashboard run-now gate', () => {

--- a/packages/dashboard/src/routes/agents.ts
+++ b/packages/dashboard/src/routes/agents.ts
@@ -281,6 +281,16 @@ agentsRouter.get('/agents', (req: Request, res: Response) => {
   const totalV2 = v2Agents.length;
   const paginatedV2 = v2Agents.slice(offset, offset + limit);
 
+  // Flash from mutation redirects (e.g. delete success). `?error=` is
+  // reserved for mutation failures so the banner kind matches user intent.
+  const flashOk = typeof req.query.flash === 'string' ? req.query.flash : undefined;
+  const flashErr = typeof req.query.error === 'string' ? req.query.error : undefined;
+  const flash = flashErr
+    ? { kind: 'error' as const, message: flashErr }
+    : flashOk
+    ? { kind: 'ok' as const, message: flashOk }
+    : undefined;
+
   res.type('html').send(renderAgentsList({
     v1: mergedV1,
     v2: paginatedV2,
@@ -293,6 +303,7 @@ agentsRouter.get('/agents', (req: Request, res: Response) => {
     limit,
     offset,
     total: totalV2,
+    flash,
   }));
 });
 

--- a/packages/dashboard/src/views/agents-list.ts
+++ b/packages/dashboard/src/views/agents-list.ts
@@ -37,6 +37,8 @@ export interface AgentsListInput {
   offset: number;
   /** Total v2 count before pagination (after filtering). */
   total: number;
+  /** Banner shown above the page (redirected from a mutation route). */
+  flash?: { kind: 'error' | 'info' | 'ok'; message: string };
 }
 
 export function renderAgentsList(input: AgentsListInput): string {
@@ -117,7 +119,7 @@ export function renderAgentsList(input: AgentsListInput): string {
     </div>
   `;
 
-  return render(layout({ title: 'Agents', activeNav: 'agents' }, body));
+  return render(layout({ title: 'Agents', activeNav: 'agents', flash: input.flash }, body));
 }
 
 function renderTabStrip(input: AgentsListInput): SafeHtml {


### PR DESCRIPTION
## Summary

Hard-delete from PR #162 redirects to \`/agents?flash=Deleted%20%22x%22.\`, but the GET handler never read \`req.query.flash\` and \`AgentsListInput\` had no \`flash\` field. The \`layout()\` call rendered without a banner, so users would delete an agent and see nothing change visually beyond the row disappearing.

Surfaced when manually testing the danger-zone delete flow — that's exactly the moment the user should see a confirmation that the deletion actually happened.

## Changes

- \`/agents\` GET handler reads both \`req.query.flash\` (kind=ok) and \`req.query.error\` (kind=error), matching the agent-detail handler's convention.
- \`AgentsListInput\` accepts an optional \`flash?: { kind, message }\` field.
- \`renderAgentsList\` passes \`flash\` into \`layout()\` — the layout already renders \`flash--ok\` / \`flash--error\` / \`flash--info\` banners via existing styles used by \`/runs\` and agent detail.
- New test: \`GET /agents?flash=...\` renders \`flash--ok\` with the message in the body.

The agents-list was the odd one out — \`/runs\` and the agent detail page already had this wiring.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm test\` green (735 / 735, +1 new flash banner test)
- [x] \`npm run build\` clean
- [ ] Manual: delete an agent via the danger zone → land on \`/agents\` → see green banner "Deleted \"x\"."

🤖 Generated with [Claude Code](https://claude.com/claude-code)