### PR TITLE
feat(core,dashboard): node catalog API + /nodes page

### DIFF
--- a/.changeset/node-catalog.md
+++ b/.changeset/node-catalog.md
@@ -1,0 +1,19 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Node catalog API + dashboard page.
+
+Hand-authored typed contract for every first-class node type (`shell`, `claude-code`, `conditional`, `switch`, `loop`, `agent-invoke`, `branch`, `end`, `break`). Each contract has a description, full inputs and outputs lists, "use when" guidance, and a copy-pasteable example.
+
+- `NODE_CATALOG` + `listNodeContracts()` + `getNodeContract()` exported from `@some-useful-agents/core`.
+- Dashboard routes: `GET /api/nodes` (full catalog as JSON), `GET /api/nodes/:type` (single entry), `GET /nodes` (browseable HTML page).
+- New "Nodes" entry in the top nav between Tools and Runs.
+
+The planner-fronted agent-builder (PR A) will query `/api/nodes` during its discover step so the LLM works from the actual node-type contract instead of guessing or inventing names like `file-write` or `template`. The page is also useful for humans browsing what's available.
+
+Forcing function: a test asserts every `NodeType` has a catalog entry — adding a new node type without documenting it fails the test.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export * from './http-auth.js';
 export * from './daemon-supervisor.js';
 export * from './agent-v2-types.js';
 export * from './agent-capabilities.js';
+export * from './node-catalog.js';
 export * from './output-widget-types.js';
 export { outputWidgetSchema } from './output-widget-schema.js';
 export {

--- a/packages/core/src/node-catalog.test.ts
+++ b/packages/core/src/node-catalog.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { NODE_CATALOG, listNodeContracts, getNodeContract } from './node-catalog.js';
+import type { NodeType } from './agent-v2-types.js';
+
+// Forcing function: every NodeType must have a catalog entry. Adding a new
+// node type without a contract should fail this test, prompting the author
+// to document it.
+const ALL_NODE_TYPES: NodeType[] = [
+  'shell',
+  'claude-code',
+  'conditional',
+  'switch',
+  'loop',
+  'agent-invoke',
+  'branch',
+  'end',
+  'break',
+];
+
+describe('node catalog', () => {
+  it('has an entry for every NodeType', () => {
+    for (const t of ALL_NODE_TYPES) {
+      expect(NODE_CATALOG[t], `missing catalog entry for ${t}`).toBeDefined();
+      expect(NODE_CATALOG[t].type).toBe(t);
+    }
+  });
+
+  it('every contract has a non-empty description', () => {
+    for (const t of ALL_NODE_TYPES) {
+      expect(NODE_CATALOG[t].description.length).toBeGreaterThan(10);
+    }
+  });
+
+  it('every contract has at least one input', () => {
+    for (const t of ALL_NODE_TYPES) {
+      expect(NODE_CATALOG[t].inputs.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every contract has at least 2 use_when bullets', () => {
+    for (const t of ALL_NODE_TYPES) {
+      expect(NODE_CATALOG[t].use_when.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it('every contract has a non-empty example', () => {
+    for (const t of ALL_NODE_TYPES) {
+      const ex = NODE_CATALOG[t].example;
+      expect(ex.length).toBeGreaterThan(0);
+      // Example should reference the node type itself.
+      expect(ex).toContain(`type: ${t}`);
+    }
+  });
+
+  it('listNodeContracts returns sorted entries', () => {
+    const list = listNodeContracts();
+    const types = list.map((c) => c.type);
+    const sorted = [...types].sort();
+    expect(types).toEqual(sorted);
+    expect(list.length).toBe(ALL_NODE_TYPES.length);
+  });
+
+  it('getNodeContract returns the right entry by type', () => {
+    expect(getNodeContract('shell')?.type).toBe('shell');
+    expect(getNodeContract('claude-code')?.type).toBe('claude-code');
+    expect(getNodeContract('agent-invoke')?.type).toBe('agent-invoke');
+  });
+
+  it('getNodeContract returns undefined for unknown types', () => {
+    expect(getNodeContract('not-a-node-type')).toBeUndefined();
+    expect(getNodeContract('')).toBeUndefined();
+  });
+});

--- a/packages/core/src/node-catalog.ts
+++ b/packages/core/src/node-catalog.ts
@@ -1,0 +1,287 @@
+/**
+ * Node catalog — typed contract for each first-class node type.
+ *
+ * Used by the planner-fronted agent-builder (PR A) to discover what
+ * primitives are available, and by the dashboard's `/nodes` page for
+ * human browsing. Hand-authored, not derived: source of truth lives in
+ * `agent-v2-types.ts` (the type enum + per-config interfaces) and the
+ * executor; this file is a friendly summary of those for both LLMs and
+ * humans.
+ *
+ * Adding a new node type: append the type to `NodeType` in
+ * `agent-v2-types.ts`, then add an entry here. The test in
+ * `node-catalog.test.ts` will fail until every NodeType has an entry,
+ * which is the intended forcing function.
+ */
+
+import type { NodeType } from './agent-v2-types.js';
+
+export interface NodeContract {
+  /** The node type literal (matches `NodeType`). */
+  type: NodeType;
+  /** One-sentence description for browsing. */
+  description: string;
+  /**
+   * Fields a YAML author sets on the node. Each entry says what the
+   * field does and whether it's required.
+   */
+  inputs: NodeContractField[];
+  /**
+   * Fields downstream nodes can read from this node's `result`. Use
+   * this to know what to put after `upstream.<id>.` in templates.
+   */
+  outputs: NodeContractField[];
+  /** When this node type is the right choice. 2–5 bullets. */
+  use_when: string[];
+  /** Minimal working YAML — copy-pasteable. */
+  example: string;
+}
+
+export interface NodeContractField {
+  name: string;
+  type: string;
+  required?: boolean;
+  description: string;
+}
+
+export const NODE_CATALOG: Record<NodeType, NodeContract> = {
+  shell: {
+    type: 'shell',
+    description: 'Run a shell command. Captures stdout, stderr, and exit code.',
+    inputs: [
+      { name: 'command', type: 'string', required: true, description: 'Bash command to run. Reference inputs as $NAME (env vars), upstream outputs as $UPSTREAM_<ID>_RESULT.' },
+      { name: 'tool', type: 'string', description: 'Optional named tool (e.g. http-get, file-read, file-write). When set, `toolInputs:` provides the tool args and `command:` is unused.' },
+      { name: 'toolInputs', type: 'object', description: 'Tool-specific input map when `tool:` is set.' },
+      { name: 'timeout', type: 'number', description: 'Seconds before the command is killed. Default 300.' },
+      { name: 'env', type: 'object', description: 'Extra env vars merged into the shell environment. Values may template {{inputs.X}}.' },
+      { name: 'envAllowlist', type: 'string[]', description: 'Restricts inherited env vars to this list (defense against secret leakage).' },
+      { name: 'secrets', type: 'string[]', description: 'Secret names (UPPERCASE_WITH_UNDERSCORES) to inject from the secrets store as env vars.' },
+      { name: 'redactSecrets', type: 'boolean', description: 'When true, scrub known-prefix tokens (AWS, GitHub, OpenAI, Slack) from captured output before storage.' },
+      { name: 'workingDirectory', type: 'string', description: 'Run the command in this directory (relative to repo root).' },
+      { name: 'dependsOn', type: 'string[]', description: 'Upstream node ids this node waits on.' },
+      { name: 'onlyIf', type: 'OnlyIfCondition', description: 'Per-edge predicate; node is skipped (not failed) when the predicate is false.' },
+    ],
+    outputs: [
+      { name: 'result', type: 'string', description: 'Captured stdout. Trailing newline stripped.' },
+      { name: 'stderr', type: 'string', description: 'Captured stderr.' },
+      { name: 'exit_code', type: 'number', description: '0 on success.' },
+    ],
+    use_when: [
+      'You need to run an existing CLI tool (curl, jq, gh, etc.).',
+      'The data manipulation fits in one bash pipeline.',
+      'You want a deterministic, no-LLM step.',
+      'A built-in tool (http-get, file-read, file-write) covers your need — set `tool:` instead of writing the curl/cat by hand.',
+    ],
+    example: `- id: fetch
+  type: shell
+  command: curl -sf "https://news.ycombinator.com/" | jq .data
+  timeout: 30`,
+  },
+
+  'claude-code': {
+    type: 'claude-code',
+    description: 'Run an LLM (Claude or Codex) with a prompt. Optional tool access via allowedTools.',
+    inputs: [
+      { name: 'prompt', type: 'string', required: true, description: 'Prompt text. References inputs via {{inputs.X}}, upstreams via {{upstream.<id>.result}}.' },
+      { name: 'provider', type: "'claude' | 'codex'", description: 'Which CLI to spawn. Defaults to the agent-level provider, then to claude.' },
+      { name: 'model', type: 'string', description: 'Override the default model for this node only.' },
+      { name: 'maxTurns', type: 'number', description: 'Cap on tool-use turns. Default 5.' },
+      { name: 'allowedTools', type: 'string[]', description: 'Tools the LLM may call. Built-ins: file-read, file-write, Edit, Write, web-search, etc. MCP tools when configured.' },
+      { name: 'timeout', type: 'number', description: 'Seconds before the LLM call is killed. Default 300.' },
+      { name: 'env', type: 'object', description: 'Extra env vars (rarely needed for claude-code).' },
+      { name: 'secrets', type: 'string[]', description: 'Secret names injected as env vars (visible to allowed shell commands the LLM runs).' },
+      { name: 'dependsOn', type: 'string[]', description: 'Upstream node ids this node waits on.' },
+      { name: 'onlyIf', type: 'OnlyIfCondition', description: 'Per-edge predicate.' },
+    ],
+    outputs: [
+      { name: 'result', type: 'string', description: "The LLM's final assistant message. Plain text unless you ask for JSON in the prompt." },
+    ],
+    use_when: [
+      'You need free-form analysis, summarization, classification, or generation.',
+      'The output shape is hard to specify with jq/regex (e.g. extracting structured data from messy HTML).',
+      'You want the LLM to make decisions inside the DAG (route, score, draft).',
+      "Don't reach for it for deterministic data shaping — shell + jq is faster, cheaper, and reproducible.",
+    ],
+    example: `- id: summarise
+  type: claude-code
+  prompt: |
+    Summarise this in 3 bullets:
+    {{upstream.fetch.result}}
+  maxTurns: 1
+  timeout: 60`,
+  },
+
+  conditional: {
+    type: 'conditional',
+    description: 'Evaluate a predicate against an upstream output. Emits `matched: true | false` for downstream nodes to branch on via onlyIf.',
+    inputs: [
+      { name: 'conditionalConfig.predicate', type: 'OnlyIfCondition', description: 'The predicate to evaluate. Same shape as onlyIf: { field, equals/notEquals/contains/greaterThan/lessThan }.' },
+      { name: 'dependsOn', type: 'string[]', required: true, description: 'Exactly one upstream — the data source the predicate reads.' },
+    ],
+    outputs: [
+      { name: 'matched', type: 'boolean', description: 'true when the predicate holds against the upstream output.' },
+    ],
+    use_when: [
+      'You want a clearly-named branch point in the DAG visualization.',
+      'Multiple downstream nodes share the same gate — checking once is cheaper than re-evaluating in every onlyIf.',
+      'For a one-shot gate to a single downstream, putting onlyIf directly on the downstream is simpler.',
+    ],
+    example: `- id: check-status
+  type: conditional
+  dependsOn: [fetch]
+  conditionalConfig:
+    predicate: { field: status_code, equals: 200 }`,
+  },
+
+  switch: {
+    type: 'switch',
+    description: 'Multi-way branch. Reads a string field from an upstream and emits `selected_case`; downstream nodes filter via onlyIf.',
+    inputs: [
+      { name: 'switchConfig.field', type: 'string', required: true, description: 'Field name in the upstream output (JSON key).' },
+      { name: 'switchConfig.cases', type: 'string[]', required: true, description: 'Allowed case values.' },
+      { name: 'switchConfig.defaultCase', type: 'string', description: 'Used when the upstream field matches no listed case.' },
+      { name: 'dependsOn', type: 'string[]', required: true, description: 'Exactly one upstream.' },
+    ],
+    outputs: [
+      { name: 'selected_case', type: 'string', description: 'The case that matched (or defaultCase).' },
+    ],
+    use_when: [
+      'You have 3+ exclusive downstream paths (low/medium/high, type-A/B/C).',
+      'A chain of conditional nodes would be noisier than one switch.',
+      "Don't reach for it with only 2 cases — a single conditional is shorter.",
+    ],
+    example: `- id: classify
+  type: switch
+  dependsOn: [analyze]
+  switchConfig:
+    field: severity
+    cases: [low, medium, high]
+    defaultCase: low`,
+  },
+
+  loop: {
+    type: 'loop',
+    description: 'Iterate a sub-agent over a list. Emits a JSON array of the sub-agent results.',
+    inputs: [
+      { name: 'loopConfig.over', type: 'string', required: true, description: 'Field name in the upstream output (must resolve to an array).' },
+      { name: 'loopConfig.agentId', type: 'string', required: true, description: 'Id of the sub-agent to invoke per item.' },
+      { name: 'loopConfig.maxIterations', type: 'number', description: 'Safety cap. Default 10.' },
+      { name: 'loopConfig.inputMapping', type: 'object', description: 'Map sub-agent inputs to per-iteration values. Use $item.<field> to reference fields on the current item.' },
+      { name: 'dependsOn', type: 'string[]', required: true, description: 'Exactly one upstream — the source of the array.' },
+    ],
+    outputs: [
+      { name: 'result', type: 'array', description: 'Array of the sub-agent results, in iteration order.' },
+    ],
+    use_when: [
+      'You have a list and need to do the same multi-step thing to each item.',
+      "The work doesn't fit cleanly in a single shell pipeline (otherwise just use jq + a bash for-loop).",
+      'You want per-iteration runs visible in the dashboard for debugging.',
+    ],
+    example: `- id: research-each
+  type: loop
+  dependsOn: [topics]
+  loopConfig:
+    over: topics
+    agentId: two-step-digest
+    maxIterations: 10
+    inputMapping:
+      TOPIC: "$item.title"`,
+  },
+
+  'agent-invoke': {
+    type: 'agent-invoke',
+    description: 'Call another agent as a single sub-workflow. The sub-agent`s final result becomes this node`s result.',
+    inputs: [
+      { name: 'agentInvokeConfig.agentId', type: 'string', required: true, description: 'Id of the sub-agent to invoke.' },
+      { name: 'agentInvokeConfig.inputMapping', type: 'object', description: 'Map sub-agent inputs from this agent`s scope. Use $upstream.<id>.<field> or {{inputs.X}}.' },
+      { name: 'dependsOn', type: 'string[]', description: 'Upstream node ids this node waits on.' },
+      { name: 'onlyIf', type: 'OnlyIfCondition', description: 'Per-edge predicate.' },
+    ],
+    outputs: [
+      { name: 'result', type: 'string | object', description: 'The sub-agent`s final result, passed through.' },
+      { name: 'invoked_run_id', type: 'string', description: 'Run id of the sub-agent`s execution. Useful for follow-up inspection.' },
+    ],
+    use_when: [
+      'You`ve built a reusable pipeline you want to compose into multiple parents.',
+      'Cross-agent composition keeps each agent`s scope focused.',
+      "Don't use it just to organize a long DAG — split into multiple agents only when reuse exists.",
+    ],
+    example: `- id: analyze
+  type: agent-invoke
+  dependsOn: [fetch]
+  agentInvokeConfig:
+    agentId: agent-analyzer
+    inputMapping:
+      AGENT_YAML: "$upstream.fetch.result"`,
+  },
+
+  branch: {
+    type: 'branch',
+    description: 'Explicit fork point. Runs no logic; splits one upstream into multiple downstream paths for visual clarity.',
+    inputs: [
+      { name: 'dependsOn', type: 'string[]', required: true, description: 'Exactly one upstream — the source being forked.' },
+    ],
+    outputs: [
+      { name: 'result', type: 'unchanged', description: 'Pass-through of the upstream`s result.' },
+    ],
+    use_when: [
+      'You want the DAG visualization to clearly show "fan-out from here."',
+      'Several independent follow-on chains all read from the same source.',
+      "If the downstream nodes can just declare dependsOn directly on the source, branch is redundant.",
+    ],
+    example: `- id: fan-out
+  type: branch
+  dependsOn: [fetch]`,
+  },
+
+  end: {
+    type: 'end',
+    description: 'Terminal node. Marks a path complete; downstream-of-end paths are skipped and the run finishes as soon as everything else is done.',
+    inputs: [
+      { name: 'endMessage', type: 'string', description: 'Human-readable reason this end fired. Surfaced in the run detail.' },
+      { name: 'dependsOn', type: 'string[]', description: 'Upstreams that must complete before this end fires.' },
+      { name: 'onlyIf', type: 'OnlyIfCondition', description: 'Conditional end — only fires when the predicate holds.' },
+    ],
+    outputs: [],
+    use_when: [
+      'You want to stop a path early when a success criterion is met (e.g. "we found what we needed; skip the fallback").',
+      'Inside a `loop`, prefer `break` (which is end-scoped to the loop).',
+    ],
+    example: `- id: short-circuit
+  type: end
+  dependsOn: [check]
+  onlyIf: { upstream: check, field: matched, equals: true }
+  endMessage: "Already up to date — nothing to do."`,
+  },
+
+  break: {
+    type: 'break',
+    description: 'Loop-scoped end. Halts the enclosing loop early when the predicate fires.',
+    inputs: [
+      { name: 'dependsOn', type: 'string[]', required: true, description: 'Usually the loop node itself or a downstream of it.' },
+      { name: 'onlyIf', type: 'OnlyIfCondition', description: 'Predicate that triggers the break.' },
+    ],
+    outputs: [],
+    use_when: [
+      'A loop should stop as soon as one iteration succeeds (early-exit search).',
+      'A loop should stop when an external condition is met mid-iteration.',
+      'For non-loop early-exit, use `end` instead.',
+    ],
+    example: `- id: stop-on-first-success
+  type: break
+  dependsOn: [try-fetch-loop]
+  onlyIf: { upstream: try-fetch-loop, field: any_matched, equals: true }`,
+  },
+};
+
+/**
+ * Helper for routes/tests: get every node type as an array, sorted
+ * alphabetically by type for stable output.
+ */
+export function listNodeContracts(): NodeContract[] {
+  return Object.values(NODE_CATALOG).slice().sort((a, b) => a.type.localeCompare(b.type));
+}
+
+export function getNodeContract(type: string): NodeContract | undefined {
+  return (NODE_CATALOG as Record<string, NodeContract>)[type];
+}

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -2287,3 +2287,53 @@ nodes:
     expect(res.text).toContain('Enter a URL');
   });
 });
+
+describe('Dashboard /nodes catalog', () => {
+  it('GET /api/nodes returns the full catalog as JSON', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/api/nodes')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.nodes)).toBe(true);
+    const types = res.body.nodes.map((n: { type: string }) => n.type);
+    expect(types).toContain('shell');
+    expect(types).toContain('claude-code');
+    expect(types).toContain('agent-invoke');
+  });
+
+  it('GET /api/nodes/:type returns one entry', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/api/nodes/conditional')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.body.type).toBe('conditional');
+    expect(res.body.inputs.length).toBeGreaterThan(0);
+    expect(res.body.outputs.length).toBeGreaterThan(0);
+  });
+
+  it('GET /api/nodes/:unknown returns 404 JSON', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/api/nodes/not-a-real-type')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/unknown node type/i);
+  });
+
+  it('GET /nodes renders an HTML page with every node type', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/nodes')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    // Page header text + each node-type id anchor.
+    expect(res.text).toContain('Nodes');
+    expect(res.text).toContain('id="shell"');
+    expect(res.text).toContain('id="claude-code"');
+    expect(res.text).toContain('id="agent-invoke"');
+    expect(res.text).toContain('id="loop"');
+    expect(res.text).toContain('href="/api/nodes"');
+  });
+});

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -33,6 +33,7 @@ import { buildRouter } from './routes/run-now-build.js';
 import { runMutationsRouter } from './routes/run-mutations.js';
 import { widgetRunRouter } from './routes/widget-run.js';
 import { toolsRouter } from './routes/tools.js';
+import { nodesRouter } from './routes/nodes.js';
 import { assetsRouter } from './routes/assets.js';
 import { outputFilesRouter } from './routes/output-files.js';
 import { settingsRouter } from './routes/settings.js';
@@ -191,6 +192,7 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   app.use(helpRouter);
   app.use(versionsRouter);
   app.use(toolsRouter);
+  app.use(nodesRouter);
   app.use(pulseRouter);
 
   // Catch-all 404 for authenticated routes.

--- a/packages/dashboard/src/routes/nodes.ts
+++ b/packages/dashboard/src/routes/nodes.ts
@@ -1,0 +1,34 @@
+/**
+ * Node catalog routes:
+ *   GET /api/nodes        — JSON list of every node type's contract
+ *   GET /api/nodes/:type  — JSON for one node type
+ *   GET /nodes            — browseable HTML page
+ *
+ * The catalog itself lives in `@some-useful-agents/core` so the
+ * planner-fronted agent-builder can query it the same way the dashboard
+ * does, without depending on dashboard-only code.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { listNodeContracts, getNodeContract } from '@some-useful-agents/core';
+import { renderNodes } from '../views/nodes.js';
+
+export const nodesRouter: Router = Router();
+
+nodesRouter.get('/api/nodes', (_req: Request, res: Response) => {
+  res.json({ nodes: listNodeContracts() });
+});
+
+nodesRouter.get('/api/nodes/:type', (req: Request, res: Response) => {
+  const type = Array.isArray(req.params.type) ? req.params.type[0] : req.params.type;
+  const contract = getNodeContract(type);
+  if (!contract) {
+    res.status(404).json({ error: `Unknown node type: ${type}` });
+    return;
+  }
+  res.json(contract);
+});
+
+nodesRouter.get('/nodes', (_req: Request, res: Response) => {
+  res.type('html').send(renderNodes({ catalog: listNodeContracts() }));
+});

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -14,7 +14,7 @@ import { footer } from './footer.js';
 export interface LayoutOptions {
   title: string;
   /** Highlight in the nav (one of: agents, tools, runs, pulse, settings, help). */
-  activeNav?: 'agents' | 'tools' | 'runs' | 'pulse' | 'settings' | 'help';
+  activeNav?: 'agents' | 'tools' | 'nodes' | 'runs' | 'pulse' | 'settings' | 'help';
   /** Flash banner shown at the top of the body (errors from prior actions). */
   flash?: { kind: 'error' | 'info' | 'ok'; message: string };
   /** Widen the main column (for screens with 2-col layouts). */
@@ -53,6 +53,7 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
   <nav class="topbar__nav">
     <a href="/agents" class="${opts.activeNav === 'agents' ? 'is-active' : ''}">Agents</a>
     <a href="/tools" class="${opts.activeNav === 'tools' ? 'is-active' : ''}">Tools</a>
+    <a href="/nodes" class="${opts.activeNav === 'nodes' ? 'is-active' : ''}">Nodes</a>
     <a href="/runs" class="${opts.activeNav === 'runs' ? 'is-active' : ''}">Runs</a>
     <a href="/pulse" class="${opts.activeNav === 'pulse' ? 'is-active' : ''}">Pulse</a>
     <a href="/settings" class="${opts.activeNav === 'settings' ? 'is-active' : ''}">Settings</a>

--- a/packages/dashboard/src/views/nodes.ts
+++ b/packages/dashboard/src/views/nodes.ts
@@ -1,0 +1,93 @@
+/**
+ * /nodes page renderer. Browseable catalog of every node type sua
+ * exposes. Same data the planner-fronted agent-builder queries via
+ * /api/nodes — this page is the human-readable view.
+ */
+
+import type { NodeContract, NodeContractField } from '@some-useful-agents/core';
+import { html, render, type SafeHtml } from './html.js';
+import { layout } from './layout.js';
+import { pageHeader } from './page-header.js';
+
+export function renderNodes(opts: { catalog: NodeContract[] }): string {
+  const cards = opts.catalog.map(renderContractCard);
+
+  const body = html`
+    ${pageHeader({
+      title: 'Nodes',
+      description:
+        'Every first-class node type sua’s executor knows. Hand-authored contracts: what each ' +
+        'node takes in, what it emits, when to reach for it. The planner-fronted agent-builder reads ' +
+        'this same catalog via /api/nodes when designing new agents.',
+    })}
+
+    <p class="dim" style="font-size: var(--font-size-xs); margin: var(--space-4) 0 var(--space-6);">
+      ${opts.catalog.length === 1 ? '1 node type' : `${opts.catalog.length} node types`} ·
+      <a href="/api/nodes">JSON API</a>
+    </p>
+
+    ${cards as unknown as SafeHtml[]}
+  `;
+
+  return render(layout({ title: 'Nodes', activeNav: 'nodes' }, body));
+}
+
+function renderContractCard(c: NodeContract): SafeHtml {
+  return html`
+    <section id="${c.type}" class="card" style="margin-bottom: var(--space-5); padding: var(--space-5);">
+      <header style="margin-bottom: var(--space-3);">
+        <h2 style="margin: 0 0 var(--space-1); font-family: var(--font-mono); font-size: var(--font-size-lg);">${c.type}</h2>
+        <p class="dim" style="margin: 0; line-height: 1.5;">${c.description}</p>
+      </header>
+
+      <div class="config-grid" style="margin-top: var(--space-4); gap: var(--space-4);">
+        <div class="config-grid__col">
+          <h3 style="font-size: var(--font-size-sm); margin: 0 0 var(--space-2);">Inputs</h3>
+          ${renderFieldsTable(c.inputs)}
+        </div>
+        <div class="config-grid__col">
+          <h3 style="font-size: var(--font-size-sm); margin: 0 0 var(--space-2);">Outputs</h3>
+          ${c.outputs.length === 0
+            ? html`<p class="dim" style="font-size: var(--font-size-xs); margin: 0;">This node emits no result fields.</p>`
+            : renderFieldsTable(c.outputs)}
+        </div>
+      </div>
+
+      <div style="margin-top: var(--space-4);">
+        <h3 style="font-size: var(--font-size-sm); margin: 0 0 var(--space-2);">Use when</h3>
+        <ul style="margin: 0 0 0 var(--space-4); padding: 0; font-size: var(--font-size-sm); line-height: 1.6;">
+          ${c.use_when.map((line) => html`<li>${line}</li>`) as unknown as SafeHtml[]}
+        </ul>
+      </div>
+
+      <div style="margin-top: var(--space-4);">
+        <h3 style="font-size: var(--font-size-sm); margin: 0 0 var(--space-2);">Example</h3>
+        <pre style="margin: 0; padding: var(--space-3); background: var(--color-surface); border-radius: var(--radius-sm); overflow-x: auto; font-size: var(--font-size-xs); line-height: 1.5;"><code>${c.example}</code></pre>
+      </div>
+    </section>
+  `;
+}
+
+function renderFieldsTable(fields: NodeContractField[]): SafeHtml {
+  if (fields.length === 0) {
+    return html`<p class="dim" style="font-size: var(--font-size-xs); margin: 0;">None.</p>`;
+  }
+  return html`
+    <table class="table" style="font-size: var(--font-size-xs);">
+      <tbody>
+        ${fields.map((f) => html`
+          <tr>
+            <td style="white-space: nowrap; vertical-align: top; padding-right: var(--space-3);">
+              <code class="mono">${f.name}</code>
+              ${f.required ? html`<br><span class="badge badge--ok" style="margin-top: var(--space-1);">required</span>` : html``}
+            </td>
+            <td style="vertical-align: top; padding-right: var(--space-3);">
+              <code class="mono dim">${f.type}</code>
+            </td>
+            <td style="vertical-align: top; line-height: 1.5;">${f.description}</td>
+          </tr>
+        `) as unknown as SafeHtml[]}
+      </tbody>
+    </table>
+  `;
+}


### PR DESCRIPTION
## Summary

PR A.7 from the [Bridge plan](https://github.com/gregmeyer/some-useful-agents/blob/main/.claude/plans/let-s-refresh-the-roadmap-iridescent-riddle.md). Last of three manifest-layer foundations (A.5 ✅, A.6 ✅, A.7 this one) before the planner-fronted agent-builder (PR A).

Hand-authored typed contract for every first-class node type. Each contract has:
- one-sentence \`description\`
- typed \`inputs[]\` and \`outputs[]\` lists with required/optional flags
- 2–5 \`use_when\` bullets (when to reach for this vs alternatives)
- copy-pasteable \`example\` YAML

## What changed

**Core**:
- \`packages/core/src/node-catalog.ts\` — \`NODE_CATALOG\` keyed by \`NodeType\`, \`listNodeContracts()\` sorted, \`getNodeContract(type)\` single lookup.
- Exported from \`@some-useful-agents/core\`.

**Dashboard**:
- \`GET /api/nodes\` — full catalog as JSON for the planner-fronted builder.
- \`GET /api/nodes/:type\` — single entry, 404 on unknown.
- \`GET /nodes\` — browseable HTML page with anchor ids per node type.
- New "Nodes" entry in the top nav between Tools and Runs (\`activeNav\` extended).

## Why this matters

Round 2 of the dogfood proved agent-builder invents node types it expects to exist (\`file-write\`, \`template\`) and silently strips them at the schema layer. With \`/api/nodes\` as a discoverable, queryable surface, the planner step can ground its output in what actually exists.

The page itself is useful for humans browsing — answers "what node type do I use for X?" without reading source code.

## Forcing function

The catalog test asserts every \`NodeType\` from the type-system enum has an entry. Adding a new node type without documenting it will fail \`npm test\`.

## Test plan

- [x] 8 new core tests — every node type covered, sort order, getter behavior.
- [x] 4 new dashboard tests — JSON list, JSON single entry, 404 on unknown, HTML page renders all types + JSON-API link.
- [x] \`npm run build\` clean.
- [x] \`npm test\` — 825 tests pass (was 813).

## What's next

PR A — the planner-fronted agent-builder DAG itself. With outputs (#184), capabilities (#185), and the node catalog (this PR) all landed, the discover step has the data it needs to make grounded decisions about what to build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)