### PR TITLE
feat(mcp-server): run-agent accepts inputs

### DIFF
--- a/.changeset/mcp-run-agent-inputs.md
+++ b/.changeset/mcp-run-agent-inputs.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+mcp-server: `run-agent` accepts inputs.
+
+The MCP `run-agent` tool now takes an optional `inputs` map so MCP clients (Claude Desktop, Claude Code, Cursor) can run agents that declare an `inputs:` block, not only the input-less ones. Values are validated through the same path as dashboard / CLI / scheduler runs (type checks, enum membership, undeclared-key rejection, missing-required errors). Validation failures surface as MCP `isError: true` with the user-readable message instead of a generic 500.
+
+Two defensive caps live at the MCP boundary specifically: 8 KB per value, 64 KB total. Dashboard / CLI / scheduler are unaffected. The `list-agents` tool now also returns each agent's declared input schema (type, required, default, enum values) so callers can introspect what to pass.
+
+Known follow-up: shell agents that interpolate raw inputs into command strings via `{{inputs.X}}` (or unquoted env-var expansion) are vulnerable to injection regardless of trigger source. Tracked separately for a hardening pass at the substitution layer.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -201,6 +201,19 @@ Secrets come from the secrets store (`sua secrets set`). Global variables (plain
 
 Opt the agent into MCP exposure. With `sua mcp start` running, Claude Desktop (or any MCP client with the bearer token) can invoke this agent via `run-agent`.
 
+The `run-agent` tool accepts an optional `inputs` map for agents that declare an `inputs:` block:
+
+```json
+{
+  "name": "graphics-creator-mcp",
+  "inputs": { "TOPIC": "Q2 wins", "LAYOUT": "hero" }
+}
+```
+
+Values are validated against each input's declared `type`, `required`, default, and (for enums) `values`. Undeclared keys are rejected. Per-value payloads are capped at 8 KB (64 KB total across all inputs) — the cap applies only to the MCP boundary, not to dashboard or CLI runs. Call `list-agents` to introspect each agent's `inputs` schema.
+
+> **Trust:** MCP callers carry the same authority as the bearer-token holder. A shell agent that interpolates raw inputs into its command string with `{{inputs.X}}` (or env-var expansion without quoting) is exposing a code-execution path to anyone with the token. Quote inputs at substitution time, prefer `claude-code` agents over `shell` for free-form text inputs, and rotate the token under [Settings → General](http://127.0.0.1:3000/settings/general) if you suspect compromise.
+
 See [MCP server (outbound)](../packages/mcp-server/README.md) for the connection details.
 
 ## Full worked example

--- a/packages/mcp-server/src/server.test.ts
+++ b/packages/mcp-server/src/server.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { startMcpServer } from './index.js';
 
 /**
@@ -90,5 +92,162 @@ describe('MCP server multi-session', () => {
     const body = (await health.json()) as { status: string; sessions: number };
     expect(body.status).toBe('ok');
     expect(body.sessions).toBe(2);
+  });
+});
+
+/**
+ * End-to-end exercise of `run-agent` with inputs. Uses the official MCP
+ * client + StreamableHTTP transport to drive the protocol so the test is
+ * close to what Claude Desktop / Cursor / claude mcp does at runtime.
+ */
+describe('MCP run-agent with inputs', () => {
+  let dataDir: string;
+  let agentDir: string;
+  let tokenPath: string;
+  let secretsPath: string;
+  let port: number;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'sua-mcp-run-'));
+    agentDir = join(dataDir, 'agents');
+    require('node:fs').mkdirSync(agentDir);
+    tokenPath = join(dataDir, 'mcp-token');
+    writeFileSync(tokenPath, 't'.repeat(64));
+    chmodSync(tokenPath, 0o600);
+    secretsPath = join(dataDir, 'secrets.enc');
+    port = 19000 + Math.floor(Math.random() * 500);
+
+    // A simple shell agent that echoes the TOPIC input. The shell command
+    // template-substitutes inputs.TOPIC at execute time. Single-quoted so
+    // the shell doesn't try to interpret the value.
+    writeFileSync(
+      join(agentDir, 'echoer.yaml'),
+      [
+        'name: echoer',
+        'type: shell',
+        "command: \"printf '%s' \\\"$TOPIC\\\"\"",
+        'mcp: true',
+        'inputs:',
+        '  TOPIC:',
+        '    type: string',
+        '    required: true',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  async function connectClient(): Promise<Client> {
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://127.0.0.1:${port}/mcp`),
+      {
+        requestInit: {
+          headers: { Authorization: `Bearer ${'t'.repeat(64)}` },
+        },
+      },
+    );
+    const client = new Client({ name: 'test', version: '0' });
+    await client.connect(transport);
+    return client;
+  }
+
+  it('list-agents returns the declared input schema', async () => {
+    await startMcpServer({
+      port,
+      host: '127.0.0.1',
+      agentDirs: [agentDir],
+      dbPath: join(dataDir, 'runs.db'),
+      secretsPath,
+      tokenPath,
+    });
+
+    const client = await connectClient();
+    try {
+      const res = await client.callTool({ name: 'list-agents', arguments: {} });
+      const payload = JSON.parse((res.content as Array<{ text: string }>)[0].text);
+      expect(payload).toHaveLength(1);
+      expect(payload[0]).toMatchObject({
+        name: 'echoer',
+        inputs: { TOPIC: { type: 'string', required: true } },
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('run-agent threads inputs through to the run', async () => {
+    await startMcpServer({
+      port,
+      host: '127.0.0.1',
+      agentDirs: [agentDir],
+      dbPath: join(dataDir, 'runs.db'),
+      secretsPath,
+      tokenPath,
+    });
+
+    const client = await connectClient();
+    try {
+      const res = await client.callTool({
+        name: 'run-agent',
+        arguments: { name: 'echoer', inputs: { TOPIC: 'Q2 wins' } },
+      });
+      expect(res.isError).toBeFalsy();
+      const payload = JSON.parse((res.content as Array<{ text: string }>)[0].text);
+      expect(payload.status).toBe('completed');
+      expect(payload.result).toBe('Q2 wins');
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('run-agent returns an MCP error when a required input is missing', async () => {
+    await startMcpServer({
+      port,
+      host: '127.0.0.1',
+      agentDirs: [agentDir],
+      dbPath: join(dataDir, 'runs.db'),
+      secretsPath,
+      tokenPath,
+    });
+
+    const client = await connectClient();
+    try {
+      const res = await client.callTool({
+        name: 'run-agent',
+        arguments: { name: 'echoer', inputs: {} },
+      });
+      expect(res.isError).toBe(true);
+      const text = (res.content as Array<{ text: string }>)[0].text;
+      expect(text).toMatch(/TOPIC/);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('run-agent rejects oversize input values before submitting', async () => {
+    await startMcpServer({
+      port,
+      host: '127.0.0.1',
+      agentDirs: [agentDir],
+      dbPath: join(dataDir, 'runs.db'),
+      secretsPath,
+      tokenPath,
+    });
+
+    const client = await connectClient();
+    try {
+      const res = await client.callTool({
+        name: 'run-agent',
+        arguments: { name: 'echoer', inputs: { TOPIC: 'x'.repeat(10_000) } },
+      });
+      expect(res.isError).toBe(true);
+      const text = (res.content as Array<{ text: string }>)[0].text;
+      expect(text).toMatch(/per-value cap/);
+    } finally {
+      await client.close();
+    }
   });
 });

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { loadMcpExposedAgents } from './tools.js';
+import { checkInputCaps, describeInputSpec, loadMcpExposedAgents } from './tools.js';
 
 describe('loadMcpExposedAgents', () => {
   let dir: string;
@@ -47,6 +47,35 @@ describe('loadMcpExposedAgents', () => {
     expect(exposed.size).toBe(0);
   });
 
+  it('exposes input declarations on agents that have them', () => {
+    writeAgent(
+      'with-inputs',
+      [
+        'name: with-inputs',
+        'type: shell',
+        'command: echo "$TOPIC"',
+        'mcp: true',
+        'inputs:',
+        '  TOPIC:',
+        '    type: string',
+        '    required: true',
+        '    description: What to echo',
+        '  STYLE:',
+        '    type: enum',
+        '    default: short',
+        '    values:',
+        '      - short',
+        '      - long',
+        '',
+      ].join('\n'),
+    );
+
+    const exposed = loadMcpExposedAgents([dir]);
+    const agent = exposed.get('with-inputs');
+    expect(agent?.inputs?.TOPIC?.required).toBe(true);
+    expect(agent?.inputs?.STYLE?.values).toEqual(['short', 'long']);
+  });
+
   it('handles claude-code agents with mcp: true', () => {
     writeAgent(
       'claude-exposed',
@@ -57,5 +86,58 @@ describe('loadMcpExposedAgents', () => {
 
     expect(exposed.has('claude-exposed')).toBe(true);
     expect(exposed.get('claude-exposed')?.type).toBe('claude-code');
+  });
+});
+
+describe('checkInputCaps', () => {
+  it('passes payloads within caps', () => {
+    expect(checkInputCaps({ TOPIC: 'hello', STYLE: 'short' })).toBeNull();
+    expect(checkInputCaps({})).toBeNull();
+  });
+
+  it('rejects per-value oversize payloads', () => {
+    const big = 'x'.repeat(8 * 1024 + 1);
+    const err = checkInputCaps({ TOPIC: big });
+    expect(err).toContain('TOPIC');
+    expect(err).toMatch(/per-value cap/);
+  });
+
+  it('rejects total oversize payloads even when each value is fine', () => {
+    // 9 values × 7800 bytes = 70200 bytes total, > 64 KB cap, each < 8 KB.
+    const inputs: Record<string, string> = {};
+    for (let i = 0; i < 9; i++) inputs[`K${i}`] = 'y'.repeat(7800);
+    const err = checkInputCaps(inputs);
+    expect(err).toMatch(/Total inputs payload/);
+  });
+
+  it('counts byte length, not character length', () => {
+    // Multi-byte UTF-8: '€' = 3 bytes, so 3000 chars = 9000 bytes > 8 KB cap.
+    const big = '€'.repeat(3000);
+    const err = checkInputCaps({ TOPIC: big });
+    expect(err).toMatch(/per-value cap/);
+  });
+});
+
+describe('describeInputSpec', () => {
+  it('omits optional fields when absent', () => {
+    expect(describeInputSpec({ type: 'string' })).toEqual({ type: 'string' });
+  });
+
+  it('includes required, default, description, and enum values when present', () => {
+    expect(
+      describeInputSpec({
+        type: 'enum',
+        required: true,
+        default: 'hero',
+        description: 'Layout preset',
+        values: ['hero', 'card'],
+      }),
+    ).toEqual({
+      type: 'enum',
+      required: true,
+      default: 'hero',
+      description: 'Layout preset',
+      values: ['hero', 'card'],
+    });
   });
 });

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { AgentDefinition, Provider } from '@some-useful-agents/core';
-import { loadAgents } from '@some-useful-agents/core';
+import type { AgentDefinition, AgentInputSpec, Provider } from '@some-useful-agents/core';
+import {
+  loadAgents,
+  MissingInputError,
+  InvalidInputTypeError,
+  UndeclaredInputError,
+  SensitiveInputNameError,
+} from '@some-useful-agents/core';
 
 /**
  * Only agents that opt in via `mcp: true` in their YAML are exposed to MCP
@@ -18,35 +24,118 @@ export function loadMcpExposedAgents(agentDirs: string[]): Map<string, AgentDefi
   return exposed;
 }
 
+/**
+ * Per-value and total caps on the `inputs` map passed to `run-agent`.
+ * MCP callers carry the same trust as the bearer-token holder, but the
+ * caps defend against runaway prompts and accidental DoS payloads. They
+ * apply only at the MCP boundary; dashboard / CLI / scheduler are
+ * unaffected.
+ */
+const MAX_INPUT_VALUE_BYTES = 8 * 1024;
+const MAX_INPUT_TOTAL_BYTES = 64 * 1024;
+
+/** Exported for tests; describes a single input spec. */
+export function describeInputSpec(spec: AgentInputSpec): Record<string, unknown> {
+  const out: Record<string, unknown> = { type: spec.type };
+  if (spec.required) out.required = true;
+  if (spec.default !== undefined) out.default = spec.default;
+  if (spec.description) out.description = spec.description;
+  if (spec.type === 'enum' && spec.values) out.values = spec.values;
+  return out;
+}
+
+function describeInputs(specs: Record<string, AgentInputSpec> | undefined): Record<string, unknown> | undefined {
+  if (!specs || Object.keys(specs).length === 0) return undefined;
+  const out: Record<string, unknown> = {};
+  for (const [name, spec] of Object.entries(specs)) {
+    out[name] = describeInputSpec(spec);
+  }
+  return out;
+}
+
+/**
+ * Reject oversize input values before they reach `submitRun`. Returns a
+ * user-readable error message, or null if the payload is within caps.
+ */
+/** Exported for tests; returns null if within caps, error message otherwise. */
+export function checkInputCaps(inputs: Record<string, string>): string | null {
+  let total = 0;
+  for (const [k, v] of Object.entries(inputs)) {
+    const size = Buffer.byteLength(v, 'utf-8');
+    if (size > MAX_INPUT_VALUE_BYTES) {
+      return `Input "${k}" is ${size} bytes; the per-value cap is ${MAX_INPUT_VALUE_BYTES} bytes.`;
+    }
+    total += size;
+  }
+  if (total > MAX_INPUT_TOTAL_BYTES) {
+    return `Total inputs payload is ${total} bytes; the cap is ${MAX_INPUT_TOTAL_BYTES} bytes.`;
+  }
+  return null;
+}
+
+function errorResult(text: string) {
+  return { content: [{ type: 'text' as const, text }], isError: true };
+}
+
 export function registerTools(server: McpServer, provider: Provider, agentDirs: string[]): void {
 
   server.tool(
     'list-agents',
-    'List agent definitions exposed to MCP (those with `mcp: true` in YAML)',
+    'List agent definitions exposed to MCP (those with `mcp: true` in YAML), including each agent\'s declared inputs schema',
     {},
     async () => {
       const agents = loadMcpExposedAgents(agentDirs);
-      const list = Array.from(agents.values()).map(a => ({
-        name: a.name,
-        type: a.type,
-        description: a.description ?? '',
-      }));
+      const list = Array.from(agents.values()).map(a => {
+        const entry: Record<string, unknown> = {
+          name: a.name,
+          type: a.type,
+          description: a.description ?? '',
+        };
+        const inputs = describeInputs(a.inputs);
+        if (inputs) entry.inputs = inputs;
+        return entry;
+      });
       return { content: [{ type: 'text' as const, text: JSON.stringify(list, null, 2) }] };
     }
   );
 
   server.tool(
     'run-agent',
-    'Start an agent run (only agents with `mcp: true` are runnable)',
-    { name: z.string().describe('Agent name to run') },
-    async ({ name }) => {
+    'Start an agent run (only agents with `mcp: true` are runnable). Pass declared inputs via the `inputs` map; call `list-agents` to see each agent\'s schema',
+    {
+      name: z.string().describe('Agent name to run'),
+      inputs: z.record(z.string(), z.string()).optional().describe(
+        'Map of input name → string value. Required inputs without a default must be supplied; undeclared keys are rejected. Values are capped at 8 KB each (64 KB total).',
+      ),
+    },
+    async ({ name, inputs }) => {
       const agents = loadMcpExposedAgents(agentDirs);
       const agent = agents.get(name);
       if (!agent) {
-        return { content: [{ type: 'text' as const, text: `Agent "${name}" not found.` }], isError: true };
+        return errorResult(`Agent "${name}" not found.`);
       }
 
-      const run = await provider.submitRun({ agent, triggeredBy: 'mcp' });
+      const provided = inputs ?? {};
+      const capError = checkInputCaps(provided);
+      if (capError) return errorResult(capError);
+
+      let run;
+      try {
+        run = await provider.submitRun({ agent, triggeredBy: 'mcp', inputs: provided });
+      } catch (err) {
+        // Surface input-validation errors as MCP errors with the user-readable
+        // message instead of a 500. Anything else is unexpected — re-throw so
+        // the SDK turns it into the standard error envelope.
+        if (
+          err instanceof MissingInputError ||
+          err instanceof InvalidInputTypeError ||
+          err instanceof UndeclaredInputError ||
+          err instanceof SensitiveInputNameError
+        ) {
+          return errorResult(err.message);
+        }
+        throw err;
+      }
 
       // Wait for completion (with timeout)
       const timeout = (agent.timeout ?? 300) * 1000 + 5000;
@@ -81,7 +170,7 @@ export function registerTools(server: McpServer, provider: Provider, agentDirs: 
     async ({ runId }) => {
       const run = await provider.getRun(runId);
       if (!run) {
-        return { content: [{ type: 'text' as const, text: `Run "${runId}" not found.` }], isError: true };
+        return errorResult(`Run "${runId}" not found.`);
       }
       return { content: [{ type: 'text' as const, text: JSON.stringify(run, null, 2) }] };
     }


### PR DESCRIPTION
## Summary
The MCP \`run-agent\` tool now takes an optional \`inputs\` map. This unblocks Claude Desktop / Claude Code / Cursor running any agent that declares an \`inputs:\` block — previously they could list those agents but not actually run them.

```json
{
  "name": "graphics-creator-mcp",
  "inputs": { "TOPIC": "Q2 wins", "LAYOUT": "hero" }
}
```

Validation flows through the same \`resolveInputs\` path as dashboard / CLI / scheduler runs (type checks, enum membership, undeclared-key rejection, missing-required errors). Validation failures surface as MCP \`isError: true\` with the user-readable message instead of a 500.

**Defensive caps at the MCP boundary** (only):
- 8 KB per input value
- 64 KB total across all inputs

Dashboard / CLI / scheduler unchanged.

\`list-agents\` is also expanded to return each agent's declared input schema (type, required, default, enum values) so callers can introspect what to pass.

## Why this scope
Considered (and skipped) registering one MCP tool per exposed agent with typed-per-agent schemas — better client DX but doubles registration complexity and changes the tool surface every time an agent's MCP flag flips. Punt unless this DX bar misses.

## Test plan
- [x] \`npm run build\` green
- [x] \`npm test\` — 766/766 green
- [x] New unit tests: cap rejection (per-value, total, byte-vs-char counting), \`describeInputSpec\` output shape
- [x] New e2e tests using the MCP client SDK: \`list-agents\` schema, \`run-agent\` happy path, missing-required error, oversize rejection
- [x] Manual smoke against live MCP: \`list-agents\` and \`run-agent\` both work; initialize-then-call sequence stable across multiple sessions

## Known follow-up (filed separately)
Shell agents that interpolate raw inputs into command strings via \`{{inputs.X}}\` (or unquoted \`$ENV\` expansion) are vulnerable to injection **regardless of trigger source** — dashboard, CLI, scheduler, and now MCP all hit the same risk. Belongs at the substitution layer, not at the MCP boundary, so all callers are protected. Tracked as a separate hardening issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)