### PR TITLE
feat: better shipped agents (graphics-creator-mcp + agent-analyzer)

### DIFF
--- a/.changeset/better-shipped-agents.md
+++ b/.changeset/better-shipped-agents.md
@@ -1,0 +1,20 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Two key shipped agents rewritten, plus a parser fix that was silently breaking both.
+
+**Parser fix.** `parsedToAgent` and `NODE_KEY_ORDER` in `agent-yaml.ts` had drifted from the v0.16+ schema, silently stripping `tool`, `action`, `toolInputs`, `onlyIf`, `conditionalConfig`, `switchConfig`, `loopConfig`, `agentInvokeConfig`, and `endMessage` from every YAML round-trip. Same shape as the `outputWidget` drift fix in #167. Any agent using MCP-driven tools or control-flow nodes lost those fields on import — so `graphics-creator-mcp` arrived in the DB as a sequence of bare `claude-code` nodes with no prompts, and `agent-analyzer`'s `onlyIf` skip-on-valid optimisation never fired because the field was dropped. Two new round-trip tests lock down every node field the schema accepts so the next addition can't slip through silently.
+
+**graphics-creator-mcp** — single-node rewrite. The previous 6-node theme → save → render → composite pipeline carried multiple latent bugs (missing prompts, broken upstream wiring, theme step that produced nothing reusable). New version is one `claude-code` node that calls the modern-graphics MCP server's `list_themes` + `generate_graphic` tools in one round-trip, returns structured JSON, and ships with an interactive output widget so the tile becomes a self-contained ask → render → preview loop on `/pulse`.
+
+**agent-analyzer** — three improvements to the "Suggest improvements" agent:
+- `fix` node now skips entirely when validate's `valid` field is true (saves a Claude round-trip on the happy path; this was already declared but didn't survive parsing — now does).
+- `fix` timeout raised from 90s to 240s and `maxTurns` from 2 to 4.
+- `fix` prompt rewritten to be tighter: leads with the validation error in an explicit fence, includes common fix recipes (shell-vs-template upstream refs, uppercase input names, missing enum values, control-flow configs), and emphasises "minimal change" so Claude doesn't try to redesign the agent on every fix attempt.
+
+**Dashboard fix-attempt fallback** — the inline auto-fix used by the "Suggest improvements" modal had `timeout: 60s` / `maxWait: 65s` / `maxTurns: 1`, no slack for any non-trivial agent. Bumped to `timeout: 180s` / `maxWait: 200s` / `maxTurns: 3`. When the auto-fix still doesn't return in time, the new error message points users to "Edit manually" with the suggested rewrite as a starting point, rather than implying the dashboard is broken.

--- a/agents/examples/agent-analyzer.yaml
+++ b/agents/examples/agent-analyzer.yaml
@@ -155,39 +155,56 @@ nodes:
     dependsOn:
       - analyze
       - validate
+    # Skip the fix call entirely when the analyzer's suggested YAML already
+    # passes schema validation. Saves a Claude round-trip on the happy path.
     onlyIf:
       upstream: validate
       field: valid
       equals: false
     prompt: |
-      IMPORTANT: Respond directly with the fixed YAML. Do NOT use any tools.
-      Everything you need is provided below.
+      IMPORTANT: Respond directly with the corrected response. Do NOT use any
+      tools. Everything you need is in this prompt.
 
-      The agent analyzer suggested improvements but the suggested YAML has
-      validation errors. Fix the YAML so it passes schema validation.
+      The analyzer's suggested YAML failed schema validation. Your ONLY job is
+      to produce a corrected response with the validation issue resolved —
+      not to redesign the agent, not to add improvements, not to revisit the
+      classification.
 
-      VALIDATION ERROR:
+      ── VALIDATION ERROR (this is what you must fix) ─────────────
       {{upstream.validate.result}}
+      ─────────────────────────────────────────────────────────────
 
-      ORIGINAL ANALYSIS (with the broken YAML):
+      Strategy:
+      1. Locate the exact node / field / line referenced in the error.
+      2. Apply the smallest possible change that resolves the named issue.
+         If the error says "replace X with Y", do exactly that.
+      3. Leave every other part of the YAML untouched.
+
+      Common fix recipes:
+      - "Shell nodes access upstream outputs via environment variables, not
+        templates" → replace upstream-result template refs with the
+        equivalent $UPSTREAM_<NAME>_RESULT env var in the shell command
+        (capitalised, dashes → underscores).
+      - "Input names must be UPPERCASE_WITH_UNDERSCORES" → uppercase the
+        input names AND update every input template ref in prompts to match.
+      - "enum type requires a non-empty values array" → add `values: [a, b, c]`.
+      - "conditional nodes must have conditionalConfig" → add a predicate block.
+      - "switch nodes must have switchConfig" → add field + cases.
+
+      Output the COMPLETE response in the same XML format the analyzer used.
+      Copy the analyzer's classification / summary / details VERBATIM — the
+      diff in the dashboard depends on those staying stable.
+
+      ANALYZER'S ORIGINAL RESPONSE (with the broken YAML):
       {{upstream.analyze.result}}
 
-      Fix ONLY the YAML errors identified above. Keep all the analysis text
-      (classification, summary, details) exactly as-is. Output the complete
-      corrected response in the same XML format:
+      Now respond with:
 
-      <classification>same as original</classification>
-      <summary>same as original</summary>
-      <details>same as original</details>
+      <classification>(verbatim from analyzer)</classification>
+      <summary>(verbatim from analyzer)</summary>
+      <details>(verbatim from analyzer)</details>
       <yaml>
-      The FIXED YAML that passes validation. Apply these rules:
-      - Input names: UPPERCASE_WITH_UNDERSCORES
-      - inputs: must be an object/map, not an array
-      - enum inputs: must have a non-empty `values` array
-      - Template refs: use double-brace inputs.NAME syntax, not bare NAME
-      - conditional nodes: must have conditionalConfig
-      - switch nodes: must have switchConfig
-      - Keep the same agent id as the original
+      (the analyzer's YAML with ONLY the validation issue resolved)
       </yaml>
-    maxTurns: 2
-    timeout: 90
+    maxTurns: 4
+    timeout: 240

--- a/agents/examples/graphics-creator-mcp.yaml
+++ b/agents/examples/graphics-creator-mcp.yaml
@@ -1,40 +1,38 @@
-# Graphics creator — turns a topic + audience brief into a rendered hero graphic.
+# Graphics creator (MCP) — single claude-code node that calls the
+# modern-graphics MCP server to render a hero graphic from a topic.
 #
-# Chains MCP-backed tools imported from the modern-graphics server:
-#   modern-graphics-set-output-root   (scope writes to a run-specific dir)
-#   modern-graphics-create-theme      (optional: brand tokens from a brief)
-#   modern-graphics-save-theme        (persist so later runs can reuse)
-#   modern-graphics-generate-graphic  (render the hero)
-#   modern-graphics-composite-image   (overlay a title / watermark)
+# Earlier versions tried a 6-node theme-then-render-then-composite pipeline
+# and accumulated bugs (missing prompts, broken upstream wiring, theme
+# steps that never produced reusable output). This version trusts the LLM
+# to pick a theme + write a punchy headline + call generate_graphic in one
+# round-trip. Simpler, faster, and actually works.
 #
-# Prereq (one-time): open /tools/mcp/import, connect the modern-graphics
-# MCP server with prefix "modern-graphics", select the five tools above.
+# Prereq (one-time): import the modern-graphics MCP server via
+# /tools/mcp/import. The agent uses these MCP tools:
+#   modern-graphics-list-themes       (browse themes when the user didn't pin one)
+#   modern-graphics-generate-graphic  (render the actual file)
 #
-# Run: sua workflow run graphics-creator-mcp -i TOPIC="Q2 growth wins" -i AUDIENCE="investors"
+# Run: sua workflow run graphics-creator-mcp -i TOPIC="Q2 growth wins"
 id: graphics-creator-mcp
 name: Graphics creator (MCP)
-description: >
-  Generate a themed hero graphic + composited variant from a topic and audience
-  using the modern-graphics MCP server. Demonstrates MCP tool chaining:
-  theme setup → graphic render → composite overlay.
+description: |
+  Generate a polished hero graphic from a topic using the modern-graphics
+  MCP server. One claude-code node: pick a theme, write a punchy title,
+  call generate_graphic, return a structured JSON pointer to the file.
 status: active
 source: examples
+mcp: false
 
 inputs:
   TOPIC:
     type: string
     required: true
     description: What the graphic is about, e.g. "Q2 growth wins".
-  AUDIENCE:
-    type: string
-    required: false
-    default: "general"
-    description: Target reader — shapes tone and palette (e.g. "investors", "devs", "executives").
   LAYOUT:
     type: enum
     required: false
-    default: "hero"
-    description: modern-graphics layout. Text layouts work with title/subtitle; chart layouts need a separate data payload (use chart-creator-mcp instead).
+    default: hero
+    description: modern-graphics layout. Stick to text-driven layouts here; chart layouts need data, use chart-creator-mcp instead.
     values:
       - hero
       - hero-triptych
@@ -42,7 +40,6 @@ inputs:
       - insight-story
       - key-insight
       - story
-      - equation
       - comparison
       - timeline
       - funnel
@@ -51,87 +48,85 @@ inputs:
     type: string
     required: false
     default: ""
-    description: Optional subtitle. Leave blank to auto-derive from AUDIENCE.
-  TONE:
-    type: string
-    required: false
-    default: "confident, modern, high-contrast"
-    description: Style direction fed into theme creation.
-  THEME_NAME:
+    description: Optional one-line subtitle. Leave blank for the LLM to derive one from TOPIC.
+  THEME:
     type: string
     required: false
     default: ""
-    description: Reuse an existing saved theme by name. Leave blank to create a fresh one per run.
+    description: Specific theme name to use (e.g. "operator", "warm"). Leave blank to let the LLM pick one that fits the topic.
+  AUDIENCE:
+    type: string
+    required: false
+    default: general
+    description: Target reader — guides tone (e.g. "investors", "developers", "executives").
   OUTPUT_DIR:
     type: string
     required: false
-    default: ".sua/graphics-output"
-    description: Where rendered assets are written (relative to project root).
-  OVERLAY_TEXT:
-    type: string
-    required: false
-    default: ""
-    description: Text overlaid on the composite. Blank = reuse TOPIC.
-  OVERLAY_POSITION:
-    type: enum
-    required: false
-    default: "bottom-right"
-    description: Overlay anchor.
-    values:
-      - top-left
-      - top-right
-      - bottom-left
-      - bottom-right
-      - center
+    default: .sua/graphics-output
+    description: Where the rendered file is written, relative to the project root.
 
 nodes:
-  - id: scope-output
+  - id: render
     type: claude-code
-    tool: modern-graphics-set-output-root
-    toolInputs:
-      root: "{{inputs.OUTPUT_DIR}}"
+    timeout: 120
+    maxTurns: 6
+    prompt: |
+      You are rendering a single graphic for: **{{inputs.TOPIC}}**
+      Audience: {{inputs.AUDIENCE}}
+      Layout: {{inputs.LAYOUT}}
+      Theme preference: {{inputs.THEME}} (blank = pick one from the list)
+      Subtitle preference: {{inputs.SUBTITLE}} (blank = derive from TOPIC)
 
-  - id: theme
-    type: claude-code
-    tool: modern-graphics-create-theme
-    dependsOn: [scope-output]
-    toolInputs:
-      name: "graphics-creator-{{inputs.AUDIENCE}}"
-      brief: |
-        Audience: {{inputs.AUDIENCE}}
-        Topic: {{inputs.TOPIC}}
-        Goals: {{inputs.TONE}}. Avoid stock-slop aesthetics.
+      Steps:
 
-  - id: persist-theme
-    type: claude-code
-    tool: modern-graphics-save-theme
-    dependsOn: [theme]
-    toolInputs:
-      theme: "{{upstream.theme.result}}"
+      1. THEME — if THEME is blank, call `list_themes` and pick the one that
+         best fits the topic + audience. Note the theme's name.
 
-  - id: hero
-    type: claude-code
-    tool: modern-graphics-generate-graphic
-    dependsOn: [persist-theme]
-    toolInputs:
-      layout: "{{inputs.LAYOUT}}"
-      theme: "graphics-creator-{{inputs.AUDIENCE}}"
-      title: "{{inputs.TOPIC}}"
-      subtitle: "{{inputs.SUBTITLE}}"
+      2. TITLE — write a punchy 4–8 word title from TOPIC. No trailing
+         punctuation. If SUBTITLE is blank, write a one-line supporting
+         sentence (≤ 12 words) yourself; otherwise use SUBTITLE verbatim.
 
-  - id: composite
-    type: claude-code
-    tool: modern-graphics-composite-image
-    dependsOn: [hero]
-    toolInputs:
-      base: "{{upstream.hero.result}}"
-      overlay_text: "{{inputs.OVERLAY_TEXT}}"
-      position: "{{inputs.OVERLAY_POSITION}}"
+      3. RENDER — call `generate_graphic` exactly once with:
+            layout: {{inputs.LAYOUT}}
+            title: <your title>
+            subtitle: <subtitle from step 2>
+            theme: <theme name from step 1>
+            output_path: {{inputs.OUTPUT_DIR}}/{{inputs.LAYOUT}}-<unix-timestamp>.png
 
-  - id: summarise
-    type: shell
-    dependsOn: [hero, composite]
-    command: |
-      echo "=== Graphics ready ==="
-      echo "Hero:      $UPSTREAM_HERO_RESULT"
-      echo "Composite: $UPSTREAM_COMPOSITE_RESULT"
+         If the call fails, inspect the error and retry ONCE with corrected
+         arguments. Do not retry more than once.
+
+      4. RETURN — output ONLY a raw JSON object — no markdown fences, no
+         prose, no surrounding text:
+
+         {
+           "title": "<title you used>",
+           "subtitle": "<subtitle you used>",
+           "layout": "{{inputs.LAYOUT}}",
+           "theme": "<theme name you used>",
+           "graphic_path": "<absolute path returned by generate_graphic>",
+           "topic": "{{inputs.TOPIC}}"
+         }
+
+      Constraints:
+      - Make exactly ONE generate_graphic call (plus at most one retry on error).
+      - Do NOT call any other tools beyond list_themes and generate_graphic.
+      - Output must be valid JSON; the agent's output widget parses it.
+
+signal:
+  title: Graphic
+  template: text-image
+  size: 2x2
+
+outputWidget:
+  type: dashboard
+  interactive: true
+  runInputs: [TOPIC, LAYOUT, THEME]
+  askLabel: Generate graphic
+  replayLabel: Generate another
+  fields:
+    - { name: title,        type: text,   label: Title }
+    - { name: subtitle,     type: text,   label: Subtitle }
+    - { name: layout,       type: badge,  label: Layout }
+    - { name: theme,        type: badge,  label: Theme }
+    - { name: graphic_path, type: preview, label: Output }

--- a/packages/core/src/agent-yaml.test.ts
+++ b/packages/core/src/agent-yaml.test.ts
@@ -211,4 +211,85 @@ nodes:
     const a2 = parseAgent(exportAgent(a1));
     expect(a2.nodes[0].prompt).toBe('Line one\nLine two\nLine three\n');
   });
+
+  it('round-trips tool-driven nodes (tool + toolInputs + action)', () => {
+    const yaml = `
+id: tooled
+name: Tooled
+status: active
+source: local
+mcp: false
+version: 1
+nodes:
+  - id: render
+    type: claude-code
+    tool: modern-graphics-generate-graphic
+    action: render
+    toolInputs:
+      layout: hero
+      title: Hello
+`;
+    const a1 = parseAgent(yaml);
+    expect(a1.nodes[0].tool).toBe('modern-graphics-generate-graphic');
+    expect(a1.nodes[0].action).toBe('render');
+    expect(a1.nodes[0].toolInputs).toEqual({ layout: 'hero', title: 'Hello' });
+    // Round-trip preserves all three.
+    const a2 = parseAgent(exportAgent(a1));
+    expect(a2).toEqual(a1);
+  });
+
+  it('round-trips control-flow nodes (conditional + switch + loop + agent-invoke + end)', () => {
+    const yaml = `
+id: ctrl
+name: Ctrl
+status: active
+source: local
+mcp: false
+version: 1
+nodes:
+  - id: gate
+    type: conditional
+    conditionalConfig:
+      predicate: { field: outputs.x, equals: ok }
+  - id: gated
+    type: shell
+    command: 'echo ran'
+    dependsOn: [gate]
+    onlyIf: { upstream: gate, field: result.matched, equals: true }
+  - id: pick
+    type: switch
+    dependsOn: [gated]
+    switchConfig:
+      field: outputs.kind
+      cases: { a: gated, b: gated }
+  - id: each
+    type: loop
+    dependsOn: [pick]
+    loopConfig:
+      over: outputs.items
+      agentId: child-agent
+      maxIterations: 5
+  - id: child
+    type: agent-invoke
+    dependsOn: [each]
+    agentInvokeConfig:
+      agentId: another-agent
+      inputMapping: { TOPIC: outputs.topic }
+  - id: stop
+    type: end
+    dependsOn: [child]
+    endMessage: All done.
+`;
+    const a1 = parseAgent(yaml);
+    // All control-flow configs survive parse.
+    expect(a1.nodes[0].conditionalConfig?.predicate.field).toBe('outputs.x');
+    expect(a1.nodes[1].onlyIf?.upstream).toBe('gate');
+    expect(a1.nodes[2].switchConfig?.field).toBe('outputs.kind');
+    expect(a1.nodes[3].loopConfig?.agentId).toBe('child-agent');
+    expect(a1.nodes[4].agentInvokeConfig?.agentId).toBe('another-agent');
+    expect(a1.nodes[5].endMessage).toBe('All done.');
+    // Round-trip preserves them.
+    const a2 = parseAgent(exportAgent(a1));
+    expect(a2).toEqual(a1);
+  });
 });

--- a/packages/core/src/agent-yaml.ts
+++ b/packages/core/src/agent-yaml.ts
@@ -51,9 +51,20 @@ export function parseAgent(yamlText: string): Agent {
 }
 
 function parsedToAgent(p: AgentV2Parsed): Agent {
+  // Pass-through for every field the agentNodeSchema accepts. Any time a
+  // new schema field is added, append it here AND to NODE_KEY_ORDER so the
+  // YAML round-trip stays lossless. Forgetting to do so silently strips
+  // the field on import — that's how graphics-creator-mcp and
+  // conditional-router agents lost their `tool` / `conditionalConfig`
+  // fields and started failing in production.
   const nodes: AgentNode[] = p.nodes.map((n) => ({
     id: n.id,
     type: n.type,
+    // tool-driven nodes (v0.16+)
+    ...(n.tool !== undefined && { tool: n.tool }),
+    ...(n.action !== undefined && { action: n.action }),
+    ...(n.toolInputs && { toolInputs: n.toolInputs }),
+    // execution
     ...(n.command !== undefined && { command: n.command }),
     ...(n.prompt !== undefined && { prompt: n.prompt }),
     ...(n.model !== undefined && { model: n.model }),
@@ -67,6 +78,13 @@ function parsedToAgent(p: AgentV2Parsed): Agent {
     ...(n.redactSecrets !== undefined && { redactSecrets: n.redactSecrets }),
     ...(n.workingDirectory !== undefined && { workingDirectory: n.workingDirectory }),
     ...(n.dependsOn && { dependsOn: n.dependsOn }),
+    // control flow (v0.17+)
+    ...(n.onlyIf && { onlyIf: n.onlyIf }),
+    ...(n.conditionalConfig && { conditionalConfig: n.conditionalConfig }),
+    ...(n.switchConfig && { switchConfig: n.switchConfig }),
+    ...(n.loopConfig && { loopConfig: n.loopConfig }),
+    ...(n.agentInvokeConfig && { agentInvokeConfig: n.agentInvokeConfig }),
+    ...(n.endMessage !== undefined && { endMessage: n.endMessage }),
     ...(n.position && { position: n.position }),
   }));
 
@@ -112,9 +130,15 @@ const AGENT_KEY_ORDER = [
 
 const NODE_KEY_ORDER = [
   'id', 'type',
+  // tool-driven nodes
+  'tool', 'action', 'toolInputs',
+  // execution
   'command', 'prompt', 'model', 'maxTurns', 'allowedTools', 'provider',
   'timeout', 'env', 'envAllowlist', 'secrets', 'redactSecrets', 'workingDirectory',
   'dependsOn',
+  // control flow
+  'onlyIf', 'conditionalConfig', 'switchConfig', 'loopConfig', 'agentInvokeConfig',
+  'endMessage',
   'position',
 ] as const;
 

--- a/packages/dashboard/src/routes/run-now-build.ts
+++ b/packages/dashboard/src/routes/run-now-build.ts
@@ -433,8 +433,8 @@ Rules:
 - Keep the same agent id ("${name}")
 
 Output ONLY the complete fixed YAML. Nothing else.`,
-      maxTurns: 1,
-      timeout: 60,
+      maxTurns: 3,
+      timeout: 180,
     }],
   };
 
@@ -449,8 +449,10 @@ Output ONLY the complete fixed YAML. Nothing else.`,
       },
     );
 
-    // Wait for completion.
-    const maxWait = 65_000;
+    // Wait for completion. Window slightly exceeds the agent's timeout
+    // so a slow Claude response surfaces as an LLM-level error rather
+    // than a router-level timeout.
+    const maxWait = 200_000;
     const pollInterval = 1_000;
     const startTime = Date.now();
     let result = ctx.runStore.getRun(run.id);
@@ -461,7 +463,13 @@ Output ONLY the complete fixed YAML. Nothing else.`,
     }
 
     if (!result?.result) {
-      res.json({ ok: false, error: 'Fix attempt timed out or produced no output.' });
+      res.json({
+        ok: false,
+        error:
+          "Auto-fix didn't return a corrected YAML in time. The suggested rewrite is still " +
+          "available — click Edit manually to apply it as a starting point and resolve the " +
+          "validation error yourself.",
+      });
       return;
     }
 


### PR DESCRIPTION
## Summary

Three changes that compound. Came out of investigating why `graphics-creator-mcp` and the auto-fix on `agent-analyzer` both kept failing.

### 1. Parser fix — single source of truth for node fields

\`parsedToAgent\` and \`NODE_KEY_ORDER\` in \`agent-yaml.ts\` had drifted from the v0.16+ schema. Every YAML round-trip silently stripped:

- \`tool\`, \`action\`, \`toolInputs\` (tool-driven nodes — v0.16)
- \`onlyIf\`, \`conditionalConfig\`, \`switchConfig\`, \`loopConfig\`, \`agentInvokeConfig\`, \`endMessage\` (control-flow — v0.17+)

Same shape as the \`outputWidget\` drift fix in #167. Any agent using MCP-driven tools or control-flow nodes lost those fields on import. Two of the most-used shipped agents were broken because of it:

- \`graphics-creator-mcp\` arrived in the DB as bare \`claude-code\` nodes with no prompts → "Claude-code node has no prompt" failure on every run
- \`agent-analyzer\`'s \`onlyIf\` skip-on-valid never fired → every analysis paid the fix-Claude-call cost even when not needed

Two new round-trip tests lock down every schema-accepted node field so the next addition can't slip through silently.

### 2. graphics-creator-mcp rewrite — single node, MCP-driven

The previous 6-node pipeline (theme → save → render → composite) had multiple latent bugs (missing prompts, broken upstream wiring, theme step producing nothing reusable). Replaced with a single \`claude-code\` node that calls the modern-graphics MCP server's \`list_themes\` + \`generate_graphic\` tools in one round-trip, returns structured JSON, and ships with an interactive \`outputWidget\`. The pulse tile becomes a self-contained ask → render → preview loop with the rendered image surfaced via the \`preview\` field type.

### 3. agent-analyzer improvements

- \`fix\` node now skips entirely when validate's \`valid\` field is true (saves a Claude round-trip on the happy path; already declared, now actually fires thanks to fix #1).
- \`fix\` timeout raised from 90s to 240s and \`maxTurns\` from 2 to 4.
- \`fix\` prompt rewritten: leads with the validation error in an explicit fence, includes common fix recipes (shell-vs-template upstream refs, uppercase input names, missing enum values, control-flow configs), and emphasises "minimal change" so Claude doesn't try to redesign on every fix attempt.

### 4. Dashboard auto-fix budget + clearer error copy

The inline auto-fix used by the "Suggest improvements" modal had \`timeout: 60s / maxWait: 65s / maxTurns: 1\` — no slack for any non-trivial agent. Bumped to \`timeout: 180s / maxWait: 200s / maxTurns: 3\`. When the auto-fix still doesn't return in time, the new error message points users to "Edit manually" with the suggested rewrite as a starting point, rather than implying the dashboard is broken.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm test\` green (752 / 752, +2 round-trip tests)
- [x] \`npm run build\` clean
- [x] Manual: \`workflow import-yaml agents/examples/graphics-creator-mcp.yaml\` + verify \`workflow export\` round-trip preserves \`outputWidget.interactive\` and node prompts.
- [x] Manual: \`workflow import-yaml agents/examples/agent-analyzer.yaml\` + verify \`onlyIf\` and \`timeout: 240\` survive.
- [ ] Manual on /pulse: trigger graphics-creator-mcp interactive tile, verify the rendered file shows up via the preview field.
- [ ] Manual: trigger Suggest improvements on a complex agent, verify the auto-fix runs to completion within the new budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)