### PR TITLE
feat(dashboard): interactive widgets — pulse tiles as mini-apps

### DIFF
--- a/.changeset/interactive-widgets.md
+++ b/.changeset/interactive-widgets.md
@@ -1,0 +1,36 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Interactive widgets — turn pulse tiles into mini-apps.
+
+Output widgets gain an opt-in `interactive: true` flag. When set, the pulse tile renders with an inline inputs form + Run button + state machine that polls `/runs/:id/widget-status` until the run completes — no navigating away. Each tile becomes a self-contained ask → think → answer → ask again loop with smooth CSS transitions between states.
+
+Five visible states (`idle | asking | running | success | error`) cross-fade at ~220 ms with a `transform: translateY` so content doesn't pop. The tile gets a subtle pulsing border while running so it reads as "active" at a glance from the pulse page. `prefers-reduced-motion` disables the animations.
+
+Schema additions on `outputWidget` (all optional):
+- `interactive: boolean` — opts the tile into the new mode
+- `runInputs: string[]` — subset of `agent.inputs` to expose in the form (defaults to all)
+- `askLabel: string` — overrides the initial Run button text (default "Run")
+- `replayLabel: string` — overrides the post-result button text (default "Run again")
+
+Two new dashboard routes:
+- `POST /agents/:name/widget-run` — accepts `input_*` form fields and returns `{ runId }` JSON. Reuses the existing DAG executor and auth.
+- `GET /runs/:id/widget-status` — lightweight `{ status, result, error }` JSON polled every 500 ms.
+
+Polling caps at 60 s (120 ticks) → tile transitions to a "still running, view details" state with a link to `/runs/:id`. Cancel button hooks the existing `/runs/:id/cancel` route.
+
+The output widget editor on agent config gains an "Interactive mode" disclosure: a checkbox to enable, checkboxes per declared input to filter what the tile shows, and label overrides for both buttons.
+
+Non-interactive widgets are completely unchanged. Existing widgets without the flag render in the same static mode they always have.
+
+Plan: `~/.claude/plans/interactive-widgets.md`.
+
+Out of scope (deferred):
+- Widget cross-fade replaces the result with the raw text in a `<pre>` for now; live re-render of the actual widget HTML on completion is a follow-up (the next pulse refresh swaps in the proper widget).
+- Streaming intermediate node outputs into the tile.
+- Channel/file/secret pickers tied to specific input types beyond text/number/enum/boolean.

--- a/packages/core/src/output-widget-schema.ts
+++ b/packages/core/src/output-widget-schema.ts
@@ -26,6 +26,23 @@ export const outputWidgetSchema = z.object({
   prompt: z.string().optional(),
   /** ai-template: sanitized HTML template with {{outputs.X}} / {{result}} placeholders. */
   template: z.string().optional(),
+  /**
+   * Interactive widget mode — when true, the widget renders with an inline
+   * inputs form + Run button so users can trigger a fresh run from the tile
+   * without navigating to the agent detail page. Result polls into place
+   * via /runs/:id/widget-status. Default false; existing widgets unchanged.
+   */
+  interactive: z.boolean().optional(),
+  /**
+   * When `interactive` is set, the names of `agent.inputs` to expose as
+   * fields in the tile. Subset semantics: omitted keys are not shown.
+   * If not set but `interactive` is true, every declared input is shown.
+   */
+  runInputs: z.array(z.string().min(1)).optional(),
+  /** Custom label for the initial Run button (default "Run"). */
+  askLabel: z.string().optional(),
+  /** Custom label for the post-result replay button (default "Run again"). */
+  replayLabel: z.string().optional(),
 }).superRefine((schema, ctx) => {
   if (schema.type === 'ai-template') {
     if (!schema.template || schema.template.trim() === '') {

--- a/packages/core/src/output-widget-types.ts
+++ b/packages/core/src/output-widget-types.ts
@@ -49,4 +49,20 @@ export interface OutputWidgetSchema {
    * verbatim. Re-rendered at run time by substituting + sanitizing.
    */
   template?: string;
+  /**
+   * Interactive widget mode. When true, the dashboard renders the widget with
+   * an inline inputs form + Run button so users can trigger fresh runs from
+   * the tile without navigating away. Result polls in via the widget-status
+   * endpoint. Default false; existing widgets render in static mode.
+   */
+  interactive?: boolean;
+  /**
+   * Subset of `agent.inputs` names to expose in the interactive tile. If
+   * absent (and `interactive` is true), every declared input is shown.
+   */
+  runInputs?: string[];
+  /** Override label for the initial run button. Default "Run". */
+  askLabel?: string;
+  /** Override label for the post-result replay button. Default "Run again". */
+  replayLabel?: string;
 }

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -3,7 +3,9 @@ import request from 'supertest';
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { LocalProvider, RunStore, AgentStore, MemorySecretsStore, ToolStore, loadAgents } from '@some-useful-agents/core';
+import { LocalProvider, RunStore, AgentStore, MemorySecretsStore, ToolStore, loadAgents, type Agent, type OutputWidgetSchema } from '@some-useful-agents/core';
+import { renderInteractiveWidget } from './views/interactive-widget.js';
+import { render } from './views/html.js';
 import { buildDashboardApp } from './index.js';
 import type { DashboardContext } from './context.js';
 import { SESSION_COOKIE } from './auth-middleware.js';
@@ -1796,6 +1798,147 @@ describe('Output widget editor UI', () => {
       .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
     expect(res.status).toBe(400);
     expect(res.text).toContain('Pick a widget type');
+  });
+});
+
+describe('Interactive widget tile + widget-run/widget-status', () => {
+  function seedInteractiveAgent(opts: { withResult?: boolean } = {}) {
+    agentStore.createAgent({
+      id: 'eight-ball',
+      name: '8-Ball',
+      status: 'active',
+      source: 'local',
+      mcp: false,
+      inputs: { question: { type: 'string', description: 'Ask the ball.' } },
+      nodes: [{ id: 'main', type: 'shell', command: 'echo "{\\"answer\\":\\"yes\\"}"' }],
+      outputWidget: {
+        type: 'key-value',
+        fields: [{ name: 'answer', type: 'text' }],
+        interactive: true,
+        runInputs: ['question'],
+        askLabel: 'Ask',
+        replayLabel: 'Ask again',
+      },
+    }, 'cli');
+    if (opts.withResult) {
+      runStore.createRun({ id: 'r-prior', agentName: 'eight-ball', status: 'completed', triggeredBy: 'cli', startedAt: new Date().toISOString() });
+      runStore.updateRun('r-prior', {
+        status: 'completed',
+        completedAt: new Date().toISOString(),
+        result: '{"answer":"signs point to yes"}',
+      });
+    }
+  }
+
+  function makeIWAgent(extra: Partial<Agent> = {}): Agent {
+    return {
+      id: 'eight-ball',
+      name: '8-Ball',
+      status: 'active',
+      source: 'local',
+      mcp: false,
+      version: 1,
+      inputs: { question: { type: 'string', description: 'Ask the ball.' } },
+      nodes: [{ id: 'main', type: 'shell', command: 'echo' }],
+      outputWidget: {
+        type: 'key-value',
+        fields: [{ name: 'answer', type: 'text' }],
+        interactive: true,
+        runInputs: ['question'],
+        askLabel: 'Ask',
+        replayLabel: 'Ask again',
+      },
+      ...extra,
+    } as Agent;
+  }
+
+  it('renders asking state for an agent without a prior run', async () => {
+    await makeApp();   // initialize fixture so afterEach cleans up cleanly
+    const agent = makeIWAgent();
+    const widget = agent.outputWidget as OutputWidgetSchema;
+    const out = render(renderInteractiveWidget({ agent, widget }));
+    expect(out).toContain('data-iw');
+    expect(out).toContain('data-iw-state="asking"');
+    expect(out).toContain('input_question');
+    expect(out).toContain('Ask');
+  });
+
+  it('hydrates idle state when given a prior completed run', async () => {
+    await makeApp();
+    const agent = makeIWAgent();
+    const widget = agent.outputWidget as OutputWidgetSchema;
+    const out = render(renderInteractiveWidget({
+      agent,
+      widget,
+      lastRun: { id: 'r-prior', result: '{"answer":"yes"}', status: 'completed' },
+    }));
+    expect(out).toContain('data-iw-state="idle"');
+    expect(out).toContain('Ask again');
+  });
+
+  it('POST /agents/:id/widget-run accepts inputs and returns a runId', async () => {
+    const app = await makeApp();
+    seedInteractiveAgent();
+    const res = await request(app)
+      .post('/agents/eight-ball/widget-run')
+      .type('form').send({ input_question: 'Will today be good?' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(202);
+    expect(res.body.runId).toMatch(/^[0-9a-f-]+$/);
+  });
+
+  it('GET /runs/:id/widget-status returns lightweight JSON for polling', async () => {
+    const app = await makeApp();
+    seedInteractiveAgent();
+    runStore.createRun({ id: 'r-poll', agentName: 'eight-ball', status: 'completed', triggeredBy: 'cli', startedAt: new Date().toISOString() });
+    runStore.updateRun('r-poll', {
+      status: 'completed',
+      completedAt: new Date().toISOString(),
+      result: 'ok',
+    });
+    const res = await request(app).get('/runs/r-poll/widget-status')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ runId: 'r-poll', status: 'completed', result: 'ok' });
+  });
+
+  it('GET /runs/:unknown/widget-status returns 404 JSON', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/runs/nope/widget-status')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/not found/i);
+  });
+
+  it('runInputs subset hides inputs not listed', async () => {
+    await makeApp();
+    const agent = makeIWAgent({
+      inputs: {
+        question: { type: 'string' },
+        secret_internal: { type: 'string' },
+      },
+    });
+    const widget = agent.outputWidget as OutputWidgetSchema;
+    const out = render(renderInteractiveWidget({ agent, widget }));
+    expect(out).toContain('input_question');
+    expect(out).not.toContain('input_secret_internal');
+  });
+
+  it('omits runInputs filter when not declared (every input shown)', async () => {
+    await makeApp();
+    const agent = makeIWAgent({
+      inputs: {
+        a: { type: 'string' },
+        b: { type: 'string' },
+      },
+    });
+    const widget = { ...(agent.outputWidget as OutputWidgetSchema), runInputs: undefined };
+    const out = render(renderInteractiveWidget({ agent, widget }));
+    expect(out).toContain('input_a');
+    expect(out).toContain('input_b');
   });
 });
 

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -31,6 +31,7 @@ import { runsRouter } from './routes/runs.js';
 import { runNowRouter } from './routes/run-now.js';
 import { buildRouter } from './routes/run-now-build.js';
 import { runMutationsRouter } from './routes/run-mutations.js';
+import { widgetRunRouter } from './routes/widget-run.js';
 import { toolsRouter } from './routes/tools.js';
 import { assetsRouter } from './routes/assets.js';
 import { outputFilesRouter } from './routes/output-files.js';
@@ -183,6 +184,7 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   app.use(runNowRouter);
   app.use(buildRouter);
   app.use(runMutationsRouter);
+  app.use(widgetRunRouter);
   app.use(settingsRouter);
   app.use(helpRouter);
   app.use(versionsRouter);

--- a/packages/dashboard/src/routes/agent-inputs.ts
+++ b/packages/dashboard/src/routes/agent-inputs.ts
@@ -212,6 +212,21 @@ agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res:
     });
   }
 
+  // Interactive-mode fields. Checkbox values arrive as 'on' (or absent).
+  // The runInputs checkbox group posts as either a string or an array.
+  const interactive = body.widget_interactive === 'on' || body.widget_interactive === 'true';
+  const rawRunInputs = body.widget_run_inputs;
+  let runInputs: string[] | undefined;
+  if (Array.isArray(rawRunInputs)) {
+    runInputs = rawRunInputs.filter((v): v is string => typeof v === 'string' && v.length > 0);
+  } else if (typeof rawRunInputs === 'string' && rawRunInputs.length > 0) {
+    runInputs = [rawRunInputs];
+  }
+  const askLabel = typeof body.widget_ask_label === 'string' && body.widget_ask_label.trim()
+    ? body.widget_ask_label.trim() : undefined;
+  const replayLabel = typeof body.widget_replay_label === 'string' && body.widget_replay_label.trim()
+    ? body.widget_replay_label.trim() : undefined;
+
   let outputWidget: OutputWidgetSchema;
   if (widgetType === 'ai-template') {
     const rawTemplate = typeof body.template === 'string' ? body.template : '';
@@ -226,11 +241,19 @@ agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res:
       template: sanitized,
       ...(promptText ? { prompt: promptText } : {}),
       ...(fields.length > 0 ? { fields } : {}),
+      ...(interactive ? { interactive: true } : {}),
+      ...(interactive && runInputs ? { runInputs } : {}),
+      ...(interactive && askLabel ? { askLabel } : {}),
+      ...(interactive && replayLabel ? { replayLabel } : {}),
     };
   } else {
     outputWidget = {
       type: widgetType as OutputWidgetType,
       fields,
+      ...(interactive ? { interactive: true } : {}),
+      ...(interactive && runInputs ? { runInputs } : {}),
+      ...(interactive && askLabel ? { askLabel } : {}),
+      ...(interactive && replayLabel ? { replayLabel } : {}),
     };
   }
 

--- a/packages/dashboard/src/routes/widget-run.ts
+++ b/packages/dashboard/src/routes/widget-run.ts
@@ -1,0 +1,108 @@
+import { Router, type Request, type Response } from 'express';
+import { executeAgentDag, type RunStatus } from '@some-useful-agents/core';
+import { getContext } from '../context.js';
+
+export const widgetRunRouter: Router = Router();
+
+/**
+ * POST /agents/:name/widget-run — start a run for an interactive widget.
+ *
+ * Mirrors the run-now route but returns JSON `{ runId }` instead of a 303
+ * redirect, so the calling tile can transition to its own polling state
+ * without navigating away. The dashboard auth middleware gates this just
+ * like every other mutating route.
+ */
+widgetRunRouter.post('/agents/:name/widget-run', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
+  const v2Agent = ctx.agentStore.getAgent(name);
+  if (!v2Agent) {
+    res.status(404).json({ error: `Agent "${name}" not found.` });
+    return;
+  }
+
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const inputs: Record<string, string> = {};
+  for (const [k, v] of Object.entries(body)) {
+    if (k.startsWith('input_') && typeof v === 'string' && v.trim() !== '') {
+      inputs[k.slice(6)] = v.trim();
+    }
+  }
+
+  const abortController = new AbortController();
+  const runPromise = executeAgentDag(
+    v2Agent,
+    { triggeredBy: 'dashboard', inputs, signal: abortController.signal },
+    {
+      runStore: ctx.runStore,
+      secretsStore: ctx.secretsStore,
+      variablesStore: ctx.variablesStore,
+      toolStore: ctx.toolStore,
+      allowUntrustedShell: ctx.allowUntrustedShell,
+      dashboardBaseUrl: ctx.dashboardBaseUrl,
+    },
+  );
+
+  // Look up the runId once the executor has created the row. Same idiom as
+  // run-now.ts — the executor creates the row synchronously near the top of
+  // executeAgentDag, so a brief setTimeout is enough to find it.
+  setTimeout(() => {
+    const { rows } = ctx.runStore.queryRuns({
+      agentName: v2Agent.id,
+      limit: 1,
+      offset: 0,
+      statuses: [] as RunStatus[],
+    });
+    const latest = rows[0];
+    if (latest && (latest.status === 'pending' || latest.status === 'running')) {
+      ctx.activeRuns.set(latest.id, abortController);
+    }
+  }, 50);
+
+  // Cleanup activeRuns on completion regardless of outcome.
+  runPromise
+    .then((run) => { ctx.activeRuns.delete(run.id); })
+    .catch(() => { /* swallowed — error surfaces via runStore on next poll */ });
+
+  // Echo back the runId so the client can start polling. We can't await
+  // runPromise here without losing the in-place UX, so we look it up.
+  setTimeout(() => {
+    const { rows } = ctx.runStore.queryRuns({
+      agentName: v2Agent.id,
+      limit: 1,
+      offset: 0,
+      statuses: [] as RunStatus[],
+    });
+    const latest = rows[0];
+    if (!latest) {
+      res.status(500).json({ error: 'Run did not start.' });
+      return;
+    }
+    res.status(202).json({ runId: latest.id });
+  }, 75);
+});
+
+/**
+ * GET /runs/:id/widget-status — lightweight status JSON for tile polling.
+ *
+ * Returns just the fields the tile needs: status + result + error. No
+ * per-node executions, no DAG, no auth payload. Polled every ~500 ms by
+ * interactive widgets.
+ */
+widgetRunRouter.get('/runs/:id/widget-status', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const run = ctx.runStore.getRun(id);
+  if (!run) {
+    res.status(404).json({ error: 'Run not found.' });
+    return;
+  }
+  res.json({
+    runId: run.id,
+    status: run.status,
+    startedAt: run.startedAt,
+    completedAt: run.completedAt,
+    result: run.result,
+    error: run.error,
+  });
+});

--- a/packages/dashboard/src/views/agent-detail-helpers.ts
+++ b/packages/dashboard/src/views/agent-detail-helpers.ts
@@ -249,6 +249,34 @@ export function renderOutputWidgetEditor(agent: Agent): SafeHtml {
         </p>
       </div>
 
+      <div id="ow-interactive-block" style="margin-bottom: var(--space-3); padding: var(--space-3); border: 1px solid var(--color-border); border-radius: var(--radius-sm);">
+        <label style="display: flex; align-items: center; gap: var(--space-2); margin-bottom: var(--space-2);">
+          <input type="checkbox" name="widget_interactive" id="ow-interactive" ${widget?.interactive ? 'checked' : ''}>
+          <strong style="font-size: var(--font-size-xs);">Interactive mode</strong>
+          <span class="dim" style="font-size: var(--font-size-xs);">tile shows inputs form + Run button; runs in place</span>
+        </label>
+        <div id="ow-interactive-fields" style="display: ${widget?.interactive ? 'block' : 'none'}; margin-left: var(--space-4);">
+          ${(() => {
+            const declared = Object.keys(agent.inputs ?? {});
+            const allow = new Set(widget?.runInputs ?? declared);
+            const checks = declared.length === 0
+              ? html`<p class="dim" style="font-size: var(--font-size-xs); margin: 0;">Agent declares no inputs — interactive mode will run with no parameters.</p>`
+              : html`<div style="display: flex; gap: var(--space-3); flex-wrap: wrap; margin-bottom: var(--space-2);">${declared.map((n) => html`<label style="font-size: var(--font-size-xs); display: inline-flex; align-items: center; gap: var(--space-1);"><input type="checkbox" name="widget_run_inputs" value="${n}" ${allow.has(n) ? 'checked' : ''}> ${n}</label>`) as unknown as SafeHtml[]}</div>`;
+            return checks;
+          })()}
+          <div style="display: flex; gap: var(--space-2); flex-wrap: wrap;">
+            <label style="font-size: var(--font-size-xs); display: flex; flex-direction: column; gap: 2px;">
+              Run button label
+              <input type="text" name="widget_ask_label" placeholder="Run" value="${widget?.askLabel ?? ''}" style="${FIELD} width: 14rem;">
+            </label>
+            <label style="font-size: var(--font-size-xs); display: flex; flex-direction: column; gap: 2px;">
+              Replay button label
+              <input type="text" name="widget_replay_label" placeholder="Run again" value="${widget?.replayLabel ?? ''}" style="${FIELD} width: 14rem;">
+            </label>
+          </div>
+        </div>
+      </div>
+
       <div style="display: flex; gap: var(--space-2); justify-content: space-between; align-items: center; flex-wrap: wrap; margin-bottom: var(--space-3);">
         <div style="display: flex; gap: var(--space-2); align-items: center;">
           <button type="button" class="btn btn--ghost btn--sm" id="add-widget-field-btn">+ Add field</button>
@@ -291,6 +319,16 @@ export function renderOutputWidgetEditor(agent: Agent): SafeHtml {
       var addBtn = document.getElementById('add-widget-field-btn');
       var exampleSel = document.getElementById('ow-example');
       var preview = document.getElementById('ow-preview');
+
+      // Interactive-mode toggle: show/hide the runInputs + label fields when
+      // the checkbox flips. No-op when the block is missing (defensive).
+      var interactiveToggle = document.getElementById('ow-interactive');
+      var interactiveFields = document.getElementById('ow-interactive-fields');
+      if (interactiveToggle && interactiveFields) {
+        interactiveToggle.addEventListener('change', function () {
+          interactiveFields.style.display = interactiveToggle.checked ? 'block' : 'none';
+        });
+      }
 
       function currentWidget() { return hidden.value; }
       function activeCard() { return cards.querySelector('.ow-card.is-active'); }

--- a/packages/dashboard/src/views/interactive-widget.ts
+++ b/packages/dashboard/src/views/interactive-widget.ts
@@ -1,0 +1,341 @@
+/**
+ * Interactive widget shell: wraps the existing output-widget renderer with
+ * an inline inputs form + Run button + state machine that polls
+ * /runs/:id/widget-status until the run completes.
+ *
+ * State machine (see ~/.claude/plans/interactive-widgets.md):
+ *
+ *   idle ──askAgain──▶ asking ──submit──▶ running ──poll──▶ success | error
+ *    ▲                  │                      │                │      │
+ *    │ replay            │ cancel(empty)        │ cancel         │      │
+ *    └───────────────────┴──────────────────────┴────────────────┴──────┘
+ *
+ * Hydration: when `lastRun` is set, the shell starts in `idle` rendering
+ * the widget against the last result. When there's no prior run, it
+ * starts in `asking` so the user lands on the form.
+ */
+
+import type { Agent, AgentInputSpec, OutputWidgetSchema, Run } from '@some-useful-agents/core';
+import { html, unsafeHtml, type SafeHtml } from './html.js';
+import { renderOutputWidget } from './output-widgets.js';
+
+const FIELD = 'padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm); width: 100%; box-sizing: border-box;';
+
+/**
+ * Returns the inputs the interactive tile should expose, in declaration
+ * order. If the widget declares `runInputs`, that subset (preserving
+ * order) is used; otherwise every input is shown.
+ */
+function pickInputs(
+  agent: Agent,
+  widget: OutputWidgetSchema,
+): Array<[string, AgentInputSpec]> {
+  const all = Object.entries(agent.inputs ?? {});
+  if (!widget.runInputs || widget.runInputs.length === 0) return all;
+  const allow = new Set(widget.runInputs);
+  return all.filter(([name]) => allow.has(name));
+}
+
+function renderInputControl(name: string, spec: AgentInputSpec): SafeHtml {
+  const def = spec.default !== undefined ? String(spec.default) : '';
+  if (spec.type === 'enum' && Array.isArray(spec.values) && spec.values.length > 0) {
+    const opts = spec.values.map((v) => {
+      const val = String(v);
+      const selected = val === def ? ' selected' : '';
+      return `<option value="${val}"${selected}>${val}</option>`;
+    }).join('');
+    return unsafeHtml(`<select name="input_${name}" data-input style="${FIELD}">${opts}</select>`);
+  }
+  if (spec.type === 'boolean') {
+    return unsafeHtml(
+      `<select name="input_${name}" data-input style="${FIELD}">` +
+      `<option value="true"${def === 'true' ? ' selected' : ''}>true</option>` +
+      `<option value="false"${def !== 'true' ? ' selected' : ''}>false</option>` +
+      `</select>`,
+    );
+  }
+  if (spec.type === 'number') {
+    return html`<input type="number" name="input_${name}" data-input value="${def}" placeholder="${def || '(empty)'}" style="${FIELD}">`;
+  }
+  return html`<input type="text" name="input_${name}" data-input value="${def}" placeholder="${def || '(empty)'}" style="${FIELD}">`;
+}
+
+/**
+ * Render the interactive widget shell for an agent. Returns the full tile
+ * body — caller wraps with the existing tile container.
+ */
+export function renderInteractiveWidget(args: {
+  agent: Agent;
+  widget: OutputWidgetSchema;
+  lastRun?: Pick<Run, 'id' | 'result' | 'status' | 'error'>;
+}): SafeHtml {
+  const { agent, widget, lastRun } = args;
+  const inputs = pickInputs(agent, widget);
+  const askLabel = widget.askLabel ?? 'Run';
+  const replayLabel = widget.replayLabel ?? 'Run again';
+  const hasResult = lastRun && lastRun.status === 'completed' && typeof lastRun.result === 'string';
+  const startState: 'idle' | 'asking' = hasResult ? 'idle' : 'asking';
+
+  const fieldRows = inputs.map(([name, spec]) => html`
+    <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-2);">
+      <span style="font-size: var(--font-size-xs); display: flex; align-items: baseline; gap: var(--space-2);">
+        <strong>${name}</strong>
+        ${spec.description ? html`<span class="dim">${spec.description}</span>` : html``}
+      </span>
+      ${renderInputControl(name, spec)}
+    </label>
+  `);
+
+  // Initial idle body — render the widget against the last result.
+  const idleBody = hasResult
+    ? renderOutputWidget(widget, String(lastRun.result), agent.id) ?? html`<p class="dim">Widget render failed.</p>`
+    : html``;
+
+  return html`
+    <div class="iw" data-iw data-iw-agent="${agent.id}" data-iw-state="${startState}">
+      <style>
+        .iw { position: relative; }
+        .iw-pane { transition: opacity 220ms ease, transform 220ms ease; }
+        .iw-pane[hidden] { display: none; }
+        .iw-pane.iw-leaving { opacity: 0; transform: translateY(-4px); }
+        .iw-pane.iw-entering { opacity: 0; transform: translateY(4px); }
+        .iw-pane.iw-entered { opacity: 1; transform: translateY(0); }
+        .iw[data-iw-state="running"] { box-shadow: 0 0 0 1px var(--color-primary, #2563eb); animation: iw-pulse 1.6s ease-in-out infinite; border-radius: var(--radius-md); }
+        @keyframes iw-pulse {
+          0%, 100% { box-shadow: 0 0 0 1px var(--color-primary, #2563eb); }
+          50%      { box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .iw-pane { transition: none; }
+          .iw[data-iw-state="running"] { animation: none; }
+        }
+        .iw-cta-row { display: flex; justify-content: flex-end; gap: var(--space-2); margin-top: var(--space-3); }
+        .iw-status { display: flex; align-items: center; gap: var(--space-2); padding: var(--space-3); }
+        .iw-spinner { width: 14px; height: 14px; border: 2px solid var(--color-border); border-top-color: var(--color-primary, #2563eb); border-radius: 50%; animation: iw-spin 700ms linear infinite; }
+        @keyframes iw-spin { to { transform: rotate(360deg); } }
+        @media (prefers-reduced-motion: reduce) { .iw-spinner { animation: none; } }
+        .iw-error { padding: var(--space-3); border: 1px solid var(--color-err); border-radius: var(--radius-sm); background: rgba(220, 38, 38, 0.04); }
+      </style>
+
+      <div class="iw-pane iw-pane-idle" ${startState === 'idle' ? '' : 'hidden'}>
+        <div class="iw-result">${idleBody}</div>
+        <div class="iw-cta-row">
+          <button type="button" class="btn btn--primary btn--sm" data-iw-replay>${replayLabel}</button>
+        </div>
+      </div>
+
+      <div class="iw-pane iw-pane-asking" ${startState === 'asking' ? '' : 'hidden'}>
+        <form data-iw-form>
+          ${inputs.length > 0 ? fieldRows as unknown as SafeHtml[] : html`<p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-2);">No inputs declared. Click ${askLabel} to run.</p>`}
+          <div class="iw-cta-row">
+            ${hasResult ? html`<button type="button" class="btn btn--ghost btn--sm" data-iw-cancel-asking>Cancel</button>` : html``}
+            <button type="submit" class="btn btn--primary btn--sm">${askLabel}</button>
+          </div>
+        </form>
+      </div>
+
+      <div class="iw-pane iw-pane-running" hidden>
+        <div class="iw-status">
+          <div class="iw-spinner" aria-hidden="true"></div>
+          <span>Running… <span data-iw-elapsed>0</span>s</span>
+          <button type="button" class="btn btn--ghost btn--sm" data-iw-cancel-run style="margin-left: auto;">Cancel</button>
+        </div>
+      </div>
+
+      <div class="iw-pane iw-pane-stuck" hidden>
+        <div class="iw-status">
+          <span>Still running. <a data-iw-stuck-link href="#">View run details</a></span>
+        </div>
+      </div>
+
+      <div class="iw-pane iw-pane-error" hidden>
+        <div class="iw-error">
+          <p style="margin: 0 0 var(--space-2); font-weight: var(--weight-bold); color: var(--color-err);">Run failed</p>
+          <p data-iw-error-msg style="margin: 0 0 var(--space-2); font-size: var(--font-size-xs); font-family: var(--font-mono); white-space: pre-wrap;"></p>
+          <div style="display: flex; gap: var(--space-2); justify-content: flex-end;">
+            <a data-iw-error-link class="btn btn--ghost btn--sm" href="#">View run</a>
+            <button type="button" class="btn btn--primary btn--sm" data-iw-retry>Retry</button>
+          </div>
+        </div>
+      </div>
+
+      ${unsafeHtml(`<script>
+      (function () {
+        var root = document.currentScript.parentElement;
+        if (!root || !root.matches('[data-iw]')) return;
+        var AGENT_ID = ${JSON.stringify(agent.id)};
+        var POLL_MS = 500;
+        var POLL_CAP = 120; // 60 s
+
+        var panes = {
+          idle: root.querySelector('.iw-pane-idle'),
+          asking: root.querySelector('.iw-pane-asking'),
+          running: root.querySelector('.iw-pane-running'),
+          stuck: root.querySelector('.iw-pane-stuck'),
+          error: root.querySelector('.iw-pane-error'),
+        };
+        var resultBox = root.querySelector('.iw-result');
+        var elapsedEl = root.querySelector('[data-iw-elapsed]');
+        var errMsgEl = root.querySelector('[data-iw-error-msg]');
+        var errLink = root.querySelector('[data-iw-error-link]');
+        var stuckLink = root.querySelector('[data-iw-stuck-link]');
+
+        var current = root.getAttribute('data-iw-state') || 'asking';
+        var pollTimer = null;
+        var elapsedTimer = null;
+        var startMs = 0;
+        var pollCount = 0;
+        var currentRunId = null;
+
+        function transition(next) {
+          if (current === next) return;
+          var leaving = panes[current];
+          var entering = panes[next];
+          root.setAttribute('data-iw-state', next);
+          if (leaving) {
+            leaving.classList.add('iw-leaving');
+            setTimeout(function () {
+              leaving.hidden = true;
+              leaving.classList.remove('iw-leaving');
+            }, 220);
+          }
+          if (entering) {
+            entering.hidden = false;
+            entering.classList.add('iw-entering');
+            requestAnimationFrame(function () {
+              entering.classList.remove('iw-entering');
+              entering.classList.add('iw-entered');
+              setTimeout(function () { entering.classList.remove('iw-entered'); }, 240);
+            });
+          }
+          current = next;
+        }
+
+        function clearPoll() {
+          if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; }
+          if (elapsedTimer) { clearInterval(elapsedTimer); elapsedTimer = null; }
+        }
+
+        function startElapsed() {
+          startMs = Date.now();
+          if (elapsedEl) elapsedEl.textContent = '0';
+          elapsedTimer = setInterval(function () {
+            if (!elapsedEl) return;
+            elapsedEl.textContent = String(Math.floor((Date.now() - startMs) / 1000));
+          }, 250);
+        }
+
+        function showError(msg, runId) {
+          if (errMsgEl) errMsgEl.textContent = msg || 'Unknown error.';
+          if (errLink && runId) errLink.setAttribute('href', '/runs/' + encodeURIComponent(runId));
+          transition('error');
+        }
+
+        function showSuccess(html) {
+          if (resultBox) resultBox.innerHTML = html;
+          transition('idle');
+        }
+
+        function poll() {
+          if (!currentRunId) return;
+          if (pollCount >= POLL_CAP) {
+            clearPoll();
+            if (stuckLink) stuckLink.setAttribute('href', '/runs/' + encodeURIComponent(currentRunId));
+            transition('stuck');
+            return;
+          }
+          pollCount += 1;
+          fetch('/runs/' + encodeURIComponent(currentRunId) + '/widget-status', { credentials: 'same-origin' })
+            .then(function (r) { return r.ok ? r.json() : Promise.reject(new Error('HTTP ' + r.status)); })
+            .then(function (data) {
+              if (data.status === 'completed') {
+                clearPoll();
+                // Re-fetch the widget rendering by asking the agent detail
+                // page for it. Cheaper: just put the raw result in a <pre>.
+                // But we want the actual widget — fetch the agent overview
+                // fragment we already render server-side. For now, reload
+                // the parent tile via re-render endpoint OR just show the
+                // raw result. Take the simpler path: show the raw result
+                // text and let the next pulse refresh swap in the widget.
+                var resultText = (data.result == null ? '' : String(data.result));
+                if (resultBox) {
+                  resultBox.innerHTML = '<pre style="margin: 0; white-space: pre-wrap; font-family: var(--font-mono); font-size: var(--font-size-xs);">' +
+                    resultText.replace(/[<>&]/g, function (c) { return c === '<' ? '&lt;' : c === '>' ? '&gt;' : '&amp;'; }) +
+                    '</pre>';
+                }
+                showSuccess(resultBox ? resultBox.innerHTML : '');
+                return;
+              }
+              if (data.status === 'failed') {
+                clearPoll();
+                showError(data.error || 'Run failed.', data.runId);
+                return;
+              }
+              if (data.status === 'cancelled') {
+                clearPoll();
+                transition(panes.idle && !panes.idle.hidden ? 'idle' : 'asking');
+                return;
+              }
+              // running / pending: keep polling
+              pollTimer = setTimeout(poll, POLL_MS);
+            })
+            .catch(function (err) {
+              clearPoll();
+              showError('Status poll failed: ' + (err.message || err), currentRunId);
+            });
+        }
+
+        function submitForm(form) {
+          var fd = new FormData(form);
+          var body = new URLSearchParams();
+          fd.forEach(function (v, k) { body.append(k, String(v)); });
+          transition('running');
+          startElapsed();
+          pollCount = 0;
+          fetch('/agents/' + encodeURIComponent(AGENT_ID) + '/widget-run', {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: body.toString(),
+          })
+            .then(function (r) {
+              if (!r.ok) return r.json().then(function (d) { throw new Error(d.error || ('HTTP ' + r.status)); });
+              return r.json();
+            })
+            .then(function (data) {
+              currentRunId = data.runId;
+              pollTimer = setTimeout(poll, POLL_MS);
+            })
+            .catch(function (err) {
+              clearPoll();
+              showError('Failed to start run: ' + (err.message || err));
+            });
+        }
+
+        // Wire events.
+        var form = root.querySelector('[data-iw-form]');
+        if (form) {
+          form.addEventListener('submit', function (ev) {
+            ev.preventDefault();
+            submitForm(form);
+          });
+        }
+        var replay = root.querySelector('[data-iw-replay]');
+        if (replay) replay.addEventListener('click', function () { transition('asking'); });
+        var cancelAsking = root.querySelector('[data-iw-cancel-asking]');
+        if (cancelAsking) cancelAsking.addEventListener('click', function () { transition('idle'); });
+        var retry = root.querySelector('[data-iw-retry]');
+        if (retry) retry.addEventListener('click', function () { transition('asking'); });
+        var cancelRun = root.querySelector('[data-iw-cancel-run]');
+        if (cancelRun) cancelRun.addEventListener('click', function () {
+          if (!currentRunId) return;
+          fetch('/runs/' + encodeURIComponent(currentRunId) + '/cancel', {
+            method: 'POST', credentials: 'same-origin',
+          }).catch(function () { /* ignore */ });
+          // Poll loop will pick up the cancelled status on the next tick.
+        });
+      })();
+      </script>`)}
+    </div>
+  `;
+}

--- a/packages/dashboard/src/views/pulse-renderers.ts
+++ b/packages/dashboard/src/views/pulse-renderers.ts
@@ -9,6 +9,7 @@ import { normalizeSignal } from './pulse-templates.js';
 import { esc, stringify, renderMarkdown, looksLikeJson, prettyJson } from './pulse-helpers.js';
 import type { PulseTile, TileWrapFn } from './pulse-types.js';
 import { renderOutputWidget } from './output-widgets.js';
+import { renderInteractiveWidget } from './interactive-widget.js';
 
 // ── Renderers ────────────────────────────────────────────────────────────
 
@@ -345,6 +346,15 @@ export function renderTile(tile: PulseTile, wrap: TileWrapFn): SafeHtml {
 
 function renderWidgetTile(tile: PulseTile, wrap: TileWrapFn): SafeHtml {
   const agent = tile.agent;
+  // Interactive mode: tile becomes a self-contained mini-app with inputs
+  // form + Run button + status polling. Doesn't require a prior run.
+  if (agent.outputWidget?.interactive) {
+    return wrap(tile, renderInteractiveWidget({
+      agent,
+      widget: agent.outputWidget,
+      lastRun: tile.lastRun ?? undefined,
+    }));
+  }
   if (!agent.outputWidget || !tile.lastRun?.result) {
     return wrap(tile, html`<p class="dim" style="font-size: var(--font-size-xs);">No widget output yet.</p>`);
   }


### PR DESCRIPTION
## Summary

PR-E from the v0.19+ queue. Output widgets gain an opt-in \`interactive: true\` flag that turns the pulse tile into a self-contained ask → think → answer loop. Smooth CSS transitions between states make the dashboard feel less like a CRUD admin and more like an application.

Plan: \`~/.claude/plans/interactive-widgets.md\`. Motivating example was the Magic 8-Ball tile — ask a question, get an answer, ask again, all in place.

## State machine

\`\`\`
   idle ──askAgain──▶ asking ──submit──▶ running ──poll──▶ success | error
    ▲                  │                      │                │      │
    │ replay            │ cancel(empty)        │ cancel         │      │
    └───────────────────┴──────────────────────┴────────────────┴──────┘
\`\`\`

Five visible states cross-fade at ~220 ms with a small \`translateY\` so content doesn't pop. The tile gets a subtle pulsing border while running so it reads as "active" at a glance. \`prefers-reduced-motion\` disables the animations.

Polling: 500 ms ticks against \`GET /runs/:id/widget-status\`, capped at 60 s → "still running, view details" link state with a link to \`/runs/:id\`. Cancel button hooks the existing \`/runs/:id/cancel\` route — the next poll tick picks up the cancelled status.

## Schema additions (additive — no break)

\`\`\`ts
interface OutputWidgetSchema {
  // ...existing
  interactive?: boolean;
  runInputs?: string[];   // subset of agent.inputs to expose; default = all
  askLabel?: string;      // default "Run"
  replayLabel?: string;   // default "Run again"
}
\`\`\`

Existing widgets without the flag render exactly as before.

## New dashboard routes

- \`POST /agents/:name/widget-run\` — accepts \`input_*\` form fields, returns \`{ runId }\` (202). Reuses the existing DAG executor + auth + dashboardBaseUrl plumbing.
- \`GET /runs/:id/widget-status\` — lightweight JSON: \`{ runId, status, startedAt, completedAt, result, error }\`. No DAG / per-node executions / auth payload.

## Editor

The output-widget editor on agent config gets an "Interactive mode" disclosure section: a checkbox to enable, per-input checkboxes for \`runInputs\` filtering, and label overrides for both buttons. Toggling the checkbox shows/hides the rest in real time.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm test\` green (743 / 743, +7 new)
- [x] \`npm run build\` clean
- [ ] Manual: agent with \`outputWidget.interactive: true\` shows the inputs form on /pulse before any run; click Ask → spinner with elapsed counter → result fades in.
- [ ] Manual: \`runInputs: ['question']\` hides agent inputs not listed (verified with two-input fixture; tested in unit).
- [ ] Manual: cancel a running widget; tile returns to idle.
- [ ] Manual: trigger a failing agent; red error card with retry + view-run link.
- [ ] Manual: open a tile after the 60 s cap with \`sleep 65\` agent; "still running" link appears.
- [ ] Manual: \`prefers-reduced-motion\` (System Settings → Accessibility → Reduce Motion) disables the cross-fade.

## Out of scope (deferred)

- The post-completion result currently renders as raw text in a \`<pre>\`. The proper widget HTML re-render on completion is a follow-up; the next pulse refresh swaps in the actual widget body.
- Streaming intermediate node outputs into the tile (would need SSE / WebSocket).
- Channel / file / secret pickers tied to specific input types beyond text / number / enum / boolean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)