### PR TITLE
fix(dashboard): stable height across interactive-widget state transitions

### DIFF
--- a/.changeset/interactive-widget-stable-height.md
+++ b/.changeset/interactive-widget-stable-height.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Fix interactive widgets resizing during state transitions.
+
+PR #166's interactive widgets used `display: none` to hide inactive panes (asking / running / success / error / stuck), which removed them from the layout entirely. That meant the tile's height jumped between states — the form pane is one height, the spinner-only running pane is much shorter, the result is variable, the error card is somewhere in between. Asking → running → success felt jarring as the container resized twice.
+
+Fix: switch to a CSS Grid stack. All panes share the same grid cell (`grid-template-areas: 'stack'`), so the cell's height is `max(child heights)` and stays stable across transitions. Inactive panes get `opacity: 0; visibility: hidden; pointer-events: none` instead of `display: none`, so they keep contributing to the cell sizing without affecting interaction. CTA rows also pin to the bottom via `margin-top: auto` so the Run button sits in the same place regardless of pane content.
+
+Short panes (running, stuck, error) center vertically inside the cell so they don't anchor awkwardly to the top of an oversized container. The container also gets a `min-height: 8rem` baseline so the very first pre-run render doesn't open at zero height.

--- a/packages/dashboard/src/views/interactive-widget.ts
+++ b/packages/dashboard/src/views/interactive-widget.ts
@@ -94,12 +94,37 @@ export function renderInteractiveWidget(args: {
   return html`
     <div class="iw" data-iw data-iw-agent="${agent.id}" data-iw-state="${startState}">
       <style>
-        .iw { position: relative; }
-        .iw-pane { transition: opacity 220ms ease, transform 220ms ease; }
-        .iw-pane[hidden] { display: none; }
+        /* Grid stack: every pane sits in the same cell, so the tile's
+           height is the tallest pane in the DOM, not the active one. No
+           jumpy resize when transitioning between asking, running, and
+           result states. */
+        .iw {
+          display: grid;
+          grid-template-areas: 'stack';
+          position: relative;
+          min-height: 8rem;
+        }
+        .iw-pane {
+          grid-area: stack;
+          display: flex;
+          flex-direction: column;
+          transition: opacity 220ms ease, transform 220ms ease;
+        }
+        /* Hidden panes still contribute to grid sizing — that's the point.
+           Use opacity + visibility instead of display:none so the cell
+           stays at max(child heights). pointer-events disabled so clicks
+           pass through to whatever is on top. */
+        .iw-pane.iw-pane-inactive {
+          opacity: 0;
+          visibility: hidden;
+          pointer-events: none;
+        }
         .iw-pane.iw-leaving { opacity: 0; transform: translateY(-4px); }
         .iw-pane.iw-entering { opacity: 0; transform: translateY(4px); }
         .iw-pane.iw-entered { opacity: 1; transform: translateY(0); }
+        /* Short panes (spinner-only, error card) center vertically in the
+           cell so they don't anchor to the top of an over-sized container. */
+        .iw-pane-running, .iw-pane-stuck, .iw-pane-error { justify-content: center; }
         .iw[data-iw-state="running"] { box-shadow: 0 0 0 1px var(--color-primary, #2563eb); animation: iw-pulse 1.6s ease-in-out infinite; border-radius: var(--radius-md); }
         @keyframes iw-pulse {
           0%, 100% { box-shadow: 0 0 0 1px var(--color-primary, #2563eb); }
@@ -109,7 +134,9 @@ export function renderInteractiveWidget(args: {
           .iw-pane { transition: none; }
           .iw[data-iw-state="running"] { animation: none; }
         }
-        .iw-cta-row { display: flex; justify-content: flex-end; gap: var(--space-2); margin-top: var(--space-3); }
+        /* Push CTA rows to the bottom so the form's button stays anchored
+           regardless of how tall the cell is. */
+        .iw-cta-row { display: flex; justify-content: flex-end; gap: var(--space-2); margin-top: auto; padding-top: var(--space-3); }
         .iw-status { display: flex; align-items: center; gap: var(--space-2); padding: var(--space-3); }
         .iw-spinner { width: 14px; height: 14px; border: 2px solid var(--color-border); border-top-color: var(--color-primary, #2563eb); border-radius: 50%; animation: iw-spin 700ms linear infinite; }
         @keyframes iw-spin { to { transform: rotate(360deg); } }
@@ -117,14 +144,14 @@ export function renderInteractiveWidget(args: {
         .iw-error { padding: var(--space-3); border: 1px solid var(--color-err); border-radius: var(--radius-sm); background: rgba(220, 38, 38, 0.04); }
       </style>
 
-      <div class="iw-pane iw-pane-idle" ${startState === 'idle' ? '' : 'hidden'}>
+      <div class="iw-pane iw-pane-idle ${startState === 'idle' ? '' : 'iw-pane-inactive'}">
         <div class="iw-result">${idleBody}</div>
         <div class="iw-cta-row">
           <button type="button" class="btn btn--primary btn--sm" data-iw-replay>${replayLabel}</button>
         </div>
       </div>
 
-      <div class="iw-pane iw-pane-asking" ${startState === 'asking' ? '' : 'hidden'}>
+      <div class="iw-pane iw-pane-asking ${startState === 'asking' ? '' : 'iw-pane-inactive'}">
         <form data-iw-form>
           ${inputs.length > 0 ? fieldRows as unknown as SafeHtml[] : html`<p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-2);">No inputs declared. Click ${askLabel} to run.</p>`}
           <div class="iw-cta-row">
@@ -134,7 +161,7 @@ export function renderInteractiveWidget(args: {
         </form>
       </div>
 
-      <div class="iw-pane iw-pane-running" hidden>
+      <div class="iw-pane iw-pane-running iw-pane-inactive">
         <div class="iw-status">
           <div class="iw-spinner" aria-hidden="true"></div>
           <span>Running… <span data-iw-elapsed>0</span>s</span>
@@ -142,13 +169,13 @@ export function renderInteractiveWidget(args: {
         </div>
       </div>
 
-      <div class="iw-pane iw-pane-stuck" hidden>
+      <div class="iw-pane iw-pane-stuck iw-pane-inactive">
         <div class="iw-status">
           <span>Still running. <a data-iw-stuck-link href="#">View run details</a></span>
         </div>
       </div>
 
-      <div class="iw-pane iw-pane-error" hidden>
+      <div class="iw-pane iw-pane-error iw-pane-inactive">
         <div class="iw-error">
           <p style="margin: 0 0 var(--space-2); font-weight: var(--weight-bold); color: var(--color-err);">Run failed</p>
           <p data-iw-error-msg style="margin: 0 0 var(--space-2); font-size: var(--font-size-xs); font-family: var(--font-mono); white-space: pre-wrap;"></p>
@@ -195,12 +222,12 @@ export function renderInteractiveWidget(args: {
           if (leaving) {
             leaving.classList.add('iw-leaving');
             setTimeout(function () {
-              leaving.hidden = true;
+              leaving.classList.add('iw-pane-inactive');
               leaving.classList.remove('iw-leaving');
             }, 220);
           }
           if (entering) {
-            entering.hidden = false;
+            entering.classList.remove('iw-pane-inactive');
             entering.classList.add('iw-entering');
             requestAnimationFrame(function () {
               entering.classList.remove('iw-entering');
@@ -275,7 +302,11 @@ export function renderInteractiveWidget(args: {
               }
               if (data.status === 'cancelled') {
                 clearPoll();
-                transition(panes.idle && !panes.idle.hidden ? 'idle' : 'asking');
+                // After a cancel, return to whichever pane was visible
+                // before submit. The "idle" pane has rendered content
+                // when the agent had a prior run; use that as the cue.
+                var hadPrior = panes.idle && panes.idle.querySelector('.iw-result *');
+                transition(hadPrior ? 'idle' : 'asking');
                 return;
               }
               // running / pending: keep polling


### PR DESCRIPTION
## Summary

PR #166's interactive widgets used \`display: none\` to swap panes (asking / running / success / error / stuck). Each pane has a different intrinsic height, so the tile resized between every state — the whole purpose of the cross-fade (smooth in-place feel) was undercut.

## Fix

CSS Grid stack: all panes share the same grid cell.

\`\`\`css
.iw {
  display: grid;
  grid-template-areas: 'stack';
  min-height: 8rem;
}
.iw-pane { grid-area: stack; }
\`\`\`

The cell sizes to \`max(child heights)\` automatically, and the height stays stable because every pane contributes — even the inactive ones — as long as we don't \`display: none\` them. So inactive panes use \`opacity: 0; visibility: hidden; pointer-events: none\` instead.

Two extras for polish:
- CTA rows pin to the bottom via \`margin-top: auto\`, so the Run button sits in the same place regardless of which pane is active.
- Short panes (running, stuck, error) center vertically inside the cell so they don't anchor awkwardly at the top of an oversized container.
- 8rem baseline \`min-height\` so the very first pre-run render doesn't open at zero height.

## JS adjustment

State transitions now toggle a \`.iw-pane-inactive\` class instead of the \`hidden\` attribute. The cancel-into-idle-vs-asking heuristic checks for rendered content in the idle pane's result box rather than the removed \`.hidden\` property.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm test\` green (750 / 750, no regressions)
- [x] \`npm run build\` clean
- [ ] Manual: ask Magic 8-Ball a question, observe the tile stays the same height through asking → running → success.
- [ ] Manual: trigger an error path; tile stays the same height through asking → running → error.
- [ ] Manual: \`prefers-reduced-motion\` still disables the cross-fade transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)