### PR TITLE
feat(dashboard): sticky DAG + result summary on run detail

### DIFF
--- a/.changeset/run-detail-sticky-summary.md
+++ b/.changeset/run-detail-sticky-summary.md
@@ -1,0 +1,11 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Run detail: sticky DAG + result summary while scrolling node logs.
+
+The DAG visualization and result widget at the top of `/runs/:id` now stick to the viewport (capped at 60vh) while the node-execution panel scrolls below. On long runs with many nodes you keep the graph and final output in view instead of having to scroll back up. Falls back to a non-sticky stacked layout below 900px wide.

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -204,6 +204,45 @@ main.main--wide {
   padding-right: var(--space-2);
 }
 
+/* Sticky variant — used on /runs/:id so DAG + result stay visible while
+ * scrolling the node-execution panel below. The whole grid sticks as one
+ * bar (sticky-in-grid only sticks within its own row, which doesn't help
+ * once the user scrolls past into the node section). Each column is
+ * bounded so a tall DAG or wide widget can't push the bar past the
+ * viewport. */
+.run-detail-grid--sticky {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  background: var(--color-bg);
+  max-height: 60vh;
+  padding: var(--space-2) 0;
+  margin-bottom: var(--space-4);
+}
+
+.run-detail-grid--sticky .run-detail-grid__dag,
+.run-detail-grid--sticky .run-detail-grid__result {
+  position: static;
+  top: auto;
+  max-height: calc(60vh - var(--space-4));
+  overflow: auto;
+  min-width: 0;
+}
+
+@media (max-width: 900px) {
+  /* Sticky bar would eat half the screen on narrow viewports — disable. */
+  .run-detail-grid--sticky {
+    position: static;
+    max-height: none;
+  }
+
+  .run-detail-grid--sticky .run-detail-grid__dag,
+  .run-detail-grid--sticky .run-detail-grid__result {
+    max-height: none;
+    overflow: visible;
+  }
+}
+
 /* Legacy: kept for backward compat with agent detail split-screen */
 .run-detail-grid__inspector {
   max-height: 80vh;

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -131,8 +131,8 @@ export function renderRunDetail(opts: RunDetailOptions): string {
       ` : html``}
 
       ${isDagRun ? html`
-        <!-- Top: DAG + Result side-by-side -->
-        <div class="run-detail-grid">
+        <!-- Top: DAG + Result side-by-side, sticky while node logs scroll. -->
+        <div class="run-detail-grid run-detail-grid--sticky">
           <div class="run-detail-grid__dag">
             ${dagSection}
             ${canReplay ? renderReplayFallback(run, agent!) : html``}


### PR DESCRIPTION
## Summary
- Wraps the DAG + result widget at the top of `/runs/:id` in a sticky bar (capped at 60vh) so both stay in view while the node-execution panel scrolls below.
- Each column scrolls internally so a tall DAG or large widget can't push the bar off-screen.
- Falls back to a non-sticky stacked layout below 900px wide.

First slice of [v0.19 dashboard story](../blob/main/CLAUDE.md) PR 1. Discovery showed most of the run-detail redesign already shipped (two-col layout, search/filter, click-DAG-node-to-scroll-panel) — this just closes the last visible gap: keeping the DAG + result pinned while reading node logs on long runs.

## Test plan
- [x] `npm test` — 752/752 green
- [x] Build green
- [x] Verified `/assets/dashboard.css` contains the new `.run-detail-grid--sticky` rules
- [x] Verified `/runs/:id` HTML renders with the new modifier class
- [ ] Manual: open a long run with > 10 nodes, scroll the node panel, confirm DAG + result stay pinned to the top
- [ ] Manual: narrow viewport (< 900px), confirm sticky disables and layout stacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)