### PR TITLE
feat(dashboard): toggle MCP exposure from the agent Config tab

### DIFF
--- a/.changeset/agent-mcp-toggle.md
+++ b/.changeset/agent-mcp-toggle.md
@@ -1,0 +1,11 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Dashboard: toggle MCP exposure from the agent Config tab.
+
+A new card on `/agents/<id>/config` flips `mcp: true/false` without editing YAML. Off → "Expose via MCP" button; on → "exposed" badge + "Stop exposing" button. The flip rewrites the agent record but does not restart the running MCP server — the form copy points at Settings → MCP for that.

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -824,6 +824,49 @@ describe('Dashboard version history + status toggle (PR 2)', () => {
     expect(agentStore.getAgent('status-test')!.status).toBe('paused');
   });
 
+  it('POST /agents/:id/mcp toggles MCP exposure on and off', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'mcp-toggle', name: 'X', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'n', type: 'shell', command: 'echo' }],
+    }, 'cli');
+
+    // Off → on.
+    let res = await request(app)
+      .post('/agents/mcp-toggle/mcp')
+      .type('form').send({ enabled: 'true' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(agentStore.getAgent('mcp-toggle')!.mcp).toBe(true);
+
+    // On → off.
+    res = await request(app)
+      .post('/agents/mcp-toggle/mcp')
+      .type('form').send({ enabled: 'false' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(agentStore.getAgent('mcp-toggle')!.mcp).toBe(false);
+  });
+
+  it('POST /agents/:id/mcp rejects an invalid enabled value', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'mcp-bad', name: 'X', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'n', type: 'shell', command: 'echo' }],
+    }, 'cli');
+
+    const res = await request(app)
+      .post('/agents/mcp-bad/mcp')
+      .type('form').send({ enabled: 'yes-please' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(decodeURIComponent(res.headers.location)).toMatch(/Invalid MCP toggle/);
+    expect(agentStore.getAgent('mcp-bad')!.mcp).toBe(false);
+  });
+
   it('POST /agents/:id/status rejects an invalid status enum', async () => {
     const app = await makeApp();
     agentStore.createAgent({

--- a/packages/dashboard/src/routes/versions.ts
+++ b/packages/dashboard/src/routes/versions.ts
@@ -135,6 +135,47 @@ versionsRouter.post('/agents/:id/status', (req: Request, res: Response) => {
   }
 });
 
+/**
+ * POST /agents/:id/mcp — toggle MCP exposure on/off.
+ *
+ * Body: { enabled: 'true' | 'false' }. The form on the Config tab posts
+ * the new state explicitly (rather than a "toggle" verb) so a stale tab
+ * reload doesn't accidentally flip the flag the wrong way.
+ */
+versionsRouter.post('/agents/:id/mcp', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const raw = typeof body.enabled === 'string' ? body.enabled : '';
+  if (raw !== 'true' && raw !== 'false') {
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent('Invalid MCP toggle value.')}`);
+    return;
+  }
+  const next = raw === 'true';
+
+  const agent = ctx.agentStore.getAgent(id);
+  if (!agent) {
+    res.status(404).redirect(303, '/agents');
+    return;
+  }
+
+  if (!!agent.mcp === next) {
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent(next ? 'Already exposed via MCP.' : 'Already not exposed.')}`);
+    return;
+  }
+
+  try {
+    ctx.agentStore.updateAgentMeta(id, { mcp: next });
+    const msg = next
+      ? 'MCP exposure on. Restart `sua mcp start` (or use Settings → MCP) so the server reloads its agent list.'
+      : 'MCP exposure off.';
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent(msg)}`);
+  } catch (err) {
+    const m = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent(`MCP toggle failed: ${m}`)}`);
+  }
+});
+
 const VALID_PROVIDERS = new Set(['claude', 'codex']);
 
 /**

--- a/packages/dashboard/src/views/agent-detail/config.ts
+++ b/packages/dashboard/src/views/agent-detail/config.ts
@@ -63,6 +63,21 @@ export async function renderAgentConfig(args: AgentDetailArgs): Promise<string> 
       </form>
     </section>
 
+    <!-- MCP exposure -->
+    <section class="card" style="margin-bottom: var(--space-6);">
+      <h3 style="margin: 0 0 var(--space-3);">MCP exposure</h3>
+      <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-3);">
+        When on, this agent appears in <code>list-agents</code> and is runnable via <code>run-agent</code> from MCP clients (Claude Desktop, Claude Code, Cursor) connected to <a href="/settings/mcp">sua's MCP server</a>.
+        Toggling rewrites the agent record but does not restart the running MCP server — restart it from <a href="/settings/mcp">Settings → MCP</a> so the new agent list is loaded.
+      </p>
+      <form method="POST" action="/agents/${agent.id}/mcp" style="display: flex; gap: var(--space-2); align-items: center;">
+        <input type="hidden" name="enabled" value="${agent.mcp ? 'false' : 'true'}">
+        ${agent.mcp
+          ? html`<span class="badge badge--ok">exposed</span><button type="submit" class="btn btn--sm btn--warn">Stop exposing</button>`
+          : html`<span class="badge badge--muted">not exposed</span><button type="submit" class="btn btn--sm btn--primary">Expose via MCP</button>`}
+      </form>
+    </section>
+
     <!-- Variables -->
     <section class="card" style="margin-bottom: var(--space-6);">
       <h3 style="margin: 0 0 var(--space-3);">Variables</h3>


### PR DESCRIPTION
## Summary
A new card on \`/agents/<id>/config\` flips \`mcp: true/false\` without editing YAML.

- **Off** → \"not exposed\" badge + \"Expose via MCP\" primary button
- **On** → \"exposed\" badge + \"Stop exposing\" warn button

The flip rewrites the agent record via \`agentStore.updateAgentMeta({ mcp })\`. It does **not** restart the running MCP server — the copy explicitly points at [Settings → MCP](http://127.0.0.1:3000/settings/mcp) for that step.

\`POST /agents/:id/mcp\` accepts \`{enabled: 'true' | 'false'}\` and rejects anything else. Posting an explicit state (instead of a \"toggle\" verb) means a stale tab reload can't accidentally flip the flag the wrong way.

## Why this matters now
Before #176 lands, only agents without inputs were callable through MCP — and even then, flipping \`mcp: true\` required hand-editing YAML or the YAML tab. After #176, you can pass inputs to MCP-exposed agents, but you still need a one-click toggle. This closes the loop.

## Test plan
- [x] \`npm test\` — 757/757 (added 2 new tests: happy-path toggle in both directions, invalid \`enabled\` value)
- [x] Manual: off → on → off cycles work against the live dashboard, flash messages render
- [x] Manual: 303 redirect lands back on the Config tab with a useful flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)