### PR TITLE
feat(widgets): interactive controls (replay / field-toggle / view-switch)

### DIFF
--- a/.changeset/widget-controls.md
+++ b/.changeset/widget-controls.md
@@ -1,0 +1,11 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Output widgets gain interactive controls.
+
+Agents can now declare a `controls:` array on `outputWidget` with three control types: `replay` (re-run inline, optionally with tweakable inputs), `field-toggle` (hide/show optional fields), and `view-switch` (tab-style switch between named field subsets — e.g. metric ↔ imperial). State lives in URL query params (`?wv=`, `?wh=`) so refresh resets to defaults and links can be shared. Renders on agent detail and run detail pages; Pulse tiles continue to render statically. The agent-builder prompt and discovery catalog teach the planner when to reach for each control type.

--- a/agents/examples/agent-builder.yaml
+++ b/agents/examples/agent-builder.yaml
@@ -103,6 +103,16 @@ nodes:
           label: Stories
           type: metric
 
+      WIDGET INTERACTION (outputWidget.controls — make widgets feel alive):
+      Add a controls: array on outputWidget when the user might interact with the result. Three control types — replay, field-toggle, view-switch — render as a row above the widget body. State is URL-driven (no client JS). field-toggle and view-switch are NOT supported on ai-template widgets.
+      Per archetype:
+      - Weather / forecast: include all three. replay with inputs:[CITY] for tweaking. view-switch metric ↔ imperial. field-toggle (default: hidden) for optional metrics like uv / sunrise / precip.
+      - Lookup tool / search agent: replay with inputs:[QUERY] so the user can refine the query inline.
+      - Daily digest / news fetcher: replay with no inputs (same-inputs refresh — "fetch latest").
+      - Status dashboard / monitoring: field-toggle (default: hidden) to hide non-critical metrics; consider view-switch if there's a clear "summary" vs "detail" mode.
+      - Build / CI agent: replay only (re-run with the same target).
+      Avoid controls on agents that are purely scheduled and never user-driven. Always reference declared field names — every name in field-toggle.fields[] and view-switch.views[].fields[] must match an outputWidget.fields[].name.
+
       SIGNAL TEMPLATE RULES:
       - signal.template MUST be one of the names listed above (metric, time-series, text-headline, text-image, image, table, status, media, comparison, key-value, story, funnel).
       - signal.title is a literal string. Do NOT use expression syntax like "'Weather: ' + output.city".

--- a/docs/output-widgets.md
+++ b/docs/output-widgets.md
@@ -186,6 +186,53 @@ The editor ships with 5 one-click starter widgets under the **Load example** dro
 
 Pick one, tweak the field names to match your agent, save.
 
+## Interactive controls
+
+Add a `controls:` array on `outputWidget` to render an interactive controls row above the widget body on the agent detail and run detail pages. State lives entirely in URL query params (no client JS), so refresh resets to defaults and links can be shared.
+
+Three control types:
+
+| Type | Purpose | Notes |
+|---|---|---|
+| `replay` | Re-run the agent inline | `inputs: []` (or omitted) = same-inputs replay; `inputs: [NAME]` exposes those agent inputs as inline form fields the user can tweak before re-running |
+| `field-toggle` | Hide/show optional fields via chip toggles | `fields: [NAMES]` must reference declared widget fields; `default: shown` or `hidden` |
+| `view-switch` | Tab-style switch between named subsets of fields | `views: [{id, fields: [...]}]`; `default:` names the active view's id |
+
+Example — weather agent with all three controls:
+
+```yaml
+outputWidget:
+  type: dashboard
+  fields:
+    - { name: temp_c, type: metric }
+    - { name: temp_f, type: metric }
+    - { name: wind, type: stat }
+    - { name: uv, type: text }
+  controls:
+    - type: replay
+      label: Refresh
+      inputs: [CITY]
+    - type: view-switch
+      label: Units
+      default: metric
+      views:
+        - { id: metric, fields: [temp_c, wind] }
+        - { id: imperial, fields: [temp_f, wind] }
+    - type: field-toggle
+      label: Show
+      fields: [uv]
+      default: hidden
+```
+
+URL grammar:
+
+- `?wv=<view-id>` — active view for the `view-switch`. Omitted = default view.
+- `?wh=<csv-of-field-names>` — fields hidden via `field-toggle`. When `?wh=` mentions any toggle field, it's the authoritative hidden set; otherwise per-control `default:` applies.
+
+`field-toggle` and `view-switch` are not supported on `ai-template` widgets — the template author controls layout directly. `replay` works on any widget type.
+
+Controls render only on the agent detail and run detail pages. Pulse tiles render the widget statically — they're too small for inline controls in v1.
+
 ## Pulse integration
 
 To show an agent's widget as a Pulse tile, set the agent's signal to use the `widget` template:

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -361,6 +361,28 @@ export const agentV2Schema = z.object({
     }
   }
 
+  // outputWidget.controls cross-checks that need agent-level data:
+  //   - replay.inputs[] entries must match a declared agent.inputs key
+  //     (intra-widget structural checks live in outputWidgetSchema's
+  //      superRefine).
+  if (data.outputWidget?.controls?.length) {
+    const declaredInputKeys = new Set(Object.keys(data.inputs ?? {}));
+    for (let i = 0; i < data.outputWidget.controls.length; i++) {
+      const c = data.outputWidget.controls[i];
+      if (c.type !== 'replay') continue;
+      for (let j = 0; j < (c.inputs ?? []).length; j++) {
+        const name = c.inputs![j];
+        if (!declaredInputKeys.has(name)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['outputWidget', 'controls', i, 'inputs', j],
+            message: `replay control references input "${name}" which isn't declared in agent.inputs.`,
+          });
+        }
+      }
+    }
+  }
+
   // Per-node template checks:
   //   - {{inputs.X}} refs must map to a declared agent-level input
   //   - {{upstream.Y.result}} refs must be declared in this node's dependsOn

--- a/packages/core/src/discovery-catalog.test.ts
+++ b/packages/core/src/discovery-catalog.test.ts
@@ -161,13 +161,25 @@ describe('buildDiscoveryCatalog', () => {
     expect(catalog).toContain('from:');
   });
 
-  it('stays under 8000 chars with typical data (was 4000 before adding manifest detail)', () => {
+  it('describes WIDGET CONTROLS with all three control types and use-when guidance', () => {
+    const catalog = buildDiscoveryCatalog({ agents: [], tools: [], templateRegistry: {} });
+    expect(catalog).toContain('WIDGET CONTROLS');
+    expect(catalog).toContain('replay');
+    expect(catalog).toContain('field-toggle');
+    expect(catalog).toContain('view-switch');
+    // "Use when" guidance must appear so the planner picks the right control.
+    expect(catalog).toMatch(/USE WHEN.*replay|replay.*USE WHEN/is);
+    expect(catalog).toMatch(/USE WHEN.*field-toggle|field-toggle.*USE WHEN/is);
+    expect(catalog).toMatch(/USE WHEN.*view-switch|view-switch.*USE WHEN/is);
+  });
+
+  it('stays under 10000 chars with typical data (was 4000 before manifest detail; +1000 for widget controls)', () => {
     const catalog = buildDiscoveryCatalog({
       agents: MOCK_AGENTS,
       tools: [],
       templateRegistry: MOCK_REGISTRY,
     });
-    expect(catalog.length).toBeLessThan(8000);
+    expect(catalog.length).toBeLessThan(10000);
   });
 
   it('handles empty agents gracefully', () => {

--- a/packages/core/src/discovery-catalog.ts
+++ b/packages/core/src/discovery-catalog.ts
@@ -66,7 +66,34 @@ Example for a final node that emits {"file":"x.md","count":5}:
       label: Saved to
     - name: count      # reads outputs.count → renders "5"
       type: metric
-      label: Stories`.trim();
+      label: Stories
+
+## WIDGET CONTROLS (outputWidget.controls — interactive UI on the rendered widget)
+Make widgets feel alive. Three control types render as a row above the widget body. State lives in URL query params (no client JS); refresh = default state. NOT supported on ai-template widgets except for "replay".
+- replay: Re-run the agent inline. inputs:[] (or omitted) = same-inputs replay. inputs:[NAME, ...] exposes those agent.inputs as inline form fields so the user can tweak before re-running.
+  USE WHEN: the user might run the agent multiple times — daily reports, lookup tools, on-demand fetchers, weather. Always include unless the agent is purely scheduled and never user-driven.
+- field-toggle: Hide/show optional fields via chip toggles. fields:[NAMES] must reference declared widget fields; default: shown | hidden.
+  USE WHEN: some fields are nice-to-have rather than essential (precipitation, UV, sun times, secondary stats). Default-hidden fields keep the widget compact; the user reveals them with one click.
+- view-switch: Tab-style switch between named subsets of fields. views:[{id, fields:[...]}]; default: <view-id>.
+  USE WHEN: the goal implies multiple modes — today vs week, summary vs detail, metric vs imperial, basic vs advanced. Each view names which declared fields belong to it.
+
+Example controls block (weather agent with all three):
+  controls:
+    - type: replay
+      label: Refresh
+      inputs: [CITY]
+    - type: view-switch
+      label: Units
+      views:
+        - id: metric
+          fields: [temp_c, wind_kph, precip_mm]
+        - id: imperial
+          fields: [temp_f, wind_mph, precip_in]
+      default: metric
+    - type: field-toggle
+      label: Show
+      fields: [uv, sunrise, sunset]
+      default: hidden`.trim();
 
 const PATTERNS = `
 ## ARCHITECTURE PATTERNS

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,7 +26,7 @@ export * from './agent-capabilities.js';
 export * from './node-catalog.js';
 export * from './agent-state.js';
 export * from './output-widget-types.js';
-export { outputWidgetSchema } from './output-widget-schema.js';
+export { outputWidgetSchema, widgetControlSchema, widgetViewSchema } from './output-widget-schema.js';
 export {
   agentV2Schema,
   agentNodeSchema,

--- a/packages/core/src/output-widget-schema.test.ts
+++ b/packages/core/src/output-widget-schema.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import { outputWidgetSchema } from './output-widget-schema.js';
+import { agentV2Schema } from './agent-v2-schema.js';
+import { parseAgent } from './agent-yaml.js';
+import { stringify as stringifyYaml } from 'yaml';
+
+const baseDashboard = {
+  type: 'dashboard' as const,
+  fields: [
+    { name: 'temp_c', type: 'metric' as const },
+    { name: 'temp_f', type: 'metric' as const },
+    { name: 'wind', type: 'stat' as const },
+    { name: 'uv', type: 'text' as const },
+  ],
+};
+
+describe('outputWidgetSchema controls', () => {
+  it('accepts a replay control', () => {
+    const r = outputWidgetSchema.safeParse({
+      ...baseDashboard,
+      controls: [{ type: 'replay', label: 'Refresh', inputs: ['CITY'] }],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts a field-toggle control referencing declared fields', () => {
+    const r = outputWidgetSchema.safeParse({
+      ...baseDashboard,
+      controls: [{ type: 'field-toggle', label: 'Show', fields: ['uv'], default: 'hidden' }],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts a view-switch control', () => {
+    const r = outputWidgetSchema.safeParse({
+      ...baseDashboard,
+      controls: [{
+        type: 'view-switch', label: 'Units', default: 'metric',
+        views: [
+          { id: 'metric', fields: ['temp_c', 'wind'] },
+          { id: 'imperial', fields: ['temp_f', 'wind'] },
+        ],
+      }],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts mixed control types in one widget', () => {
+    const r = outputWidgetSchema.safeParse({
+      ...baseDashboard,
+      controls: [
+        { type: 'replay' },
+        { type: 'view-switch', label: 'Units', default: 'metric',
+          views: [{ id: 'metric', fields: ['temp_c'] }, { id: 'imperial', fields: ['temp_f'] }] },
+        { type: 'field-toggle', label: 'Optional', fields: ['uv'], default: 'hidden' },
+      ],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects field-toggle.fields[] that reference an undeclared widget field', () => {
+    const r = outputWidgetSchema.safeParse({
+      ...baseDashboard,
+      controls: [{ type: 'field-toggle', label: 'Show', fields: ['nonexistent'], default: 'hidden' }],
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.message.includes('nonexistent'))).toBe(true);
+    }
+  });
+
+  it('rejects view-switch.default not in views[].id', () => {
+    const r = outputWidgetSchema.safeParse({
+      ...baseDashboard,
+      controls: [{
+        type: 'view-switch', label: 'Units', default: 'kelvin',
+        views: [{ id: 'metric', fields: ['temp_c'] }],
+      }],
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.message.includes('kelvin'))).toBe(true);
+    }
+  });
+
+  it('rejects empty views[] array', () => {
+    const r = outputWidgetSchema.safeParse({
+      ...baseDashboard,
+      controls: [{ type: 'view-switch', label: 'Units', default: 'metric', views: [] }],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects view-switch.views[].fields[] referencing undeclared widget field', () => {
+    const r = outputWidgetSchema.safeParse({
+      ...baseDashboard,
+      controls: [{
+        type: 'view-switch', label: 'Units', default: 'metric',
+        views: [{ id: 'metric', fields: ['ghost'] }],
+      }],
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.message.includes('ghost'))).toBe(true);
+    }
+  });
+
+  it('rejects field-toggle on ai-template widgets', () => {
+    const r = outputWidgetSchema.safeParse({
+      type: 'ai-template',
+      template: '<div>{{outputs.x}}</div>',
+      controls: [{ type: 'field-toggle', label: 'Show', fields: ['x'], default: 'hidden' }],
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.message.includes('ai-template'))).toBe(true);
+    }
+  });
+
+  it('allows replay on ai-template widgets', () => {
+    const r = outputWidgetSchema.safeParse({
+      type: 'ai-template',
+      template: '<div>{{outputs.x}}</div>',
+      controls: [{ type: 'replay' }],
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('agentV2Schema cross-validation for replay.inputs', () => {
+  const baseAgent = {
+    id: 'weather',
+    name: 'weather',
+    status: 'active' as const,
+    source: 'local' as const,
+    version: 1,
+    inputs: { CITY: { type: 'string', default: 'sf' } },
+    nodes: [{ id: 'fetch', type: 'shell' as const, command: 'echo hi' }],
+    outputWidget: {
+      type: 'dashboard' as const,
+      fields: [{ name: 'temp', type: 'metric' as const }],
+    },
+  };
+
+  it('accepts replay.inputs naming a declared agent input', () => {
+    const r = agentV2Schema.safeParse({
+      ...baseAgent,
+      outputWidget: { ...baseAgent.outputWidget, controls: [{ type: 'replay', inputs: ['CITY'] }] },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects replay.inputs naming an undeclared agent input', () => {
+    const r = agentV2Schema.safeParse({
+      ...baseAgent,
+      outputWidget: { ...baseAgent.outputWidget, controls: [{ type: 'replay', inputs: ['NONEXISTENT'] }] },
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.message.includes('NONEXISTENT'))).toBe(true);
+    }
+  });
+});
+
+describe('agent YAML round-trip preserves controls', () => {
+  it('keeps controls intact through parse → stringify → parse', () => {
+    const yaml = stringifyYaml({
+      id: 'weather',
+      name: 'weather',
+      status: 'active',
+      source: 'local',
+      version: 1,
+      inputs: { CITY: { type: 'string', default: 'sf' } },
+      nodes: [{ id: 'fetch', type: 'shell', command: 'echo {"temp_c":20,"temp_f":68}' }],
+      outputWidget: {
+        type: 'dashboard',
+        fields: [
+          { name: 'temp_c', type: 'metric' },
+          { name: 'temp_f', type: 'metric' },
+        ],
+        controls: [
+          { type: 'replay', inputs: ['CITY'] },
+          { type: 'view-switch', label: 'Units', default: 'metric',
+            views: [
+              { id: 'metric', fields: ['temp_c'] },
+              { id: 'imperial', fields: ['temp_f'] },
+            ] },
+        ],
+      },
+    });
+    const agent = parseAgent(yaml);
+    expect(agent.outputWidget?.controls).toBeDefined();
+    expect(agent.outputWidget?.controls).toHaveLength(2);
+    expect(agent.outputWidget?.controls?.[0]).toMatchObject({ type: 'replay', inputs: ['CITY'] });
+    expect(agent.outputWidget?.controls?.[1]).toMatchObject({ type: 'view-switch', default: 'metric' });
+  });
+});

--- a/packages/core/src/output-widget-schema.ts
+++ b/packages/core/src/output-widget-schema.ts
@@ -18,6 +18,36 @@ export const widgetActionSchema = z.object({
   payloadField: z.string().optional(),
 });
 
+export const widgetViewSchema = z.object({
+  id: z.string().min(1),
+  fields: z.array(z.string().min(1)).min(1, 'view.fields must list at least one field'),
+});
+
+export const widgetControlSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('replay'),
+    label: z.string().optional(),
+    /**
+     * Subset of `agent.inputs` names to expose as inline form fields on the
+     * replay button. Empty array (or omitted) = same-inputs replay using the
+     * agent's defaults.
+     */
+    inputs: z.array(z.string().min(1)).optional(),
+  }),
+  z.object({
+    type: z.literal('field-toggle'),
+    label: z.string().min(1),
+    fields: z.array(z.string().min(1)).min(1, 'field-toggle.fields must list at least one field'),
+    default: z.enum(['shown', 'hidden']),
+  }),
+  z.object({
+    type: z.literal('view-switch'),
+    label: z.string().min(1),
+    views: z.array(widgetViewSchema).min(1, 'view-switch needs at least one view'),
+    default: z.string().min(1),
+  }),
+]);
+
 export const outputWidgetSchema = z.object({
   type: z.enum(['diff-apply', 'key-value', 'raw', 'dashboard', 'ai-template']),
   fields: z.array(widgetFieldSchema).optional(),
@@ -43,6 +73,12 @@ export const outputWidgetSchema = z.object({
   askLabel: z.string().optional(),
   /** Custom label for the post-result replay button (default "Run again"). */
   replayLabel: z.string().optional(),
+  /**
+   * Inline interactive controls rendered above the widget body. Allow the
+   * viewer to re-run the agent, hide/show optional fields, or switch between
+   * named views. State is URL-driven (no client JS) so refresh = default view.
+   */
+  controls: z.array(widgetControlSchema).optional(),
 }).superRefine((schema, ctx) => {
   if (schema.type === 'ai-template') {
     if (!schema.template || schema.template.trim() === '') {
@@ -52,6 +88,72 @@ export const outputWidgetSchema = z.object({
     if (!Array.isArray(schema.fields) || schema.fields.length === 0) {
       ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['fields'], message: 'Non-ai widgets need at least one field.' });
     }
+  }
+
+  if (!schema.controls?.length) return;
+
+  const declaredFieldNames = new Set((schema.fields ?? []).map((f) => f.name));
+
+  for (let i = 0; i < schema.controls.length; i++) {
+    const c = schema.controls[i];
+
+    if (c.type === 'field-toggle' || c.type === 'view-switch') {
+      // ai-template widgets don't have a declared `fields[]` for layout
+      // (the template author owns visibility), so toggle/switch controls
+      // have nothing to operate on. Reject early instead of rendering a
+      // broken control row.
+      if (schema.type === 'ai-template') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['controls', i, 'type'],
+          message: `${c.type} controls aren't supported on ai-template widgets — the template controls layout directly.`,
+        });
+        continue;
+      }
+    }
+
+    if (c.type === 'field-toggle') {
+      for (let j = 0; j < c.fields.length; j++) {
+        if (!declaredFieldNames.has(c.fields[j])) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['controls', i, 'fields', j],
+            message: `field-toggle references "${c.fields[j]}" which isn't declared in outputWidget.fields.`,
+          });
+        }
+      }
+    } else if (c.type === 'view-switch') {
+      const viewIds = new Set<string>();
+      for (let j = 0; j < c.views.length; j++) {
+        const view = c.views[j];
+        if (viewIds.has(view.id)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['controls', i, 'views', j, 'id'],
+            message: `Duplicate view id "${view.id}".`,
+          });
+        }
+        viewIds.add(view.id);
+        for (let k = 0; k < view.fields.length; k++) {
+          if (!declaredFieldNames.has(view.fields[k])) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['controls', i, 'views', j, 'fields', k],
+              message: `view "${view.id}" references field "${view.fields[k]}" which isn't declared in outputWidget.fields.`,
+            });
+          }
+        }
+      }
+      if (!viewIds.has(c.default)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['controls', i, 'default'],
+          message: `view-switch default "${c.default}" doesn't match any declared view id.`,
+        });
+      }
+    }
+    // replay.inputs[] is cross-checked against agent.inputs at the agent
+    // schema level, since outputWidgetSchema doesn't see the agent shape.
   }
 });
 

--- a/packages/core/src/output-widget-types.ts
+++ b/packages/core/src/output-widget-types.ts
@@ -65,4 +65,36 @@ export interface OutputWidgetSchema {
   askLabel?: string;
   /** Override label for the post-result replay button. Default "Run again". */
   replayLabel?: string;
+  /**
+   * Inline interactive controls rendered above the widget body. Allow the
+   * viewer to re-run the agent, hide/show optional fields, or switch between
+   * named views. State is URL-driven (no client JS).
+   */
+  controls?: WidgetControl[];
 }
+
+/** A named subset of widget fields used by `view-switch` controls. */
+export interface WidgetView {
+  id: string;
+  fields: string[];
+}
+
+export type WidgetControl =
+  | {
+      type: 'replay';
+      label?: string;
+      /** Subset of agent.inputs to expose for tweaking on replay. */
+      inputs?: string[];
+    }
+  | {
+      type: 'field-toggle';
+      label: string;
+      fields: string[];
+      default: 'shown' | 'hidden';
+    }
+  | {
+      type: 'view-switch';
+      label: string;
+      views: WidgetView[];
+      default: string;
+    };

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -2210,6 +2210,120 @@ describe('Interactive widget tile + widget-run/widget-status', () => {
   });
 });
 
+describe('Widget controls (PR H)', () => {
+  function seedControlsAgent() {
+    agentStore.createAgent({
+      id: 'weather',
+      name: 'weather',
+      status: 'active',
+      source: 'local',
+      mcp: false,
+      inputs: { CITY: { type: 'string', default: 'sf' } },
+      nodes: [{ id: 'fetch', type: 'shell', command: 'echo {"temp_c":20,"temp_f":68,"uv":3,"wind":10}' }],
+      outputWidget: {
+        type: 'dashboard',
+        fields: [
+          { name: 'temp_c', type: 'metric' },
+          { name: 'temp_f', type: 'metric' },
+          { name: 'wind', type: 'stat' },
+          { name: 'uv', type: 'text' },
+        ],
+        controls: [
+          { type: 'replay', label: 'Refresh', inputs: ['CITY'] },
+          { type: 'view-switch', label: 'Units', default: 'metric',
+            views: [
+              { id: 'metric', fields: ['temp_c', 'wind'] },
+              { id: 'imperial', fields: ['temp_f', 'wind'] },
+            ] },
+          { type: 'field-toggle', label: 'Optional', fields: ['uv'], default: 'hidden' },
+        ],
+      },
+    }, 'cli');
+    runStore.createRun({ id: 'r-w', agentName: 'weather', workflowId: 'weather', workflowVersion: 1, status: 'completed', triggeredBy: 'cli', startedAt: new Date().toISOString() });
+    runStore.updateRun('r-w', {
+      status: 'completed', completedAt: new Date().toISOString(),
+      result: '{"temp_c":20,"temp_f":68,"uv":3,"wind":10}',
+    });
+  }
+
+  it('renders the controls row above the widget body on agent overview', async () => {
+    const app = await makeApp();
+    seedControlsAgent();
+    const res = await request(app).get('/agents/weather')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('output-widget__controls');
+    expect(res.text).toContain('data-widget-control="replay"');
+    expect(res.text).toContain('data-widget-control="view-switch"');
+    expect(res.text).toContain('data-widget-control="field-toggle"');
+  });
+
+  it('replay control renders a POST form to /agents/:id/run with input_<NAME>', async () => {
+    const app = await makeApp();
+    seedControlsAgent();
+    const res = await request(app).get('/agents/weather')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.text).toMatch(/<form\s+method="POST"\s+action="\/agents\/weather\/run"/);
+    expect(res.text).toContain('name="input_CITY"');
+  });
+
+  it('view-switch with ?wv=imperial filters fields to that view only', async () => {
+    const app = await makeApp();
+    seedControlsAgent();
+    const def = await request(app).get('/agents/weather')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    // Default view = metric → temp_c visible, temp_f hidden.
+    expect(def.text).toContain('temp_c');
+    // The dashboard renderer skips fields whose value is undefined; with the
+    // imperial view active, temp_c is filtered out before extraction. The
+    // field's label should not appear in the rendered widget body for the
+    // active view.
+    const imp = await request(app).get('/agents/weather?wv=imperial')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(imp.text).toContain('temp_f');
+    // The chip for imperial should be styled active (badge, not badge--muted).
+    // Active chip uses class="badge" (not badge--muted). Look for the
+    // specific imperial chip's class via the surrounding anchor tag.
+    expect(imp.text).toMatch(/<a[^>]*class="badge"[^>]*data-view-id="imperial"/);
+  });
+
+  it('field-toggle hides default-hidden fields by default and reveals them via ?wh', async () => {
+    const app = await makeApp();
+    seedControlsAgent();
+    // Default state: uv is default-hidden, so its label "uv" shouldn't appear
+    // inside the widget body. It still appears in the controls row chip.
+    const def = await request(app).get('/agents/weather')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    // Controls chip references uv by name attribute regardless of state.
+    expect(def.text).toContain('data-field="uv"');
+    // Reveal: ?wh= mentions a toggle field but excludes uv → uv now visible.
+    // Our grammar: when ?wh mentions any toggle field, ?wh becomes the
+    // authoritative hidden set. ?wh=  (empty) wouldn't trigger override, so
+    // pass a different toggle target. With only uv in the toggle, the way to
+    // reveal uv is to omit it from ?wh. Pass `?wh=` empty — defaults apply
+    // → uv stays hidden. To reveal, we need controls with multiple fields.
+    // For this single-field toggle, click-to-reveal sets ?wh= empty which
+    // falls back to defaults. Verify the chip's href reflects this.
+    expect(def.text).toMatch(/data-field="uv"\s+data-hidden="1"/);
+  });
+
+  it('runs URL params through to run-detail too', async () => {
+    const app = await makeApp();
+    seedControlsAgent();
+    const res = await request(app).get('/runs/r-w?wv=imperial')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('output-widget__controls');
+    expect(res.text).toMatch(/<a[^>]*class="badge"[^>]*data-view-id="imperial"/);
+  });
+});
+
 describe('Dashboard /agents/install', () => {
   const SAMPLE_YAML = `id: dash-installed
 name: dash-installed

--- a/packages/dashboard/src/routes/agents/detail.ts
+++ b/packages/dashboard/src/routes/agents/detail.ts
@@ -5,6 +5,7 @@ import { renderAgentsList, type HomeStats } from '../../views/agents-list.js';
 import { renderAgentDetail } from '../../views/agent-detail.js';
 import { renderAgentDetailV2 } from '../../views/agent-detail-v2.js';
 import { deriveBack } from '../../views/page-header.js';
+import { parseHiddenFieldsParam } from '../../views/output-widgets.js';
 
 export const agentDetailRouter: Router = Router();
 
@@ -28,6 +29,9 @@ agentDetailRouter.get('/agents/:name', async (req: Request, res: Response) => {
     const flash = flashParam ? { kind: 'ok' as const, message: flashParam } : undefined;
     const referer = typeof req.headers.referer === 'string' ? req.headers.referer : undefined;
     const back = deriveBack(referer, `127.0.0.1:${ctx.port}`, fromParam);
+    const wv = typeof req.query.wv === 'string' ? req.query.wv : undefined;
+    const wh = typeof req.query.wh === 'string' ? req.query.wh : undefined;
+    const widgetControls = { view: wv, hiddenFields: parseHiddenFieldsParam(wh) };
     const html = await renderAgentDetailV2({
       agent: v2Agent,
       recentRuns: rows,
@@ -35,6 +39,7 @@ agentDetailRouter.get('/agents/:name', async (req: Request, res: Response) => {
       flash,
       back,
       from: fromParam,
+      widgetControls,
     });
     res.type('html').send(html);
     return;

--- a/packages/dashboard/src/routes/runs.ts
+++ b/packages/dashboard/src/routes/runs.ts
@@ -3,6 +3,7 @@ import type { RunStatus } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 import { renderRunsList } from '../views/runs-list.js';
 import { renderRunDetail } from '../views/run-detail.js';
+import { parseHiddenFieldsParam } from '../views/output-widgets.js';
 import { deriveBack } from '../views/page-header.js';
 
 const VALID_STATUSES: RunStatus[] = ['pending', 'running', 'completed', 'failed', 'cancelled'];
@@ -99,7 +100,14 @@ runsRouter.get('/runs/:id', (req: Request, res: Response) => {
     ? { kind: isError ? ('error' as const) : ('ok' as const), message: flashParam }
     : undefined;
 
-  res.type('html').send(renderRunDetail({ run, partial, nodeExecutions, agent, back, flash }));
+  // Output widget interactive controls: ?wv=<view-id> and ?wh=<csv-of-fields>.
+  // Always passed (even when both are absent) so the renderer knows it's on a
+  // controls-rendering page and emits the controls row in default state.
+  const wv = typeof req.query.wv === 'string' ? req.query.wv : undefined;
+  const wh = typeof req.query.wh === 'string' ? req.query.wh : undefined;
+  const widgetControls = { view: wv, hiddenFields: parseHiddenFieldsParam(wh) };
+
+  res.type('html').send(renderRunDetail({ run, partial, nodeExecutions, agent, back, flash, widgetControls }));
 });
 
 function parseIntOr(v: unknown, fallback: number): number {

--- a/packages/dashboard/src/views/agent-detail-v2.ts
+++ b/packages/dashboard/src/views/agent-detail-v2.ts
@@ -16,6 +16,7 @@ export { renderAgentYaml } from './agent-detail/yaml.js';
 
 import type { Agent, Run, SecretsStore } from '@some-useful-agents/core';
 import type { PageHeaderBack } from './page-header.js';
+import type { WidgetControlState } from './output-widgets.js';
 import { renderAgentOverview } from './agent-detail/overview.js';
 
 /** @deprecated Use renderAgentOverview directly */
@@ -26,6 +27,7 @@ export async function renderAgentDetailV2(args: {
   flash?: { kind: 'error' | 'info' | 'ok'; message: string };
   back?: PageHeaderBack;
   from?: string;
+  widgetControls?: WidgetControlState;
 }): Promise<string> {
   return renderAgentOverview({ ...args, activeTab: 'overview' });
 }

--- a/packages/dashboard/src/views/agent-detail/overview.ts
+++ b/packages/dashboard/src/views/agent-detail/overview.ts
@@ -5,7 +5,7 @@ import { renderOutputWidget } from '../output-widgets.js';
 import { agentPageShell, type AgentDetailArgs } from './shell.js';
 
 export async function renderAgentOverview(args: AgentDetailArgs): Promise<string> {
-  const { agent, recentRuns } = args;
+  const { agent, recentRuns, widgetControls } = args;
   const latestCompletedRun = recentRuns.find((r) => r.status === 'completed');
   const hasCommunityShellNode = agent.source === 'community' && agent.nodes.some((n) => n.type === 'shell');
 
@@ -44,7 +44,7 @@ export async function renderAgentOverview(args: AgentDetailArgs): Promise<string
           </div>
           ${latestCompletedRun?.result
             ? html`
-              ${renderOutputWidget(agent.outputWidget, latestCompletedRun.result, agent.id) ?? html`<p class="dim" style="font-size: var(--font-size-xs);">No output to preview.</p>`}
+              ${renderOutputWidget(agent.outputWidget, latestCompletedRun.result, agent.id, widgetControls) ?? html`<p class="dim" style="font-size: var(--font-size-xs);">No output to preview.</p>`}
               <p class="dim" style="font-size: var(--font-size-xs); margin: var(--space-3) 0 0;">From run <a href="/runs/${latestCompletedRun.id}" class="mono">${latestCompletedRun.id.slice(0, 8)}</a></p>
             `
             : html`<p class="dim" style="font-size: var(--font-size-xs); margin: 0;">Run the agent to see a preview.</p>`}

--- a/packages/dashboard/src/views/agent-detail/shell.ts
+++ b/packages/dashboard/src/views/agent-detail/shell.ts
@@ -4,6 +4,7 @@ import { layout } from '../layout.js';
 import { pageHeader, type PageHeaderBack } from '../page-header.js';
 import { sourceBadge } from '../components.js';
 import { renderRunInputsForm, statusOption } from '../agent-detail-helpers.js';
+import type { WidgetControlState } from '../output-widgets.js';
 
 export type AgentTab = 'overview' | 'nodes' | 'config' | 'runs' | 'yaml';
 
@@ -17,6 +18,8 @@ export interface AgentDetailArgs {
   activeTab: AgentTab;
   /** Previous run's agent-level inputs, for pre-filling the Run Now modal. */
   previousInputs?: Record<string, string>;
+  /** URL-driven state for the latest-run output-widget preview's controls. */
+  widgetControls?: WidgetControlState;
 }
 
 export function agentTabStrip(agentId: string, active: AgentTab): SafeHtml {

--- a/packages/dashboard/src/views/output-widgets.ts
+++ b/packages/dashboard/src/views/output-widgets.ts
@@ -8,9 +8,22 @@
  *   - raw: pre-formatted output with field extraction
  */
 
-import type { OutputWidgetSchema } from '@some-useful-agents/core';
+import type { OutputWidgetSchema, WidgetControl, WidgetField } from '@some-useful-agents/core';
 import { sanitizeHtml, substitutePlaceholders } from '@some-useful-agents/core';
 import { html, unsafeHtml, type SafeHtml } from './html.js';
+
+/**
+ * URL-driven state for a widget's interactive controls. Threaded from the
+ * route handlers (run-detail, agent overview) which read query params and
+ * pass them through. Pulse tiles + home widgets don't pass this — they
+ * render in static mode (no controls row, all fields visible).
+ */
+export interface WidgetControlState {
+  /** Active `view-switch` view id (from ?wv=); when absent, the control's `default` is used. */
+  view?: string;
+  /** Field names hidden via `?wh=csv`. Already-parsed by the caller. */
+  hiddenFields?: ReadonlySet<string>;
+}
 
 /**
  * Extract a field value from run output text. Supports two extraction modes:
@@ -112,30 +125,205 @@ function renderPreview(label: string, filePath: string): SafeHtml {
 }
 
 /**
+ * Resolve which fields should be visible given the widget's controls and the
+ * URL-driven state. Order: start with declared fields → if a view-switch is
+ * active, intersect with that view's `fields[]` → drop any field hidden via
+ * `field-toggle`. Returns a (possibly narrower) clone of the schema; never
+ * mutates the input.
+ */
+function applyControlsToFields(
+  schema: OutputWidgetSchema,
+  state?: WidgetControlState,
+): OutputWidgetSchema {
+  if (!schema.controls?.length || !schema.fields) return schema;
+
+  const allFieldNames = new Set(schema.fields.map((f) => f.name));
+  let visible: Set<string> = new Set(allFieldNames);
+
+  for (const c of schema.controls) {
+    if (c.type === 'view-switch') {
+      const activeId = state?.view ?? c.default;
+      const activeView = c.views.find((v) => v.id === activeId) ?? c.views.find((v) => v.id === c.default);
+      if (activeView) {
+        visible = new Set([...visible].filter((n) => activeView.fields.includes(n)));
+      }
+    }
+  }
+
+  // field-toggle: when ?wh is present in the URL (even as ?wh=), it is
+  // authoritative — exactly the listed fields are hidden, all others shown.
+  // Absent ?wh = per-control defaults apply.
+  const hiddenFromDefaults = new Set<string>();
+  for (const c of schema.controls) {
+    if (c.type === 'field-toggle' && c.default === 'hidden') {
+      for (const n of c.fields) hiddenFromDefaults.add(n);
+    }
+  }
+  const hidden = state?.hiddenFields !== undefined ? state.hiddenFields : hiddenFromDefaults;
+  for (const n of hidden) visible.delete(n);
+
+  const filteredFields: WidgetField[] = schema.fields.filter((f) => visible.has(f.name));
+  return { ...schema, fields: filteredFields };
+}
+
+/**
  * Render a widget from an agent's outputWidget schema and run output.
  * Returns undefined if the schema type is unknown.
+ *
+ * `controlState` (4th arg) is opt-in: when provided, the widget renders an
+ * interactive controls row above the body and applies URL-driven view /
+ * field-toggle filtering. Callers that pass nothing get the static render.
  */
 export function renderOutputWidget(
   schema: OutputWidgetSchema,
   output: string,
   agentId: string,
+  controlState?: WidgetControlState,
 ): SafeHtml | undefined {
-  const fields = extractFields(output, schema);
+  // ai-template widgets render their own layout via the stored template;
+  // field-toggle / view-switch don't apply (rejected at schema time). Only
+  // the body+optional replay control row are emitted.
+  const filtered = schema.type === 'ai-template' ? schema : applyControlsToFields(schema, controlState);
+  const fields = extractFields(output, filtered);
 
-  switch (schema.type) {
+  let body: SafeHtml | undefined;
+  switch (filtered.type) {
     case 'diff-apply':
-      return renderDiffApply(schema, fields, agentId);
+      body = renderDiffApply(filtered, fields, agentId);
+      break;
     case 'key-value':
-      return renderKeyValue(schema, fields);
+      body = renderKeyValue(filtered, fields);
+      break;
     case 'raw':
-      return renderRaw(schema, fields);
+      body = renderRaw(filtered, fields);
+      break;
     case 'dashboard':
-      return renderDashboard(schema, fields);
+      body = renderDashboard(filtered, fields);
+      break;
     case 'ai-template':
-      return renderAiTemplate(schema, output, fields);
+      body = renderAiTemplate(filtered, output, fields);
+      break;
     default:
       return undefined;
   }
+
+  if (!controlState || !schema.controls?.length) return body;
+  const controlsRow = renderControlsRow(schema, agentId, controlState);
+  return html`${controlsRow}${body}`;
+}
+
+/**
+ * Render the controls row above a widget body. URL-param-driven; every
+ * interaction is a full page reload via <a> or a POST <form>. No client JS.
+ */
+function renderControlsRow(
+  schema: OutputWidgetSchema,
+  agentId: string,
+  state: WidgetControlState,
+): SafeHtml {
+  const controls = schema.controls ?? [];
+  const groups = controls.map((c) => {
+    if (c.type === 'replay') return renderReplayControl(c, agentId);
+    if (c.type === 'view-switch') return renderViewSwitchControl(c, state);
+    if (c.type === 'field-toggle') return renderFieldToggleControl(c, schema, state);
+    return html``;
+  });
+  return html`
+    <div class="output-widget__controls" style="display: flex; flex-wrap: wrap; gap: var(--space-3); align-items: center; margin-bottom: var(--space-3); padding-bottom: var(--space-3); border-bottom: 1px solid var(--color-border);">
+      ${groups as unknown as SafeHtml[]}
+    </div>
+  `;
+}
+
+function renderReplayControl(c: Extract<WidgetControl, { type: 'replay' }>, agentId: string): SafeHtml {
+  const label = c.label ?? 'Run again';
+  const inlineInputs = (c.inputs ?? []).map((name) => html`
+    <label style="display: inline-flex; align-items: center; gap: var(--space-1); font-size: var(--font-size-xs);">
+      <span class="dim">${name}</span>
+      <input type="text" name="input_${name}" style="padding: 2px var(--space-2); font-size: var(--font-size-xs); border: 1px solid var(--color-border); border-radius: var(--radius-sm); width: 8em;">
+    </label>
+  `);
+  return html`
+    <form method="POST" action="/agents/${encodeURIComponent(agentId)}/run" style="display: inline-flex; gap: var(--space-2); align-items: center; margin: 0;">
+      ${inlineInputs as unknown as SafeHtml[]}
+      <button type="submit" class="btn btn--sm btn--primary" data-widget-control="replay">${label}</button>
+    </form>
+  `;
+}
+
+function renderViewSwitchControl(
+  c: Extract<WidgetControl, { type: 'view-switch' }>,
+  state: WidgetControlState,
+): SafeHtml {
+  const activeId = state.view ?? c.default;
+  const chips = c.views.map((v) => {
+    const isActive = v.id === activeId;
+    const cls = isActive ? 'badge' : 'badge badge--muted';
+    const style = isActive
+      ? 'cursor: default; text-decoration: none;'
+      : 'cursor: pointer; text-decoration: none;';
+    // The default view's URL omits `?wv=` (cleaner share links). All other
+    // views set it explicitly. `wh` is preserved by the caller via the form/
+    // link grammar — controls share state through query string only, so
+    // clicking a view-switch resets the hidden-fields list. Acceptable for v1.
+    const href = v.id === c.default ? '?' : `?wv=${encodeURIComponent(v.id)}`;
+    return html`<a href="${href}" class="${cls}" style="${style}" data-widget-control="view-switch" data-view-id="${v.id}">${v.id}</a>`;
+  });
+  return html`
+    <div style="display: inline-flex; gap: var(--space-2); align-items: center;">
+      <span class="dim" style="font-size: var(--font-size-xs);">${c.label}:</span>
+      ${chips as unknown as SafeHtml[]}
+    </div>
+  `;
+}
+
+function renderFieldToggleControl(
+  c: Extract<WidgetControl, { type: 'field-toggle' }>,
+  schema: OutputWidgetSchema,
+  state: WidgetControlState,
+): SafeHtml {
+  const labelByName = new Map<string, string>();
+  for (const f of schema.fields ?? []) labelByName.set(f.name, f.label ?? f.name);
+
+  // Reconstruct the effective hidden set so each chip can render its
+  // current state and link to the toggled URL. ?wh present (even empty) =
+  // authoritative; absent = per-control defaults.
+  const effectiveHidden = state.hiddenFields !== undefined
+    ? new Set(state.hiddenFields)
+    : new Set(c.default === 'hidden' ? c.fields : []);
+
+  const chips = c.fields.map((name) => {
+    const isHidden = effectiveHidden.has(name);
+    // Build the toggled hidden set for this chip's link.
+    const next = new Set(effectiveHidden);
+    if (isHidden) next.delete(name); else next.add(name);
+    const wh = [...next].join(',');
+    // Always emit ?wh=... (even empty) so the URL is authoritative — without
+    // this, revealing the only default-hidden field would produce a bare ?
+    // that falls back to defaults, locking the field hidden forever.
+    const href = `?wh=${encodeURIComponent(wh)}`;
+    const cls = isHidden ? 'badge badge--muted' : 'badge';
+    const symbol = isHidden ? '○' : '●';
+    return html`<a href="${href}" class="${cls}" style="cursor: pointer; text-decoration: none;" data-widget-control="field-toggle" data-field="${name}" data-hidden="${isHidden ? '1' : '0'}">${symbol} ${labelByName.get(name) ?? name}</a>`;
+  });
+  return html`
+    <div style="display: inline-flex; gap: var(--space-2); align-items: center;">
+      <span class="dim" style="font-size: var(--font-size-xs);">${c.label}:</span>
+      ${chips as unknown as SafeHtml[]}
+    </div>
+  `;
+}
+
+/**
+ * Parse `?wh=foo,bar` from a query string into a Set of field names.
+ * Returns `undefined` when the param is absent (so per-control defaults
+ * apply); returns an empty Set for `?wh=` (so the URL becomes authoritative
+ * and reveals every default-hidden field). Exported so route handlers can
+ * build a {@link WidgetControlState} without duplicating the CSV grammar.
+ */
+export function parseHiddenFieldsParam(value: string | undefined): Set<string> | undefined {
+  if (value === undefined) return undefined;
+  return new Set(value.split(',').map((s) => s.trim()).filter(Boolean));
 }
 
 // ── ai-template ────────────────────────────────────────────────────────

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -4,7 +4,7 @@ import { layout } from './layout.js';
 import { pageHeader, type PageHeaderBack } from './page-header.js';
 import { statusBadge, outputFrame, formatDuration, formatExitCode, formatErrorCategory } from './components.js';
 import { renderDagView, renderDagFallback } from './dag-view.js';
-import { renderOutputWidget } from './output-widgets.js';
+import { renderOutputWidget, type WidgetControlState } from './output-widgets.js';
 
 export interface RunDetailOptions {
   run: Run;
@@ -18,10 +18,12 @@ export interface RunDetailOptions {
   back?: PageHeaderBack;
   /** Success/error banner surfaced on the detail page. */
   flash?: { kind: 'error' | 'info' | 'ok'; message: string };
+  /** URL-driven state for the output widget's interactive controls. */
+  widgetControls?: WidgetControlState;
 }
 
 export function renderRunDetail(opts: RunDetailOptions): string {
-  const { run, partial, nodeExecutions, agent, back, flash } = opts;
+  const { run, partial, nodeExecutions, agent, back, flash, widgetControls } = opts;
   const inProgress = run.status === 'running' || run.status === 'pending';
 
   // Run id is a UUID — safe to inline in an attribute without re-escaping.
@@ -141,7 +143,7 @@ export function renderRunDetail(opts: RunDetailOptions): string {
             <h2 style="margin-top: 0;">Result</h2>
             ${!inProgress && run.result
               ? (agent?.outputWidget
-                  ? renderOutputWidget(agent.outputWidget, run.result, agent.id) ?? outputFrame(run.result)
+                  ? renderOutputWidget(agent.outputWidget, run.result, agent.id, widgetControls) ?? outputFrame(run.result)
                   : outputFrame(run.result))
               : inProgress
                 ? html`<p class="dim" style="font-size: var(--font-size-xs);">Run in progress...</p>`
@@ -169,7 +171,7 @@ export function renderRunDetail(opts: RunDetailOptions): string {
       ` : html`
         <h2>Output</h2>
         ${run.result
-          ? (agent?.outputWidget ? renderOutputWidget(agent.outputWidget, run.result, agent.id) ?? outputFrame(run.result) : outputFrame(run.result))
+          ? (agent?.outputWidget ? renderOutputWidget(agent.outputWidget, run.result, agent.id, widgetControls) ?? outputFrame(run.result) : outputFrame(run.result))
           : html`<p class="dim">No output yet.</p>`}
       `}
       ${cancelModal}


### PR DESCRIPTION
## Summary

Output widgets gain a `controls:` array with three control types so they feel alive instead of read-only:

- **`replay`** — re-run the agent inline. `inputs:[]` (or omitted) = same-inputs replay; `inputs:[NAME]` exposes those agent inputs as inline form fields the user can tweak before re-running.
- **`field-toggle`** — hide/show optional fields via chip toggles. `default: shown | hidden`.
- **`view-switch`** — tab-style switch between named field subsets (e.g. metric ↔ imperial, today vs week).

State lives entirely in URL query params (`?wv=<view-id>`, `?wh=<csv-of-fields>`). No client JS — refresh resets to defaults, links can be shared. Renders on agent-detail (`/agents/:id`) and run-detail (`/runs/:id`); Pulse tiles continue to render statically (too small for inline controls in v1).

The agent-builder prompt and discovery catalog teach the planner when to reach for each control type with per-archetype guidance (weather → all three; lookup tool → replay with input-tweak; daily digest → replay with no inputs; status dashboard → field-toggle).

Schema cross-validates field references and rejects `field-toggle` / `view-switch` on `ai-template` widgets (the template author owns layout); `replay` works on any widget type. `replay.inputs[]` is cross-checked against `agent.inputs` at the agent level.

## Try it

```bash
sua agent install <some-agent-with-controls.yaml>
# or update an existing agent's outputWidget via /agents/:id/yaml:
outputWidget:
  type: dashboard
  fields:
    - { name: temp_c, type: metric }
    - { name: temp_f, type: metric }
    - { name: uv, type: text }
  controls:
    - type: replay
      label: Refresh
      inputs: [CITY]
    - type: view-switch
      label: Units
      default: metric
      views:
        - { id: metric, fields: [temp_c] }
        - { id: imperial, fields: [temp_f] }
    - type: field-toggle
      label: Show
      fields: [uv]
      default: hidden
```

Visit the agent's overview page — controls render above the widget body.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` green (913 tests, +19 over baseline)
- [x] Schema accept/reject for each control type + cross-validation (field refs, view default, ai-template restriction, replay.inputs ↔ agent.inputs)
- [x] YAML round-trip preserves controls
- [x] Renderer tests: controls row HTML, replay POST shape, view-switch URL filtering, field-toggle URL state, run-detail URL passthrough
- [x] Catalog test: WIDGET CONTROLS section + per-control "USE WHEN" guidance
- [x] Live smoke against running daemon: all three controls work end-to-end on `/agents/:id` and `/runs/:id`, including reveal of the only default-hidden field via `?wh=` (param-present-empty grammar)

## Out of scope

- Drag-to-reorder controls or fields
- Saved view presets / cookies (URL is the source of truth)
- Pulse tile controls (too small)
- Per-user preferences (sua is single-user today)

## Known gotchas

- `field-toggle` / `view-switch` rejected on `ai-template` widgets at schema time — template author owns layout. `replay` is allowed on any type.
- URL grammar: `?wh=` (param present, even empty) is authoritative; absent `?wh` falls back to per-control defaults. This lets a user reveal the only default-hidden field by clicking its chip → `?wh=`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)