### PR TITLE
fix(core): single source of truth for outputWidget schema (YAML round-trip)

### DIFF
--- a/.changeset/agent-schema-widget-dedup.md
+++ b/.changeset/agent-schema-widget-dedup.md
@@ -1,0 +1,23 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Fix YAML round-trip silently stripping `outputWidget` fields.
+
+`agent-v2-schema.ts` carried its own inline `outputWidget` zod definition that had drifted from the canonical `outputWidgetSchema` in `output-widget-schema.ts`. Anything that round-tripped agents through YAML (`workflow import-yaml`, `agent install`, `workflow export` → re-import) lost the missing fields silently because zod accepted the document but the inline definition didn't list those keys.
+
+Drift accumulated over time:
+- `ai-template` widget type
+- `preview` field type
+- `prompt` and `template` fields (ai-template generator output)
+- `interactive`, `runInputs`, `askLabel`, `replayLabel` (PR #166)
+
+Fix: the inline schema is replaced with `outputWidgetSchema.optional()` so there's a single source of truth.
+
+Surfaced when adding `interactive: true` to the Magic 8-Ball agent via `workflow export → patch → workflow import-yaml` and observing the field disappear on re-export. Also fixes the latent bug where ai-template widgets authored via the dashboard couldn't survive YAML round-trip — they parsed cleanly but the prompt/template fields were stripped.
+
+No agent data migration needed; existing DB-stored widgets keep their fields and now correctly survive a YAML round-trip.

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -18,6 +18,7 @@ import { z } from 'zod';
 import { validateScheduleInterval, CronInvalidError, CronTooFrequentError } from './cron-validator.js';
 import { extractInputReferences, SENSITIVE_ENV_NAMES } from './input-resolver.js';
 import { inputSpecSchema } from './schema.js';
+import { outputWidgetSchema } from './output-widget-schema.js';
 
 const AGENT_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
 const NODE_ID_RE = /^[a-z0-9][a-z0-9_-]*$/;
@@ -216,21 +217,11 @@ export const agentV2Schema = z.object({
     }
   }).optional(),
 
-  outputWidget: z.object({
-    type: z.enum(['diff-apply', 'key-value', 'raw', 'dashboard']),
-    fields: z.array(z.object({
-      name: z.string().min(1),
-      label: z.string().optional(),
-      type: z.enum(['text', 'code', 'badge', 'action', 'metric', 'stat']),
-    })).min(1),
-    actions: z.array(z.object({
-      id: z.string().min(1),
-      label: z.string().min(1),
-      method: z.literal('POST'),
-      endpoint: z.string().min(1),
-      payloadField: z.string().optional(),
-    })).optional(),
-  }).optional(),
+  // Reuse the canonical outputWidgetSchema instead of an inline duplicate.
+  // The inline version had drifted: missing ai-template type, preview field
+  // type, prompt/template fields, and (most recently) the interactive-mode
+  // fields — all of which YAML import would silently strip.
+  outputWidget: outputWidgetSchema.optional(),
 
   author: z.string().optional(),
   tags: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary

\`agent-v2-schema.ts\` carried a duplicate inline \`outputWidget\` zod definition that had drifted from the canonical \`outputWidgetSchema\` in \`output-widget-schema.ts\`. Anything that round-tripped agents through YAML (\`workflow import-yaml\`, \`agent install\`, \`workflow export\` → re-import) silently dropped fields the inline definition didn't list — zod accepted the document but the missing keys never made it into the parsed Agent.

Drift had accumulated:
- \`ai-template\` widget type
- \`preview\` field type
- \`prompt\` and \`template\` (ai-template generator output)
- \`interactive\`, \`runInputs\`, \`askLabel\`, \`replayLabel\` (PR #166)

## How it surfaced

Trying to enable interactive mode on the Magic 8-Ball agent via \`workflow export → edit → import-yaml\`. \`interactive: true\` disappeared from re-export every time. Tracing through \`parseAgent\` showed the field landing as undefined despite zod parsing \`success\`.

The pattern was: the canonical schema accepts unknown fields if no \`.strict()\` is applied, but the inline schema in agent-v2 didn't \`pick\` from the canonical one — it was its own object that happened to match the old field set. Drift was inevitable.

## Fix

Replace the inline schema with \`outputWidgetSchema.optional()\`. Single source of truth.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm test\` green (749 / 749, 0 regressions)
- [x] \`npm run build\` clean
- [x] Manual: export an agent with \`outputWidget.interactive: true\`, verify field survives \`workflow export → import-yaml → export\` round-trip.
- [ ] Manual: same for an ai-template widget that has \`prompt\` + \`template\` set.

## No migration

Existing DB-stored widgets keep all their fields. The fix just lets YAML round-trip preserve them too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)