### PR TITLE
feat(retry): agent-declared auto-retry policy (R2)

### DIFF
--- a/.changeset/auto-retry.md
+++ b/.changeset/auto-retry.md
@@ -1,0 +1,23 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Auto-retry on transient failures (R2 of failed-runs-and-retry plan).
+
+Agents can declare a top-level `retry:` block. When a run fails with a configured `errorCategory`, the orchestrator sleeps with backoff and spawns a fresh attempt, linked back to the head of the chain via `retryOfRunId` (same shape as R1's manual retry).
+
+```yaml
+retry:
+  attempts: 3                   # total tries including the first; default 1
+  backoff: exponential          # exponential (default) | linear | fixed
+  delaySeconds: 30              # base; 30 → 60 → 120 for exponential
+  categories: [timeout, spawn_failure]   # default; conservative
+```
+
+`cancelled`, `setup`, `input_resolution`, `condition_not_met`, `flow_ended` are NEVER retried regardless of policy — they're deterministic or user-driven.
+
+Implementation lives ABOVE the executor as a thin wrapper (`executeAgentWithRetry` in core/retry.ts). Callers — Run Now, manual retry, widget run, `sua workflow run` — switched from `executeAgentDag` to the wrapper. Replay route stays on the raw executor (replay is investigation, not auto-recovery). Agents without a `retry:` block fall through to a single executor call (zero overhead).

--- a/docs/retry.md
+++ b/docs/retry.md
@@ -59,9 +59,46 @@ Form body: `confirm_community_shell=yes` if the agent has community shell nodes 
 
 Returns `303` redirect to the new run on success, or back to the prior run with a `?flash=` error message on failure (e.g. "Only failed runs can be retried").
 
+## Auto-retry (agent-declared policy)
+
+Agents can declare a `retry:` block to recover from transient failures without manual intervention:
+
+```yaml
+retry:
+  attempts: 3              # total tries including the first; 1 = no retry
+  backoff: exponential     # exponential | linear | fixed; default exponential
+  delaySeconds: 30         # base delay; 30s → 60s → 120s for exponential
+  categories:              # which errorCategory values trigger a retry
+    - timeout
+    - spawn_failure
+```
+
+When a run fails with a category in the policy's `categories:` list, the orchestrator sleeps with backoff and spawns a fresh attempt. Each attempt is its own `runs` row, linked back to the head via `retryOfRunId` — the same flat-chain shape as one-click manual retry. You'll see attempt 1, 2, 3 as siblings in the dashboard.
+
+### Default categories
+
+When `categories:` is omitted, the policy defaults to `[timeout, spawn_failure]` — flake-shaped failures only. Authors broaden by listing additional categories explicitly (e.g. `[timeout, spawn_failure, exit_nonzero]` for a flaky CLI).
+
+### Categories that NEVER retry
+
+These are deterministic (`setup`, `input_resolution`) or user-driven (`cancelled`) or already-skipped states (`condition_not_met`, `flow_ended`). Retrying changes nothing, so the orchestrator skips them regardless of policy.
+
+### Backoff modes
+
+| Mode | Formula | Example with `delaySeconds: 30` |
+|---|---|---|
+| `exponential` (default) | `delaySeconds × 2^(attempt-1)` | 30s → 60s → 120s → 240s |
+| `linear` | `delaySeconds × attempt` | 30s → 60s → 90s → 120s |
+| `fixed` | `delaySeconds` always | 30s → 30s → 30s |
+
+All sleeps are capped at 1 hour.
+
+### Auto-retry + manual retry interplay
+
+Manual retry and auto-retry share the same chain. If a user clicks Retry on a run that's already part of an auto-retry chain, the new attempt picks up where the chain left off and counts further auto-retries against the policy's `attempts` budget. Manual retries can take you over the policy budget — they're explicit user overrides — but no further auto-retries fire after that point.
+
 ## What's coming next
 
-- **Auto-retry** ([plan](https://github.com/anthropics/some-useful-agents/issues)) — agents declare `retry: { attempts, backoff, delaySeconds, categories }` and the executor re-fires transient failures (timeouts, spawn failures) without paging anyone.
-- **Notify deferral** — when auto-retry is in play, `failure` notifications wait until the final attempt fails.
-- **Triage surface** — per-agent consecutive-failure tracking and a "now broken" view.
-- **Scheduler backoff** — after N consecutive failed terminal attempts, the cron tick is skipped to stop spamming.
+- **Notify deferral** (R3) — when auto-retry is in play, `failure` notifications wait until the final attempt fails.
+- **Triage surface** (R4) — per-agent consecutive-failure tracking and a "now broken" view.
+- **Scheduler backoff** (R5) — after N consecutive failed terminal attempts, the cron tick is skipped to stop spamming.

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -9,6 +9,7 @@ import {
   EncryptedFileStore,
   loadAgents,
   executeAgentDag,
+  executeAgentWithRetry,
   planMigration,
   applyMigration,
   exportAgent,
@@ -297,7 +298,7 @@ workflowCommand
         process.exitCode = 1;
         return;
       }
-      const run = await executeAgentDag(
+      const run = await executeAgentWithRetry(
         agent,
         { triggeredBy: 'cli', inputs: options.input },
         {

--- a/packages/core/src/agent-store.ts
+++ b/packages/core/src/agent-store.ts
@@ -375,6 +375,7 @@ export class AgentStore {
     if (agent.signal) dag.signal = agent.signal;
     if (agent.outputWidget) dag.outputWidget = agent.outputWidget;
     if (agent.notify) dag.notify = agent.notify;
+    if (agent.retry) dag.retry = agent.retry;
     if (agent.author !== undefined) dag.author = agent.author;
     if (agent.tags) dag.tags = agent.tags;
     return dag;
@@ -417,6 +418,7 @@ export class AgentStore {
       signal: dag.signal,
       outputWidget: dag.outputWidget,
       notify: dag.notify,
+      retry: dag.retry,
       author: dag.author,
       tags: dag.tags,
     };

--- a/packages/core/src/agent-v2-schema.test.ts
+++ b/packages/core/src/agent-v2-schema.test.ts
@@ -158,6 +158,45 @@ describe('agentV2Schema — happy paths', () => {
     expect(r.success).toBe(false);
   });
 
+  it('accepts a retry policy with all fields', () => {
+    const r = agentV2Schema.safeParse(validSingleNode({
+      retry: { attempts: 3, backoff: 'exponential', delaySeconds: 30, categories: ['timeout', 'spawn_failure'] },
+    }));
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.retry?.attempts).toBe(3);
+      expect(r.data.retry?.backoff).toBe('exponential');
+    }
+  });
+
+  it('accepts a retry policy with only attempts (defaults applied at runtime)', () => {
+    const r = agentV2Schema.safeParse(validSingleNode({
+      retry: { attempts: 2 },
+    }));
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects retry.attempts > 10 (sanity cap)', () => {
+    const r = agentV2Schema.safeParse(validSingleNode({
+      retry: { attempts: 100 },
+    }));
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects retry.delaySeconds > 3600 (1 hour cap)', () => {
+    const r = agentV2Schema.safeParse(validSingleNode({
+      retry: { attempts: 3, delaySeconds: 99999 },
+    }));
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects unknown retry.backoff mode', () => {
+    const r = agentV2Schema.safeParse(validSingleNode({
+      retry: { attempts: 3, backoff: 'jittered' as unknown },
+    }));
+    expect(r.success).toBe(false);
+  });
+
   it('omits the outputs key when not declared', () => {
     const r = agentV2Schema.safeParse(validSingleNode());
     expect(r.success).toBe(true);

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -260,6 +260,20 @@ export const agentV2Schema = z.object({
   // fields — all of which YAML import would silently strip.
   outputWidget: outputWidgetSchema.optional(),
 
+  /**
+   * Auto-retry policy. Opt-in. Transient failures (configurable via
+   * `categories`) trigger a fresh run with backoff. See `retry.ts`.
+   */
+  retry: z.object({
+    attempts: z.number().int().min(1).max(10),
+    backoff: z.enum(['exponential', 'linear', 'fixed']).optional(),
+    delaySeconds: z.number().int().min(1).max(3600).optional(),
+    categories: z.array(z.enum([
+      'setup', 'input_resolution', 'spawn_failure', 'exit_nonzero',
+      'timeout', 'cancelled', 'upstream_failed', 'condition_not_met', 'flow_ended',
+    ])).optional(),
+  }).optional(),
+
   author: z.string().optional(),
   tags: z.array(z.string()).optional(),
 }).superRefine((data, ctx) => {

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -73,6 +73,40 @@ export type NodeErrorCategory =
 export type { AgentSource };
 
 /**
+ * Backoff strategies for `retry:` policies.
+ *   exponential — `delaySeconds * 2^(attempt-1)`. Default.
+ *   linear      — `delaySeconds * attempt`.
+ *   fixed       — `delaySeconds` every attempt.
+ * All capped at 1 hour to prevent runaway sleeps.
+ */
+export type RetryBackoffMode = 'exponential' | 'linear' | 'fixed';
+
+/**
+ * Agent-declared automatic retry policy. Opt-in. When omitted (or `attempts`
+ * is `1` / undefined), the executor runs once and reports the final status.
+ *
+ * Each retry creates a new `runs` row with `retryOfRunId` linking back to
+ * the head of the chain (same flat-chain shape as manual retry). On the
+ * dashboard you see attempt 1, 2, 3 as siblings under the original.
+ *
+ * `categories` controls which `NodeErrorCategory` values trigger a retry.
+ * Defaults to a conservative `[timeout, spawn_failure]` — flaky-network /
+ * port-in-use territory. Authors can broaden to `[exit_nonzero]` etc. when
+ * an agent is known to be transient. Categories `cancelled`, `setup`,
+ * `input_resolution`, `condition_not_met`, `flow_ended` are NEVER retried
+ * regardless of policy — they're deterministic or user-driven.
+ */
+export interface RetryPolicy {
+  /** Total tries including the first. 1 = no retry; default 1. */
+  attempts: number;
+  backoff?: RetryBackoffMode;
+  /** Base delay in seconds. Default 30. */
+  delaySeconds?: number;
+  /** Categories that trigger retry. Default `['timeout', 'spawn_failure']`. */
+  categories?: NodeErrorCategory[];
+}
+
+/**
  * A single executable step within an agent's DAG. Corresponds 1:1 with what
  * a v1 `AgentDefinition` described, minus the cross-file chaining fields
  * (`dependsOn`/`input`/`source`) which now live at the agent or edge level.
@@ -303,6 +337,15 @@ export interface Agent {
    */
   notify?: import('./notify-dispatcher.js').NotifyConfig;
 
+  /**
+   * Automatic retry policy. Opt-in. When set with `attempts > 1`, transient
+   * failures (configurable via `categories`) trigger a fresh run with
+   * exponential / linear / fixed backoff between attempts. Each retry is a
+   * new `runs` row linked to the head via `retryOfRunId` — the same chain
+   * shape as one-click manual retry. See `retry.ts` for the orchestrator.
+   */
+  retry?: RetryPolicy;
+
   // Metadata
   author?: string;
   tags?: string[];
@@ -394,6 +437,7 @@ export interface AgentVersionDag {
   signal?: AgentSignal;
   outputWidget?: import('./output-widget-types.js').OutputWidgetSchema;
   notify?: import('./notify-dispatcher.js').NotifyConfig;
+  retry?: RetryPolicy;
   author?: string;
   tags?: string[];
 }

--- a/packages/core/src/agent-yaml.ts
+++ b/packages/core/src/agent-yaml.ts
@@ -115,6 +115,7 @@ function parsedToAgent(p: AgentV2Parsed): Agent {
     nodes,
     ...(p.signal && { signal: p.signal }),
     ...(p.outputWidget && { outputWidget: p.outputWidget }),
+    ...(p.retry && { retry: p.retry }),
     ...(p.notify && { notify: p.notify as Agent['notify'] }),
     ...(p.author !== undefined && { author: p.author }),
     ...(p.tags && { tags: p.tags }),
@@ -137,6 +138,7 @@ const AGENT_KEY_ORDER = [
   'nodes',
   'signal',
   'outputWidget',
+  'retry',
   'notify',
   'author', 'tags',
 ] as const;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,13 @@ export * from './output-widget-types.js';
 export { outputWidgetSchema, widgetControlSchema, widgetViewSchema } from './output-widget-schema.js';
 export { extractPriorAgentInputs } from './run-inputs.js';
 export {
+  executeAgentWithRetry,
+  isRetryableCategory,
+  computeBackoffDelay,
+  DEFAULT_RETRY_CATEGORIES,
+  type ExecuteAgentWithRetryHooks,
+} from './retry.js';
+export {
   agentV2Schema,
   agentNodeSchema,
   extractUpstreamReferences,

--- a/packages/core/src/retry.test.ts
+++ b/packages/core/src/retry.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { RunStore } from './run-store.js';
+import {
+  executeAgentWithRetry,
+  isRetryableCategory,
+  computeBackoffDelay,
+  DEFAULT_RETRY_CATEGORIES,
+} from './retry.js';
+import type { Agent, NodeErrorCategory, RetryPolicy } from './agent-v2-types.js';
+import type { Run } from './types.js';
+import type { DagExecuteOptions, DagExecutorDeps } from './dag-executor.js';
+
+const TEST_DB = join(import.meta.dirname, '__test-data__', 'retry.db');
+
+let store: RunStore;
+beforeEach(() => { store = new RunStore(TEST_DB); });
+afterEach(() => {
+  store.close();
+  rmSync(join(import.meta.dirname, '__test-data__'), { recursive: true, force: true });
+});
+
+function makeAgent(retry?: RetryPolicy): Agent {
+  return {
+    id: 'flake', name: 'flake', status: 'active', source: 'local',
+    version: 1, mcp: false,
+    nodes: [{ id: 'main', type: 'shell', command: 'exit 1' }],
+    retry,
+  } as Agent;
+}
+
+// Build a minimal deps fixture. The test never calls the real executor;
+// we stub through executeAgentWithRetry's hooks + a fake executor injected
+// via the deps' spawnNode. But the wrapper calls executeAgentDag directly,
+// so for these tests we instead test the wrapper's PURE helpers and
+// orchestrate behaviour by writing pre-canned runs to the store and
+// stubbing executeAgentDag at the module boundary via a thin shim.
+//
+// Rather than mock the executor, we run a minimal fake by invoking the
+// wrapper with a custom deps object whose runStore is real and whose
+// downstream behaviour is encoded by a deterministic stand-in. The
+// wrapper calls `executeAgentDag(agent, options, deps)`; we'd need to
+// substitute that. Since the wrapper uses a static import, we test the
+// helpers directly and then add a smaller integration test below that
+// uses a real (cheap) shell command.
+
+describe('isRetryableCategory', () => {
+  it('returns false for undefined', () => {
+    expect(isRetryableCategory(undefined, { categories: ['timeout'] })).toBe(false);
+  });
+
+  it('honours the policy categories list', () => {
+    expect(isRetryableCategory('timeout', { categories: ['timeout'] })).toBe(true);
+    expect(isRetryableCategory('exit_nonzero', { categories: ['timeout'] })).toBe(false);
+  });
+
+  it('falls back to DEFAULT_RETRY_CATEGORIES when policy.categories is undefined', () => {
+    expect(isRetryableCategory('timeout', {})).toBe(true);
+    expect(isRetryableCategory('spawn_failure', {})).toBe(true);
+    expect(isRetryableCategory('exit_nonzero', {})).toBe(false);
+    expect(DEFAULT_RETRY_CATEGORIES).toContain('timeout');
+    expect(DEFAULT_RETRY_CATEGORIES).toContain('spawn_failure');
+  });
+
+  it('NEVER retries deterministic / user-driven categories regardless of policy', () => {
+    const broad: { categories: NodeErrorCategory[] } = {
+      categories: ['setup', 'input_resolution', 'cancelled', 'condition_not_met', 'flow_ended', 'upstream_failed'],
+    };
+    expect(isRetryableCategory('setup', broad)).toBe(false);
+    expect(isRetryableCategory('input_resolution', broad)).toBe(false);
+    expect(isRetryableCategory('cancelled', broad)).toBe(false);
+    expect(isRetryableCategory('condition_not_met', broad)).toBe(false);
+    expect(isRetryableCategory('flow_ended', broad)).toBe(false);
+    // upstream_failed isn't on the never-retry list, but it's a cascade —
+    // the wrapper looks for the root-cause category, not this.
+    expect(isRetryableCategory('upstream_failed', broad)).toBe(true);
+  });
+});
+
+describe('computeBackoffDelay', () => {
+  it('exponential doubles per attempt', () => {
+    const p = { backoff: 'exponential' as const, delaySeconds: 10 };
+    expect(computeBackoffDelay(p, 1)).toBe(10);
+    expect(computeBackoffDelay(p, 2)).toBe(20);
+    expect(computeBackoffDelay(p, 3)).toBe(40);
+    expect(computeBackoffDelay(p, 4)).toBe(80);
+  });
+
+  it('linear scales with attempt', () => {
+    const p = { backoff: 'linear' as const, delaySeconds: 10 };
+    expect(computeBackoffDelay(p, 1)).toBe(10);
+    expect(computeBackoffDelay(p, 2)).toBe(20);
+    expect(computeBackoffDelay(p, 3)).toBe(30);
+  });
+
+  it('fixed always returns the base delay', () => {
+    const p = { backoff: 'fixed' as const, delaySeconds: 10 };
+    expect(computeBackoffDelay(p, 1)).toBe(10);
+    expect(computeBackoffDelay(p, 5)).toBe(10);
+  });
+
+  it('defaults to exponential when backoff is unset', () => {
+    expect(computeBackoffDelay({ delaySeconds: 5 }, 3)).toBe(20);
+  });
+
+  it('defaults delaySeconds to 30 when unset', () => {
+    expect(computeBackoffDelay({}, 1)).toBe(30);
+  });
+
+  it('caps at MAX_BACKOFF_SECONDS (3600)', () => {
+    expect(computeBackoffDelay({ delaySeconds: 1000 }, 5)).toBe(3600);
+  });
+});
+
+// -- executeAgentWithRetry orchestration --
+//
+// To avoid spawning real shells, we exercise the wrapper by stubbing
+// executeAgentDag via a custom deps.spawnNode — but the wrapper itself
+// imports executeAgentDag directly, not through deps. The cleanest route
+// is to use the helpers above for the bulk of the logic and add one
+// end-to-end test below using a tiny shell command. However we can also
+// test the wrapper's "no policy → single executor call" fast path by
+// observing that a passing run (status: completed) doesn't loop.
+
+describe('executeAgentWithRetry — fall-through semantics', () => {
+  it('agents without retry policy go through executeAgentDag exactly once', async () => {
+    const agent = makeAgent(/* no retry */);
+    let calls = 0;
+    const fakeOptions: DagExecuteOptions = { triggeredBy: 'cli' };
+    const fakeDeps: DagExecutorDeps = {
+      runStore: store,
+      // The real executor runs `exit 1` and would write a failed run row.
+      // We stub by passing a spawnNode that returns a synthetic completed
+      // result so the executor doesn't actually fork a process.
+      spawnNode: async () => {
+        calls++;
+        return { result: 'ok', exitCode: 0 };
+      },
+    };
+    const run = await executeAgentWithRetry(agent, fakeOptions, fakeDeps);
+    expect(run.status).toBe('completed');
+    expect(calls).toBe(1);
+  });
+
+  it('attempts <= 1 (or unset) skips the retry loop', async () => {
+    const agent = makeAgent({ attempts: 1 });
+    let calls = 0;
+    const fakeOptions: DagExecuteOptions = { triggeredBy: 'cli' };
+    const fakeDeps: DagExecutorDeps = {
+      runStore: store,
+      spawnNode: async () => {
+        calls++;
+        return { result: '', exitCode: 1, error: 'boom', category: 'exit_nonzero' };
+      },
+    };
+    const run = await executeAgentWithRetry(agent, fakeOptions, fakeDeps);
+    expect(run.status).toBe('failed');
+    expect(calls).toBe(1);
+  });
+});
+
+describe('executeAgentWithRetry — retry loop', () => {
+  // The cleanest way to exercise the loop is to seed deps.spawnNode to
+  // fail twice (with a retryable category) then succeed on the third
+  // attempt. The wrapper's getFailureCategory reads node_executions, which
+  // the executor populates per-attempt — so we don't need to stub category
+  // detection.
+
+  it('retries on transient failure and succeeds on attempt 2', async () => {
+    const agent = makeAgent({ attempts: 3, delaySeconds: 1, categories: ['timeout'] });
+    let calls = 0;
+    const fakeOptions: DagExecuteOptions = { triggeredBy: 'cli' };
+    const onRetryAttempts: number[] = [];
+
+    const fakeDeps: DagExecutorDeps = {
+      runStore: store,
+      spawnNode: async () => {
+        calls++;
+        if (calls === 1) {
+          // First call: simulate a timeout — exit code -1 + the executor
+          // categorises as 'timeout' when stderr looks like one, but the
+          // simpler shape is to throw a TimeoutError. The local executor
+          // sets errorCategory based on the spawn result. For this test
+          // we use a non-zero exit and rely on the wrapper not treating
+          // 'exit_nonzero' as retryable (since policy is timeout-only).
+          // To get 'timeout' classification, the spawnNode promise needs
+          // to throw with the right shape. We sidestep by manually writing
+          // the node_execution row's errorCategory after the executor
+          // creates it… but executor owns that path.
+          //
+          // Simpler: use a category the executor naturally produces.
+          // exit_nonzero is the natural one for `exit 1`. Switch the
+          // policy to retry on exit_nonzero for this test.
+          return { result: '', exitCode: 1, error: 'fail', category: 'exit_nonzero' };
+        }
+        return { result: 'ok', exitCode: 0 };
+      },
+    };
+
+    // Adjust policy to use exit_nonzero (the category the fake spawn produces).
+    agent.retry = { attempts: 3, delaySeconds: 0, categories: ['exit_nonzero'] };
+    const run = await executeAgentWithRetry(agent, fakeOptions, fakeDeps, {
+      sleepFn: async () => {},
+      onRetry: (attempt) => onRetryAttempts.push(attempt),
+    });
+
+    expect(run.status).toBe('completed');
+    expect(calls).toBe(2);
+    expect(run.attempt).toBe(2);
+    expect(run.retryOfRunId).toBeDefined();
+    expect(onRetryAttempts).toEqual([2]);
+  });
+
+  it('exhausts the budget when failures keep coming', async () => {
+    const agent = makeAgent({ attempts: 3, delaySeconds: 0, categories: ['exit_nonzero'] });
+    let calls = 0;
+    const fakeDeps: DagExecutorDeps = {
+      runStore: store,
+      spawnNode: async () => {
+        calls++;
+        return { result: '', exitCode: 1, error: 'fail', category: 'exit_nonzero' };
+      },
+    };
+    const run = await executeAgentWithRetry(
+      agent, { triggeredBy: 'cli' }, fakeDeps,
+      { sleepFn: async () => {} },
+    );
+    expect(run.status).toBe('failed');
+    expect(calls).toBe(3);
+    expect(run.attempt).toBe(3);
+
+    // Chain has all 3 attempts.
+    const chain = store.getRetryChain(run.id);
+    expect(chain.length).toBe(3);
+    expect(chain.map((r) => r.attempt).sort()).toEqual([1, 2, 3]);
+  });
+
+  it('does not retry when the failure category is not in the policy list', async () => {
+    const agent = makeAgent({ attempts: 5, delaySeconds: 0, categories: ['timeout'] });
+    let calls = 0;
+    const fakeDeps: DagExecutorDeps = {
+      runStore: store,
+      spawnNode: async () => {
+        calls++;
+        // exit_nonzero — not in the retry list.
+        return { result: '', exitCode: 1, error: 'fail', category: 'exit_nonzero' };
+      },
+    };
+    const run = await executeAgentWithRetry(
+      agent, { triggeredBy: 'cli' }, fakeDeps,
+      { sleepFn: async () => {} },
+    );
+    expect(run.status).toBe('failed');
+    expect(calls).toBe(1);
+  });
+
+  it('honours options.retryOf as the starting attempt number', async () => {
+    // Manual retry already burned attempts 1 + 2; this run starts at 3
+    // with a 4-attempt policy → only 1 more auto-retry is allowed.
+    const agent = makeAgent({ attempts: 4, delaySeconds: 0, categories: ['exit_nonzero'] });
+    let calls = 0;
+    const fakeDeps: DagExecutorDeps = {
+      runStore: store,
+      spawnNode: async () => {
+        calls++;
+        return { result: '', exitCode: 1, error: 'fail', category: 'exit_nonzero' };
+      },
+    };
+    // Pre-create the head run so retryOf has somewhere to point. The
+    // wrapper itself doesn't validate the parent exists; the executor's
+    // createRun does. For this test the chain integrity is covered by R1.
+    store.createRun({
+      id: 'head', agentName: 'flake', status: 'failed',
+      startedAt: new Date().toISOString(), triggeredBy: 'cli',
+    });
+    const run = await executeAgentWithRetry(
+      agent,
+      { triggeredBy: 'cli', retryOf: { originalRunId: 'head', attempt: 3 } },
+      fakeDeps,
+      { sleepFn: async () => {} },
+    );
+    expect(run.status).toBe('failed');
+    // Started at 3, can go to 4 (one more attempt under attempts=4) → 2 calls total.
+    expect(calls).toBe(2);
+  });
+
+  it('aborts the loop when the signal fires between attempts', async () => {
+    const agent = makeAgent({ attempts: 5, delaySeconds: 0, categories: ['exit_nonzero'] });
+    let calls = 0;
+    const ctl = new AbortController();
+    const fakeDeps: DagExecutorDeps = {
+      runStore: store,
+      spawnNode: async () => {
+        calls++;
+        if (calls === 1) ctl.abort();
+        return { result: '', exitCode: 1, error: 'fail', category: 'exit_nonzero' };
+      },
+    };
+    const run = await executeAgentWithRetry(
+      agent,
+      { triggeredBy: 'cli', signal: ctl.signal },
+      fakeDeps,
+      { sleepFn: async () => {} },
+    );
+    // Loop entered, signal aborted before attempt 2 → only 1 spawn.
+    expect(calls).toBe(1);
+    expect(run.status).toBe('failed');
+  });
+});

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -1,0 +1,173 @@
+/**
+ * Auto-retry orchestrator. Wraps `executeAgentDag` with the agent's
+ * declared `retry:` policy: when a run fails with a retryable
+ * `errorCategory`, sleep with backoff and spawn a fresh run linked to the
+ * head of the chain via `retryOfRunId`. Each attempt is its own `runs`
+ * row — the same flat-chain shape produced by one-click manual retry.
+ *
+ * Sits ABOVE the executor on purpose. Per the failed-runs-and-retry plan
+ * (R2): orchestrator-level retry composes with R1's manual retry plumbing,
+ * surfaces every attempt in the dashboard, and doesn't park the executor's
+ * event loop on `setTimeout` between attempts.
+ *
+ * Callers (Run Now, manual retry, widget run, CLI workflow run) swap
+ * `executeAgentDag` for `executeAgentWithRetry` — agents without a
+ * `retry:` block fall through to a single executor call (zero overhead).
+ */
+
+import type { Agent, NodeErrorCategory, RetryPolicy } from './agent-v2-types.js';
+import type { Run } from './types.js';
+import { executeAgentDag, type DagExecuteOptions, type DagExecutorDeps } from './dag-executor.js';
+
+/**
+ * Default categories that trigger auto-retry when `retry.categories` is
+ * unset. Conservative: only flake-shaped failures. Authors broaden by
+ * declaring `categories: [exit_nonzero, ...]` on the agent.
+ */
+export const DEFAULT_RETRY_CATEGORIES: NodeErrorCategory[] = ['timeout', 'spawn_failure'];
+
+/**
+ * Categories that NEVER trigger a retry, regardless of the agent's
+ * declared `retry.categories`. These are deterministic (`setup`,
+ * `input_resolution`) or user-driven (`cancelled`) or already-skipped
+ * states (`condition_not_met`, `flow_ended`) — retrying changes nothing.
+ */
+const NEVER_RETRY: ReadonlySet<NodeErrorCategory> = new Set([
+  'setup', 'input_resolution', 'cancelled', 'condition_not_met', 'flow_ended',
+]);
+
+/** Cap a single backoff sleep to 1 hour. Above that, stop trying. */
+const MAX_BACKOFF_SECONDS = 3600;
+
+export function isRetryableCategory(
+  category: NodeErrorCategory | undefined,
+  policy: Pick<RetryPolicy, 'categories'>,
+): boolean {
+  if (!category) return false;
+  if (NEVER_RETRY.has(category)) return false;
+  const allowed = policy.categories ?? DEFAULT_RETRY_CATEGORIES;
+  return allowed.includes(category);
+}
+
+/**
+ * Compute the wait between attempts for a given attempt number.
+ * `attempt` is 1-indexed; the wait FOLLOWS attempt N (i.e. before
+ * attempt N+1). For exponential backoff, attempt 1 waits `delaySeconds`,
+ * attempt 2 waits `delaySeconds * 2`, attempt 3 waits `delaySeconds * 4`.
+ */
+export function computeBackoffDelay(
+  policy: Pick<RetryPolicy, 'backoff' | 'delaySeconds'>,
+  attempt: number,
+): number {
+  const base = policy.delaySeconds ?? 30;
+  const mode = policy.backoff ?? 'exponential';
+  let delay = base;
+  if (mode === 'exponential') delay = base * Math.pow(2, Math.max(0, attempt - 1));
+  else if (mode === 'linear') delay = base * Math.max(1, attempt);
+  // 'fixed' just returns base.
+  return Math.min(delay, MAX_BACKOFF_SECONDS);
+}
+
+/**
+ * Promise-based sleep that resolves early when an AbortSignal fires.
+ * No-op when ms <= 0 (defensive — tests pass 0 to skip waits).
+ */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0 || signal?.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const t = setTimeout(resolve, ms);
+    if (signal) {
+      const onAbort = () => { clearTimeout(t); resolve(); };
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+  });
+}
+
+/**
+ * Find the category of the first failed node in a run. The DAG executor
+ * marks the first node that breaks the run's success path; downstream
+ * skips inherit `upstream_failed`. We want the *root cause* category,
+ * not the cascade — so prefer non-`upstream_failed` failures.
+ */
+function getFailureCategory(runId: string, deps: DagExecutorDeps): NodeErrorCategory | undefined {
+  const execs = deps.runStore.listNodeExecutions(runId);
+  // First pass: look for the genuine root-cause category.
+  for (const e of execs) {
+    if (e.status === 'failed' && e.errorCategory && e.errorCategory !== 'upstream_failed') {
+      return e.errorCategory;
+    }
+  }
+  // Fallback: any failed category (rare — the run failed without a typed
+  // category, e.g. replay-mode setup failure).
+  for (const e of execs) {
+    if (e.status === 'failed' && e.errorCategory) return e.errorCategory;
+  }
+  return undefined;
+}
+
+export interface ExecuteAgentWithRetryHooks {
+  /**
+   * Optional sleep override. Production passes `setTimeout`-backed sleep;
+   * tests pass `() => Promise.resolve()` to skip waits without faking
+   * timers. The wrapper falls back to its own implementation when omitted.
+   */
+  sleepFn?: (ms: number, signal?: AbortSignal) => Promise<void>;
+  /**
+   * Called before every retry attempt with the upcoming attempt number
+   * and the sleep duration in ms. Useful for tests to assert ordering
+   * and for production logs.
+   */
+  onRetry?: (attempt: number, delayMs: number, category: NodeErrorCategory) => void;
+}
+
+/**
+ * Wrapper around `executeAgentDag` that honours the agent's `retry:` policy.
+ * Falls through to a single executor call when no policy is declared or
+ * `attempts <= 1` — zero overhead for agents that opt out.
+ *
+ * Manual retry interplay: when called with `options.retryOf` set (e.g. by
+ * the `/runs/:id/retry` route), the wrapper starts at `options.retryOf.attempt`
+ * and counts up from there. So a user clicking Retry on attempt 1 against
+ * an agent with `attempts: 3` can still produce attempt 2 and 3
+ * automatically if the manually-spawned run also fails transiently.
+ */
+export async function executeAgentWithRetry(
+  agent: Agent,
+  options: DagExecuteOptions,
+  deps: DagExecutorDeps,
+  hooks: ExecuteAgentWithRetryHooks = {},
+): Promise<Run> {
+  const policy = agent.retry;
+  // No policy → single execution. The executor's existing return value is
+  // exactly what we'd produce, so don't even iterate.
+  if (!policy || policy.attempts <= 1) {
+    return executeAgentDag(agent, options, deps);
+  }
+
+  const sleeper = hooks.sleepFn ?? sleep;
+
+  let attempt = options.retryOf?.attempt ?? 1;
+  let currentRun = await executeAgentDag(agent, options, deps);
+
+  while (
+    currentRun.status === 'failed' &&
+    attempt < policy.attempts &&
+    !options.signal?.aborted
+  ) {
+    const category = getFailureCategory(currentRun.id, deps);
+    if (!isRetryableCategory(category, policy)) break;
+
+    const delayMs = computeBackoffDelay(policy, attempt) * 1000;
+    if (hooks.onRetry && category) hooks.onRetry(attempt + 1, delayMs, category);
+    await sleeper(delayMs, options.signal);
+    if (options.signal?.aborted) break;
+
+    attempt += 1;
+    const headRunId = currentRun.retryOfRunId ?? currentRun.id;
+    currentRun = await executeAgentDag(agent, {
+      ...options,
+      retryOf: { originalRunId: headRunId, attempt },
+    }, deps);
+  }
+  return currentRun;
+}

--- a/packages/dashboard/src/routes/agent-nodes.ts
+++ b/packages/dashboard/src/routes/agent-nodes.ts
@@ -416,19 +416,9 @@ agentNodesRouter.post('/agents/:name/yaml', (req: Request, res: Response) => {
     ctx.agentStore.createNewVersion(
       agent.id,
       {
-        id: parsed.id,
-        name: parsed.name,
-        description: parsed.description,
-        status: parsed.status,
-        schedule: parsed.schedule,
-        source: agent.source, // preserve source — don't let YAML override trust level
-        mcp: parsed.mcp,
-        nodes: parsed.nodes,
-        inputs: parsed.inputs,
-        signal: parsed.signal,
-        outputWidget: parsed.outputWidget,
-        author: parsed.author,
-        tags: parsed.tags,
+        ...parsed,
+        // Preserve source — don't let YAML override trust level.
+        source: agent.source,
       },
       'dashboard',
       'Updated via YAML editor',

--- a/packages/dashboard/src/routes/run-mutations.ts
+++ b/packages/dashboard/src/routes/run-mutations.ts
@@ -1,5 +1,5 @@
 import { Router, type Request, type Response } from 'express';
-import { executeAgentDag, extractPriorAgentInputs, topologicalSort, type RunStatus } from '@some-useful-agents/core';
+import { executeAgentDag, executeAgentWithRetry, extractPriorAgentInputs, topologicalSort, type RunStatus } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 
 export const runMutationsRouter: Router = Router();
@@ -264,7 +264,7 @@ runMutationsRouter.post('/runs/:id/retry', async (req: Request, res: Response) =
   const nextAttempt = maxAttempt + 1;
 
   const abortController = new AbortController();
-  const runPromise = executeAgentDag(
+  const runPromise = executeAgentWithRetry(
     agent,
     {
       triggeredBy: 'dashboard',

--- a/packages/dashboard/src/routes/run-now.ts
+++ b/packages/dashboard/src/routes/run-now.ts
@@ -3,7 +3,7 @@
  */
 
 import { Router, type Request, type Response } from 'express';
-import { executeAgentDag, type RunStatus } from '@some-useful-agents/core';
+import { executeAgentWithRetry, type RunStatus } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 
 export const runNowRouter: Router = Router();
@@ -56,7 +56,7 @@ runNowRouter.post('/agents/:name/run', async (req: Request, res: Response) => {
     // before spawning nodes, so the redirect to /runs/:id lands on a
     // valid page that polls for progress.
     const abortController = new AbortController();
-    const runPromise = executeAgentDag(
+    const runPromise = executeAgentWithRetry(
       v2Agent,
       { triggeredBy: 'dashboard', inputs, signal: abortController.signal },
       {

--- a/packages/dashboard/src/routes/widget-run.ts
+++ b/packages/dashboard/src/routes/widget-run.ts
@@ -1,5 +1,5 @@
 import { Router, type Request, type Response } from 'express';
-import { executeAgentDag, type RunStatus } from '@some-useful-agents/core';
+import { executeAgentWithRetry, type RunStatus } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 import { renderOutputWidget } from '../views/output-widgets.js';
 import { render } from '../views/html.js';
@@ -32,7 +32,7 @@ widgetRunRouter.post('/agents/:name/widget-run', (req: Request, res: Response) =
   }
 
   const abortController = new AbortController();
-  const runPromise = executeAgentDag(
+  const runPromise = executeAgentWithRetry(
     v2Agent,
     { triggeredBy: 'dashboard', inputs, signal: abortController.signal },
     {


### PR DESCRIPTION
## Summary

Agents can declare a top-level `retry:` block to recover from transient failures without manual intervention:

```yaml
retry:
  attempts: 3                          # total tries; default 1 (no retry)
  backoff: exponential                 # exponential | linear | fixed; default exponential
  delaySeconds: 30                     # base delay; 30s → 60s → 120s for exponential
  categories: [timeout, spawn_failure] # default; conservative
```

When a run fails with a configured `errorCategory`, the orchestrator sleeps with backoff and spawns a fresh attempt, linked back to the head of the chain via R1's `retryOfRunId`. Each attempt is its own `runs` row — the same flat-chain shape as one-click manual retry. Dashboard shows `attempt 2`, `attempt 3` badges.

This is **R2 of the failed-runs-and-retry plan**. R3 (notify deferral), R4 (triage surface), R5 (scheduler backoff) build on top.

## Design

- **Orchestrator-level retry**, not transparent inside the executor. `executeAgentWithRetry` (new, core/retry.ts) wraps `executeAgentDag` and spawns new run rows per attempt. Composes cleanly with R1's manual retry plumbing; surfaces every attempt in the dashboard; doesn't park the executor's event loop on `setTimeout`.
- **Opt-in per agent.** No retry block = single execution, zero overhead.
- **Conservative default categories** = `[timeout, spawn_failure]`. Authors broaden explicitly (e.g. add `exit_nonzero` for a known-flaky CLI).
- **Hard-coded never-retry** = `cancelled`, `setup`, `input_resolution`, `condition_not_met`, `flow_ended`. Deterministic or user-driven; retrying changes nothing.
- **Whole-run retry**, not per-node. Per-node retry would force partial-success semantics that conflicts with the existing replay-from-node feature.
- **Manual + auto compose.** Manual retries can take you over the policy budget; further auto-retries don't fire after that point.

## Wiring

Callers switched from `executeAgentDag` → `executeAgentWithRetry`:
- Run Now (`POST /agents/:name/run`)
- Manual retry (`POST /runs/:id/retry`)
- Interactive widget run (`POST /agents/:name/widget-run`)
- CLI (`sua workflow run`)

**Replay route stays on `executeAgentDag` directly** — replay is investigation, not auto-recovery.

## Bug fixed during smoke testing

The dashboard YAML save route (`POST /agents/:name/yaml`) hand-rolled the `createNewVersion` payload and silently dropped `retry`, `notify`, `outputs`, `provider`, `model`, `description`, `allowHighFrequency`, `pulseVisible`, `dashboardVisible`, `stateMaxBytes`. Replaced with a `...parsed` spread (preserving the `source` override). Same class of bug bit graphics-creator-mcp in the past — this fix prevents it from recurring on every new top-level field.

Also added retry round-trip plumbing to `AgentStore.extractDag` + `mergeRowWithVersion` — without this, the AgentVersionDag would persist correctly only on first save and lose the field on read-back.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` green (957 tests, +28 over baseline: 17 retry orchestrator + 5 schema + others)
- [x] Schema accept/reject: full retry policy, attempts only, attempts > 10 rejected, delaySeconds > 3600 rejected, unknown backoff mode rejected
- [x] Orchestrator: fall-through (no policy → 1 call), policy with attempts=1 (still 1 call), retry on transient → success on attempt 2, exhaust budget over 3 attempts, never-retry categories blocked, signal cancellation between attempts
- [x] Backoff math: exponential / linear / fixed across multiple attempts, defaults, 1h cap
- [x] **Live smoke against running daemon**: created `auto-retry-smoke` agent (`exit 1`) with `retry: { attempts: 3, backoff: fixed, delaySeconds: 1, categories: [exit_nonzero] }`, hit Run Now. Saw chain attempt 1 → 2 → 3, all linked to head, stopped at policy limit, ~3s wall clock total.

## Out of scope (future PRs in the plan)

- **R3** — notify deferral until final attempt
- **R4** — triage surface (per-agent consecutive failures, "now broken" badge)
- **R5** — scheduler backoff after N consecutive terminal failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)