### PR TITLE
feat(dashboard): Output Widget editor on its own page with sub-tabs

### DIFF
--- a/.changeset/agent-output-widget-page.md
+++ b/.changeset/agent-output-widget-page.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Dashboard: move Output Widget editor to its own page with sub-tabs, and make Preview match Pulse.
+
+The Output Widget editor was a ~1200px inline section on the Config tab — widget-type cards, contextual helper, field table, AI-template branch, interactive-mode subform, action bar, and live preview all stacked in one form. It now lives at `/agents/<id>/output-widget` with sub-tabs **Type**, **Fields**, **Interactive**, and **Preview** filtering which sections are visible. The action bar (Save / Remove) stays visible across all tabs. Save and validation errors return you to the editor (preserving iteration) instead of bouncing to Config. The Config tab's Output Widget card collapses to a one-line summary (`Type: dashboard, Layout: 5 fields, Interactive: yes`) plus an "Edit" link.
+
+Preview now respects `interactive: true`. When the editor's Interactive checkbox is on, the Preview tab renders the same `renderInteractiveWidget` Pulse uses (with the configured runInputs filter, askLabel, and replayLabel applied) — in `staticPreview` mode so clicks don't accidentally submit a real run. Previously the preview always rendered the static widget output, hiding the visual effect of every Interactive setting.

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -344,6 +344,78 @@ main.main--wide {
 .config-empty-cta > summary::-webkit-details-marker { display: none; }
 .config-empty-cta > summary::marker { content: ''; }
 
+/* ---------- Output Widget editor page ----------
+ * `/agents/:id/output-widget` hosts the existing editor (one big <form>)
+ * but groups its sections into 4 sub-tabs. The editor's element IDs
+ * stay identical — these rules just hide whichever sections aren't
+ * the active tab. The editor's own JS still toggles between
+ * #ow-fields-block and #ow-ai-block based on widget type, and that
+ * toggle nests inside the Fields tab without conflict.
+ */
+.ow-tab-strip {
+  display: flex;
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+  padding: 0 var(--space-2);
+}
+
+.ow-tab-strip a {
+  padding: var(--space-2) var(--space-1);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+}
+
+.ow-tab-strip a:hover {
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.ow-tab-strip a.is-active {
+  color: var(--color-text);
+  border-bottom-color: var(--color-primary);
+  font-weight: var(--weight-semibold);
+}
+
+/* Per-tab visibility — the editor's existing element IDs are the
+ * source of truth. Action bar (Save/Remove/Add field/Load example)
+ * has no `data-section` and no matching ID below, so it stays
+ * visible across all tabs. The intro `<p>` at the top of the
+ * editor also stays visible — it's short and orienting. */
+/* `!important` is needed because the editor's section divs (#ow-cards
+ * etc.) carry inline `style="display: ..."` set by the original
+ * inline-editor renderer — external rules would otherwise lose. */
+.ow-page[data-active-tab="type"] #ow-fields-block,
+.ow-page[data-active-tab="type"] #ow-ai-block,
+.ow-page[data-active-tab="type"] #ow-interactive-block,
+.ow-page[data-active-tab="type"] #ow-preview-card { display: none !important; }
+
+.ow-page[data-active-tab="fields"] #ow-cards,
+.ow-page[data-active-tab="fields"] #ow-helper,
+.ow-page[data-active-tab="fields"] #ow-interactive-block,
+.ow-page[data-active-tab="fields"] #ow-preview-card { display: none !important; }
+
+.ow-page[data-active-tab="interactive"] #ow-cards,
+.ow-page[data-active-tab="interactive"] #ow-helper,
+.ow-page[data-active-tab="interactive"] #ow-fields-block,
+.ow-page[data-active-tab="interactive"] #ow-ai-block,
+.ow-page[data-active-tab="interactive"] #ow-preview-card { display: none !important; }
+
+.ow-page[data-active-tab="preview"] #ow-cards,
+.ow-page[data-active-tab="preview"] #ow-helper,
+.ow-page[data-active-tab="preview"] #ow-fields-block,
+.ow-page[data-active-tab="preview"] #ow-ai-block,
+.ow-page[data-active-tab="preview"] #ow-interactive-block { display: none !important; }
+
+/* "+ Add field" and "Load example" only make sense on the Fields tab.
+ * Save / Remove stay visible across tabs (they live in their own
+ * action-bar div). */
+.ow-page:not([data-active-tab="fields"]) #add-widget-field-btn,
+.ow-page:not([data-active-tab="fields"]) #ow-example { display: none; }
+
 /* ---------- Settings shell ---------- */
 .settings-shell {
   display: flex;

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -1880,13 +1880,13 @@ describe('Dashboard /tools/mcp/import form validation', () => {
 });
 
 describe('Output widget editor UI', () => {
-  it('renders all 4 widget-type cards on the config page', async () => {
+  it('renders all 4 widget-type cards on the dedicated editor page', async () => {
     const app = await makeApp();
     agentStore.createAgent({
       id: 'ow-cards', name: 'ow-cards', status: 'active', source: 'local', mcp: false,
       nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
     }, 'cli');
-    const res = await request(app).get('/agents/ow-cards/config')
+    const res = await request(app).get('/agents/ow-cards/output-widget')
       .set('Host', `127.0.0.1:${PORT}`)
       .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
     expect(res.status).toBe(200);
@@ -1898,6 +1898,26 @@ describe('Output widget editor UI', () => {
     // Load-example dropdown + preview container.
     expect(res.text).toContain('id="ow-example"');
     expect(res.text).toContain('id="ow-preview"');
+    // Sub-tab nav is present and defaults to "type".
+    expect(res.text).toContain('class="ow-tab-strip"');
+    expect(res.text).toContain('data-active-tab="type"');
+  });
+
+  it('Config tab links to the dedicated editor instead of inlining it', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'ow-link', name: 'ow-link', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
+    }, 'cli');
+    const res = await request(app).get('/agents/ow-link/config')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    // Link to the new page is present.
+    expect(res.text).toContain('/agents/ow-link/output-widget');
+    // The full editor's IDs are NOT inlined on Config any more.
+    expect(res.text).not.toContain('id="ow-cards"');
+    expect(res.text).not.toContain('id="ow-preview"');
   });
 
   it('POST /output-widget/preview renders HTML for a valid body', async () => {
@@ -1925,7 +1945,7 @@ describe('Output widget editor UI', () => {
       id: 'ow-ai-cards', name: 'ow-ai-cards', status: 'active', source: 'local', mcp: false,
       nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
     }, 'cli');
-    const res = await request(app).get('/agents/ow-ai-cards/config')
+    const res = await request(app).get('/agents/ow-ai-cards/output-widget')
       .set('Host', `127.0.0.1:${PORT}`)
       .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
     expect(res.status).toBe(200);

--- a/packages/dashboard/src/routes/agent-inputs.ts
+++ b/packages/dashboard/src/routes/agent-inputs.ts
@@ -3,6 +3,8 @@ import type { AgentInputSpec, OutputWidgetSchema, OutputWidgetType, WidgetFieldT
 import { getContext } from '../context.js';
 import { mergeNewInput, parseEnumValues } from './agent-nodes.js';
 import { renderOutputWidget } from '../views/output-widgets.js';
+import { renderInteractiveWidget } from '../views/interactive-widget.js';
+import { renderOutputWidgetPage, type OutputWidgetTab } from '../views/agent-output-widget.js';
 import { synthPreviewOutput, type FieldType } from '../views/output-widget-help.js';
 import { render } from '../views/html.js';
 import { sanitizeHtml, getTemplateGenerator, agentV2Schema } from '@some-useful-agents/core';
@@ -156,6 +158,34 @@ agentInputsRouter.post('/agents/:name/inputs/update', (req: Request, res: Respon
   }
 });
 
+// ── Output widget editor page ───────────────────────────────────────────
+
+const OUTPUT_WIDGET_TABS = new Set<OutputWidgetTab>(['type', 'fields', 'interactive', 'preview']);
+
+/**
+ * GET /agents/:name/output-widget — focused page for the Output Widget
+ * editor with sub-tabs (Type / Fields / Interactive / Preview). The
+ * editor itself is reused unchanged — the page just adds tab nav.
+ *
+ * Replaces the inline editor that used to live on the Config tab.
+ */
+agentInputsRouter.get('/agents/:name/output-widget', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
+  const agent = ctx.agentStore.getAgent(name);
+  if (!agent) {
+    res.status(404).redirect(303, '/agents');
+    return;
+  }
+  const tabRaw = typeof req.query.tab === 'string' ? req.query.tab : 'type';
+  const activeTab: OutputWidgetTab = OUTPUT_WIDGET_TABS.has(tabRaw as OutputWidgetTab)
+    ? (tabRaw as OutputWidgetTab)
+    : 'type';
+  const flashParam = typeof req.query.flash === 'string' ? req.query.flash : undefined;
+  const flash = flashParam ? { kind: 'ok' as const, message: flashParam } : undefined;
+  res.type('html').send(renderOutputWidgetPage({ agent, activeTab, flash }));
+});
+
 // ── Output widget update ────────────────────────────────────────────────
 
 const VALID_WIDGET_TYPES = new Set<string>(['dashboard', 'key-value', 'diff-apply', 'raw', 'ai-template']);
@@ -182,10 +212,11 @@ agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res:
         'dashboard',
         'Removed output widget via dashboard',
       );
+      // Widget gone — return to Config since there's nothing left to edit here.
       res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/config?flash=${encodeURIComponent('Output widget removed.')}`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/config?flash=${encodeURIComponent(`Failed: ${msg}`)}`);
+      res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/output-widget?flash=${encodeURIComponent(`Failed: ${msg}`)}`);
     }
     return;
   }
@@ -193,7 +224,7 @@ agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res:
   // Save widget.
   const widgetType = typeof body.widgetType === 'string' ? body.widgetType : 'raw';
   if (!VALID_WIDGET_TYPES.has(widgetType)) {
-    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/config?flash=${encodeURIComponent('Invalid widget type.')}`);
+    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/output-widget?flash=${encodeURIComponent('Invalid widget type.')}`);
     return;
   }
 
@@ -233,7 +264,7 @@ agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res:
     const promptText = typeof body.prompt === 'string' ? body.prompt : '';
     const sanitized = sanitizeHtml(rawTemplate).trim();
     if (!sanitized) {
-      res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/config?flash=${encodeURIComponent('Generate or paste a template before saving.')}`);
+      res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/output-widget?tab=fields&flash=${encodeURIComponent('Generate or paste a template before saving.')}`);
       return;
     }
     outputWidget = {
@@ -264,10 +295,11 @@ agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res:
       'dashboard',
       'Updated output widget via dashboard',
     );
-    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/config?flash=${encodeURIComponent('Output widget saved. New version created.')}`);
+    // Stay on the editor so iteration is one click, not a back-and-forth.
+    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/output-widget?flash=${encodeURIComponent('Output widget saved. New version created.')}`);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/config?flash=${encodeURIComponent(`Save failed: ${msg}`)}`);
+    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/output-widget?flash=${encodeURIComponent(`Save failed: ${msg}`)}`);
   }
 });
 
@@ -331,6 +363,48 @@ agentInputsRouter.post('/agents/:name/output-widget/preview', (req: Request, res
       ...(typeof fieldLabel === 'string' && fieldLabel.trim() ? { label: fieldLabel.trim() } : {}),
       type: ft as WidgetFieldType,
     });
+  }
+
+  // Interactive-mode preview: render the same `renderInteractiveWidget`
+  // Pulse renders, in `staticPreview` mode (no inline state-machine JS,
+  // so clicking the form doesn't accidentally submit a real run). This
+  // is the only way the editor's labels + runInputs picker can be
+  // visually verified before saving.
+  const interactive = body.widget_interactive === 'on' || body.widget_interactive === 'true';
+  if (interactive) {
+    const ctx = getContext(req.app.locals);
+    const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
+    const agent = ctx.agentStore.getAgent(name);
+    if (!agent) {
+      res.type('html').send('<span class="dim">Agent not found.</span>');
+      return;
+    }
+    const rawRunInputs = body.widget_run_inputs;
+    let runInputs: string[] | undefined;
+    if (Array.isArray(rawRunInputs)) {
+      runInputs = rawRunInputs.filter((v): v is string => typeof v === 'string' && v.length > 0);
+    } else if (typeof rawRunInputs === 'string' && rawRunInputs.length > 0) {
+      runInputs = [rawRunInputs];
+    }
+    const askLabel = typeof body.widget_ask_label === 'string' && body.widget_ask_label.trim()
+      ? body.widget_ask_label.trim() : undefined;
+    const replayLabel = typeof body.widget_replay_label === 'string' && body.widget_replay_label.trim()
+      ? body.widget_replay_label.trim() : undefined;
+    const schema: OutputWidgetSchema = {
+      type: widgetType as OutputWidgetType,
+      fields,
+      interactive: true,
+      ...(runInputs ? { runInputs } : {}),
+      ...(askLabel ? { askLabel } : {}),
+      ...(replayLabel ? { replayLabel } : {}),
+    };
+    try {
+      const html = renderInteractiveWidget({ agent, widget: schema, staticPreview: true });
+      res.type('html').send(render(html));
+    } catch {
+      res.type('html').send('<span class="dim">Preview unavailable.</span>');
+    }
+    return;
   }
 
   if (fields.length === 0) {

--- a/packages/dashboard/src/views/agent-detail-helpers.ts
+++ b/packages/dashboard/src/views/agent-detail-helpers.ts
@@ -292,7 +292,7 @@ export function renderOutputWidgetEditor(agent: Agent): SafeHtml {
       </div>
     </form>
 
-    <div class="card" style="margin-top: var(--space-3);">
+    <div id="ow-preview-card" class="card" style="margin-top: var(--space-3);">
       <p class="card__title" style="display: flex; align-items: center; justify-content: space-between;">
         Preview
         <span class="dim" style="font-size: var(--font-size-xs); font-weight: var(--weight-regular);">rendered with sample data</span>

--- a/packages/dashboard/src/views/agent-detail/config.ts
+++ b/packages/dashboard/src/views/agent-detail/config.ts
@@ -1,7 +1,6 @@
 import { html, type SafeHtml } from '../html.js';
 import {
   renderVariablesEditor,
-  renderOutputWidgetEditor,
   renderNotifyEditor,
   providerOption,
   renderModelOptions,
@@ -115,22 +114,32 @@ export async function renderAgentConfig(args: AgentDetailArgs): Promise<string> 
   `);
 
   // ── Right column: heavyweight collapsibles ─────────────────────────
-  const outputWidgetSection = collapsibleSection({
-    title: 'Output Widget',
-    configured: !!agent.outputWidget,
-    emptyCta: html`
-      <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-3);">
-        Render run output as a widget on the agent overview and the Pulse tile.
-      </p>
-      <details class="config-empty-cta">
-        <summary><span class="btn btn--sm">Set up output widget</span></summary>
-        <div style="margin-top: var(--space-3);">
-          ${renderOutputWidgetEditor(agent)}
-        </div>
-      </details>
-    `,
-    editor: renderOutputWidgetEditor(agent),
-  });
+  // Output Widget editor lives on its own page — `/agents/<id>/output-widget`
+  // — because the editor is large enough to deserve a focused surface
+  // with sub-tabs (Type / Fields / Interactive / Preview). On the Config
+  // tab we just summarise + link.
+  const outputWidgetSection = (() => {
+    if (!agent.outputWidget) {
+      return configCard('Output Widget', html`
+        <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-3);">
+          Render run output as a widget on the agent overview and the Pulse tile.
+        </p>
+        <a class="btn btn--sm" href="/agents/${agent.id}/output-widget">Set up output widget</a>
+      `);
+    }
+    const fieldCount = agent.outputWidget.fields?.length ?? 0;
+    const summary = agent.outputWidget.type === 'ai-template'
+      ? 'AI-generated HTML template'
+      : `${String(fieldCount)} field${fieldCount === 1 ? '' : 's'}`;
+    return configCard('Output Widget', html`
+      <dl class="kv" style="margin: 0 0 var(--space-3); font-size: var(--font-size-xs);">
+        <dt>Type</dt><dd class="mono">${agent.outputWidget.type}</dd>
+        <dt>Layout</dt><dd>${summary}</dd>
+        ${agent.outputWidget.interactive ? html`<dt>Interactive</dt><dd>yes — runs in place</dd>` : html``}
+      </dl>
+      <a class="btn btn--sm" href="/agents/${agent.id}/output-widget">Edit output widget</a>
+    `);
+  })();
 
   const notifySection = collapsibleSection({
     title: 'Notify',

--- a/packages/dashboard/src/views/agent-output-widget.ts
+++ b/packages/dashboard/src/views/agent-output-widget.ts
@@ -1,0 +1,97 @@
+import type { Agent } from '@some-useful-agents/core';
+import { html, render, unsafeHtml, type SafeHtml } from './html.js';
+import { layout } from './layout.js';
+import { pageHeader } from './page-header.js';
+import { renderOutputWidgetEditor } from './agent-detail-helpers.js';
+
+/**
+ * Output Widget editor on its own page (rather than inline on the
+ * agent Config tab). The editor renders unchanged — the page just
+ * adds a tab strip that filters which sections are visible. CSS
+ * targets the editor's existing element IDs so no editor changes
+ * are required beyond adding `id="ow-preview-card"` to the preview
+ * pane.
+ *
+ * Tabs:
+ *   Type        — widget-type cards + helper paragraph
+ *   Fields      — field table OR ai-template block (the editor's JS
+ *                 picks which based on selected type)
+ *   Interactive — run-in-place toggle + run inputs + label fields
+ *   Preview     — the live preview pane (`#ow-preview-card`)
+ *
+ * Save / Remove buttons live in the editor's action bar, which is
+ * always visible (no `data-section` attribute → not hidden by tab CSS).
+ */
+export type OutputWidgetTab = 'type' | 'fields' | 'interactive' | 'preview';
+
+export interface RenderOutputWidgetPageArgs {
+  agent: Agent;
+  /** Active sub-tab; falls back to 'type'. Driven by `?tab=...` query param. */
+  activeTab?: OutputWidgetTab;
+  flash?: { kind: 'error' | 'info' | 'ok'; message: string };
+}
+
+const TABS: Array<{ id: OutputWidgetTab; label: string }> = [
+  { id: 'type', label: 'Type' },
+  { id: 'fields', label: 'Fields' },
+  { id: 'interactive', label: 'Interactive' },
+  { id: 'preview', label: 'Preview' },
+];
+
+export function renderOutputWidgetPage(args: RenderOutputWidgetPageArgs): string {
+  const { agent, flash } = args;
+  const active: OutputWidgetTab = args.activeTab ?? 'type';
+
+  const tabStrip = html`
+    <nav class="ow-tab-strip" role="tablist" aria-label="Output Widget editor">
+      ${TABS.map((t) => html`
+        <a href="?tab=${t.id}" class="${t.id === active ? 'is-active' : ''}" role="tab" aria-selected="${t.id === active ? 'true' : 'false'}" data-tab="${t.id}">${t.label}</a>
+      `) as unknown as SafeHtml[]}
+    </nav>
+  `;
+
+  const body = html`
+    ${pageHeader({
+      title: 'Output Widget',
+      meta: [html`<span class="dim mono">${agent.id}</span>`],
+      cta: html`<a class="btn btn--ghost btn--sm" href="/agents/${agent.id}/config">Done</a>`,
+      back: { href: `/agents/${agent.id}/config`, label: 'Back to Config' },
+    })}
+
+    <div class="ow-page" data-active-tab="${active}">
+      ${tabStrip}
+      <div class="ow-page__body">
+        ${renderOutputWidgetEditor(agent)}
+      </div>
+    </div>
+
+    ${unsafeHtml(`<script>
+    (function () {
+      // Client-side tab switch: clicking a tab updates data-active-tab
+      // and the URL hash without a full reload, so the editor's form
+      // state survives. Falls back to the href on no-JS.
+      var page = document.querySelector('.ow-page');
+      if (!page) return;
+      var tabs = page.querySelectorAll('.ow-tab-strip a[data-tab]');
+      function activate(id) {
+        page.setAttribute('data-active-tab', id);
+        for (var i = 0; i < tabs.length; i++) {
+          var t = tabs[i];
+          var on = t.getAttribute('data-tab') === id;
+          t.classList.toggle('is-active', on);
+          t.setAttribute('aria-selected', on ? 'true' : 'false');
+        }
+        try { history.replaceState(null, '', '?tab=' + encodeURIComponent(id)); } catch (e) { /* ignore */ }
+      }
+      for (var i = 0; i < tabs.length; i++) {
+        tabs[i].addEventListener('click', function (e) {
+          e.preventDefault();
+          activate(this.getAttribute('data-tab'));
+        });
+      }
+    })();
+    </script>`)}
+  `;
+
+  return render(layout({ title: `Output Widget · ${agent.id}`, activeNav: 'agents', flash }, body));
+}

--- a/packages/dashboard/src/views/interactive-widget.ts
+++ b/packages/dashboard/src/views/interactive-widget.ts
@@ -68,8 +68,15 @@ export function renderInteractiveWidget(args: {
   agent: Agent;
   widget: OutputWidgetSchema;
   lastRun?: Pick<Run, 'id' | 'result' | 'status' | 'error'>;
+  /**
+   * When true, omit the inline <script> that wires the run state machine.
+   * Used by the Output Widget editor's Preview tab so users see the same
+   * inputs form + button labels Pulse will render, without the preview
+   * accidentally submitting a real run when they click around.
+   */
+  staticPreview?: boolean;
 }): SafeHtml {
-  const { agent, widget, lastRun } = args;
+  const { agent, widget, lastRun, staticPreview } = args;
   const inputs = pickInputs(agent, widget);
   const askLabel = widget.askLabel ?? 'Run';
   const replayLabel = widget.replayLabel ?? 'Run again';
@@ -186,7 +193,7 @@ export function renderInteractiveWidget(args: {
         </div>
       </div>
 
-      ${unsafeHtml(`<script>
+      ${staticPreview ? html`` : unsafeHtml(`<script>
       (function () {
         var root = document.currentScript.parentElement;
         if (!root || !root.matches('[data-iw]')) return;
@@ -369,6 +376,7 @@ export function renderInteractiveWidget(args: {
         });
       })();
       </script>`)}
+      ${staticPreview ? html`<p class="dim" style="font-size: var(--font-size-xs); margin: var(--space-3) 0 0; padding: var(--space-2) var(--space-3); background: var(--color-surface); border-radius: var(--radius-sm); border-left: 3px solid var(--color-info);">Preview only — clicking the form here doesn't run the agent. Save and visit the Pulse tile to interact for real.</p>` : html``}
     </div>
   `;
 }


### PR DESCRIPTION
## Summary
The Output Widget editor was a ~1200px inline section on the Config tab. Now lives at \`/agents/<id>/output-widget\` with sub-tabs: **Type | Fields | Interactive | Preview**. CSS filters visibility per tab using the editor's existing element IDs; the action bar (Save / Remove) stays visible across all tabs.

**Preview now matches Pulse.** When the Interactive checkbox is on, the Preview tab renders the same \`renderInteractiveWidget\` Pulse uses (with \`staticPreview: true\` so clicks don't submit a real run). Previously every Interactive setting was invisible until you saved and visited Pulse.

The Config tab's Output Widget card collapses to a one-line summary + Edit link. Save and validation errors stay on the editor so iteration is one click.

## Files
- New: \`views/agent-output-widget.ts\` — page shell + tab strip
- New: tab styling + per-tab visibility rules in \`screens.css\`
- Edited: \`agent-detail-helpers.ts\` — added \`id="ow-preview-card"\` so the preview block can be targeted
- Edited: \`interactive-widget.ts\` — new \`staticPreview\` option that omits the state-machine \`<script>\`
- Edited: \`routes/agent-inputs.ts\` — new GET handler; preview branch now respects interactive flag
- Edited: \`views/agent-detail/config.ts\` — Output Widget card is a summary + link, not the inline editor
- Edited: \`dashboard.test.ts\` — 2 existing tests retargeted to the new page; 1 new test asserts Config no longer inlines

## Test plan
- [x] \`npm test\` — 769/769 green
- [x] Manual: each tab renders the right sections; action bar visible across all
- [x] Manual: Preview tab on a non-interactive widget shows the static rendering
- [x] Manual: Preview tab on an interactive widget shows inputs form + askLabel button + replayLabel disclaimer (matches Pulse)
- [x] Manual: Config tab Output Widget card shows summary (\`Type: dashboard, Layout: 5 fields, Interactive: yes\`) + Edit link
- [x] Manual: Save returns to /output-widget; Remove returns to /config

## Known follow-ups (separate PRs)
- **Magic-8-ball-style UX**: the interactive widget's idle pane shows only \"Ask again\" — to actually edit the question, user has to click that, wait for transition, then edit + submit. Idle should show result *and* form together. Form should also pre-fill with the previous run's input value, not the agent's declared default.
- Variables editor refactor (per the [agent-config-editors-followup](../blob/main/.claude/plans/agent-config-editors-followup.md) plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)