### PR TITLE
fix(dashboard): interactive widgets re-render the actual widget on completion

### DIFF
--- a/.changeset/interactive-widget-rerender.md
+++ b/.changeset/interactive-widget-rerender.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Fix interactive widgets rendering raw JSON in a `<pre>` on completion.
+
+PR #166's interactive widgets shipped with a known follow-up: when a run completed in the tile, the result body got pretty-printed JSON instead of the actual widget. The proper widget render only appeared on the next pulse refresh, which broke the in-place feel — the whole point of interactive mode.
+
+Fix: `GET /runs/:id/widget-status` now server-renders the agent's `outputWidget` against the run result and includes a `widgetHtml` string in the response when the run is `completed` and the agent has a widget. The tile JS swaps that HTML into the result box on success, with the same fade-in transition as before. Falls back to the prior `<pre>` behavior when no widget is configured (e.g. agent without an outputWidget) or the widget renderer rejects the result.
+
+Same renderer that powers the static pulse tile now runs on the widget-status endpoint, so the rendering is identical between first-load and post-run states. No client-side widget logic to keep in sync.

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -2026,6 +2026,23 @@ describe('Interactive widget tile + widget-run/widget-status', () => {
     expect(res.body).toMatchObject({ runId: 'r-poll', status: 'completed', result: 'ok' });
   });
 
+  it('widget-status returns server-rendered widgetHtml on completion when the agent has an outputWidget', async () => {
+    const app = await makeApp();
+    seedInteractiveAgent();
+    runStore.createRun({ id: 'r-html', agentName: 'eight-ball', status: 'completed', triggeredBy: 'cli', startedAt: new Date().toISOString() });
+    runStore.updateRun('r-html', {
+      status: 'completed',
+      completedAt: new Date().toISOString(),
+      result: '{"answer":"yes"}',
+    });
+    const res = await request(app).get('/runs/r-html/widget-status')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(typeof res.body.widgetHtml).toBe('string');
+    expect(res.body.widgetHtml).toContain('yes');
+  });
+
   it('GET /runs/:unknown/widget-status returns 404 JSON', async () => {
     const app = await makeApp();
     const res = await request(app).get('/runs/nope/widget-status')

--- a/packages/dashboard/src/routes/widget-run.ts
+++ b/packages/dashboard/src/routes/widget-run.ts
@@ -1,6 +1,8 @@
 import { Router, type Request, type Response } from 'express';
 import { executeAgentDag, type RunStatus } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
+import { renderOutputWidget } from '../views/output-widgets.js';
+import { render } from '../views/html.js';
 
 export const widgetRunRouter: Router = Router();
 
@@ -97,6 +99,21 @@ widgetRunRouter.get('/runs/:id/widget-status', (req: Request, res: Response) => 
     res.status(404).json({ error: 'Run not found.' });
     return;
   }
+
+  // On terminal success, render the agent's outputWidget against the run
+  // result and ship the HTML to the tile. Saves the JS from re-implementing
+  // the widget renderer just to swap a pretty-printed JSON blob into the
+  // result box; the same renderer that runs on the server-side pulse render
+  // also runs here.
+  let widgetHtml: string | undefined;
+  if (run.status === 'completed' && typeof run.result === 'string') {
+    const agent = ctx.agentStore.getAgent(run.agentName);
+    if (agent?.outputWidget) {
+      const safe = renderOutputWidget(agent.outputWidget, run.result, agent.id);
+      if (safe) widgetHtml = render(safe);
+    }
+  }
+
   res.json({
     runId: run.id,
     status: run.status,
@@ -104,5 +121,6 @@ widgetRunRouter.get('/runs/:id/widget-status', (req: Request, res: Response) => 
     completedAt: run.completedAt,
     result: run.result,
     error: run.error,
+    ...(widgetHtml ? { widgetHtml } : {}),
   });
 });

--- a/packages/dashboard/src/views/interactive-widget.ts
+++ b/packages/dashboard/src/views/interactive-widget.ts
@@ -250,20 +250,22 @@ export function renderInteractiveWidget(args: {
             .then(function (data) {
               if (data.status === 'completed') {
                 clearPoll();
-                // Re-fetch the widget rendering by asking the agent detail
-                // page for it. Cheaper: just put the raw result in a <pre>.
-                // But we want the actual widget — fetch the agent overview
-                // fragment we already render server-side. For now, reload
-                // the parent tile via re-render endpoint OR just show the
-                // raw result. Take the simpler path: show the raw result
-                // text and let the next pulse refresh swap in the widget.
-                var resultText = (data.result == null ? '' : String(data.result));
-                if (resultBox) {
-                  resultBox.innerHTML = '<pre style="margin: 0; white-space: pre-wrap; font-family: var(--font-mono); font-size: var(--font-size-xs);">' +
+                // Server-side rendered widget HTML when the agent has an
+                // outputWidget — keeps the rendering identical to the static
+                // pulse tile path. Falls back to a JSON-pretty <pre> only
+                // when no widget can be rendered (no outputWidget, or the
+                // schema rejected the result).
+                var html = '';
+                if (typeof data.widgetHtml === 'string' && data.widgetHtml.length > 0) {
+                  html = data.widgetHtml;
+                } else {
+                  var resultText = (data.result == null ? '' : String(data.result));
+                  html = '<pre style="margin: 0; white-space: pre-wrap; font-family: var(--font-mono); font-size: var(--font-size-xs);">' +
                     resultText.replace(/[<>&]/g, function (c) { return c === '<' ? '&lt;' : c === '>' ? '&gt;' : '&amp;'; }) +
                     '</pre>';
                 }
-                showSuccess(resultBox ? resultBox.innerHTML : '');
+                if (resultBox) resultBox.innerHTML = html;
+                showSuccess(html);
                 return;
               }
               if (data.status === 'failed') {


### PR DESCRIPTION
## Summary

Closes the known follow-up from PR #166 — when an interactive widget run completed, the tile dropped pretty-printed JSON in a \`<pre>\` instead of the actual widget body. The Magic 8-Ball completion looked like a JSON inspector instead of a 8-Ball card. The proper widget only re-appeared on the next pulse refresh, which broke the in-place feel that's the whole point of interactive mode.

## Fix

Server-side render the widget on completion and ship the HTML in the polling response:

- \`GET /runs/:id/widget-status\` now looks up the agent and (when \`status === 'completed'\` + the agent has an \`outputWidget\`) calls the existing \`renderOutputWidget\` against the run result. The rendered HTML lands in the response as \`widgetHtml\`.
- The tile JS prefers \`widgetHtml\` when present and falls back to the prior \`<pre>\` when no widget is configured (e.g. interactive agent with no \`outputWidget\`).

Reuses the same renderer that powers the static pulse tile path, so first-load and post-run renders are identical. No client-side widget logic to keep in sync.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm test\` green (750 / 750, +1 new test)
- [x] \`npm run build\` clean
- [ ] Manual: enable interactive mode on Magic 8-Ball, ask a question on /pulse, verify the result fades in as the actual dashboard widget (label / metric / badge layout) instead of JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)