### PR TITLE
fix(core): allow-same-origin in iframe sandbox so YouTube posters render

### DIFF
--- a/.changeset/iframe-sandbox-allow-same-origin.md
+++ b/.changeset/iframe-sandbox-allow-same-origin.md
@@ -1,0 +1,18 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Add `allow-same-origin` to the iframe sandbox so YouTube/Vimeo embeds can
+load posters and play-button overlays.
+
+YouTube's embed page hits its own origin's storage on init to render the
+poster image and player chrome. Without `allow-same-origin`, those calls
+fail and the iframe shows blank. Safe under the existing host allowlist
+invariant: every approved host is a third-party origin (youtube.com,
+vimeo.com), so granting same-origin lets the embed reach **its own**
+cookies, never ours. Locked the invariant in a comment so future hosts
+can't be added on the dashboard's origin without explicit review.

--- a/packages/core/src/html-sanitizer.test.ts
+++ b/packages/core/src/html-sanitizer.test.ts
@@ -81,7 +81,7 @@ describe('sanitizeHtml', () => {
       );
       expect(out).toContain('<iframe');
       expect(out).toContain('src="https://www.youtube.com/embed/abc123"');
-      expect(out).toContain('sandbox="allow-scripts allow-presentation"');
+      expect(out).toContain('sandbox="allow-scripts allow-same-origin allow-presentation"');
       expect(out).toContain('</iframe>');
     });
 
@@ -111,11 +111,12 @@ describe('sanitizeHtml', () => {
 
     it('overrides an author-supplied sandbox with the safe one', () => {
       const out = sanitizeHtml(
-        '<iframe src="https://www.youtube.com/embed/x" sandbox="allow-same-origin allow-top-navigation"></iframe>',
+        '<iframe src="https://www.youtube.com/embed/x" sandbox="allow-top-navigation allow-popups allow-forms"></iframe>',
       );
-      expect(out).toContain('sandbox="allow-scripts allow-presentation"');
-      expect(out).not.toContain('allow-same-origin');
+      expect(out).toContain('sandbox="allow-scripts allow-same-origin allow-presentation"');
       expect(out).not.toContain('allow-top-navigation');
+      expect(out).not.toContain('allow-popups');
+      expect(out).not.toContain('allow-forms');
     });
 
     it('drops iframe with no src', () => {

--- a/packages/core/src/html-sanitizer.ts
+++ b/packages/core/src/html-sanitizer.ts
@@ -96,10 +96,13 @@ const SVG_CASED_ATTRS: Record<string, string> = {
 /**
  * Hosts approved for `<iframe src>`. HTTPS-only, exact-match.
  *
- * Tight allowlist on purpose: anything we add here can frame-bust into the
- * dashboard or render arbitrary content under a trusted origin. Start with
- * the embed providers users actually reach for in agent templates
- * (YouTube + Vimeo). Add others case-by-case, never wildcard a domain.
+ * INVARIANT: every host here must be a third-party origin, never our own.
+ * The sandbox below grants `allow-same-origin` so embeds work; with that
+ * flag, the framed page can read its own origin's cookies/storage. Safe
+ * for youtube.com (their cookies, not ours) — would be a credential leak
+ * if we ever added a host on our dashboard's origin.
+ *
+ * Tight allowlist on purpose. Add hosts case-by-case, never wildcard.
  */
 const IFRAME_ALLOWED_HOSTS = new Set<string>([
   'www.youtube.com',
@@ -110,13 +113,16 @@ const IFRAME_ALLOWED_HOSTS = new Set<string>([
 ]);
 
 /**
- * Sandbox flags injected on every accepted iframe. Deliberately omits
- * `allow-same-origin` (would let the framed page reach back into our
- * cookies/storage if served from a future allowlisted host on our origin),
- * and `allow-top-navigation` (frame-busting). YouTube + Vimeo embeds
- * function with just allow-scripts + allow-presentation.
+ * Sandbox flags injected on every accepted iframe. Includes:
+ *  - allow-scripts: required by every modern embed
+ *  - allow-same-origin: required for YouTube/Vimeo to load posters,
+ *    play-button overlays, and player chrome (they hit their own origin's
+ *    storage on init). Safe under the allowlist invariant above.
+ *  - allow-presentation: enables the picture-in-picture / fullscreen UX.
+ * Deliberately omits allow-top-navigation (frame-busting), allow-popups,
+ * allow-forms (no embed needs them), and allow-modals.
  */
-const SAFE_IFRAME_SANDBOX = 'allow-scripts allow-presentation';
+const SAFE_IFRAME_SANDBOX = 'allow-scripts allow-same-origin allow-presentation';
 
 function isIframeSrcAllowed(src: string): boolean {
   let u: URL;


### PR DESCRIPTION
## Summary

Tightening the iframe sandbox in #197 broke the actual UX it was meant to enable. YouTube's embed page hits its own origin's storage on init to render the poster image + center play button. With `sandbox="allow-scripts allow-presentation"` (no `allow-same-origin`), those calls fail and the iframe renders blank.

Add `allow-same-origin`. Safe under the existing host allowlist invariant: every approved host (youtube.com, vimeo.com) is a third-party origin, so the framed page can read **its own** cookies but never ours. Locked the invariant in a comment so future allowlist additions on the dashboard's own origin require explicit review (would be a credential leak).

Still omits `allow-top-navigation`, `allow-popups`, `allow-forms`, `allow-modals` — no embed needs them.

## Test plan
- [x] `npm test` — sanitizer suite green (43 tests)
- [x] Updated the existing sandbox-override test to expect the new value
- [ ] Reviewer: reload an agent with a YouTube embed; verify the poster + play overlay render before clicking

🤖 Generated with [Claude Code](https://claude.com/claude-code)