### PR TITLE
feat(core): $STATE_DIR primitive for stateful agents

### DIFF
--- a/.changeset/state-dir-primitive.md
+++ b/.changeset/state-dir-primitive.md
@@ -1,0 +1,40 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+`$STATE_DIR` primitive for stateful agents.
+
+Agents that need to persist data across runs (diff-over-time, caches, last-fired markers) get a per-agent directory at `data/agent-state/<agent-id>/`. Created lazily on first use, chmod 0o700, removed automatically when the agent is deleted.
+
+Available as:
+- `$STATE_DIR` env var in shell nodes (and as a string in any built-in tool input)
+- `{{state}}` template token in claude-code prompts and built-in tool inputs (e.g. `file-write`'s `path:`)
+
+```yaml
+nodes:
+  - id: diff
+    type: shell
+    command: |
+      mkdir -p "$STATE_DIR"
+      PREV="$STATE_DIR/last-readme.md"
+      NEW="$STATE_DIR/current-readme.md"
+      echo "$UPSTREAM_FETCH_RESULT" > "$NEW"
+      if [ -f "$PREV" ] && ! diff -q "$PREV" "$NEW" > /dev/null; then
+        echo '{"changed":true}'
+      fi
+      cp "$NEW" "$PREV"
+```
+
+Promotes the convention agents had been inventing by hand (`.sua/state/<id>/`) into a first-class primitive. Surfaced by Round 2 dogfood Bug 8: the README diff agent invented its own state convention, and downstream agents would each invent a different one.
+
+**Cascading delete**: `agentStore.deleteAgent(id)` now also removes `data/agent-state/<id>/`. Idempotent (no-op when the dir was never created). State is **not** swept by the run-retention timer — it persists until the agent is deleted.
+
+**New `DagExecutorDeps.dataRoot`**: optional. When set, the executor exposes the state dir; when absent, `$STATE_DIR` is unset and `{{state}}` resolves to empty string. Tests and one-shot CLI runs typically omit it. Production paths (dashboard run-now / build / replay / widget-run, `sua workflow run` / `replay`) thread it through automatically.
+
+**Known limitation**: `sua schedule start` uses the v1 chain executor (via `LocalProvider`), not the DAG executor — scheduled agents going through that path don't get `$STATE_DIR` yet. The migration to the v2 path will pick this up.
+
+Sandbox: agent ids are validated against the lowercase+hyphens regex before path resolution; `removeStateDir` re-checks for defense in depth.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -178,6 +178,38 @@ You are on the hook for:
 5. **Lock down the repo.** Enable "Require review from Code Owners" on your `main` branch ruleset if you are running a multi-contributor fork. `.github/CODEOWNERS` is inert until you do.
 6. **Keep secrets out of agent output.** Don't `echo $SECRET`. Set `redactSecrets: true` on agents that call third-party APIs whose responses might contain tokens.
 
+## Future security work
+
+Items below are known gaps with explicit threat-model framing. Each says what it would defend against and why it's not in scope today. Tracked here so security planning is honest about what we have vs what we'd want.
+
+### Subprocess filesystem sandbox
+
+**What it would defend against**: a community-shell agent (or an LLM-generated agent saved without close inspection) reading or writing arbitrary paths outside its declared inputs. Today, shell nodes inherit the working directory and can `cat /etc/passwd`, `rm -rf $HOME/anything`, etc. — anything the OS user running sua can do.
+
+**Why not now**: requires platform-specific subprocess sandboxing — `chroot` (Linux, root needed) or `firejail` / `bubblewrap` (Linux, package install) or `sandbox-exec` (macOS, deprecated by Apple, no Windows equivalent). Each has different failure modes and capability surfaces. Multi-day cross-platform effort. Stays on the long list until we either (a) have a concrete attack we're trying to prevent or (b) ship a v1 hosted offering where the trust boundary changes.
+
+### State directory encryption at rest
+
+**What it would defend against**: an attacker with read access to `data/agent-state/<id>/` (e.g. via a separate compromise that landed disk-read-only) recovering plaintext intermediate artifacts an agent persisted across runs (cached API responses, diff snapshots, last-fired timestamps). Today, state is plain files chmod 0o700.
+
+**Why not now**: the existing secrets KEK (PR v0.10) is the obvious candidate to reuse — wrap state writes through the same `data/secrets.enc`-style envelope. The complication is that agents read state via raw filesystem APIs (`cat`, `jq`, `read -r`), not through a sua API. Encrypting state means either (a) injecting a decrypt shim into every shell node — fragile — or (b) FUSE-mounting an encrypted volume — heavyweight, platform-specific. Neither lands in a single PR. **Today's mitigation**: docs warn against putting secrets in state.
+
+### Sibling state-dir prevention
+
+**What it would defend against**: an agent reading another agent's state via `$STATE_DIR/../other-agent/`. Today the regex on agent ids prevents `..` *injection*, but `$STATE_DIR/../` is a literal valid path the agent can compose itself.
+
+**Why not now**: cheap defense-in-depth (symlink `$STATE_DIR` to a randomized location inside `data/agent-state/`, breaking `..` traversal) but it breaks any agent that hardcodes the path elsewhere or shares state intentionally between two agents owned by the same operator. Trade-off worth thinking about before shipping. Also: the same OS user can already read everything under `data/` directly, so this only buys defense against accidental cross-agent reads, not malicious ones.
+
+### Read-only state for community agents
+
+**What it would defend against**: an installed community agent filling your disk by appending to a state file forever, or persisting telemetry / fingerprints across runs. Today community agents get full read-write state access, same as local agents.
+
+**Why not now**: requires a per-agent capability flag in the executor and a clean error when the cap is hit. Useful but the simpler mitigation (the per-agent size cap planned in PR D.1) covers the disk-fill case. Telemetry persistence is a real privacy concern with no good answer except "don't install community agents you don't trust" — same posture as the existing community-shell gate.
+
+### Tracking
+
+These items live on [ROADMAP.md](../ROADMAP.md) under "Security audit follow-through" but the threat-model framing here is the source of truth. Promote out as concrete PRs are scheduled.
+
 ## Reporting vulnerabilities
 
 Do not open a public GitHub issue for a security report.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -64,6 +64,46 @@ inputs:
 
 Names must match `[A-Z_][A-Z0-9_]*` (uppercase letters, digits, underscores). The dashboard renders inputs in its Run modal: text fields for string/number, toggles for boolean, dropdowns for enum.
 
+## Persistent state — `$STATE_DIR` and `{{state}}`
+
+Agents that need to persist data across runs (diff-over-time, caches, last-fired markers) get a per-agent directory at `data/agent-state/<agent-id>/`. Created lazily on first use, chmod 0o700, removed automatically when the agent is deleted.
+
+Available as:
+- **`$STATE_DIR`** env var in shell nodes (and as a top-level template variable in built-in tool inputs)
+- **`{{state}}`** template token in claude-code prompts and built-in tool inputs (e.g. `file-write`'s `path:`)
+
+Example — README change watcher:
+
+```yaml
+nodes:
+  - id: fetch
+    type: shell
+    command: |
+      curl -sf "https://api.github.com/repos/$REPO/readme" | jq -r '.content' | base64 -d
+  - id: diff
+    type: shell
+    dependsOn: [fetch]
+    command: |
+      mkdir -p "$STATE_DIR"
+      PREV="$STATE_DIR/last-readme.md"
+      NEW="$STATE_DIR/current-readme.md"
+      echo "$UPSTREAM_FETCH_RESULT" > "$NEW"
+      if [ -f "$PREV" ]; then
+        if ! diff -q "$PREV" "$NEW" > /dev/null; then
+          echo '{"changed":true,"diff":"'"$(diff "$PREV" "$NEW" | head -20 | base64)"'"}'
+        else
+          echo '{"changed":false}'
+        fi
+      else
+        echo '{"changed":false,"first_run":true}'
+      fi
+      cp "$NEW" "$PREV"
+```
+
+State is **not** swept by run retention — it persists until the agent is deleted. Don't put secrets in there; the dir lives on disk in plain text.
+
+Currently available to: dashboard runs, `sua workflow run`, `sua workflow replay`. **Not yet available** to scheduled agents going through `sua schedule start` (uses the v1 chain executor; will be wired in a follow-up).
+
 ## `outputs`
 
 Author-declared shape of the agent's final-node JSON result. Optional but recommended — used by the planner for cross-agent composition (`agent-invoke` chaining) and by the widget editor for field-name suggestions.

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -303,8 +303,10 @@ workflowCommand
         {
           runStore: stores.runs,
           secretsStore,
+          agentStore: stores.agents,
           allowUntrustedShell: new Set(options.allowUntrustedShell),
           dashboardBaseUrl: getDashboardBaseUrl(config),
+          dataRoot: stores.agents.dataRoot,
         },
       );
       if (run.status === 'completed') {
@@ -533,8 +535,10 @@ workflowCommand
         {
           runStore: stores.runs,
           secretsStore,
+          agentStore: stores.agents,
           allowUntrustedShell: new Set(options.allowUntrustedShell),
           dashboardBaseUrl: getDashboardBaseUrl(config),
+          dataRoot: stores.agents.dataRoot,
         },
       );
       if (replay.status === 'completed') {

--- a/packages/core/src/agent-state.test.ts
+++ b/packages/core/src/agent-state.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, statSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { stateDirFor, ensureStateDir, removeStateDir } from './agent-state.js';
+
+describe('agent-state', () => {
+  let dataRoot: string;
+  beforeEach(() => { dataRoot = mkdtempSync(join(tmpdir(), 'sua-state-')); });
+  afterEach(() => { rmSync(dataRoot, { recursive: true, force: true }); });
+
+  describe('stateDirFor', () => {
+    it('returns <dataRoot>/agent-state/<id>', () => {
+      const dir = stateDirFor('hn-digest', dataRoot);
+      expect(dir).toBe(join(dataRoot, 'agent-state', 'hn-digest'));
+    });
+
+    it('rejects unsafe agent ids (path traversal defense)', () => {
+      expect(() => stateDirFor('../escape', dataRoot)).toThrow(/unsafe agent id/);
+      expect(() => stateDirFor('a/b', dataRoot)).toThrow(/unsafe agent id/);
+      expect(() => stateDirFor('UPPER', dataRoot)).toThrow(/unsafe agent id/);
+      expect(() => stateDirFor('', dataRoot)).toThrow(/unsafe agent id/);
+    });
+
+    it('does not create the directory', () => {
+      const dir = stateDirFor('never-touched', dataRoot);
+      expect(existsSync(dir)).toBe(false);
+    });
+  });
+
+  describe('ensureStateDir', () => {
+    it('creates the directory and chmod 0o700', () => {
+      const dir = ensureStateDir('my-agent', dataRoot);
+      expect(existsSync(dir)).toBe(true);
+      // Permission check is best-effort across platforms; only assert when supported.
+      if (process.platform !== 'win32') {
+        const mode = statSync(dir).mode & 0o777;
+        expect(mode).toBe(0o700);
+      }
+    });
+
+    it('is idempotent — second call doesn\'t throw or wipe contents', () => {
+      const dir = ensureStateDir('persist-test', dataRoot);
+      writeFileSync(join(dir, 'state.json'), '{"count":1}');
+      ensureStateDir('persist-test', dataRoot); // second call
+      expect(readFileSync(join(dir, 'state.json'), 'utf-8')).toBe('{"count":1}');
+    });
+
+    it('creates parent agent-state/ dir lazily', () => {
+      ensureStateDir('first', dataRoot);
+      expect(existsSync(join(dataRoot, 'agent-state'))).toBe(true);
+      ensureStateDir('second', dataRoot);
+      expect(existsSync(join(dataRoot, 'agent-state', 'first'))).toBe(true);
+      expect(existsSync(join(dataRoot, 'agent-state', 'second'))).toBe(true);
+    });
+  });
+
+  describe('removeStateDir', () => {
+    it('removes the directory and all contents', () => {
+      const dir = ensureStateDir('to-delete', dataRoot);
+      writeFileSync(join(dir, 'state.json'), '{}');
+      removeStateDir('to-delete', dataRoot);
+      expect(existsSync(dir)).toBe(false);
+    });
+
+    it('is idempotent — silently no-ops when the dir doesn\'t exist', () => {
+      expect(() => removeStateDir('never-created', dataRoot)).not.toThrow();
+    });
+
+    it('rejects unsafe ids before touching the filesystem', () => {
+      expect(() => removeStateDir('../etc', dataRoot)).toThrow(/unsafe agent id/);
+    });
+  });
+
+  it('persists state across simulated runs', () => {
+    // Run 1: write state
+    const dir1 = ensureStateDir('cross-run', dataRoot);
+    writeFileSync(join(dir1, 'last-fired.txt'), '2026-01-01');
+
+    // Run 2: read state (same agent, same dataRoot)
+    const dir2 = ensureStateDir('cross-run', dataRoot);
+    expect(dir1).toBe(dir2);
+    expect(readFileSync(join(dir2, 'last-fired.txt'), 'utf-8')).toBe('2026-01-01');
+  });
+});
+
+describe('STATE_DIR env-var integration via buildNodeEnv', () => {
+  let dataRoot: string;
+  beforeEach(() => { dataRoot = mkdtempSync(join(tmpdir(), 'sua-state-env-')); });
+  afterEach(() => { rmSync(dataRoot, { recursive: true, force: true }); });
+
+  it('sets STATE_DIR in env when deps.dataRoot is configured', async () => {
+    const { buildNodeEnv } = await import('./node-env.js');
+    const agent = {
+      id: 'env-test',
+      name: 'env-test',
+      status: 'active' as const,
+      source: 'local' as const,
+      mcp: false,
+      version: 1,
+      nodes: [{ id: 'main', type: 'shell' as const, command: 'echo hi' }],
+    };
+    const env = await buildNodeEnv(
+      agent,
+      agent.nodes[0],
+      {},
+      {},
+      { runStore: { } as never, dataRoot },
+    );
+    expect(env.STATE_DIR).toBe(stateDirFor('env-test', dataRoot));
+    expect(existsSync(env.STATE_DIR)).toBe(true);
+  });
+
+  it('omits STATE_DIR when deps.dataRoot is absent', async () => {
+    const { buildNodeEnv } = await import('./node-env.js');
+    const agent = {
+      id: 'no-state',
+      name: 'no-state',
+      status: 'active' as const,
+      source: 'local' as const,
+      mcp: false,
+      version: 1,
+      nodes: [{ id: 'main', type: 'shell' as const, command: 'echo hi' }],
+    };
+    const env = await buildNodeEnv(
+      agent,
+      agent.nodes[0],
+      {},
+      {},
+      { runStore: { } as never },
+    );
+    expect(env.STATE_DIR).toBeUndefined();
+  });
+});
+
+describe('resolveStateTemplate', () => {
+  // co-located test for the template helper since it's tightly coupled
+  // to the agent-state primitive
+  it('replaces {{state}} with the dir path', async () => {
+    const { resolveStateTemplate } = await import('./node-templates.js');
+    expect(resolveStateTemplate('cat {{state}}/log.txt', '/data/agent-state/x'))
+      .toBe('cat /data/agent-state/x/log.txt');
+  });
+
+  it('replaces with empty string when stateDir is undefined', async () => {
+    const { resolveStateTemplate } = await import('./node-templates.js');
+    expect(resolveStateTemplate('cat {{state}}/log.txt', undefined))
+      .toBe('cat /log.txt');
+  });
+
+  it('handles multiple references in one string', async () => {
+    const { resolveStateTemplate } = await import('./node-templates.js');
+    expect(resolveStateTemplate('{{state}}/a {{state}}/b', '/x'))
+      .toBe('/x/a /x/b');
+  });
+
+  it('leaves text without {{state}} untouched', async () => {
+    const { resolveStateTemplate } = await import('./node-templates.js');
+    expect(resolveStateTemplate('no template here', '/x')).toBe('no template here');
+  });
+});

--- a/packages/core/src/agent-state.ts
+++ b/packages/core/src/agent-state.ts
@@ -1,0 +1,44 @@
+/**
+ * Per-agent state directory. Lazily created at `<dataRoot>/agent-state/<id>/`,
+ * chmod 0o700 (owner-only). Promotes the convention agents had to invent
+ * by hand into a first-class primitive available as `$STATE_DIR` for
+ * shell nodes and `{{state}}` for claude-code prompts.
+ *
+ * Lifecycle:
+ *   - Created on first run that touches `ensureStateDir`.
+ *   - Persists across runs (the whole point — diff-over-time agents need it).
+ *   - Removed when the agent is deleted via `agentStore.deleteAgent`.
+ *   - NOT swept by the run-retention timer; state outlives runs.
+ *
+ * Sandboxing: the agent id is regex-validated by the schema
+ * (lowercase + hyphens), but we re-check here as defense in depth so a
+ * caller can't traverse via "../" if validation is ever bypassed.
+ */
+
+import { join, resolve } from 'node:path';
+import { rmSync } from 'node:fs';
+import { ensureDir, chmod0700Safe } from './fs-utils.js';
+
+const SAFE_AGENT_ID = /^[a-z0-9][a-z0-9-]*$/;
+
+/** Resolve the state directory path for an agent. Does not touch disk. */
+export function stateDirFor(agentId: string, dataRoot: string): string {
+  if (!SAFE_AGENT_ID.test(agentId)) {
+    throw new Error(`Refusing to compute state dir for unsafe agent id: ${agentId}`);
+  }
+  return resolve(join(dataRoot, 'agent-state', agentId));
+}
+
+/** Create the state directory if it doesn't exist; chmod 0o700. Returns the path. */
+export function ensureStateDir(agentId: string, dataRoot: string): string {
+  const dir = stateDirFor(agentId, dataRoot);
+  ensureDir(dir);
+  chmod0700Safe(dir);
+  return dir;
+}
+
+/** Remove an agent's state directory and everything in it. Idempotent. */
+export function removeStateDir(agentId: string, dataRoot: string): void {
+  const dir = stateDirFor(agentId, dataRoot);
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/packages/core/src/agent-store.test.ts
+++ b/packages/core/src/agent-store.test.ts
@@ -245,6 +245,26 @@ describe('AgentStore.deleteAgent', () => {
     expect(store.getAgent('hello')).toBeNull();
     expect(store.listVersions('hello')).toHaveLength(0);
   });
+
+  it('cascades to remove the agent state directory', async () => {
+    const { ensureStateDir, stateDirFor } = await import('./agent-state.js');
+    const { writeFileSync, existsSync } = await import('node:fs');
+    const { join } = await import('node:path');
+
+    store.createAgent(seed(), 'cli');
+    const stateDir = ensureStateDir('hello', store.dataRoot);
+    writeFileSync(join(stateDir, 'state.json'), '{"x":1}');
+    expect(existsSync(stateDir)).toBe(true);
+
+    store.deleteAgent('hello');
+
+    expect(existsSync(stateDirFor('hello', store.dataRoot))).toBe(false);
+  });
+
+  it('does not throw when no state dir exists', () => {
+    store.createAgent(seed(), 'cli');
+    expect(() => store.deleteAgent('hello')).not.toThrow();
+  });
 });
 
 describe('AgentStore.fromHandle — shared connection with RunStore', () => {

--- a/packages/core/src/agent-store.ts
+++ b/packages/core/src/agent-store.ts
@@ -2,6 +2,7 @@ import { DatabaseSync } from 'node:sqlite';
 import { mkdirSync, existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { chmod600Safe } from './fs-utils.js';
+import { removeStateDir } from './agent-state.js';
 import type {
   Agent,
   AgentNode,
@@ -36,6 +37,8 @@ type SqlValue = string | number | null | bigint | Uint8Array;
 export class AgentStore {
   private db: DatabaseSync;
   private readonly ownsConnection: boolean;
+  /** Base data dir (parent of the sqlite file). Used for cascading state-dir cleanup on delete. */
+  public readonly dataRoot: string;
 
   constructor(dbPath: string) {
     const dir = dirname(dbPath);
@@ -45,6 +48,7 @@ export class AgentStore {
     this.db = new DatabaseSync(dbPath);
     this.ownsConnection = true;
     chmod600Safe(dbPath);
+    this.dataRoot = dir;
     this.ensureSchema();
   }
 
@@ -333,6 +337,15 @@ export class AgentStore {
       );
     }
     this.db.prepare(`DELETE FROM agents WHERE id = ?`).run(id);
+    // Cascade: remove the agent's persistent state directory if it exists.
+    // Idempotent — no-op when the dir was never created.
+    try {
+      removeStateDir(id, this.dataRoot);
+    } catch {
+      // Defense-in-depth: a malformed id would have failed the DELETE above,
+      // and removeStateDir's regex check would also reject it. Swallow any
+      // residual failure here so a successful delete doesn't roll back.
+    }
   }
 
   close(): void {

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -31,8 +31,9 @@ import type { ToolOutput, BuiltinToolContext } from './tool-types.js';
 import { getBuiltinTool } from './builtin-tools.js';
 import { buildToolOutput } from './output-framing.js';
 import { callMcpTool } from './mcp-client.js';
-import { resolveUpstreamTemplate, resolveVarsTemplate } from './node-templates.js';
+import { resolveUpstreamTemplate, resolveVarsTemplate, resolveStateTemplate } from './node-templates.js';
 import { substituteInputs } from './input-resolver.js';
+import { stateDirFor } from './agent-state.js';
 import { UntrustedCommunityShellError } from './agent-executor.js';
 import { buildNodeEnv, buildUpstreamSnapshot, filterEnvForLog } from './node-env.js';
 import { type SpawnResult, type SpawnNodeFn, type SpawnProgress, spawnNodeReal } from './node-spawner.js';
@@ -98,6 +99,17 @@ export interface DagExecutorDeps {
   notifyFetch?: typeof fetch;
   /** Logger for notify handler failures. Defaults to console.warn. */
   notifyLogger?: NotifyLogger;
+  /**
+   * Base directory for sua's persistent data (usually `dirname(dbPath)`).
+   * When set, the executor:
+   *   - creates `<dataRoot>/agent-state/<agent-id>/` lazily on first use
+   *   - exposes its path as `$STATE_DIR` (shell) and `{{state}}` (templates)
+   *     so agents can persist data across runs (e.g. diff-over-time, caches).
+   * When absent, the state-dir features are simply unavailable —
+   * `$STATE_DIR` is unset and `{{state}}` resolves to empty string. Tests
+   * and one-shot CLI runs typically omit it.
+   */
+  dataRoot?: string;
 }
 
 export interface DagExecuteOptions {
@@ -617,14 +629,19 @@ export async function executeAgentDag(
         // Built-in tool: call execute() directly, no child process.
         // Merge tool-level config (project defaults) with per-invocation
         // inputs so the user doesn't repeat common values every node.
-        // Resolve {{upstream.X.field}}, {{vars.X}}, and {{inputs.X}} in
-        // string-typed inputs so first-class node types like file-write
-        // can template path/content from upstream output and inputs.
+        // Resolve {{upstream.X.field}}, {{vars.X}}, {{state}}, and
+        // {{inputs.X}} in string-typed inputs so first-class node types
+        // like file-write can template path/content from upstream
+        // output, inputs, and the per-agent state directory.
         const vars = deps.variablesStore ? deps.variablesStore.getAll() : {};
         const resolvedInputs = options.inputs ?? {};
+        const stateDir = deps.dataRoot ? stateDirFor(agent.id, deps.dataRoot) : undefined;
         const resolveStr = (s: string): string =>
           substituteInputs(
-            resolveVarsTemplate(resolveUpstreamTemplate(s, upstreamSnapshot), vars),
+            resolveStateTemplate(
+              resolveVarsTemplate(resolveUpstreamTemplate(s, upstreamSnapshot), vars),
+              stateDir,
+            ),
             resolvedInputs,
           );
         const rawInputs = {

--- a/packages/core/src/fs-utils.ts
+++ b/packages/core/src/fs-utils.ts
@@ -22,3 +22,24 @@ export function ensureParentDir(path: string): void {
     mkdirSync(dir, { recursive: true });
   }
 }
+
+/**
+ * Best-effort chmod 0o700 (rwx-only-for-owner) on a directory. Same
+ * silent-no-op posture as `chmod600Safe` for filesystems without POSIX
+ * permission support (Windows, some network mounts). Used for per-agent
+ * state directories that may hold sensitive intermediate artifacts.
+ */
+export function chmod0700Safe(path: string): void {
+  try {
+    chmodSync(path, 0o700);
+  } catch {
+    // Intentional: filesystem doesn't support POSIX perms.
+  }
+}
+
+/** Ensure a directory exists (mkdir -p). */
+export function ensureDir(path: string): void {
+  if (!existsSync(path)) {
+    mkdirSync(path, { recursive: true });
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,7 @@ export * from './daemon-supervisor.js';
 export * from './agent-v2-types.js';
 export * from './agent-capabilities.js';
 export * from './node-catalog.js';
+export * from './agent-state.js';
 export * from './output-widget-types.js';
 export { outputWidgetSchema } from './output-widget-schema.js';
 export {

--- a/packages/core/src/node-env.ts
+++ b/packages/core/src/node-env.ts
@@ -9,6 +9,7 @@ import type { DagExecutorDeps } from './dag-executor.js';
 import { resolveUpstreamTemplate, resolveVarsTemplate } from './node-templates.js';
 import { substituteInputs, SENSITIVE_ENV_NAMES } from './input-resolver.js';
 import { looksLikeSensitive } from './variables-store.js';
+import { ensureStateDir } from './agent-state.js';
 
 // ── Allowlists ─────────────────────────────────────────────────────────
 
@@ -60,6 +61,13 @@ export async function buildNodeEnv(
       if (deps.variablesStore) resolved = resolveVarsTemplate(resolved, deps.variablesStore.getAll());
       env[k] = substituteInputs(resolved, mergedInputs(agent, callerInputs));
     }
+  }
+
+  // 3.5: STATE_DIR. Lazy-created per-agent dir for persistent state across
+  // runs (diff-over-time, caches, last-fired markers). Available to shell as
+  // $STATE_DIR; claude-code prompts and built-in tool inputs use {{state}}.
+  if (deps.dataRoot) {
+    env.STATE_DIR = ensureStateDir(agent.id, deps.dataRoot);
   }
 
   // 4: secrets. Each node only gets what it declares; never shares across nodes.

--- a/packages/core/src/node-spawner.ts
+++ b/packages/core/src/node-spawner.ts
@@ -12,7 +12,7 @@ import { spawn } from 'node:child_process';
 import type { Agent, AgentNode, NodeErrorCategory } from './agent-v2-types.js';
 import type { ExecutionResult } from './agent-executor.js';
 import { substituteInputs } from './input-resolver.js';
-import { resolveUpstreamTemplate, resolveVarsTemplate } from './node-templates.js';
+import { resolveUpstreamTemplate, resolveVarsTemplate, resolveStateTemplate } from './node-templates.js';
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -224,6 +224,9 @@ export async function spawnNodeReal(
   }
   resolvedPrompt = resolveUpstreamTemplate(resolvedPrompt, upstreamMap);
   resolvedPrompt = resolveVarsTemplate(resolvedPrompt, env);
+  // {{state}} resolves to $STATE_DIR (set by node-env when dataRoot is
+  // configured). Falls through to empty string when unset.
+  resolvedPrompt = resolveStateTemplate(resolvedPrompt, env.STATE_DIR);
   resolvedPrompt = substituteInputs(resolvedPrompt, env);
 
   const spawner = getSpawner(node.provider ?? 'claude');

--- a/packages/core/src/node-templates.ts
+++ b/packages/core/src/node-templates.ts
@@ -66,3 +66,15 @@ export function resolveVarsTemplate(text: string, vars: Record<string, string>):
   }
   return out;
 }
+
+/**
+ * Substitute `{{state}}` with the per-agent state-dir path. When stateDir
+ * is undefined (executor running without dataRoot) the token resolves to
+ * empty string — agents that reference `{{state}}` in those contexts
+ * effectively become broken, but no template error fires; that's the
+ * intended graceful degradation for tests + one-shot CLI runs.
+ */
+export function resolveStateTemplate(text: string, stateDir: string | undefined): string {
+  if (!text.includes('{{state}}')) return text;
+  return text.split('{{state}}').join(stateDir ?? '');
+}

--- a/packages/dashboard/src/routes/run-mutations.ts
+++ b/packages/dashboard/src/routes/run-mutations.ts
@@ -159,8 +159,10 @@ runMutationsRouter.post('/runs/:id/replay', async (req: Request, res: Response) 
     {
       runStore: ctx.runStore,
       secretsStore: ctx.secretsStore,
+      agentStore: ctx.agentStore,
       allowUntrustedShell: ctx.allowUntrustedShell,
       dashboardBaseUrl: ctx.dashboardBaseUrl,
+      dataRoot: ctx.agentStore.dataRoot,
     },
   );
 

--- a/packages/dashboard/src/routes/run-now-build.ts
+++ b/packages/dashboard/src/routes/run-now-build.ts
@@ -324,6 +324,7 @@ buildRouter.post('/agents/:name/analyze', async (req: Request, res: Response) =>
       runStore: ctx.runStore,
       secretsStore: ctx.secretsStore,
       variablesStore: ctx.variablesStore,
+      dataRoot: ctx.agentStore.dataRoot,
     },
   );
 
@@ -522,6 +523,7 @@ Output ONLY the complete fixed YAML. Nothing else.`,
         runStore: ctx.runStore,
         secretsStore: ctx.secretsStore,
         variablesStore: ctx.variablesStore,
+        dataRoot: ctx.agentStore.dataRoot,
       },
     );
 
@@ -635,6 +637,7 @@ buildRouter.post('/agents/build', async (req: Request, res: Response) => {
       runStore: ctx.runStore,
       secretsStore: ctx.secretsStore,
       variablesStore: ctx.variablesStore,
+      dataRoot: ctx.agentStore.dataRoot,
     },
   );
 

--- a/packages/dashboard/src/routes/run-now.ts
+++ b/packages/dashboard/src/routes/run-now.ts
@@ -64,8 +64,10 @@ runNowRouter.post('/agents/:name/run', async (req: Request, res: Response) => {
         secretsStore: ctx.secretsStore,
         variablesStore: ctx.variablesStore,
         toolStore: ctx.toolStore,
+        agentStore: ctx.agentStore,
         allowUntrustedShell: ctx.allowUntrustedShell,
         dashboardBaseUrl: ctx.dashboardBaseUrl,
+        dataRoot: ctx.agentStore.dataRoot,
       },
     );
 

--- a/packages/dashboard/src/routes/widget-run.ts
+++ b/packages/dashboard/src/routes/widget-run.ts
@@ -40,8 +40,10 @@ widgetRunRouter.post('/agents/:name/widget-run', (req: Request, res: Response) =
       secretsStore: ctx.secretsStore,
       variablesStore: ctx.variablesStore,
       toolStore: ctx.toolStore,
+      agentStore: ctx.agentStore,
       allowUntrustedShell: ctx.allowUntrustedShell,
       dashboardBaseUrl: ctx.dashboardBaseUrl,
+      dataRoot: ctx.agentStore.dataRoot,
     },
   );
 


### PR DESCRIPTION
## Summary

PR D from the Bridge plan. Promotes the \`.sua/state/<id>/\` convention agents had been inventing by hand (Round 2 dogfood Bug 8) into a first-class primitive at \`data/agent-state/<id>/\`.

\`\`\`yaml
nodes:
  - id: diff
    type: shell
    command: |
      mkdir -p "\$STATE_DIR"
      PREV="\$STATE_DIR/last-readme.md"
      echo "\$UPSTREAM_FETCH_RESULT" > /tmp/new
      if [ -f "\$PREV" ] && ! diff -q "\$PREV" /tmp/new > /dev/null; then
        echo '{"changed":true}'
      fi
      cp /tmp/new "\$PREV"
\`\`\`

## What's available

- **\`\$STATE_DIR\`** — env var in shell nodes and any built-in tool's string input
- **\`{{state}}\`** — template token in claude-code prompts and string-typed tool inputs (e.g. \`file-write\`'s \`path:\`)

## Lifecycle

- **Lazy creation** on first use (\`mkdir -p\` + \`chmod 0o700\`)
- **Persistent** across runs — diff-over-time, caches, last-fired markers all just work
- **Cascading delete**: \`agentStore.deleteAgent(id)\` removes \`data/agent-state/<id>/\`. Idempotent.
- **Not swept** by the run-retention timer — state outlives runs

## Implementation

- New \`packages/core/src/agent-state.ts\` exports \`stateDirFor\`, \`ensureStateDir\`, \`removeStateDir\`. Agent ids are regex-validated against \`^[a-z0-9][a-z0-9-]*$\` before path resolution; \`removeStateDir\` re-checks for defense in depth.
- New \`DagExecutorDeps.dataRoot\` (optional). When set, the executor exposes the state dir; when absent, \`$STATE_DIR\` is unset and \`{{state}}\` resolves to empty string (graceful degradation for tests + one-shot CLI runs).
- \`AgentStore.dataRoot\` exposed as a public field (= \`dirname(dbPath)\`); production callers thread it as \`dataRoot: ctx.agentStore.dataRoot\`.
- Wired into: dashboard run-now / build / replay / widget-run, plus \`sua workflow run\` / \`replay\`.
- Template wiring: \`resolveStateTemplate\` extends the existing chain in both \`dag-executor.ts\` (built-in tool inputs) and \`node-spawner.ts\` (claude-code prompts).

## Known limit (documented)

\`sua schedule start\` uses the v1 chain executor via \`LocalProvider\`, not the DAG executor. Scheduled agents going through that path don't get \`\$STATE_DIR\` yet — will pick up when the v2 migration completes. Documented in \`docs/agents.md\`.

## Test plan

- [x] 16 new agent-state tests (path resolution, sandbox rejection, idempotent ensure/remove, persistence across runs, env-var integration)
- [x] 2 new agent-store cascade tests (state dir removed on delete, no-throw when absent)
- [x] \`npm run build\` clean
- [x] \`npm test\` — 880 tests pass (was 862)
- [x] **Live smoke**: counter agent (\`echo \$N > \$STATE_DIR/counter.txt\`) ran 3 times against the daemon, counter persisted (1 → 2 → 3), dir was \`drwx------\`, cascade-on-delete removed the dir cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)