### PR TITLE
feat(retry): notify deferral until terminal attempt (R3)

### DIFF
--- a/.changeset/notify-deferral.md
+++ b/.changeset/notify-deferral.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Notify deferral: one page per retry chain, not one per attempt (R3).
+
+When an agent has a `retry:` policy, `notify:` handlers now fire **once per chain** at the terminal outcome instead of once per attempt. A 3-attempt agent that recovers on attempt 2 produces one `success` notify and zero `failure` notifies. A run that exhausts its budget over three failed attempts produces one `failure` notify, not three.
+
+Mechanism: `executeAgentDag` accepts a new `suppressNotify` option that the orchestrator sets on every internal attempt. The wrapper fires notify itself after the chain settles. Agents without a `retry:` policy fall through to single-attempt mode and fire notify exactly as before — no behavior change.
+
+Builds on R1 (manual retry) + R2 (auto-retry policy). R4 (triage surface) and R5 (scheduler backoff) still to come.

--- a/docs/retry.md
+++ b/docs/retry.md
@@ -97,8 +97,20 @@ All sleeps are capped at 1 hour.
 
 Manual retry and auto-retry share the same chain. If a user clicks Retry on a run that's already part of an auto-retry chain, the new attempt picks up where the chain left off and counts further auto-retries against the policy's `attempts` budget. Manual retries can take you over the policy budget — they're explicit user overrides — but no further auto-retries fire after that point.
 
+### Notify deferral
+
+When the agent has a `retry:` policy, `notify:` triggers fire **once per chain**, not once per attempt:
+
+| Outcome | What fires |
+|---|---|
+| Recover on attempt 2 (after attempt 1 failed) | One `success` notify, zero `failure` notifies |
+| Exhaust budget over 3 failed attempts | One `failure` notify (not three) |
+| Non-retryable failure on attempt 1 | One `failure` notify immediately |
+| Signal cancelled mid-chain | One notify on whatever the terminal attempt was |
+
+The mechanism: every internal attempt runs with `suppressNotify: true` so the executor stays silent. The wrapper fires notify once after the chain settles, with the run object reflecting the terminal attempt's status. Agents without a `retry:` policy fall through to single-attempt mode and fire notify exactly as before — no behavior change.
+
 ## What's coming next
 
-- **Notify deferral** (R3) — when auto-retry is in play, `failure` notifications wait until the final attempt fails.
 - **Triage surface** (R4) — per-agent consecutive-failure tracking and a "now broken" view.
 - **Scheduler backoff** (R5) — after N consecutive failed terminal attempts, the cron tick is skipped to stop spamming.

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -160,6 +160,17 @@ export interface DagExecuteOptions {
    * retry).
    */
   retryOf?: { originalRunId: string; attempt: number };
+  /**
+   * Set by `executeAgentWithRetry` on every internal attempt. When true,
+   * the executor skips the post-run `dispatchNotify` call so the wrapper
+   * can fire notify EXACTLY ONCE after the retry chain settles. Without
+   * this flag, a 3-attempt run that fails 3× would page 3 times — the
+   * whole point of R3 is one page on the final outcome.
+   *
+   * Direct callers (replay route, agents without a retry policy) leave it
+   * unset and get per-call notify dispatch as before.
+   */
+  suppressNotify?: boolean;
 }
 
 
@@ -872,8 +883,10 @@ export async function executeAgentDag(
 
   // Notify dispatch fires AFTER the run row is committed. Wrapped so any
   // dispatcher exception can never bubble into the run path — the run
-  // result is final by this point.
-  if (agent.notify) {
+  // result is final by this point. Suppressed when the caller is
+  // `executeAgentWithRetry` mid-chain (R3): the wrapper fires once on
+  // the final attempt to avoid paging on every transient failure.
+  if (agent.notify && !options.suppressNotify) {
     try {
       await dispatchNotify(agent.notify, {
         agent,

--- a/packages/core/src/retry.test.ts
+++ b/packages/core/src/retry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { rmSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { RunStore } from './run-store.js';
 import {
@@ -306,5 +306,145 @@ describe('executeAgentWithRetry — retry loop', () => {
     // Loop entered, signal aborted before attempt 2 → only 1 spawn.
     expect(calls).toBe(1);
     expect(run.status).toBe('failed');
+  });
+});
+
+describe('executeAgentWithRetry — notify deferral (R3)', () => {
+  // The `file` notify handler appends a JSON line per fire — counting lines
+  // is the simplest way to count notify dispatches without faking fetch
+  // (the webhook handler runs an SSRF check that rejects test URLs).
+  // The handler also enforces a path-traversal guard against process.cwd(),
+  // so we write to a relative path under cwd rather than tmpdir.
+  let notifyDir: string;
+  let notifyPath: string; // path passed to the handler — relative to cwd
+  let notifyAbs: string;  // absolute path for readback
+  beforeEach(() => {
+    const rel = `.tmp-r3-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    notifyDir = join(process.cwd(), rel);
+    mkdirSync(notifyDir, { recursive: true });
+    notifyPath = join(rel, 'notify.jsonl');
+    notifyAbs = join(notifyDir, 'notify.jsonl');
+  });
+  afterEach(() => {
+    rmSync(notifyDir, { recursive: true, force: true });
+  });
+
+  function makeNotifyAgent(retry: RetryPolicy, on: Array<'failure' | 'success' | 'always'>): Agent {
+    return {
+      ...makeAgent(retry),
+      notify: {
+        on,
+        handlers: [{ type: 'file', path: notifyPath, append: true }],
+      },
+    } as Agent;
+  }
+
+  function readNotifyLines(): Array<Record<string, unknown>> {
+    let raw: string;
+    try { raw = readFileSync(notifyAbs, 'utf8'); } catch { return []; }
+    return raw.split('\n').filter(Boolean).map((line) => JSON.parse(line));
+  }
+
+  it('3 attempts all fail → fires failure notify exactly once (not three times)', async () => {
+    const agent = makeNotifyAgent(
+      { attempts: 3, delaySeconds: 0, categories: ['exit_nonzero'] },
+      ['failure'],
+    );
+    let calls = 0;
+    const fakeDeps: DagExecutorDeps = {
+      runStore: store,
+      spawnNode: async () => {
+        calls++;
+        return { result: '', exitCode: 1, error: 'fail', category: 'exit_nonzero' };
+      },
+    };
+    await executeAgentWithRetry(
+      agent, { triggeredBy: 'cli' }, fakeDeps,
+      { sleepFn: async () => {} },
+    );
+    expect(calls).toBe(3);
+    expect(readNotifyLines()).toHaveLength(1);
+  });
+
+  it('succeeds on attempt 2 → fires success notify once, zero failure notifies', async () => {
+    const agent = makeNotifyAgent(
+      { attempts: 3, delaySeconds: 0, categories: ['exit_nonzero'] },
+      ['failure', 'success'],
+    );
+    let calls = 0;
+    const fakeDeps: DagExecutorDeps = {
+      runStore: store,
+      spawnNode: async () => {
+        calls++;
+        if (calls === 1) return { result: '', exitCode: 1, error: 'flake', category: 'exit_nonzero' };
+        return { result: 'ok', exitCode: 0 };
+      },
+    };
+    await executeAgentWithRetry(
+      agent, { triggeredBy: 'cli' }, fakeDeps,
+      { sleepFn: async () => {} },
+    );
+    expect(calls).toBe(2);
+    const lines = readNotifyLines();
+    expect(lines).toHaveLength(1);
+    // The single notify must reflect the SUCCEEDED attempt, not the failed one.
+    expect(lines[0].status).toBe('completed');
+  });
+
+  it('non-retryable failure category → fires failure notify once on attempt 1', async () => {
+    const agent = makeNotifyAgent(
+      { attempts: 5, delaySeconds: 0, categories: ['timeout'] }, // exit_nonzero NOT listed
+      ['failure'],
+    );
+    let calls = 0;
+    const fakeDeps: DagExecutorDeps = {
+      runStore: store,
+      spawnNode: async () => {
+        calls++;
+        return { result: '', exitCode: 1, error: 'real bug', category: 'exit_nonzero' };
+      },
+    };
+    await executeAgentWithRetry(
+      agent, { triggeredBy: 'cli' }, fakeDeps,
+      { sleepFn: async () => {} },
+    );
+    expect(calls).toBe(1);
+    expect(readNotifyLines()).toHaveLength(1);
+  });
+
+  it('agents WITHOUT a retry policy still fire notify per call (regression guard)', async () => {
+    // attempts: 1 means the wrapper falls through to a single executeAgentDag.
+    // The executor itself fires notify (suppressNotify is unset). One call → one notify.
+    const agent = makeNotifyAgent({ attempts: 1 }, ['failure']);
+    const fakeDeps: DagExecutorDeps = {
+      runStore: store,
+      spawnNode: async () => ({ result: '', exitCode: 1, error: 'fail', category: 'exit_nonzero' }),
+    };
+    await executeAgentWithRetry(agent, { triggeredBy: 'cli' }, fakeDeps);
+    expect(readNotifyLines()).toHaveLength(1);
+  });
+
+  it('signal aborted between attempts still fires notify once on the failed run', async () => {
+    const agent = makeNotifyAgent(
+      { attempts: 5, delaySeconds: 0, categories: ['exit_nonzero'] },
+      ['failure'],
+    );
+    const ctl = new AbortController();
+    let calls = 0;
+    const fakeDeps: DagExecutorDeps = {
+      runStore: store,
+      spawnNode: async () => {
+        calls++;
+        if (calls === 1) ctl.abort();
+        return { result: '', exitCode: 1, error: 'fail', category: 'exit_nonzero' };
+      },
+    };
+    await executeAgentWithRetry(
+      agent, { triggeredBy: 'cli', signal: ctl.signal }, fakeDeps,
+      { sleepFn: async () => {} },
+    );
+    expect(calls).toBe(1);
+    // Fires once on the (failed) terminal attempt — silent failure would be a regression.
+    expect(readNotifyLines()).toHaveLength(1);
   });
 });

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -18,6 +18,7 @@
 import type { Agent, NodeErrorCategory, RetryPolicy } from './agent-v2-types.js';
 import type { Run } from './types.js';
 import { executeAgentDag, type DagExecuteOptions, type DagExecutorDeps } from './dag-executor.js';
+import { dispatchNotify } from './notify-dispatcher.js';
 
 /**
  * Default categories that trigger auto-retry when `retry.categories` is
@@ -139,15 +140,21 @@ export async function executeAgentWithRetry(
 ): Promise<Run> {
   const policy = agent.retry;
   // No policy → single execution. The executor's existing return value is
-  // exactly what we'd produce, so don't even iterate.
+  // exactly what we'd produce, so don't even iterate. Notify dispatch is
+  // handled inside the executor as before — this path stays unchanged.
   if (!policy || policy.attempts <= 1) {
     return executeAgentDag(agent, options, deps);
   }
 
   const sleeper = hooks.sleepFn ?? sleep;
 
+  // Internal attempts run with `suppressNotify: true` so the executor
+  // doesn't fire a notify per attempt. We fire ONCE at the end of the
+  // chain — see the dispatchNotify call after the loop.
+  const internalOptions: DagExecuteOptions = { ...options, suppressNotify: true };
+
   let attempt = options.retryOf?.attempt ?? 1;
-  let currentRun = await executeAgentDag(agent, options, deps);
+  let currentRun = await executeAgentDag(agent, internalOptions, deps);
 
   while (
     currentRun.status === 'failed' &&
@@ -165,9 +172,31 @@ export async function executeAgentWithRetry(
     attempt += 1;
     const headRunId = currentRun.retryOfRunId ?? currentRun.id;
     currentRun = await executeAgentDag(agent, {
-      ...options,
+      ...internalOptions,
       retryOf: { originalRunId: headRunId, attempt },
     }, deps);
+  }
+
+  // R3: fire notify ONCE for the chain's terminal outcome. A 3-attempt
+  // run that recovers on attempt 2 produces zero failure pages and one
+  // success notify. A run that exhausts the budget produces one failure
+  // notify, not three.
+  if (agent.notify) {
+    try {
+      await dispatchNotify(agent.notify, {
+        agent,
+        run: currentRun,
+        secretsStore: deps.secretsStore,
+        variablesStore: deps.variablesStore,
+        dashboardBaseUrl: deps.dashboardBaseUrl,
+        fetchImpl: deps.notifyFetch,
+        logger: deps.notifyLogger,
+      });
+    } catch (err) {
+      // Defense-in-depth: dispatchNotify catches handler errors itself.
+      const logger = deps.notifyLogger ?? { warn: (m: string) => console.warn(`[notify] ${m}`) };
+      logger.warn(`dispatch failed: ${(err as Error).message}`);
+    }
   }
   return currentRun;
 }


### PR DESCRIPTION
## Summary

When an agent has a `retry:` policy, `notify:` handlers now fire **once per chain** at the terminal outcome instead of once per attempt. Stops the alert spam: a flaky agent that recovers within budget produces zero pages; a genuinely broken agent produces one page, not three.

| Scenario | Before R3 | After R3 |
|---|---|---|
| 3-attempt chain exhausts budget | 3 `failure` notifies | 1 `failure` notify |
| Recover on attempt 2 (attempt 1 failed) | 1 `failure` + 1 `success` | 0 `failure`, 1 `success` |
| Non-retryable failure on attempt 1 | 1 `failure` | 1 `failure` (unchanged) |
| Signal cancelled mid-chain | 1 `failure` (per attempt run) | 1 `failure` on terminal attempt |
| Agent with no `retry:` policy | 1 notify per call | 1 notify per call (unchanged) |

This is **R3 of the failed-runs-and-retry plan**. R4 (triage surface) and R5 (scheduler backoff) still to come.

## Mechanism

`executeAgentDag` gains a new `suppressNotify?: boolean` option. `executeAgentWithRetry` (the orchestrator) sets it on every internal attempt and fires `dispatchNotify` itself after the chain settles, with the run object reflecting the terminal attempt.

Why split it this way:
- Direct callers of `executeAgentDag` (replay route, agents with no policy) leave `suppressNotify` unset → executor fires per-call → no behavior change.
- Wrapper-controlled chains route notify dispatch to a single fire point at the end, with full information about whether the chain converged or exhausted.

Notify config + dispatcher itself unchanged — the deferral lives entirely in the orchestrator. `shouldFire` still does its same trigger-vs-status match; we just call it on the terminal run, not every attempt.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` green (962 tests, +5 over baseline; 22 retry tests now)
- [x] 3 attempts all fail → 1 notify
- [x] Succeed on attempt 2 → 1 notify, body reflects `status: completed`
- [x] Non-retryable category → 1 notify on attempt 1
- [x] No retry policy → 1 notify per call (regression guard for direct executor callers)
- [x] Signal aborted between attempts → 1 notify on terminal failed run
- [x] **Live smoke against running daemon**: configured `auto-retry-smoke` agent with `retry: { attempts: 3 }` + `notify: { on: [failure, success], handlers: [{ type: file, ... }] }`. Hit Run Now. Chain exhausted budget over 3 attempts. Notify file has exactly **1** JSON line with `status: failed` for the attempt-3 run id. Pre-R3 this would have been 3 lines.

## Out of scope (future PRs in the plan)

- **R4** — triage surface (per-agent consecutive failures, "now broken" badge)
- **R5** — scheduler backoff after N consecutive terminal failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)