### PR TITLE
feat(retry): one-click manual retry on failed runs (R1)

### DIFF
--- a/.changeset/manual-retry.md
+++ b/.changeset/manual-retry.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+One-click manual retry on failed runs.
+
+Failed runs (`status: failed`) gain a Retry button on the run-detail page. Clicking it recovers the original agent-level inputs from the prior run, creates a fresh run with `attempt: N+1`, and links back to the head of the chain via the new `retryOfRunId` field. Distinct from Replay (which re-runs from a specific node reusing upstream outputs); Retry redoes the whole run from scratch — the right tool for transient failures. Run-detail header now shows an "attempt N" badge on any retry, plus a "Retry of" link back to the original.
+
+Schema additions: `runs.attempt INTEGER DEFAULT 1`, `runs.retry_of_run_id TEXT` (nullable). Migrations are additive — existing runs default to `attempt=1, retry_of_run_id=NULL`.
+
+Foundation for upcoming auto-retry (agent-declared `retry:` policy), notify deferral, and triage surfaces.

--- a/docs/retry.md
+++ b/docs/retry.md
@@ -1,0 +1,67 @@
+# Retrying failed runs
+
+When a run fails — flaky API, transient network glitch, race condition — you have two ways to recover:
+
+| Tool | When | Effect |
+|---|---|---|
+| **Retry** (this page) | The whole run failed; you want to redo it from scratch | Creates a new run with the same agent-level inputs, links back via `retryOfRunId`. Each retry is a fresh top-to-bottom execution. |
+| **Replay from node** ([replay docs](../packages/dashboard/src/routes/run-mutations.ts)) | A specific node failed mid-DAG; upstream completed fine | Re-runs from a chosen node, reusing stored upstream outputs. |
+
+Replay is for "node 4 broke; reuse the work from nodes 1–3." Retry is for "the whole thing failed transiently; just do it again."
+
+## Manual retry (one click)
+
+On any failed run's detail page (`/runs/:id`), the error block shows a **Retry run** button:
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ ⚠  Simulated failure        [Retry run]  [Suggest improvements] │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Clicking it:
+
+1. Recovers the original agent-level inputs from the prior run's first node execution.
+2. Creates a new run with `attempt: N+1` and `retryOfRunId` pointing at the head of the chain.
+3. Redirects to the new run's page.
+
+Only **failed** runs are retryable. Cancelled runs (deliberately stopped) and completed runs are not — use **Run now** for those.
+
+## Retry chain semantics
+
+The chain is **flat**: every retry points at the original run, not at the immediate previous attempt. This makes sibling counts cheap (`SELECT * FROM runs WHERE retry_of_run_id = ?`).
+
+Each retry's `attempt` is the chain's `MAX(attempt) + 1`, so:
+
+```
+orig (attempt 1, failed)
+  ↓ retry
+attempt 2 (also failed)
+  ↓ retry
+attempt 3 (succeeded)
+```
+
+The run-detail page shows an **attempt N** badge in the header on any retry, plus a "Retry of: <run-id>" row in the metadata block linking back to the original.
+
+## What does not get retried
+
+- **`cancelled`** runs (a deliberate stop).
+- **`completed`** runs (use Run now to re-execute with fresh inputs).
+- The whole agent — only the run gets recreated; the agent definition isn't touched.
+
+## API
+
+```
+POST /runs/:id/retry
+```
+
+Form body: `confirm_community_shell=yes` if the agent has community shell nodes (same gate as Run now).
+
+Returns `303` redirect to the new run on success, or back to the prior run with a `?flash=` error message on failure (e.g. "Only failed runs can be retried").
+
+## What's coming next
+
+- **Auto-retry** ([plan](https://github.com/anthropics/some-useful-agents/issues)) — agents declare `retry: { attempts, backoff, delaySeconds, categories }` and the executor re-fires transient failures (timeouts, spawn failures) without paging anyone.
+- **Notify deferral** — when auto-retry is in play, `failure` notifications wait until the final attempt fails.
+- **Triage surface** — per-agent consecutive-failure tracking and a "now broken" view.
+- **Scheduler backoff** — after N consecutive failed terminal attempts, the cron tick is skipped to stop spamming.

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -152,6 +152,14 @@ export interface DagExecuteOptions {
    *  by an `agent-invoke` or `loop` node in a parent run. */
   parentRunId?: string;
   parentNodeId?: string;
+  /**
+   * Retry chain metadata. Set when this execution is a manual retry of a
+   * prior failed run. `originalRunId` always points at the head of the
+   * chain (never an intermediate retry); `attempt` is 1-indexed and
+   * already incremented for the new run (i.e. attempt=2 for the first
+   * retry).
+   */
+  retryOf?: { originalRunId: string; attempt: number };
 }
 
 
@@ -186,6 +194,8 @@ export async function executeAgentDag(
     replayedFromNodeId: options.replayFrom?.fromNodeId,
     parentRunId: options.parentRunId,
     parentNodeId: options.parentNodeId,
+    retryOfRunId: options.retryOf?.originalRunId,
+    attempt: options.retryOf?.attempt,
   });
 
   const outputs = new Map<string, NodeOutput>();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,7 @@ export * from './node-catalog.js';
 export * from './agent-state.js';
 export * from './output-widget-types.js';
 export { outputWidgetSchema, widgetControlSchema, widgetViewSchema } from './output-widget-schema.js';
+export { extractPriorAgentInputs } from './run-inputs.js';
 export {
   agentV2Schema,
   agentNodeSchema,

--- a/packages/core/src/run-inputs.test.ts
+++ b/packages/core/src/run-inputs.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { RunStore } from './run-store.js';
+import { extractPriorAgentInputs } from './run-inputs.js';
+import type { Agent } from './agent-v2-types.js';
+
+const TEST_DB = join(import.meta.dirname, '__test-data__', 'run-inputs.db');
+
+let store: RunStore;
+
+beforeEach(() => { store = new RunStore(TEST_DB); });
+afterEach(() => {
+  store.close();
+  rmSync(join(import.meta.dirname, '__test-data__'), { recursive: true, force: true });
+});
+
+const agent: Pick<Agent, 'inputs'> = {
+  inputs: {
+    CITY: { type: 'string', default: 'sf' },
+    UNITS: { type: 'string', default: 'metric' },
+  },
+};
+
+describe('extractPriorAgentInputs', () => {
+  it('returns the declared agent inputs from the first node execution', () => {
+    store.createRun({
+      id: 'r1', agentName: 'weather', status: 'completed',
+      startedAt: new Date().toISOString(), triggeredBy: 'cli',
+    });
+    store.createNodeExecution({
+      runId: 'r1', nodeId: 'fetch', workflowVersion: 1,
+      status: 'completed', startedAt: new Date().toISOString(),
+      inputsJson: JSON.stringify({
+        CITY: 'tokyo', UNITS: 'metric',
+        // Non-input env vars must be filtered out.
+        PATH: '/usr/bin', SECRET_TOKEN: 'redacted',
+      }),
+    });
+    const got = extractPriorAgentInputs(agent, 'r1', store);
+    expect(got).toEqual({ CITY: 'tokyo', UNITS: 'metric' });
+  });
+
+  it('returns empty object when the agent declares no inputs', () => {
+    store.createRun({
+      id: 'r2', agentName: 'noop', status: 'completed',
+      startedAt: new Date().toISOString(), triggeredBy: 'cli',
+    });
+    expect(extractPriorAgentInputs({ inputs: undefined }, 'r2', store)).toEqual({});
+    expect(extractPriorAgentInputs({ inputs: {} }, 'r2', store)).toEqual({});
+  });
+
+  it('returns empty object when the run has no node executions yet', () => {
+    store.createRun({
+      id: 'r3', agentName: 'weather', status: 'pending',
+      startedAt: new Date().toISOString(), triggeredBy: 'cli',
+    });
+    expect(extractPriorAgentInputs(agent, 'r3', store)).toEqual({});
+  });
+
+  it('returns empty object when inputsJson is malformed', () => {
+    store.createRun({
+      id: 'r4', agentName: 'weather', status: 'failed',
+      startedAt: new Date().toISOString(), triggeredBy: 'cli',
+    });
+    store.createNodeExecution({
+      runId: 'r4', nodeId: 'fetch', workflowVersion: 1,
+      status: 'failed', startedAt: new Date().toISOString(),
+      inputsJson: 'not valid json',
+    });
+    expect(extractPriorAgentInputs(agent, 'r4', store)).toEqual({});
+  });
+
+  it('skips empty-string values', () => {
+    store.createRun({
+      id: 'r5', agentName: 'weather', status: 'completed',
+      startedAt: new Date().toISOString(), triggeredBy: 'cli',
+    });
+    store.createNodeExecution({
+      runId: 'r5', nodeId: 'fetch', workflowVersion: 1,
+      status: 'completed', startedAt: new Date().toISOString(),
+      inputsJson: JSON.stringify({ CITY: 'paris', UNITS: '' }),
+    });
+    expect(extractPriorAgentInputs(agent, 'r5', store)).toEqual({ CITY: 'paris' });
+  });
+});

--- a/packages/core/src/run-inputs.ts
+++ b/packages/core/src/run-inputs.ts
@@ -1,0 +1,40 @@
+/**
+ * Recover an agent's user-provided agent-level inputs from a prior run.
+ *
+ * Agent-level inputs (the user-typed `input_NAME` form fields) aren't stored
+ * directly on `runs` — they flow into per-node `inputsJson` after merging
+ * with secrets, env, defaults, etc. This helper reads the first node
+ * execution's `inputsJson` and intersects with the agent's declared
+ * `inputs:` keys to recover the original agent-level values.
+ *
+ * Used by:
+ *   - the Run Now modal pre-fill
+ *   - one-click manual retry (POST /runs/:id/retry)
+ *
+ * Returns an empty object if the run has no node executions yet, the agent
+ * declares no inputs, or `inputsJson` is malformed. Never throws.
+ */
+
+import type { Agent } from './agent-v2-types.js';
+import type { RunStore } from './run-store.js';
+
+export function extractPriorAgentInputs(
+  agent: Pick<Agent, 'inputs'>,
+  runId: string,
+  runStore: RunStore,
+): Record<string, string> {
+  if (!agent.inputs || Object.keys(agent.inputs).length === 0) return {};
+  try {
+    const execs = runStore.listNodeExecutions(runId);
+    if (execs.length === 0 || !execs[0].inputsJson) return {};
+    const allEnv = JSON.parse(execs[0].inputsJson) as Record<string, string>;
+    const declared = new Set(Object.keys(agent.inputs));
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(allEnv)) {
+      if (declared.has(k) && typeof v === 'string' && v !== '') out[k] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}

--- a/packages/core/src/run-store.test.ts
+++ b/packages/core/src/run-store.test.ts
@@ -407,3 +407,50 @@ describe('RunStore.distinctValues', () => {
     expect(store.distinctValues('triggeredBy')).toEqual(['cli', 'schedule']);
   });
 });
+
+describe('RunStore retry chain', () => {
+  it('createRun defaults attempt to 1 and retryOfRunId to undefined', () => {
+    const run = makeRun({ id: 'r-orig' });
+    store.createRun(run);
+    const got = store.getRun('r-orig');
+    expect(got!.attempt).toBe(1);
+    expect(got!.retryOfRunId).toBeUndefined();
+  });
+
+  it('persists attempt + retryOfRunId on createRun', () => {
+    store.createRun(makeRun({ id: 'r-orig' }));
+    store.createRun(makeRun({
+      id: 'r-retry-1',
+      retryOfRunId: 'r-orig',
+      attempt: 2,
+    }));
+    const got = store.getRun('r-retry-1');
+    expect(got!.retryOfRunId).toBe('r-orig');
+    expect(got!.attempt).toBe(2);
+  });
+
+  it('getRetryChain returns original + retries ordered by attempt', () => {
+    store.createRun(makeRun({ id: 'r-orig', startedAt: '2026-05-04T10:00:00Z' }));
+    store.createRun(makeRun({
+      id: 'r-retry-2', retryOfRunId: 'r-orig', attempt: 2, startedAt: '2026-05-04T10:01:00Z',
+    }));
+    store.createRun(makeRun({
+      id: 'r-retry-3', retryOfRunId: 'r-orig', attempt: 3, startedAt: '2026-05-04T10:02:00Z',
+    }));
+    const chain = store.getRetryChain('r-retry-2');
+    expect(chain.map((r) => r.id)).toEqual(['r-orig', 'r-retry-2', 'r-retry-3']);
+    // Calling on the head should also return the full chain.
+    const chainFromHead = store.getRetryChain('r-orig');
+    expect(chainFromHead.map((r) => r.id)).toEqual(['r-orig', 'r-retry-2', 'r-retry-3']);
+  });
+
+  it('getRetryChain on a non-retry run returns just that run', () => {
+    store.createRun(makeRun({ id: 'r-solo' }));
+    const chain = store.getRetryChain('r-solo');
+    expect(chain.map((r) => r.id)).toEqual(['r-solo']);
+  });
+
+  it('getRetryChain returns empty array for unknown run id', () => {
+    expect(store.getRetryChain('does-not-exist')).toEqual([]);
+  });
+});

--- a/packages/core/src/run-store.ts
+++ b/packages/core/src/run-store.ts
@@ -170,6 +170,21 @@ export class RunStore {
       this.db.exec(`ALTER TABLE runs ADD COLUMN parent_node_id TEXT`);
     }
 
+    // Retry chain: a one-click retry creates a new run that links back to
+    // the head of the chain via `retry_of_run_id`. `attempt` is 1-indexed
+    // (1 = first attempt). Flat chain — every retry points at the original,
+    // not at the immediate previous attempt — so counting siblings is cheap.
+    if (!runCols.has('retry_of_run_id')) {
+      this.db.exec(`ALTER TABLE runs ADD COLUMN retry_of_run_id TEXT`);
+    }
+    if (!runCols.has('attempt')) {
+      this.db.exec(`ALTER TABLE runs ADD COLUMN attempt INTEGER NOT NULL DEFAULT 1`);
+    }
+    this.db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_runs_retry_of
+        ON runs(retry_of_run_id) WHERE retry_of_run_id IS NOT NULL;
+    `);
+
     // v0.16: structured tool outputs stored alongside the flat result.
     const execCols = columnNames(this.db, 'node_executions');
     if (!execCols.has('outputsjson')) {
@@ -205,12 +220,12 @@ export class RunStore {
     return Number(result.changes ?? 0);
   }
 
-  createRun(run: Run & { workflowId?: string; workflowVersion?: number; replayedFromRunId?: string; replayedFromNodeId?: string; parentRunId?: string; parentNodeId?: string }): void {
+  createRun(run: Run & { workflowId?: string; workflowVersion?: number; replayedFromRunId?: string; replayedFromNodeId?: string; parentRunId?: string; parentNodeId?: string; retryOfRunId?: string; attempt?: number }): void {
     const stmt = this.db.prepare(`
       INSERT INTO runs (id, agentName, status, startedAt, completedAt, result, exitCode, error, triggeredBy,
                         workflow_id, workflow_version, replayed_from_run_id, replayed_from_node_id,
-                        parent_run_id, parent_node_id)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        parent_run_id, parent_node_id, retry_of_run_id, attempt)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     stmt.run(
       run.id, run.agentName, run.status, run.startedAt,
@@ -219,7 +234,26 @@ export class RunStore {
       run.workflowId ?? null, run.workflowVersion ?? null,
       run.replayedFromRunId ?? null, run.replayedFromNodeId ?? null,
       run.parentRunId ?? null, run.parentNodeId ?? null,
+      run.retryOfRunId ?? null, run.attempt ?? 1,
     );
+  }
+
+  /**
+   * Return every run in a retry chain (the original + all retries) ordered
+   * by attempt ascending. `runId` may be either the head of the chain or
+   * any retry within it. Empty array if `runId` is unknown.
+   */
+  getRetryChain(runId: string): Run[] {
+    const head = this.getRun(runId);
+    if (!head) return [];
+    const headId = head.retryOfRunId ?? head.id;
+    const stmt = this.db.prepare(`
+      SELECT * FROM runs
+      WHERE id = ? OR retry_of_run_id = ?
+      ORDER BY attempt ASC, startedAt ASC
+    `);
+    const rows = stmt.all(headId, headId) as Record<string, unknown>[];
+    return rows.map((r) => this.rowToRun(r));
   }
 
   getRun(id: string): Run | null {
@@ -458,6 +492,8 @@ export class RunStore {
       replayedFromNodeId: (row.replayed_from_node_id as string | null) ?? undefined,
       parentRunId: (row.parent_run_id as string | null) ?? undefined,
       parentNodeId: (row.parent_node_id as string | null) ?? undefined,
+      retryOfRunId: (row.retry_of_run_id as string | null) ?? undefined,
+      attempt: typeof row.attempt === 'number' ? row.attempt : 1,
     };
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -106,6 +106,15 @@ export interface Run {
    */
   parentRunId?: string;
   parentNodeId?: string;
+  /**
+   * One-click manual retry: link back to the original (head of chain) run.
+   * `attempt` is 1-indexed; first attempt is 1, first retry is 2, etc.
+   * `retryOfRunId` is null/undefined for first attempts and for non-retried
+   * runs. The chain is flat — every retry points at the original head, not
+   * at the immediate previous attempt.
+   */
+  retryOfRunId?: string;
+  attempt?: number;
 }
 
 export interface RunRequest {

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -1643,6 +1643,132 @@ describe('Dashboard /runs/:id/replay (PR 5)', () => {
   });
 });
 
+describe('Dashboard /runs/:id/retry (R1)', () => {
+  function seedFailedRun(opts: { agentId?: string; runId?: string } = {}) {
+    const agentId = opts.agentId ?? 'retry-test';
+    const runId = opts.runId ?? 'failed-run-1';
+    agentStore.createAgent({
+      id: agentId, name: 'Retry Test', status: 'active', source: 'local', mcp: false,
+      inputs: { CITY: { type: 'string', default: 'sf' } },
+      nodes: [{ id: 'fetch', type: 'shell', command: 'echo {"temp":20}' }],
+    }, 'cli', 'seed');
+    runStore.createRun({
+      id: runId, agentName: agentId, status: 'failed',
+      startedAt: new Date(Date.now() - 60_000).toISOString(),
+      completedAt: new Date().toISOString(),
+      triggeredBy: 'cli',
+      workflowId: agentId, workflowVersion: 1,
+      error: 'Simulated failure',
+    });
+    runStore.createNodeExecution({
+      runId, nodeId: 'fetch', workflowVersion: 1,
+      status: 'failed', startedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(), exitCode: 1,
+      inputsJson: JSON.stringify({ CITY: 'tokyo' }),
+    });
+    return { agentId, runId };
+  }
+
+  it('renders Retry button on the error block of a failed run', async () => {
+    const app = await makeApp();
+    const { runId } = seedFailedRun();
+    const res = await request(app).get(`/runs/${runId}`)
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain(`action="/runs/${runId}/retry"`);
+    expect(res.text).toContain('Retry run');
+  });
+
+  it('does NOT render Retry button on a completed run', async () => {
+    const app = await makeApp();
+    const { agentId } = seedFailedRun({ agentId: 'retry-ok', runId: 'ok-run' });
+    runStore.updateRun('ok-run', { status: 'completed', error: undefined });
+    // Completed runs without an error block don't show retry — re-fetch.
+    const res = await request(app).get(`/runs/ok-run`)
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).not.toContain(`/runs/ok-run/retry"`);
+    expect(agentId).toBe('retry-ok');
+  });
+
+  it('POST /runs/:id/retry on a failed run creates a new attempt and redirects', async () => {
+    const app = await makeApp();
+    const { agentId, runId } = seedFailedRun();
+    const res = await request(app).post(`/runs/${runId}/retry`)
+      .type('form').send({})
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/^\/runs\/[^/?]+\?flash=/);
+    expect(res.headers.location).not.toContain(runId);
+    expect(decodeURIComponent(res.headers.location)).toMatch(/Retry attempt 2/);
+
+    // Wait briefly for the executor to settle, then inspect the chain.
+    await new Promise((r) => setTimeout(r, 700));
+    const chain = runStore.getRetryChain(runId);
+    expect(chain.length).toBeGreaterThanOrEqual(2);
+    const newRun = chain.find((r) => r.attempt === 2);
+    expect(newRun).toBeDefined();
+    expect(newRun!.retryOfRunId).toBe(runId);
+    expect(newRun!.agentName).toBe(agentId);
+  });
+
+  it('POST /runs/:id/retry on a completed run is rejected', async () => {
+    const app = await makeApp();
+    const { runId } = seedFailedRun({ runId: 'completed-run' });
+    runStore.updateRun(runId, { status: 'completed' });
+    const res = await request(app).post(`/runs/${runId}/retry`)
+      .type('form').send({})
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toBe(`/runs/${runId}?flash=${encodeURIComponent('Only failed runs can be retried (this one is completed).')}`);
+  });
+
+  it('POST /runs/:id/retry recovers prior agent inputs', async () => {
+    const app = await makeApp();
+    const { agentId, runId } = seedFailedRun({ agentId: 'retry-inputs', runId: 'inputs-run' });
+    await request(app).post(`/runs/${runId}/retry`)
+      .type('form').send({})
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    await new Promise((r) => setTimeout(r, 700));
+    // The new run's first node-execution should have CITY=tokyo (from the
+    // prior run's inputsJson), not the agent's default of 'sf'.
+    const chain = runStore.getRetryChain(runId);
+    const newRun = chain.find((r) => r.attempt === 2);
+    expect(newRun).toBeDefined();
+    const execs = runStore.listNodeExecutions(newRun!.id);
+    expect(execs.length).toBeGreaterThan(0);
+    const env = JSON.parse(execs[0].inputsJson ?? '{}');
+    expect(env.CITY).toBe('tokyo');
+    expect(agentId).toBe('retry-inputs');
+  });
+
+  it('renders attempt badge in run-detail header when run is a retry', async () => {
+    const app = await makeApp();
+    const { agentId } = seedFailedRun({ agentId: 'attempt-badge', runId: 'orig-run' });
+    runStore.createRun({
+      id: 'retry-run-2', agentName: agentId, status: 'completed',
+      startedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(),
+      triggeredBy: 'dashboard',
+      workflowId: agentId, workflowVersion: 1,
+      retryOfRunId: 'orig-run',
+      attempt: 2,
+    });
+    const res = await request(app).get('/runs/retry-run-2')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('attempt 2');
+    expect(res.text).toContain('Retry of');
+    expect(res.text).toContain('/runs/orig-run');
+  });
+});
+
 describe('Dashboard /tools (v0.16 PR 3)', () => {
   it('GET /tools lists built-in tools', async () => {
     const app = await makeApp();

--- a/packages/dashboard/src/routes/agents/tabs.ts
+++ b/packages/dashboard/src/routes/agents/tabs.ts
@@ -1,5 +1,5 @@
 import { Router, type Request, type Response } from 'express';
-import type { RunStatus } from '@some-useful-agents/core';
+import { extractPriorAgentInputs, type RunStatus } from '@some-useful-agents/core';
 import { getContext } from '../../context.js';
 import { renderAgentNodes, renderAgentConfig, renderAgentRuns } from '../../views/agent-detail-v2.js';
 import { deriveBack } from '../../views/page-header.js';
@@ -21,18 +21,9 @@ async function buildTabArgs(req: Request, ctx: ReturnType<typeof getContext>, na
 
   // Extract previous run's agent-level inputs for the Run Now modal.
   let previousInputs: Record<string, string> | undefined;
-  if (rows.length > 0 && agent.inputs) {
-    try {
-      const execs = ctx.runStore.listNodeExecutions(rows[0].id);
-      if (execs.length > 0 && execs[0].inputsJson) {
-        const allEnv = JSON.parse(execs[0].inputsJson) as Record<string, string>;
-        const inputNames = new Set(Object.keys(agent.inputs));
-        previousInputs = {};
-        for (const [k, v] of Object.entries(allEnv)) {
-          if (inputNames.has(k) && v !== '') previousInputs[k] = v;
-        }
-      }
-    } catch { /* no node executions yet */ }
+  if (rows.length > 0) {
+    const recovered = extractPriorAgentInputs(agent, rows[0].id, ctx.runStore);
+    if (Object.keys(recovered).length > 0) previousInputs = recovered;
   }
 
   return { agent, recentRuns: rows, secretsStore: ctx.secretsStore, flash, back, from: fromParam, previousInputs };

--- a/packages/dashboard/src/routes/run-mutations.ts
+++ b/packages/dashboard/src/routes/run-mutations.ts
@@ -1,5 +1,5 @@
 import { Router, type Request, type Response } from 'express';
-import { executeAgentDag, topologicalSort, type RunStatus } from '@some-useful-agents/core';
+import { executeAgentDag, extractPriorAgentInputs, topologicalSort, type RunStatus } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 
 export const runMutationsRouter: Router = Router();
@@ -194,6 +194,132 @@ runMutationsRouter.post('/runs/:id/replay', async (req: Request, res: Response) 
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     res.redirect(303, `/runs/${encodeURIComponent(id)}?flash=${encodeURIComponent(`Replay failed: ${message}`)}`);
+  }
+});
+
+/**
+ * POST /runs/:id/retry — one-click manual retry of a failed run.
+ *
+ * Creates a fresh run with the same agent-level inputs as the prior run
+ * (recovered from the prior run's first node-execution `inputsJson`).
+ * Links the new run back to the head of the retry chain via
+ * `retryOfRunId` and increments `attempt`.
+ *
+ * Distinct from `/replay`: replay re-runs from a specific node reusing
+ * upstream outputs (partial re-execution); retry redoes the whole run
+ * from scratch with the same inputs (full re-execution). For a flaky
+ * upstream that recovered, retry is the right tool.
+ *
+ * Defense layers (on top of requireAuth cookie + Host + Origin):
+ *   1. Prior run must exist + be a v2 DAG run.
+ *   2. Prior run must be terminally failed (status === 'failed'). Cancelled
+ *      and completed runs are not retried — cancellation was deliberate,
+ *      and completed runs should use Run Now.
+ *   3. Agent must still be in AgentStore.
+ *   4. Community shell agents require `confirm_community_shell=yes`.
+ */
+runMutationsRouter.post('/runs/:id/retry', async (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const confirmed = body.confirm_community_shell === 'yes';
+
+  const priorRun = ctx.runStore.getRun(id);
+  if (!priorRun) {
+    res.status(404).redirect(303, '/runs');
+    return;
+  }
+  if (!priorRun.workflowId) {
+    res.redirect(303, `/runs/${encodeURIComponent(id)}?flash=${encodeURIComponent('Retry only works on v2 DAG runs.')}`);
+    return;
+  }
+  if (priorRun.status !== 'failed') {
+    res.redirect(303, `/runs/${encodeURIComponent(id)}?flash=${encodeURIComponent(`Only failed runs can be retried (this one is ${priorRun.status}).`)}`);
+    return;
+  }
+
+  const agent = ctx.agentStore.getAgent(priorRun.workflowId);
+  if (!agent) {
+    res.redirect(303, `/runs/${encodeURIComponent(id)}?flash=${encodeURIComponent(`Agent "${priorRun.workflowId}" not found in store.`)}`);
+    return;
+  }
+
+  const needsConfirm = agent.source === 'community' && agent.nodes.some((n) => n.type === 'shell');
+  if (needsConfirm && !confirmed) {
+    res.redirect(303, `/runs/${encodeURIComponent(id)}?flash=${encodeURIComponent('Community shell retries need explicit confirmation.')}`);
+    return;
+  }
+
+  // Recover the agent-level inputs from the prior run. Empty object is fine
+  // — agents without declared inputs go straight to the executor with {}.
+  const recoveredInputs = extractPriorAgentInputs(agent, id, ctx.runStore);
+
+  // Compute attempt + chain head. Flat chain: every retry points at the
+  // original head, never an intermediate retry. So if priorRun is itself a
+  // retry, the new attempt links to its head and increments based on the
+  // chain's max attempt (resilient against gaps from manual deletions).
+  const headId = priorRun.retryOfRunId ?? priorRun.id;
+  const chain = ctx.runStore.getRetryChain(headId);
+  const maxAttempt = chain.reduce((m, r) => Math.max(m, r.attempt ?? 1), 1);
+  const nextAttempt = maxAttempt + 1;
+
+  const abortController = new AbortController();
+  const runPromise = executeAgentDag(
+    agent,
+    {
+      triggeredBy: 'dashboard',
+      inputs: recoveredInputs,
+      signal: abortController.signal,
+      retryOf: { originalRunId: headId, attempt: nextAttempt },
+    },
+    {
+      runStore: ctx.runStore,
+      secretsStore: ctx.secretsStore,
+      variablesStore: ctx.variablesStore,
+      toolStore: ctx.toolStore,
+      agentStore: ctx.agentStore,
+      allowUntrustedShell: ctx.allowUntrustedShell,
+      dashboardBaseUrl: ctx.dashboardBaseUrl,
+      dataRoot: ctx.agentStore.dataRoot,
+    },
+  );
+
+  // Track for cancel.
+  runPromise.then((run) => { ctx.activeRuns.delete(run.id); }).catch(() => {});
+  setTimeout(() => {
+    const { rows } = ctx.runStore.queryRuns({
+      agentName: agent.id,
+      statuses: ['running'] as RunStatus[],
+      limit: 1,
+      offset: 0,
+    });
+    if (rows.length > 0) ctx.activeRuns.set(rows[0].id, abortController);
+  }, 100);
+
+  try {
+    const result = await Promise.race([
+      runPromise,
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), 500)),
+    ]);
+    if (result) {
+      res.redirect(303, `/runs/${encodeURIComponent(result.id)}?flash=${encodeURIComponent(`Retry attempt ${String(nextAttempt)} complete.`)}`);
+    } else {
+      const { rows } = ctx.runStore.queryRuns({
+        agentName: agent.id,
+        statuses: ['running'] as RunStatus[],
+        limit: 1,
+        offset: 0,
+      });
+      if (rows.length > 0) {
+        res.redirect(303, `/runs/${encodeURIComponent(rows[0].id)}?flash=${encodeURIComponent(`Retry attempt ${String(nextAttempt)} started...`)}`);
+      } else {
+        const fullResult = await runPromise;
+        res.redirect(303, `/runs/${encodeURIComponent(fullResult.id)}?flash=${encodeURIComponent(`Retry attempt ${String(nextAttempt)} complete.`)}`);
+      }
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/runs/${encodeURIComponent(id)}?flash=${encodeURIComponent(`Retry failed: ${message}`)}`);
   }
 });
 

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -39,6 +39,14 @@ export function renderRunDetail(opts: RunDetailOptions): string {
     </dd>
   ` : html``;
 
+  const retryOf = run.retryOfRunId ? html`
+    <dt>Retry of</dt>
+    <dd class="mono">
+      <a href="/runs/${run.retryOfRunId}">${run.retryOfRunId.slice(0, 8)}</a>
+      <span class="dim"> · attempt ${String(run.attempt ?? 1)}</span>
+    </dd>
+  ` : html``;
+
   // Terminal v2 runs get clickable DAG nodes that offer "Replay from
   // here". Running / pending runs intentionally don't — the executor
   // hasn't finalised upstream outputs yet.
@@ -98,11 +106,15 @@ export function renderRunDetail(opts: RunDetailOptions): string {
     : html``;
 
 
+  const attemptBadge = (run.attempt ?? 1) > 1
+    ? html`<span class="badge badge--muted" title="This run is a retry of an earlier attempt">attempt ${String(run.attempt)}</span>`
+    : html``;
+
   const header = partial
-    ? html`<h1>Run <span class="mono">${run.id.slice(0, 8)}</span> ${statusBadge(run.status)} ${cancelButton}</h1>`
+    ? html`<h1>Run <span class="mono">${run.id.slice(0, 8)}</span> ${statusBadge(run.status)} ${attemptBadge} ${cancelButton}</h1>`
     : pageHeader({
         title: `Run ${run.id.slice(0, 8)}`,
-        meta: [statusBadge(run.status)],
+        meta: [statusBadge(run.status), attemptBadge],
         cta: cancelButton,
         back,
       });
@@ -120,6 +132,7 @@ export function renderRunDetail(opts: RunDetailOptions): string {
           <dt>Exit code</dt><dd class="mono">${formatExitCode(run.exitCode)}</dd>
           <dt>Triggered by</dt><dd>${run.triggeredBy}</dd>
           ${replayedFrom}
+          ${retryOf}
         </dl>
       </div>
 
@@ -127,8 +140,15 @@ export function renderRunDetail(opts: RunDetailOptions): string {
         <h2>Error</h2>
         <div class="flash flash--error" style="display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-3);">
           <span>${run.error}</span>
-          <a href="/agents/${run.agentName}?suggest=1&focus=${encodeURIComponent(run.error)}"
-            class="btn btn--sm btn--primary" style="white-space: nowrap; flex-shrink: 0;">Suggest improvements</a>
+          <span style="display: inline-flex; gap: var(--space-2); flex-shrink: 0; white-space: nowrap;">
+            ${run.status === 'failed' ? html`
+              <form method="POST" action="/runs/${run.id}/retry" style="display: inline; margin: 0;">
+                <button type="submit" class="btn btn--sm btn--primary" data-retry-run>Retry run</button>
+              </form>
+            ` : html``}
+            <a href="/agents/${run.agentName}?suggest=1&focus=${encodeURIComponent(run.error)}"
+              class="btn btn--sm btn--ghost">Suggest improvements</a>
+          </span>
         </div>
       ` : html``}
 


### PR DESCRIPTION
## Summary

Failed runs gain a **Retry** button on the run-detail error block. Clicking it:

1. Recovers the original agent-level inputs from the prior run's first node execution.
2. Creates a fresh run with `attempt: N+1` and `retryOfRunId` linking to the head of the chain.
3. Redirects to the new run.

This is **R1 of the failed-runs-and-retry plan** — keystone PR. R2 (auto-retry policy), R3 (notify deferral), R4 (triage surface), R5 (scheduler backoff) build on top. Plan at `~/.claude/plans/failed-runs-and-retry.md`.

## Manual retry vs replay

| Tool | When | Effect |
|---|---|---|
| **Retry** (new) | Whole run failed; redo it | Fresh top-to-bottom run with same inputs, links back via `retryOfRunId`. |
| **Replay from node** (existing) | A node failed mid-DAG; upstream OK | Re-runs from a chosen node, reusing stored upstream outputs. |

## Schema additions

Additive, idempotent migrations on `runs`:
- `attempt INTEGER NOT NULL DEFAULT 1`
- `retry_of_run_id TEXT` (nullable)
- `idx_runs_retry_of` partial index on `retry_of_run_id IS NOT NULL`

Existing runs default to `attempt=1, retry_of_run_id=NULL`. No data migration needed.

## Retry chain semantics

The chain is **flat** — every retry points at the original head, never an intermediate retry. Each new retry's `attempt = MAX(attempt) + 1` across the chain. Run-detail shows an "attempt N" badge in the header on any retry, plus a "Retry of" row linking back to the original.

## What does not get retried

- `cancelled` runs (deliberate stop).
- `completed` runs (use Run now to re-execute).
- v1 (non-DAG) runs.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` green (929 tests, +16 over baseline)
- [x] Schema migration on existing DB doesn't break (idempotent)
- [x] `getRetryChain` returns chain in attempt order whether called on head or any retry
- [x] POST `/runs/:id/retry`: 303 with new run id on `failed`, 303 to prior run with explanatory `?flash` on `completed`/`running`/`cancelled`
- [x] New run inherits prior agent-level inputs (recovered from first node-execution `inputsJson`)
- [x] Live smoke against running daemon: created a failing agent, retried 3× — chain shows attempts 1 → 2 → 3, each linking back to the head correctly

## Out of scope (future PRs in the plan)

- Auto-retry policy (`retry: { attempts, backoff, delaySeconds, categories }`) — R2
- Notify deferral until final attempt — R3
- Triage surface ("which agents are broken right now") — R4
- Scheduler skip/backoff after N consecutive failures — R5

🤖 Generated with [Claude Code](https://claude.com/claude-code)