### PR TITLE
feat(core): file-write first-class node type

### DIFF
--- a/.changeset/file-write-node-type.md
+++ b/.changeset/file-write-node-type.md
@@ -1,0 +1,30 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+`file-write` first-class node type.
+
+A real schema gap surfaced by the dogfood: agent-builder kept reaching for `type: file-write` (a node type that didn't exist) instead of the longer `type: shell` + `tool: file-write` + `toolInputs: { path, content }` form. Promoting it to a first-class node type makes the LLM's intuition correct and keeps YAML readable.
+
+```yaml
+- id: save
+  type: file-write
+  dependsOn: [build-summary]
+  path: "output/digest-{{inputs.DATE}}.md"
+  content: "{{upstream.build-summary.result}}"
+  append: false  # optional; default false
+```
+
+Top-level `path:` and `content:` desugar to `tool: 'file-write'` + `toolInputs: { path, content, append }` at dispatch time — no executor branch added, just a small `resolveToolId`/`resolveToolInputs` extension. The existing `file-write` tool gained an `append:` mode (writes with `flag: 'a'`).
+
+Templating: built-in tool dispatch now resolves `{{upstream.X.field}}`, `{{vars.X}}`, and `{{inputs.X}}` in string-typed tool inputs, so `path:` and `content:` (and any other built-in tool's string fields) can reference upstream outputs and inputs. Previously only MCP tools had this.
+
+Schema enforces `path` + `content` are required when `type: file-write`, and validates that any `{{upstream.X.result}}` reference in `path` or `content` declares `X` in `dependsOn` (same rule as for shell/claude-code).
+
+Capabilities derivation (PR A.6) updated to recognize `type: file-write` as the `file-write` tool, so `tools_used` and `side_effects: ['writes_files']` populate correctly.
+
+Node catalog (PR A.7) gets a new entry with description, inputs, outputs, use-when guidance, and example. The forcing-function test ensures the new `NodeType` enum value has a catalog entry.

--- a/packages/core/src/agent-capabilities.test.ts
+++ b/packages/core/src/agent-capabilities.test.ts
@@ -58,6 +58,14 @@ describe('deriveCapabilities — tools_used', () => {
     expect(c.tools_used).toEqual(['shell-exec']);
   });
 
+  it('detects file-write node type as the file-write tool', () => {
+    const c = deriveCapabilities(makeAgent({
+      nodes: [{ id: 'save', type: 'file-write', path: 'out.md', content: 'x' }],
+    }));
+    expect(c.tools_used).toContain('file-write');
+    expect(c.side_effects).toContain('writes_files');
+  });
+
   it('returns empty for flow-control-only DAGs', () => {
     const c = deriveCapabilities(makeAgent({
       nodes: [{ id: 'end', type: 'end', endMessage: 'done' }],

--- a/packages/core/src/agent-capabilities.ts
+++ b/packages/core/src/agent-capabilities.ts
@@ -116,6 +116,7 @@ function collectFromNode(
   const explicitTool = typeof node.tool === 'string' && node.tool ? node.tool : undefined;
   const desugaredTool = node.type === 'shell' ? 'shell-exec'
     : node.type === 'claude-code' ? 'claude-code'
+    : node.type === 'file-write' ? 'file-write'
     : undefined;
   const primaryTool = explicitTool ?? desugaredTool;
   if (primaryTool) {

--- a/packages/core/src/agent-v2-schema.test.ts
+++ b/packages/core/src/agent-v2-schema.test.ts
@@ -28,6 +28,54 @@ describe('agentV2Schema — happy paths', () => {
     }
   });
 
+  it('accepts a file-write node with path + content', () => {
+    const r = agentV2Schema.safeParse(validSingleNode({
+      nodes: [
+        { id: 'fetch', type: 'shell', command: 'curl https://example.com' },
+        { id: 'save', type: 'file-write', path: 'out.md', content: 'static text', dependsOn: ['fetch'] },
+      ],
+    }));
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts file-write with append: true', () => {
+    const r = agentV2Schema.safeParse(validSingleNode({
+      nodes: [{ id: 'log', type: 'file-write', path: 'log.txt', content: 'entry\n', append: true }],
+    }));
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts file-write content templating an upstream', () => {
+    const r = agentV2Schema.safeParse(validSingleNode({
+      nodes: [
+        { id: 'fetch', type: 'shell', command: 'curl https://example.com' },
+        { id: 'save', type: 'file-write', path: 'out.md', content: '{{upstream.fetch.result}}', dependsOn: ['fetch'] },
+      ],
+    }));
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects file-write missing path', () => {
+    const r = agentV2Schema.safeParse(validSingleNode({
+      nodes: [{ id: 'save', type: 'file-write', content: 'hi' }],
+    }));
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects file-write missing content', () => {
+    const r = agentV2Schema.safeParse(validSingleNode({
+      nodes: [{ id: 'save', type: 'file-write', path: 'out.md' }],
+    }));
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects file-write referencing an upstream not in dependsOn', () => {
+    const r = agentV2Schema.safeParse(validSingleNode({
+      nodes: [{ id: 'save', type: 'file-write', path: 'out.md', content: '{{upstream.phantom.result}}' }],
+    }));
+    expect(r.success).toBe(false);
+  });
+
   it('accepts a three-node DAG with declared dependencies', () => {
     const r = agentV2Schema.safeParse({
       id: 'news-digest',

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -84,7 +84,7 @@ const agentInvokeConfigSchema = z.object({
 export const agentNodeSchema = z.object({
   id: z.string().regex(NODE_ID_RE, 'Node ids must be lowercase with hyphens/underscores only'),
   type: z.enum([
-    'shell', 'claude-code',
+    'shell', 'claude-code', 'file-write',
     'conditional', 'switch', 'loop', 'agent-invoke', 'branch', 'end', 'break',
   ]),
 
@@ -98,6 +98,11 @@ export const agentNodeSchema = z.object({
   maxTurns: z.number().int().positive().optional(),
   allowedTools: z.array(z.string()).optional(),
   provider: z.enum(['claude', 'codex']).optional(),
+
+  // file-write node fields (top-level for ergonomics; desugar to toolInputs at dispatch).
+  path: z.string().optional(),
+  content: z.string().optional(),
+  append: z.boolean().optional(),
 
   timeout: z.number().positive().optional(),
   env: z.record(z.string()).optional(),
@@ -126,9 +131,11 @@ export const agentNodeSchema = z.object({
     // v0.15 compat: shell needs command, claude-code needs prompt.
     if (data.type === 'shell') return !!data.command;
     if (data.type === 'claude-code') return !!data.prompt;
+    // file-write needs path + content (or toolInputs if author preferred that form).
+    if (data.type === 'file-write') return !!data.path && !!data.content;
     return false;
   },
-  { message: 'Execution nodes without a tool require command (shell) or prompt (claude-code)' },
+  { message: 'Execution nodes without a tool require command (shell), prompt (claude-code), or path+content (file-write)' },
 );
 
 export const agentV2Schema = z.object({
@@ -418,6 +425,13 @@ export const agentV2Schema = z.object({
 
     if (node.type === 'claude-code') {
       checkText(node.prompt, ['prompt']);
+    }
+
+    if (node.type === 'file-write') {
+      // file-write content may reference upstream outputs and inputs via
+      // template syntax — the dispatch path resolves these before writing.
+      checkText(node.content, ['content']);
+      checkText(node.path, ['path']);
     }
 
     // env values (both shell and claude-code) may reference inputs + upstream

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -28,6 +28,7 @@ export type AgentStatus = 'active' | 'paused' | 'archived' | 'draft';
 export type NodeType =
   | 'shell'
   | 'claude-code'
+  | 'file-write'
   | 'conditional'
   | 'switch'
   | 'loop'
@@ -156,6 +157,14 @@ export interface AgentNode {
   model?: string;
   maxTurns?: number;
   allowedTools?: string[];
+
+  // file-write (first-class node type — desugars to tool: 'file-write')
+  /** Path to write (relative to working directory). Required when type is file-write. */
+  path?: string;
+  /** Content to write. Required when type is file-write. May template {{upstream.X.result}} / {{inputs.X}}. */
+  content?: string;
+  /** When true, append instead of overwrite. Defaults to false. file-write only. */
+  append?: boolean;
 
   /**
    * v0.17+: LLM provider for claude-code nodes. Defaults to 'claude'.

--- a/packages/core/src/agent-yaml.ts
+++ b/packages/core/src/agent-yaml.ts
@@ -74,6 +74,10 @@ function parsedToAgent(p: AgentV2Parsed): Agent {
     ...(n.maxTurns !== undefined && { maxTurns: n.maxTurns }),
     ...(n.allowedTools && { allowedTools: n.allowedTools }),
     ...(n.provider !== undefined && { provider: n.provider }),
+    // file-write fields
+    ...(n.path !== undefined && { path: n.path }),
+    ...(n.content !== undefined && { content: n.content }),
+    ...(n.append !== undefined && { append: n.append }),
     ...(n.timeout !== undefined && { timeout: n.timeout }),
     ...(n.env && { env: n.env }),
     ...(n.envAllowlist && { envAllowlist: n.envAllowlist }),
@@ -142,6 +146,8 @@ const NODE_KEY_ORDER = [
   'tool', 'action', 'toolInputs',
   // execution
   'command', 'prompt', 'model', 'maxTurns', 'allowedTools', 'provider',
+  // file-write
+  'path', 'content', 'append',
   'timeout', 'env', 'envAllowlist', 'secrets', 'redactSecrets', 'workingDirectory',
   'dependsOn',
   // control flow

--- a/packages/core/src/builtin-tools.test.ts
+++ b/packages/core/src/builtin-tools.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { getBuiltinTool, listBuiltinTools, isBuiltinTool, assertSafeUrl } from './builtin-tools.js';
 
 describe('Builtin tool registry', () => {
@@ -65,6 +68,48 @@ describe('Builtin tool registry', () => {
     const result = await entry.execute({ path: 'package.json' }, {});
     expect(result.content).toContain('some-useful-agents');
     expect(result.bytes).toBeGreaterThan(0);
+  });
+
+  describe('file-write', () => {
+    let tmp: string;
+    beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'sua-fw-')); });
+    afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+    it('writes content to a file (overwrite default)', async () => {
+      const entry = getBuiltinTool('file-write')!;
+      const result = await entry.execute(
+        { path: 'out.txt', content: 'hello' },
+        { workingDirectory: tmp },
+      );
+      expect(result.bytes).toBe(5);
+      expect(result.append).toBe(false);
+      expect(readFileSync(join(tmp, 'out.txt'), 'utf-8')).toBe('hello');
+    });
+
+    it('overwrites by default on second write', async () => {
+      const entry = getBuiltinTool('file-write')!;
+      await entry.execute({ path: 'out.txt', content: 'first' }, { workingDirectory: tmp });
+      await entry.execute({ path: 'out.txt', content: 'second' }, { workingDirectory: tmp });
+      expect(readFileSync(join(tmp, 'out.txt'), 'utf-8')).toBe('second');
+    });
+
+    it('appends when append: true', async () => {
+      const entry = getBuiltinTool('file-write')!;
+      await entry.execute({ path: 'log.txt', content: 'one\n' }, { workingDirectory: tmp });
+      const result = await entry.execute(
+        { path: 'log.txt', content: 'two\n', append: true },
+        { workingDirectory: tmp },
+      );
+      expect(result.append).toBe(true);
+      expect(readFileSync(join(tmp, 'log.txt'), 'utf-8')).toBe('one\ntwo\n');
+    });
+
+    it('refuses paths that escape the working directory', async () => {
+      const entry = getBuiltinTool('file-write')!;
+      await expect(
+        entry.execute({ path: '../escape.txt', content: 'x' }, { workingDirectory: tmp }),
+      ).rejects.toThrow(/escapes the working directory/);
+    });
   });
 
   it('http-get fetches a URL (skipped without network)', async () => {

--- a/packages/core/src/builtin-tools.ts
+++ b/packages/core/src/builtin-tools.ts
@@ -285,14 +285,16 @@ const BUILTINS: BuiltinToolEntry[] = [
   def(
     'file-write',
     'File write',
-    'Write content to a file in the project directory.',
+    'Write content to a file in the project directory. Optionally append.',
     {
       path: { type: 'string', description: 'Relative path within the project.', required: true },
       content: { type: 'string', description: 'Content to write.', required: true },
+      append: { type: 'boolean', description: 'When true, append to the file instead of overwriting. Default false.' },
     },
     {
       bytes: { type: 'number', description: 'Bytes written.' },
       path: { type: 'string', description: 'Resolved file path.' },
+      append: { type: 'boolean', description: 'Whether the write was an append.' },
       result: { type: 'string', description: 'Resolved file path.' },
     },
     async (inputs, ctx) => {
@@ -302,8 +304,9 @@ const BUILTINS: BuiltinToolEntry[] = [
         throw new Error(`Path "${String(inputs.path)}" escapes the working directory.`);
       }
       const content = String(inputs.content);
-      writeFileSync(filePath, content, 'utf-8');
-      return { bytes: Buffer.byteLength(content), path: filePath, result: filePath };
+      const append = inputs.append === true;
+      writeFileSync(filePath, content, { encoding: 'utf-8', flag: append ? 'a' : 'w' });
+      return { bytes: Buffer.byteLength(content), path: filePath, append, result: filePath };
     },
   ),
 

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -32,6 +32,7 @@ import { getBuiltinTool } from './builtin-tools.js';
 import { buildToolOutput } from './output-framing.js';
 import { callMcpTool } from './mcp-client.js';
 import { resolveUpstreamTemplate, resolveVarsTemplate } from './node-templates.js';
+import { substituteInputs } from './input-resolver.js';
 import { UntrustedCommunityShellError } from './agent-executor.js';
 import { buildNodeEnv, buildUpstreamSnapshot, filterEnvForLog } from './node-env.js';
 import { type SpawnResult, type SpawnNodeFn, type SpawnProgress, spawnNodeReal } from './node-spawner.js';
@@ -616,11 +617,25 @@ export async function executeAgentDag(
         // Built-in tool: call execute() directly, no child process.
         // Merge tool-level config (project defaults) with per-invocation
         // inputs so the user doesn't repeat common values every node.
-        const toolInputs = {
+        // Resolve {{upstream.X.field}}, {{vars.X}}, and {{inputs.X}} in
+        // string-typed inputs so first-class node types like file-write
+        // can template path/content from upstream output and inputs.
+        const vars = deps.variablesStore ? deps.variablesStore.getAll() : {};
+        const resolvedInputs = options.inputs ?? {};
+        const resolveStr = (s: string): string =>
+          substituteInputs(
+            resolveVarsTemplate(resolveUpstreamTemplate(s, upstreamSnapshot), vars),
+            resolvedInputs,
+          );
+        const rawInputs = {
           ...(builtinEntry.definition.config ?? {}),
           ...resolveToolInputs(node, upstreamSnapshot),
           ...(node.action ? { _action: node.action } : {}),
         };
+        const toolInputs: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(rawInputs)) {
+          toolInputs[k] = typeof v === 'string' ? resolveStr(v) : v;
+        }
         const ctx: BuiltinToolContext = {
           workingDirectory: node.workingDirectory,
           env,

--- a/packages/core/src/node-catalog.test.ts
+++ b/packages/core/src/node-catalog.test.ts
@@ -8,6 +8,7 @@ import type { NodeType } from './agent-v2-types.js';
 const ALL_NODE_TYPES: NodeType[] = [
   'shell',
   'claude-code',
+  'file-write',
   'conditional',
   'switch',
   'loop',

--- a/packages/core/src/node-catalog.ts
+++ b/packages/core/src/node-catalog.ts
@@ -111,6 +111,36 @@ export const NODE_CATALOG: Record<NodeType, NodeContract> = {
   timeout: 60`,
   },
 
+  'file-write': {
+    type: 'file-write',
+    description: 'Write content to a file in the working directory. Optionally append. Sandbox: paths cannot escape via "..".',
+    inputs: [
+      { name: 'path', type: 'string', required: true, description: 'Relative path within the working directory. May template {{inputs.X}}.' },
+      { name: 'content', type: 'string', required: true, description: 'Content to write. May template {{upstream.<id>.result}} / {{upstream.<id>.<field>}} / {{inputs.X}}.' },
+      { name: 'append', type: 'boolean', description: 'When true, append to the file instead of overwriting. Default false.' },
+      { name: 'workingDirectory', type: 'string', description: 'Override the working directory the path resolves against (defaults to project root).' },
+      { name: 'dependsOn', type: 'string[]', description: 'Upstream node ids this node waits on.' },
+      { name: 'onlyIf', type: 'OnlyIfCondition', description: 'Per-edge predicate.' },
+    ],
+    outputs: [
+      { name: 'path', type: 'string', description: 'Resolved file path.' },
+      { name: 'bytes', type: 'number', description: 'Bytes written.' },
+      { name: 'append', type: 'boolean', description: 'Whether the write was an append.' },
+      { name: 'result', type: 'string', description: 'Resolved file path (alias of `path`).' },
+    ],
+    use_when: [
+      'You need to write a file as part of the DAG. Cleaner than `type: shell` with a heredoc + redirect.',
+      'The content comes from an upstream output you want to template directly into the file.',
+      'You want the executor to handle path safety (the sandbox prevents `../` escape) instead of trusting shell quoting.',
+      'For appending across runs (e.g. a daily log), set append: true.',
+    ],
+    example: `- id: save
+  type: file-write
+  dependsOn: [build-summary]
+  path: "output/digest-{{inputs.DATE}}.md"
+  content: "{{upstream.build-summary.result}}"`,
+  },
+
   conditional: {
     type: 'conditional',
     description: 'Evaluate a predicate against an upstream output. Emits `matched: true | false` for downstream nodes to branch on via onlyIf.',

--- a/packages/core/src/tool-dispatch.test.ts
+++ b/packages/core/src/tool-dispatch.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { resolveToolId, resolveToolInputs } from './tool-dispatch.js';
+import type { AgentNode } from './agent-v2-types.js';
+
+function node(overrides: Partial<AgentNode>): AgentNode {
+  return { id: 'x', type: 'shell', ...overrides } as AgentNode;
+}
+
+describe('resolveToolId', () => {
+  it('returns explicit tool: when set', () => {
+    expect(resolveToolId(node({ tool: 'http-get' }))).toBe('http-get');
+  });
+
+  it('desugars type: file-write to the file-write tool', () => {
+    expect(resolveToolId(node({ type: 'file-write' }))).toBe('file-write');
+  });
+
+  it('returns undefined for plain shell/claude-code (legacy spawn path)', () => {
+    expect(resolveToolId(node({ type: 'shell', command: 'echo' }))).toBeUndefined();
+    expect(resolveToolId(node({ type: 'claude-code', prompt: 'hi' }))).toBeUndefined();
+  });
+
+  it('returns undefined for control-flow node types', () => {
+    expect(resolveToolId(node({ type: 'conditional' }))).toBeUndefined();
+    expect(resolveToolId(node({ type: 'branch' }))).toBeUndefined();
+  });
+
+  it('explicit tool: wins over file-write desugaring', () => {
+    // edge case: someone sets both type: file-write AND tool: my-custom
+    expect(resolveToolId(node({ type: 'file-write', tool: 'custom-writer' }))).toBe('custom-writer');
+  });
+});
+
+describe('resolveToolInputs', () => {
+  it('passes through toolInputs when set', () => {
+    expect(resolveToolInputs(node({ toolInputs: { url: 'https://x.com' } }), {}))
+      .toEqual({ url: 'https://x.com' });
+  });
+
+  it('folds shell command into toolInputs.command', () => {
+    expect(resolveToolInputs(node({ type: 'shell', command: 'echo hi' }), {}))
+      .toEqual({ command: 'echo hi' });
+  });
+
+  it('folds claude-code fields into toolInputs', () => {
+    expect(resolveToolInputs(node({
+      type: 'claude-code', prompt: 'p', model: 'm', maxTurns: 3, allowedTools: ['x'],
+    }), {})).toEqual({ prompt: 'p', model: 'm', maxTurns: 3, allowedTools: ['x'] });
+  });
+
+  it('desugars file-write top-level path/content/append', () => {
+    expect(resolveToolInputs(node({
+      type: 'file-write', path: 'out.md', content: 'hi', append: true,
+    }), {})).toEqual({ path: 'out.md', content: 'hi', append: true });
+  });
+
+  it('omits append when not specified on file-write', () => {
+    expect(resolveToolInputs(node({
+      type: 'file-write', path: 'out.md', content: 'hi',
+    }), {})).toEqual({ path: 'out.md', content: 'hi' });
+  });
+});

--- a/packages/core/src/tool-dispatch.ts
+++ b/packages/core/src/tool-dispatch.ts
@@ -6,18 +6,23 @@
 import type { AgentNode } from './agent-v2-types.js';
 
 /**
- * Derive the tool id for a node. Only nodes that explicitly set `tool:`
- * go through the tool dispatch path. v0.15 nodes without `tool:` use
- * the existing spawn path directly.
+ * Derive the tool id for a node. Nodes that explicitly set `tool:` use
+ * that. Nodes with first-class types that have a built-in tool counterpart
+ * (currently only `file-write`) auto-resolve. v0.15 nodes (`shell` /
+ * `claude-code`) without `tool:` use the existing spawn path directly.
  */
 export function resolveToolId(node: AgentNode): string | undefined {
-  return node.tool;
+  if (node.tool) return node.tool;
+  if (node.type === 'file-write') return 'file-write';
+  return undefined;
 }
 
 /**
  * Build the inputs map for a tool invocation. For v0.16 nodes with
- * `toolInputs:`, use those directly. For v0.15 nodes, fold the inline
- * `command` / `prompt` into the shape the built-in tool expects.
+ * `toolInputs:`, use those directly. For first-class nodes with their own
+ * top-level fields (file-write's path/content/append), desugar those.
+ * For v0.15 nodes, fold the inline `command` / `prompt` into the shape the
+ * built-in tool expects.
  */
 export function resolveToolInputs(
   node: AgentNode,
@@ -33,6 +38,13 @@ export function resolveToolInputs(
       model: node.model,
       maxTurns: node.maxTurns,
       allowedTools: node.allowedTools,
+    };
+  }
+  if (node.type === 'file-write') {
+    return {
+      path: node.path,
+      content: node.content,
+      ...(node.append !== undefined ? { append: node.append } : {}),
     };
   }
   return {};


### PR DESCRIPTION
## Summary

PR C from the Bridge plan. Promotes \`file-write\` from a tool you invoke via \`type: shell\` + \`tool: file-write\` + \`toolInputs:\` to a first-class node type with top-level fields:

\`\`\`yaml
- id: save
  type: file-write
  dependsOn: [summary]
  path: "out/digest.md"
  content: "{{upstream.summary.result}}"
  append: false  # optional; default false
\`\`\`

Surfaced by the dogfood (Bug 7 — invented node types): agent-builder consistently reaches for \`type: file-write\` because it's the natural shape. Promoting it makes the LLM's intuition correct and keeps YAML readable.

## Implementation notes

- **No new executor branch.** Top-level \`path\`/\`content\`/\`append\` desugar to \`tool: 'file-write'\` + \`toolInputs: { path, content, append }\` via small \`resolveToolId\` / \`resolveToolInputs\` extensions in [tool-dispatch.ts](packages/core/src/tool-dispatch.ts).
- **\`append:\` added** to the existing file-write tool (\`flag: 'a'\` when true).
- **Schema enforces** \`path\` + \`content\` required when \`type: file-write\`. Upstream template references in \`path\`/\`content\` validated against \`dependsOn\` (same rule as shell/claude-code).
- **Built-in tool dispatch now resolves \`{{upstream.X.field}}\`, \`{{vars.X}}\`, and \`{{inputs.X}}\`** in string-typed tool inputs — previously only MCP tools had this. Without it, file-write's \`content:\` couldn't reference upstream output, defeating the feature's purpose. Affects every built-in tool that takes string inputs.
- **Capabilities derivation** (PR A.6) recognises \`file-write\` nodes → \`tools_used: file-write\`, \`side_effects: writes_files\`.
- **Node catalog** (PR A.7) gets a new entry. The forcing-function test fails until \`NODE_CATALOG\` has an entry for every \`NodeType\` enum value, so future additions can't silently skip the catalog.

## Test plan

- [x] **End-to-end smoke**: \`file-write-smoke\` agent (gather → file-write) installed, ran, wrote resolved file at \`data/file-write-output.txt\`, sandbox correctly rejected an absolute-path escape attempt with a clear error.
- [x] 4 new file-write tool tests (overwrite, second-write overwrite, append, sandbox escape rejection)
- [x] 6 new schema tests (path+content required, append, upstream templating, missing path/content rejection, dependsOn enforcement)
- [x] 1 new capability test
- [x] 10 new tool-dispatch tests (explicit tool wins, file-write desugaring, control-flow returns undefined)
- [x] Catalog completeness test now requires file-write entry
- [x] \`npm run build\` clean
- [x] \`npm test\` — 862 tests pass (was 841)

🤖 Generated with [Claude Code](https://claude.com/claude-code)