### PR TITLE
feat(dashboard): structured form for notify editor (replaces JSON textarea)

### DIFF
--- a/.changeset/notify-form-editor.md
+++ b/.changeset/notify-form-editor.md
@@ -1,0 +1,21 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Form-based notify editor for the dashboard.
+
+Replaces the JSON textarea on agent config with a structured form. Top-level checkboxes for `on` (failure/success/always), a comma-separated list for declared `secrets`, and per-handler cards with type-specific fields:
+
+- **slack** — `webhook_secret` dropdown (populated from the secrets list), `channel`, `mention`
+- **file** — `path`, `append` checkbox
+- **webhook** — `url`, `method` (POST/PUT), `headers_secret` dropdown (optional, also populated from the secrets list)
+
+Three "+ Add slack / + Add file / + Add webhook" buttons let operators compose the handler array without remembering schema field names. Removing a handler is an in-row "Remove" button. Saving serializes the form state to a single hidden `notify_json` field; the route validates the payload through the same `agentV2Schema` as the YAML import path so cross-checks (e.g. handler-referenced secrets must be declared) still fire.
+
+Backwards compat: the route accepts either the new `notify_json` field (preferred) or the legacy `notify` JSON blob — ad-hoc API callers and existing tests aren't broken.
+
+Out of scope (future): live Block Kit preview for slack handlers; channel picker via Slack OAuth (depends on PR-C); secret-name autocomplete (the cross-check at save time covers typos).

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -1051,6 +1051,128 @@ describe('Dashboard hard-delete (POST /agents/:name/delete)', () => {
   });
 });
 
+describe('Dashboard notify editor (form-based)', () => {
+  function seedAgent(notify?: unknown) {
+    agentStore.createAgent({
+      id: 'notif',
+      name: 'Notif',
+      status: 'active',
+      source: 'local',
+      mcp: false,
+      nodes: [{ id: 'main', type: 'shell', command: 'echo hi' }],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ...(notify ? { notify: notify as any } : {}),
+    }, 'cli');
+  }
+
+  it('renders the structured form with the three add-handler buttons for an agent without notify', async () => {
+    const app = await makeApp();
+    seedAgent();
+    const res = await request(app).get('/agents/notif/config')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('id="notify-form"');
+    expect(res.text).toContain('data-add-handler="slack"');
+    expect(res.text).toContain('data-add-handler="file"');
+    expect(res.text).toContain('data-add-handler="webhook"');
+    // Hydration payload reflects the empty defaults.
+    expect(res.text).toContain('"on":["failure"]');
+    expect(res.text).toContain('"handlers":[]');
+  });
+
+  it('hydrates the form from an existing notify config', async () => {
+    const app = await makeApp();
+    seedAgent({
+      on: ['failure'],
+      secrets: ['SLACK_HOOK'],
+      handlers: [{ type: 'slack', webhook_secret: 'SLACK_HOOK', channel: '#alerts' }],
+    });
+    const res = await request(app).get('/agents/notif/config')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('"secrets":["SLACK_HOOK"]');
+    expect(res.text).toContain('"webhook_secret":"SLACK_HOOK"');
+    expect(res.text).toContain('"channel":"#alerts"');
+  });
+
+  it('saves a valid notify_json payload and creates a new version', async () => {
+    const app = await makeApp();
+    seedAgent();
+    const before = agentStore.getAgent('notif')!.version;
+    const payload = JSON.stringify({
+      on: ['failure'],
+      secrets: ['SLACK_HOOK'],
+      handlers: [{ type: 'slack', webhook_secret: 'SLACK_HOOK', channel: '#alerts' }],
+    });
+    const res = await request(app)
+      .post('/agents/notif/notify/update')
+      .type('form').send({ action: 'save', notify_json: payload })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(decodeURIComponent(res.headers.location)).toMatch(/Notify saved/);
+    const after = agentStore.getAgent('notif')!;
+    expect(after.version).toBe(before + 1);
+    expect(after.notify?.handlers[0]).toMatchObject({ type: 'slack', webhook_secret: 'SLACK_HOOK', channel: '#alerts' });
+  });
+
+  it('flashes a validation error when a handler references an undeclared secret', async () => {
+    const app = await makeApp();
+    seedAgent();
+    const payload = JSON.stringify({
+      on: ['failure'],
+      secrets: [],   // empty — but slack handler references SLACK_HOOK
+      handlers: [{ type: 'slack', webhook_secret: 'SLACK_HOOK', channel: '#alerts' }],
+    });
+    const res = await request(app)
+      .post('/agents/notif/notify/update')
+      .type('form').send({ action: 'save', notify_json: payload })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(decodeURIComponent(res.headers.location)).toMatch(/Validation failed/);
+    expect(decodeURIComponent(res.headers.location)).toMatch(/SLACK_HOOK/);
+    // Agent unchanged.
+    expect(agentStore.getAgent('notif')!.notify).toBeUndefined();
+  });
+
+  it('still accepts the legacy `notify` JSON blob field (back-compat)', async () => {
+    const app = await makeApp();
+    seedAgent();
+    const blob = JSON.stringify({
+      on: ['always'],
+      handlers: [{ type: 'file', path: 'logs/all.log', append: true }],
+    });
+    const res = await request(app)
+      .post('/agents/notif/notify/update')
+      .type('form').send({ action: 'save', notify: blob })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(decodeURIComponent(res.headers.location)).toMatch(/Notify saved/);
+    expect(agentStore.getAgent('notif')!.notify?.handlers[0]).toMatchObject({ type: 'file', path: 'logs/all.log' });
+  });
+
+  it('removes notify when action=remove', async () => {
+    const app = await makeApp();
+    seedAgent({
+      on: ['failure'],
+      handlers: [{ type: 'file', path: 'logs/x.log' }],
+    });
+    expect(agentStore.getAgent('notif')!.notify).toBeDefined();
+    const res = await request(app)
+      .post('/agents/notif/notify/update')
+      .type('form').send({ action: 'remove' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(decodeURIComponent(res.headers.location)).toMatch(/Notify removed/);
+    expect(agentStore.getAgent('notif')!.notify).toBeUndefined();
+  });
+});
+
 describe('Dashboard run-now gate', () => {
   it('POST /agents/hello/run submits and redirects to /runs/:id', async () => {
     const app = await makeApp();

--- a/packages/dashboard/src/routes/agent-inputs.ts
+++ b/packages/dashboard/src/routes/agent-inputs.ts
@@ -421,7 +421,11 @@ agentInputsRouter.post('/agents/:name/notify/update', (req: Request, res: Respon
     return;
   }
 
-  const raw = typeof body.notify === 'string' ? body.notify.trim() : '';
+  // Accept either `notify_json` (structured form, preferred) or the legacy
+  // `notify` JSON blob (back-compat with old textarea + ad-hoc API calls).
+  const fromForm = typeof body.notify_json === 'string' ? body.notify_json.trim() : '';
+  const fromBlob = typeof body.notify === 'string' ? body.notify.trim() : '';
+  const raw = fromForm || fromBlob;
   if (!raw) {
     res.redirect(303, `${flashBase}?flash=${encodeURIComponent('Notify body is empty.')}`);
     return;

--- a/packages/dashboard/src/views/agent-detail-helpers.ts
+++ b/packages/dashboard/src/views/agent-detail-helpers.ts
@@ -540,33 +540,203 @@ function fieldTypeSelectWithTooltip(name: string, current: string, _widgetType: 
  * agent-v2 schema, so any error surfaces inline as a flash.
  */
 export function renderNotifyEditor(agent: Agent): SafeHtml {
-  const FIELD = 'padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs); font-family: var(--font-mono); width: 100%;';
-  const current = agent.notify ? JSON.stringify(agent.notify, null, 2) : '';
-  const placeholder = JSON.stringify({
-    on: ['failure'],
-    secrets: ['SLACK_WEBHOOK'],
-    handlers: [
-      { type: 'slack', webhook_secret: 'SLACK_WEBHOOK', channel: '#alerts' },
-      { type: 'file', path: 'logs/failures.jsonl' },
-    ],
-  }, null, 2);
+  const FIELD = 'padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs);';
+  const FIELD_MONO = `${FIELD} font-family: var(--font-mono);`;
+
+  // Existing config (or empty defaults) — JS hydrates the form from this
+  // payload on load so the server-rendered HTML matches the JS state.
+  const initialJson = JSON.stringify(
+    agent.notify ?? { on: ['failure'], secrets: [], handlers: [] },
+  );
 
   return html`
     <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-3);">
       Fires after every run commits. Handlers run in parallel; a broken handler
       logs and is skipped — it never fails the run.
     </p>
-    <form method="POST" action="/agents/${agent.id}/notify/update">
-      <textarea name="notify" rows="14" placeholder="${placeholder}" style="${FIELD}">${current}</textarea>
-      <p class="dim" style="font-size: var(--font-size-xs); margin: var(--space-2) 0;">
-        JSON shape mirrors the YAML <code>notify:</code> block. Trigger: <code>failure</code>, <code>success</code>, or <code>always</code>.
-        Secrets must be declared in <code>secrets:</code> and set via <a href="/settings/secrets">Settings → Secrets</a>.
-      </p>
+
+    <form id="notify-form" method="POST" action="/agents/${agent.id}/notify/update">
+      <!-- Hidden serialized state — populated by JS on submit. The server
+           accepts either this notify_json field (preferred, shape matches
+           agent.notify exactly) or a legacy notify JSON blob (back-compat). -->
+      <input type="hidden" name="notify_json" id="notify-json-out">
+
+      <fieldset style="border: 1px solid var(--color-border); padding: var(--space-3); margin: 0 0 var(--space-3);">
+        <legend style="font-size: var(--font-size-xs); padding: 0 var(--space-2);">Trigger</legend>
+        <label style="margin-right: var(--space-3);"><input type="checkbox" data-on value="failure"> failure</label>
+        <label style="margin-right: var(--space-3);"><input type="checkbox" data-on value="success"> success</label>
+        <label><input type="checkbox" data-on value="always"> always</label>
+      </fieldset>
+
+      <fieldset style="border: 1px solid var(--color-border); padding: var(--space-3); margin: 0 0 var(--space-3);">
+        <legend style="font-size: var(--font-size-xs); padding: 0 var(--space-2);">Declared secrets</legend>
+        <input type="text" id="notify-secrets" placeholder="SLACK_WEBHOOK, WEBHOOK_TOKEN" style="${FIELD_MONO} width: 100%;">
+        <p class="dim" style="font-size: var(--font-size-xs); margin: var(--space-2) 0 0;">
+          Comma-separated, <code>UPPERCASE_WITH_UNDERSCORES</code>. Each name resolved from <a href="/settings/secrets">Settings → Secrets</a> at fire time.
+        </p>
+      </fieldset>
+
+      <fieldset style="border: 1px solid var(--color-border); padding: var(--space-3); margin: 0 0 var(--space-3);">
+        <legend style="font-size: var(--font-size-xs); padding: 0 var(--space-2);">Handlers</legend>
+        <div id="notify-handlers" style="display: flex; flex-direction: column; gap: var(--space-3);"></div>
+        <div id="notify-handlers-empty" class="dim" style="font-size: var(--font-size-xs); padding: var(--space-2); display: none;">
+          No handlers yet. Add one below.
+        </div>
+        <div style="display: flex; gap: var(--space-2); margin-top: var(--space-3); flex-wrap: wrap;">
+          <button type="button" class="btn btn--ghost btn--sm" data-add-handler="slack">+ Add slack</button>
+          <button type="button" class="btn btn--ghost btn--sm" data-add-handler="file">+ Add file</button>
+          <button type="button" class="btn btn--ghost btn--sm" data-add-handler="webhook">+ Add webhook</button>
+        </div>
+      </fieldset>
+
       <div style="display: flex; gap: var(--space-2); justify-content: flex-end;">
         ${agent.notify ? html`<button type="submit" name="action" value="remove" class="btn btn--ghost btn--sm" style="color: var(--color-err);">Remove notify</button>` : html``}
         <button type="submit" name="action" value="save" class="btn btn--primary btn--sm">Save notify</button>
       </div>
     </form>
+
+    ${unsafeHtml(`<script>
+    (function () {
+      var INITIAL = ${initialJson};
+      var FIELD = ${JSON.stringify(FIELD)};
+      var FIELD_MONO = ${JSON.stringify(FIELD_MONO)};
+
+      var form = document.getElementById('notify-form');
+      var jsonOut = document.getElementById('notify-json-out');
+      var secretsInput = document.getElementById('notify-secrets');
+      var handlersWrap = document.getElementById('notify-handlers');
+      var handlersEmpty = document.getElementById('notify-handlers-empty');
+      var onChecks = form.querySelectorAll('input[data-on]');
+
+      function declaredSecrets() {
+        return (secretsInput.value || '')
+          .split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+      }
+
+      function refreshSecretSelects() {
+        var names = declaredSecrets();
+        var selects = handlersWrap.querySelectorAll('select[data-secret-picker]');
+        selects.forEach(function (sel) {
+          var current = sel.value;
+          // Clear + repopulate (keeps the empty placeholder option)
+          while (sel.options.length > 0) sel.remove(0);
+          var optional = sel.getAttribute('data-secret-picker') === 'optional';
+          if (optional) {
+            sel.add(new Option('(none)', ''));
+          } else if (names.length === 0) {
+            sel.add(new Option('(declare a secret first)', ''));
+          }
+          names.forEach(function (n) { sel.add(new Option(n, n)); });
+          if (current && Array.from(sel.options).some(function (o) { return o.value === current; })) {
+            sel.value = current;
+          }
+        });
+      }
+
+      function updateEmptyState() {
+        handlersEmpty.style.display = handlersWrap.children.length === 0 ? '' : 'none';
+      }
+
+      function addHandlerRow(type, prefill) {
+        var row = document.createElement('div');
+        row.className = 'card';
+        row.setAttribute('data-handler-row', type);
+        row.style.cssText = 'padding: var(--space-3);';
+        var inner = '';
+        var header = '<div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--space-2);">' +
+          '<strong style="font-size: var(--font-size-xs); text-transform: uppercase; letter-spacing: 0.05em;">' + type + '</strong>' +
+          '<button type="button" class="btn btn--ghost btn--sm" data-remove-handler style="color: var(--color-err);">Remove</button>' +
+          '</div>';
+        if (type === 'slack') {
+          inner = header +
+            '<label style="display: block; margin-bottom: var(--space-2); font-size: var(--font-size-xs);">Webhook secret <select data-field="webhook_secret" data-secret-picker="required" style="' + FIELD + ' margin-left: var(--space-2);"></select></label>' +
+            '<label style="display: block; margin-bottom: var(--space-2); font-size: var(--font-size-xs);">Channel <input type="text" data-field="channel" placeholder="#alerts" style="' + FIELD + ' margin-left: var(--space-2); width: 14rem;"></label>' +
+            '<label style="display: block; font-size: var(--font-size-xs);">Mention <input type="text" data-field="mention" placeholder="@oncall" style="' + FIELD + ' margin-left: var(--space-2); width: 14rem;"></label>';
+        } else if (type === 'file') {
+          inner = header +
+            '<label style="display: block; margin-bottom: var(--space-2); font-size: var(--font-size-xs);">Path <input type="text" data-field="path" placeholder="logs/failures.jsonl" style="' + FIELD_MONO + ' margin-left: var(--space-2); width: 22rem;"></label>' +
+            '<label style="display: block; font-size: var(--font-size-xs);"><input type="checkbox" data-field="append" checked> Append (else overwrite)</label>';
+        } else if (type === 'webhook') {
+          inner = header +
+            '<label style="display: block; margin-bottom: var(--space-2); font-size: var(--font-size-xs);">URL <input type="text" data-field="url" placeholder="https://hooks.example.com/..." style="' + FIELD_MONO + ' margin-left: var(--space-2); width: 24rem;"></label>' +
+            '<label style="display: block; margin-bottom: var(--space-2); font-size: var(--font-size-xs);">Method <select data-field="method" style="' + FIELD + ' margin-left: var(--space-2);"><option value="POST">POST</option><option value="PUT">PUT</option></select></label>' +
+            '<label style="display: block; font-size: var(--font-size-xs);">Headers secret <select data-field="headers_secret" data-secret-picker="optional" style="' + FIELD + ' margin-left: var(--space-2);"></select></label>';
+        }
+        row.innerHTML = inner;
+        handlersWrap.appendChild(row);
+        refreshSecretSelects();
+
+        if (prefill) {
+          Object.keys(prefill).forEach(function (k) {
+            if (k === 'type') return;
+            var el = row.querySelector('[data-field="' + k + '"]');
+            if (!el) return;
+            if (el.type === 'checkbox') el.checked = !!prefill[k];
+            else el.value = prefill[k] == null ? '' : String(prefill[k]);
+          });
+        }
+        row.querySelector('[data-remove-handler]').addEventListener('click', function () {
+          row.remove();
+          updateEmptyState();
+        });
+        updateEmptyState();
+      }
+
+      function serializeHandlers() {
+        var rows = handlersWrap.querySelectorAll('[data-handler-row]');
+        var out = [];
+        rows.forEach(function (row) {
+          var type = row.getAttribute('data-handler-row');
+          var obj = { type: type };
+          row.querySelectorAll('[data-field]').forEach(function (el) {
+            var key = el.getAttribute('data-field');
+            if (el.type === 'checkbox') {
+              obj[key] = el.checked;
+            } else {
+              var v = el.value;
+              if (v !== '' && v != null) obj[key] = v;
+            }
+          });
+          out.push(obj);
+        });
+        return out;
+      }
+
+      // Hydrate from initial state.
+      onChecks.forEach(function (c) {
+        c.checked = (INITIAL.on || []).indexOf(c.value) !== -1;
+      });
+      secretsInput.value = (INITIAL.secrets || []).join(', ');
+      (INITIAL.handlers || []).forEach(function (h) { addHandlerRow(h.type, h); });
+      updateEmptyState();
+      refreshSecretSelects();
+
+      // Wire the Add buttons.
+      form.querySelectorAll('[data-add-handler]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          addHandlerRow(btn.getAttribute('data-add-handler'), null);
+        });
+      });
+
+      // Live refresh of secret selects when the secrets list changes.
+      secretsInput.addEventListener('input', refreshSecretSelects);
+
+      // Serialize on submit (skip for the Remove button so the server can
+      // see action=remove without a payload).
+      form.addEventListener('submit', function (ev) {
+        var btn = ev.submitter;
+        if (btn && btn.value === 'remove') return;
+        var on = [];
+        onChecks.forEach(function (c) { if (c.checked) on.push(c.value); });
+        var payload = {
+          on: on,
+          secrets: declaredSecrets(),
+          handlers: serializeHandlers(),
+        };
+        jsonOut.value = JSON.stringify(payload);
+      });
+    })();
+    </script>`)}
   `;
 }
 


### PR DESCRIPTION
## Summary

PR-B from the v0.19 follow-up queue. Replaces the JSON textarea on agent config with a structured form that exposes all three notify handler types' fields explicitly. Plan: \`~/.claude/plans/notify-form-editor.md\`.

## Form layout

\`\`\`
─ Notify ────────────────────────────────────────────────────
  Trigger:  [✓] failure   [ ] success   [ ] always
  Declared secrets:
    [ SLACK_HOOK, WEBHOOK_TOKEN                          ]

  Handlers:
  ┌─ slack ─────────────────────────────────── [Remove] ─┐
  │ Webhook secret:  [ SLACK_HOOK ▾ ]                    │
  │ Channel:         [ #alerts                       ]   │
  │ Mention:         [ @oncall                       ]   │
  └──────────────────────────────────────────────────────┘
  ┌─ file ──────────────────────────────────── [Remove] ─┐
  │ Path:    [ logs/failures.jsonl                    ]   │
  │ Append:  [✓] yes                                     │
  └──────────────────────────────────────────────────────┘

  [+ Add slack]  [+ Add file]  [+ Add webhook]

  [Remove notify]  [Save]
─────────────────────────────────────────────────────────────
\`\`\`

## Notable mechanics

- **Secret dropdowns auto-populate from the secrets list.** Type \`SLACK_HOOK\` in the secrets input → it shows up in every \`webhook_secret\` / \`headers_secret\` dropdown. Empty list + required picker (slack) → dropdown shows \`(declare a secret first)\` and the form blocks save.
- **Single hidden \`notify_json\` field.** Form state is serialized on submit by JS; the route accepts that as one JSON payload. Avoids indexed-name reconstruction gymnastics.
- **Backwards compat.** Route still accepts the legacy \`notify\` JSON blob for ad-hoc API callers, existing tests, and any tooling that posted to the old textarea endpoint.
- **Same validation.** Server runs the payload through \`agentV2Schema\` — the existing handler-referenced-secrets cross-check still fires, so a slack handler that names \`UNDECLARED_HOOK\` flashes a clear error.

## Out of scope (deferred)

- **Block Kit preview** for slack handlers — needs rendering work.
- **Channel picker via Slack API** — needs PR-C (Slack OAuth, plan in \`slack-app-oauth.md\`).
- **Secret autocomplete from the encrypted store** — would need a new endpoint; the cross-check at save time covers typos.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm test\` green (742 / 742, +6 new dashboard tests)
- [x] \`npm run build\` clean
- [ ] Manual: open agent config tab → form renders with the three add buttons; click \"+ Add slack\" → row appears.
- [ ] Manual: type a secret in the secrets list → it appears in the slack handler's webhook_secret dropdown.
- [ ] Manual: save with a slack handler referencing an undeclared secret → flash banner shows the cross-check error.
- [ ] Manual: existing agents authored via YAML/CLI show their notify config hydrated in the form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)