### PR TITLE
feat(core): derived agent capabilities at parse boundary

### DIFF
--- a/.changeset/agent-capabilities-derivation.md
+++ b/.changeset/agent-capabilities-derivation.md
@@ -1,0 +1,22 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Derived agent capabilities at the parse boundary.
+
+New `deriveCapabilities(agent: Agent): AgentCapabilities` in core. Computes a static, best-effort summary of what an agent uses and does — populated by `parseAgent` and `agent-store.rowToAgent` and exposed on `Agent.capabilities`.
+
+```ts
+{
+  tools_used:        string[],   // shell-exec, claude-code, http-get, allowedTools entries…
+  mcp_servers_used:  string[],   // extracted from mcp__server__tool naming
+  side_effects:      ('sends_notifications' | 'writes_files' | 'posts_http')[],
+  reads_external:    string[],   // URLs from toolInputs.url/endpoint, regex hits in command/prompt
+}
+```
+
+Heuristic and conservative — an empty array means "couldn't statically prove," not "doesn't do X." Not a security boundary. Used by the planner-fronted agent-builder (PR A) for cross-agent composition decisions and by the upcoming preflight checks ("does this agent need MCP servers I haven't installed?"). Recomputed on every read; never persisted.

--- a/packages/core/src/agent-capabilities.test.ts
+++ b/packages/core/src/agent-capabilities.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from 'vitest';
+import { deriveCapabilities } from './agent-capabilities.js';
+import type { Agent } from './agent-v2-types.js';
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: 'a',
+    name: 'A',
+    status: 'active',
+    source: 'local',
+    mcp: false,
+    version: 1,
+    nodes: [{ id: 'main', type: 'shell', command: 'echo hi' }],
+    ...overrides,
+  };
+}
+
+describe('deriveCapabilities — tools_used', () => {
+  it('lists shell-exec for plain shell nodes', () => {
+    const c = deriveCapabilities(makeAgent());
+    expect(c.tools_used).toEqual(['shell-exec']);
+  });
+
+  it('lists claude-code for plain claude-code nodes', () => {
+    const c = deriveCapabilities(makeAgent({
+      nodes: [{ id: 'main', type: 'claude-code', prompt: 'say hi' }],
+    }));
+    expect(c.tools_used).toEqual(['claude-code']);
+  });
+
+  it('captures explicit tool: names', () => {
+    const c = deriveCapabilities(makeAgent({
+      nodes: [
+        { id: 'fetch', type: 'shell', tool: 'http-get', toolInputs: { url: 'https://example.com' } },
+        { id: 'save', type: 'shell', tool: 'file-write', toolInputs: { path: '/tmp/x' } },
+      ],
+    }));
+    expect(c.tools_used).toEqual(['file-write', 'http-get']);
+  });
+
+  it('includes allowedTools entries from claude-code nodes', () => {
+    const c = deriveCapabilities(makeAgent({
+      nodes: [{
+        id: 'main', type: 'claude-code', prompt: 'do thing',
+        allowedTools: ['file-read', 'file-write', 'web-search'],
+      }],
+    }));
+    expect(c.tools_used).toEqual(['claude-code', 'file-read', 'file-write', 'web-search']);
+  });
+
+  it('dedupes tool names across nodes', () => {
+    const c = deriveCapabilities(makeAgent({
+      nodes: [
+        { id: 'a', type: 'shell', command: 'echo 1' },
+        { id: 'b', type: 'shell', command: 'echo 2' },
+      ],
+    }));
+    expect(c.tools_used).toEqual(['shell-exec']);
+  });
+
+  it('returns empty for flow-control-only DAGs', () => {
+    const c = deriveCapabilities(makeAgent({
+      nodes: [{ id: 'end', type: 'end', endMessage: 'done' }],
+    }));
+    expect(c.tools_used).toEqual([]);
+  });
+});
+
+describe('deriveCapabilities — mcp_servers_used', () => {
+  it('extracts server name from mcp__server__tool naming', () => {
+    const c = deriveCapabilities(makeAgent({
+      nodes: [{
+        id: 'main', type: 'claude-code', prompt: 'x',
+        allowedTools: ['mcp__github__list_prs', 'mcp__notion__search'],
+      }],
+    }));
+    expect(c.mcp_servers_used).toEqual(['github', 'notion']);
+  });
+
+  it('also detects MCP tool when used as the primary tool: field', () => {
+    const c = deriveCapabilities(makeAgent({
+      nodes: [{ id: 'main', type: 'shell', tool: 'mcp__linear__create_issue' }],
+    }));
+    expect(c.mcp_servers_used).toEqual(['linear']);
+  });
+
+  it('returns empty when no MCP-prefixed tools are used', () => {
+    const c = deriveCapabilities(makeAgent({
+      nodes: [{ id: 'main', type: 'shell', tool: 'http-get' }],
+    }));
+    expect(c.mcp_servers_used).toEqual([]);
+  });
+});
+
+describe('deriveCapabilities — side_effects', () => {
+  it('detects sends_notifications when notify is set', () => {
+    const c = deriveCapabilities(makeAgent({
+      notify: {
+        on: ['failure'],
+        secrets: ['SLACK_WEBHOOK'],
+        handlers: [{ type: 'slack', webhook_secret: 'SLACK_WEBHOOK' }],
+      },
+    }));
+    expect(c.side_effects).toContain('sends_notifications');
+  });
+
+  it('detects posts_http for webhook notify handlers', () => {
+    const c = deriveCapabilities(makeAgent({
+      notify: {
+        on: ['always'],
+        handlers: [{ type: 'webhook', url: 'https://example.com/hook' }],
+      },
+    }));
+    expect(c.side_effects).toContain('posts_http');
+    expect(c.side_effects).toContain('sends_notifications');
+  });
+
+  it('detects writes_files for file-write tool', () => {
+    const c = deriveCapabilities(makeAgent({
+      nodes: [{ id: 'save', type: 'shell', tool: 'file-write', toolInputs: { path: '/tmp/x' } }],
+    }));
+    expect(c.side_effects).toContain('writes_files');
+  });
+
+  it('detects writes_files for claude-code Edit/Write in allowedTools', () => {
+    const c = deriveCapabilities(makeAgent({
+      nodes: [{
+        id: 'main', type: 'claude-code', prompt: 'x',
+        allowedTools: ['Edit', 'Write'],
+      }],
+    }));
+    expect(c.side_effects).toContain('writes_files');
+  });
+
+  it('detects writes_files for shell redirects (>, >>, tee, mkdir, mv, cp, rm)', () => {
+    for (const cmd of [
+      'echo hi > out.txt',
+      'echo hi >> out.txt',
+      'echo hi | tee out.txt',
+      'mkdir -p /tmp/x',
+      'mv a b',
+      'cp a b',
+      'rm -f x',
+    ]) {
+      const c = deriveCapabilities(makeAgent({
+        nodes: [{ id: 'main', type: 'shell', command: cmd }],
+      }));
+      expect(c.side_effects).toContain('writes_files');
+    }
+  });
+
+  it('detects posts_http for http-post tool', () => {
+    const c = deriveCapabilities(makeAgent({
+      nodes: [{ id: 'main', type: 'shell', tool: 'http-post', toolInputs: { url: 'https://x.com' } }],
+    }));
+    expect(c.side_effects).toContain('posts_http');
+  });
+
+  it('returns empty side_effects for read-only agents', () => {
+    const c = deriveCapabilities(makeAgent({
+      nodes: [{ id: 'fetch', type: 'shell', tool: 'http-get', toolInputs: { url: 'https://x.com' } }],
+    }));
+    expect(c.side_effects).toEqual([]);
+  });
+});
+
+describe('deriveCapabilities — reads_external', () => {
+  it('captures URLs from toolInputs.url', () => {
+    const c = deriveCapabilities(makeAgent({
+      nodes: [{ id: 'fetch', type: 'shell', tool: 'http-get', toolInputs: { url: 'https://api.example.com/v1/things' } }],
+    }));
+    expect(c.reads_external).toEqual(['https://api.example.com/v1/things']);
+  });
+
+  it('captures URLs from toolInputs.endpoint', () => {
+    const c = deriveCapabilities(makeAgent({
+      nodes: [{ id: 'a', type: 'shell', tool: 'http-post', toolInputs: { endpoint: 'https://hooks.example.com/x' } }],
+    }));
+    expect(c.reads_external).toContain('https://hooks.example.com/x');
+  });
+
+  it('captures URLs embedded in shell commands', () => {
+    const c = deriveCapabilities(makeAgent({
+      nodes: [{ id: 'main', type: 'shell', command: 'curl -sf "https://news.ycombinator.com/" | grep title' }],
+    }));
+    expect(c.reads_external).toEqual(['https://news.ycombinator.com/']);
+  });
+
+  it('captures URLs embedded in claude-code prompts', () => {
+    const c = deriveCapabilities(makeAgent({
+      nodes: [{ id: 'main', type: 'claude-code', prompt: 'Look at https://example.com/docs and summarize.' }],
+    }));
+    expect(c.reads_external).toEqual(['https://example.com/docs']);
+  });
+
+  it('strips trailing punctuation from URLs in prose', () => {
+    const c = deriveCapabilities(makeAgent({
+      nodes: [{ id: 'main', type: 'claude-code', prompt: 'Check https://example.com/path. It might be down.' }],
+    }));
+    expect(c.reads_external).toEqual(['https://example.com/path']);
+  });
+
+  it('dedupes URLs across nodes', () => {
+    const c = deriveCapabilities(makeAgent({
+      nodes: [
+        { id: 'a', type: 'shell', command: 'curl https://api.example.com/x' },
+        { id: 'b', type: 'shell', command: 'curl https://api.example.com/x', dependsOn: ['a'] },
+      ],
+    }));
+    expect(c.reads_external).toEqual(['https://api.example.com/x']);
+  });
+
+  it('returns sorted output across all four arrays', () => {
+    const c = deriveCapabilities(makeAgent({
+      nodes: [
+        { id: 'a', type: 'shell', command: 'curl https://b.com && curl https://a.com' },
+        { id: 'b', type: 'claude-code', prompt: 'x', allowedTools: ['file-write', 'Edit'] },
+      ],
+    }));
+    expect(c.reads_external).toEqual(['https://a.com', 'https://b.com']);
+    expect(c.tools_used).toEqual(['Edit', 'claude-code', 'file-write', 'shell-exec']);
+  });
+});

--- a/packages/core/src/agent-capabilities.ts
+++ b/packages/core/src/agent-capabilities.ts
@@ -1,0 +1,164 @@
+/**
+ * Derived agent capabilities — a parse-time, best-effort static analysis
+ * of what an agent uses and what it does. Computed at the parse boundary
+ * (parseAgent + agent-store rowToAgent) and attached to the Agent record.
+ * Not persisted; recomputed every read.
+ *
+ * Used by:
+ *   - the planner-fronted agent-builder (PR A): "what existing agents
+ *     can I compose? what tools are needed? what side effects are
+ *     incurred?"
+ *   - the future "test this agent" preflight: "does this agent need MCP
+ *     servers I haven't installed?"
+ *
+ * This is heuristic and intentionally conservative — an empty array
+ * means "I couldn't statically prove this," NOT "the agent doesn't do X."
+ * Don't treat the output as a security boundary.
+ */
+
+import type { Agent, AgentNode } from './agent-v2-types.js';
+
+export interface AgentCapabilities {
+  /**
+   * Every tool this agent invokes. Includes `shell-exec` for plain shell
+   * nodes and `claude-code` for plain claude-code nodes (the desugared
+   * defaults), every explicit `node.tool`, and every entry in any
+   * `node.allowedTools`. Sorted, deduped.
+   */
+  tools_used: string[];
+
+  /**
+   * MCP servers this agent references. Detected via the
+   * `mcp__<server>__<tool>` naming convention. Empty when no MCP-prefixed
+   * tools are referenced (sua's tool-store ids are flat, so this is
+   * usually empty until/unless the prefix convention is adopted).
+   */
+  mcp_servers_used: string[];
+
+  /**
+   * What the agent does to the outside world. A non-exhaustive set:
+   *   - 'sends_notifications' — has a `notify:` block
+   *   - 'writes_files' — uses file-writing tools or shell redirects
+   *   - 'posts_http' — uses http-post or webhook handlers
+   * Sorted.
+   */
+  side_effects: SideEffect[];
+
+  /**
+   * External URLs the agent statically references. Sourced from
+   * `toolInputs.url` / `toolInputs.endpoint`, plus regex hits in
+   * shell commands and claude-code prompts. Sorted, deduped.
+   */
+  reads_external: string[];
+}
+
+export type SideEffect =
+  | 'sends_notifications'
+  | 'writes_files'
+  | 'posts_http';
+
+/** Tool names that imply 'writes_files' when present in tool: or allowedTools. */
+const FILE_WRITING_TOOLS = new Set([
+  'file-write',
+  'file-append',
+  'Write',  // claude-code built-in
+  'Edit',   // claude-code built-in
+  'NotebookEdit',
+]);
+
+/**
+ * Tool names that imply 'posts_http' when used as `tool:` on a node.
+ * `webhook` notify handlers are caught separately by inspecting `notify:`.
+ */
+const HTTP_POSTING_TOOLS = new Set(['http-post']);
+
+/** Heuristic regex for file-writing shell patterns. Catches the common cases. */
+const SHELL_WRITES_RE = /(?:>>?|\btee\b|\bmkdir\b|\bmv\b|\bcp\b|\brm\b)/;
+
+/** Extract URLs from arbitrary text. Conservative — only http(s)://. */
+const URL_RE = /https?:\/\/[^\s'"`<>{}|\\^]+/g;
+
+const MCP_TOOL_RE = /^mcp__([a-zA-Z0-9_-]+)__/;
+
+export function deriveCapabilities(agent: Agent): AgentCapabilities {
+  const tools = new Set<string>();
+  const mcpServers = new Set<string>();
+  const sideEffects = new Set<SideEffect>();
+  const urls = new Set<string>();
+
+  if (agent.notify) sideEffects.add('sends_notifications');
+  for (const handler of agent.notify?.handlers ?? []) {
+    if (handler.type === 'webhook') sideEffects.add('posts_http');
+  }
+
+  for (const node of agent.nodes ?? []) {
+    collectFromNode(node, tools, mcpServers, sideEffects, urls);
+  }
+
+  return {
+    tools_used: [...tools].sort(),
+    mcp_servers_used: [...mcpServers].sort(),
+    side_effects: [...sideEffects].sort(),
+    reads_external: [...urls].sort(),
+  };
+}
+
+function collectFromNode(
+  node: AgentNode,
+  tools: Set<string>,
+  mcpServers: Set<string>,
+  sideEffects: Set<SideEffect>,
+  urls: Set<string>,
+): void {
+  // Tool resolution: prefer explicit `tool:`, else fall back to type-based
+  // desugaring. Flow-control node types (conditional/branch/end/...) have
+  // no tool; skip them silently.
+  const explicitTool = typeof node.tool === 'string' && node.tool ? node.tool : undefined;
+  const desugaredTool = node.type === 'shell' ? 'shell-exec'
+    : node.type === 'claude-code' ? 'claude-code'
+    : undefined;
+  const primaryTool = explicitTool ?? desugaredTool;
+  if (primaryTool) {
+    tools.add(primaryTool);
+    classifyTool(primaryTool, sideEffects);
+    const mcp = primaryTool.match(MCP_TOOL_RE);
+    if (mcp) mcpServers.add(mcp[1]);
+  }
+
+  for (const allowed of node.allowedTools ?? []) {
+    if (typeof allowed !== 'string' || allowed.length === 0) continue;
+    tools.add(allowed);
+    classifyTool(allowed, sideEffects);
+    const mcp = allowed.match(MCP_TOOL_RE);
+    if (mcp) mcpServers.add(mcp[1]);
+  }
+
+  // Shell command heuristics for file-writing.
+  if (typeof node.command === 'string' && SHELL_WRITES_RE.test(node.command)) {
+    sideEffects.add('writes_files');
+  }
+
+  // URLs from toolInputs (canonical key names: url, endpoint).
+  const ti = node.toolInputs ?? {};
+  for (const key of ['url', 'endpoint']) {
+    const v = ti[key];
+    if (typeof v === 'string' && /^https?:\/\//.test(v)) urls.add(v);
+  }
+
+  // URLs from free text in command + prompt.
+  for (const text of [node.command, node.prompt] as Array<string | undefined>) {
+    if (!text) continue;
+    const matches = text.match(URL_RE);
+    if (matches) for (const u of matches) urls.add(stripTrailingPunct(u));
+  }
+}
+
+function classifyTool(tool: string, sideEffects: Set<SideEffect>): void {
+  if (FILE_WRITING_TOOLS.has(tool)) sideEffects.add('writes_files');
+  if (HTTP_POSTING_TOOLS.has(tool)) sideEffects.add('posts_http');
+}
+
+/** Trailing `.`, `,`, `)` are common in prose URLs and aren't part of the URL. */
+function stripTrailingPunct(u: string): string {
+  return u.replace(/[.,;:!?)\]}]+$/, '');
+}

--- a/packages/core/src/agent-store.ts
+++ b/packages/core/src/agent-store.ts
@@ -10,6 +10,7 @@ import type {
   AgentVersion,
   AgentVersionDag,
 } from './agent-v2-types.js';
+import { deriveCapabilities } from './agent-capabilities.js';
 
 type SqlValue = string | number | null | bigint | Uint8Array;
 
@@ -378,7 +379,7 @@ export class AgentStore {
     version: AgentVersion,
   ): Agent {
     const dag = version.dag;
-    return {
+    const agent: Agent = {
       id: row.id as string,
       name: row.name as string,
       description: ((row.description as string | null) ?? undefined) as string | undefined,
@@ -401,6 +402,8 @@ export class AgentStore {
       author: dag.author,
       tags: dag.tags,
     };
+    agent.capabilities = deriveCapabilities(agent);
+    return agent;
   }
 }
 

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -14,6 +14,7 @@
  */
 
 import type { AgentInputSpec, AgentOutputSpec } from './types.js';
+import type { AgentCapabilities } from './agent-capabilities.js';
 import type { AgentSource } from './agent-loader.js';
 
 export type AgentStatus = 'active' | 'paused' | 'archived' | 'draft';
@@ -255,6 +256,16 @@ export interface Agent {
    * a runtime contract.
    */
   outputs?: Record<string, AgentOutputSpec>;
+
+  /**
+   * Static analysis of what this agent uses and does. Computed at the
+   * parse boundary (parseAgent + agent-store rowToAgent) — never persisted.
+   * See `agent-capabilities.ts` for the derivation rules; the field is a
+   * heuristic (an empty array is "couldn't statically prove," not "doesn't
+   * do X") and must not be treated as a security boundary. Optional only
+   * because tests sometimes construct Agent objects by hand.
+   */
+  capabilities?: AgentCapabilities;
 
   nodes: AgentNode[];
 

--- a/packages/core/src/agent-yaml.ts
+++ b/packages/core/src/agent-yaml.ts
@@ -14,6 +14,7 @@
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import type { Agent, AgentNode, AgentStatus, AgentSource } from './agent-v2-types.js';
 import { agentV2Schema, type AgentV2Parsed } from './agent-v2-schema.js';
+import { deriveCapabilities } from './agent-capabilities.js';
 
 export class AgentYamlParseError extends Error {
   constructor(message: string, public readonly issues?: unknown[]) {
@@ -47,7 +48,9 @@ export function parseAgent(yamlText: string): Agent {
     throw new AgentYamlParseError(`Agent schema validation failed: ${summary}`, result.error.issues);
   }
 
-  return parsedToAgent(result.data);
+  const agent = parsedToAgent(result.data);
+  agent.capabilities = deriveCapabilities(agent);
+  return agent;
 }
 
 function parsedToAgent(p: AgentV2Parsed): Agent {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export * from './input-resolver.js';
 export * from './http-auth.js';
 export * from './daemon-supervisor.js';
 export * from './agent-v2-types.js';
+export * from './agent-capabilities.js';
 export * from './output-widget-types.js';
 export { outputWidgetSchema } from './output-widget-schema.js';
 export {


### PR DESCRIPTION
## Summary

PR A.6 from the [Bridge plan](https://github.com/gregmeyer/some-useful-agents/blob/main/.claude/plans/let-s-refresh-the-roadmap-iridescent-riddle.md). Second of three manifest-layer foundations (A.5 ✅, A.6 this one, A.7 next) before the planner-fronted agent-builder (PR A).

Adds \`deriveCapabilities(agent: Agent): AgentCapabilities\` — a static, best-effort summary of what an agent uses and does. Populated automatically at the parse boundary (\`parseAgent\` and \`agent-store.rowToAgent\`), attached as \`Agent.capabilities\`.

\`\`\`ts
{
  tools_used:        string[],   // shell-exec, claude-code, http-get, allowedTools entries…
  mcp_servers_used:  string[],   // extracted from mcp__server__tool naming
  side_effects:      ('sends_notifications' | 'writes_files' | 'posts_http')[],
  reads_external:    string[],   // URLs from toolInputs.url/endpoint, regex hits in command/prompt
}
\`\`\`

## Heuristics

| Field | Sources |
|---|---|
| \`tools_used\` | \`node.tool\` + \`shell-exec\`/\`claude-code\` defaults + \`node.allowedTools[]\` |
| \`mcp_servers_used\` | \`mcp__<server>__\*\` regex on tool names (sua's tool-store ids are flat today, so usually empty) |
| \`side_effects\` | \`notify:\` block → sends_notifications · file-writing tools (\`file-write\`/\`Edit\`/\`Write\`) → writes_files · shell redirects (\`>\`,\`>>\`,\`tee\`,\`mkdir\`,\`mv\`,\`cp\`,\`rm\`) → writes_files · \`http-post\` tool / webhook handler → posts_http |
| \`reads_external\` | \`toolInputs.url\` and \`toolInputs.endpoint\` (string + http(s)://) plus regex hits in \`command\`/\`prompt\` |

**Conservative by design**: an empty array means "couldn't statically prove," NOT "doesn't do X." Not a security boundary. Recomputed on every read; never persisted (so re-derivation rules can change without DB migrations).

## Test plan

- [x] 23 new tests covering all four derivations: defaults, explicit tool, allowedTools, dedupe, sort, MCP detection, all side-effect classes, URL extraction from toolInputs and free text, trailing-punctuation strip, empty cases.
- [x] \`npm run build\` clean.
- [x] \`npm test\` — 813 tests pass (was 790).

## Out of scope

- Tool-store-aware MCP detection (looking up \`mcp_server_id\` per tool name) — this PR's static heuristic is enough for the planner; a richer derivation can layer on later.
- Surfacing \`capabilities\` in the dashboard agent-detail view — separate UX PR.
- Auto-suggested fixes when \`mcp_servers_used\` references a server that isn't installed — preflight check, separate PR.

## What's next

PR A.7 — node catalog API + \`/nodes\` page (typed contract for each node type, queried by the planner during discover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)