### PR TITLE
feat(examples): three ai-template agents for widget controls + iframe + #if/#each

### DIFF
--- a/.changeset/widget-controls-dogfood.md
+++ b/.changeset/widget-controls-dogfood.md
@@ -1,0 +1,25 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Three new example agents that exercise the recently-shipped ai-template
+widget capabilities end-to-end:
+
+- **`vimeo-staff-picks`** — `ai-template` + `<iframe>` (player.vimeo.com,
+  on the new sanitiser allowlist) + `{{#each}}` iteration + `replay`
+  control. Renders the latest Vimeo Staff Picks as inline players.
+- **`weather-forecast`** — `dashboard` widget + `view-switch`
+  (today/week) + `field-toggle` (extras) + `replay` (different city).
+  Live wttr.in data; stress-tests every dashboard widget control type.
+- **`cat-video-finder`** — `ai-template` + `{{#if outputs.thumbnail}}` /
+  `{{#unless outputs.url}}` + `replay` with input-tweak. Facade-pattern
+  card around a YouTube search hit (clickable thumbnail, opens on
+  YouTube).
+
+Together these cover all 7 capabilities that previously had zero
+in-repo examples: `replay`, `field-toggle`, `view-switch`, `{{#if}}`,
+`{{#unless}}`, `{{#each}}`, and `<iframe>` from the host allowlist.

--- a/agents/examples/cat-video-finder.yaml
+++ b/agents/examples/cat-video-finder.yaml
@@ -1,0 +1,143 @@
+# Cat Video Finder — facade-pattern card around a YouTube search hit.
+#
+# Scrapes a YouTube search results page for the first cat video, then
+# renders an `ai-template` widget with a clickable thumbnail + play
+# overlay that opens the video on YouTube in a new tab. Tests the
+# {{#if outputs.thumbnail}} / {{#unless outputs.url}} conditional pair
+# and the replay control with input-tweak (pass a different query).
+#
+# Embedding-via-iframe was deliberately dropped — YouTube's player
+# rejects many videos at runtime (error 153) and the embed JS bloats
+# the page. The facade is more robust + faster + privacy-preserving.
+#
+# Run:
+#   sua workflow run cat-video-finder
+#   sua workflow run cat-video-finder --input SEARCH_QUERY="kitten compilation"
+
+id: cat-video-finder
+name: Cat Video Finder
+description: Searches YouTube for a popular cat video and returns a playable link.
+status: draft
+source: local
+mcp: false
+version: 11
+inputs:
+  SEARCH_QUERY:
+    type: string
+    default: funny cat video
+    description: What kind of cat video to find
+outputs:
+  url:
+    type: string
+    description: Full YouTube watch URL
+  thumbnail:
+    type: string
+    description: Video thumbnail image URL
+  title:
+    type: string
+    description: Video title
+  caption:
+    type: string
+    description: Fun caption
+  media_type:
+    type: string
+    description: Always "video"
+  status:
+    type: string
+    description: '"found" or "not_found"'
+  message:
+    type: string
+    description: Markdown-formatted watch link
+nodes:
+  - id: search
+    type: shell
+    command: |
+      QUERY=$(echo "$SEARCH_QUERY" | sed 's/ /+/g')
+      HTML=$(curl -sf -L -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" \
+        -H "Accept-Language: en-US,en;q=0.9" \
+        "https://www.youtube.com/results?search_query=${QUERY}")
+      if [ $? -ne 0 ] || [ -z "$HTML" ]; then
+        echo "curl failed or returned empty response" >&2
+        exit 1
+      fi
+      VIDEO_ID=$(echo "$HTML" | grep -oE '"videoId":"[A-Za-z0-9_-]{11}"' | head -1 | sed 's/"videoId":"//;s/"//')
+      if [ -z "$VIDEO_ID" ]; then
+        VIDEO_ID=$(echo "$HTML" | grep -oE '/watch\?v=[A-Za-z0-9_-]{11}' | head -1 | sed 's|/watch?v=||')
+      fi
+      TITLE=$(echo "$HTML" | grep -oE '"title":\{"runs":\[\{"text":"[^"]*"' | head -1 | sed 's/.*"text":"//;s/"$//')
+      if [ -z "$TITLE" ]; then TITLE="Cat Video"; fi
+      jq -n --arg vid "${VIDEO_ID:-}" --arg title "$TITLE" --arg query "$SEARCH_QUERY" \
+        '{found: ($vid | length > 0), videoId: $vid, title: $title, query: $query}'
+    timeout: 30
+  - id: format
+    type: shell
+    command: |
+      SEARCH_OUTPUT="$UPSTREAM_SEARCH_RESULT"
+      VIDEO_ID=$(echo "$SEARCH_OUTPUT" | jq -r '.videoId')
+      FOUND=$(echo "$SEARCH_OUTPUT" | jq -r '.found')
+      TITLE=$(echo "$SEARCH_OUTPUT" | jq -r '.title')
+      if [ "$FOUND" = "true" ] && [ -n "$VIDEO_ID" ] && [ "$VIDEO_ID" != "null" ]; then
+        URL="https://www.youtube.com/watch?v=${VIDEO_ID}"
+        THUMB="https://img.youtube.com/vi/${VIDEO_ID}/hqdefault.jpg"
+        jq -n \
+          --arg url "$URL" \
+          --arg thumb "$THUMB" \
+          --arg title "$TITLE" \
+          '{
+            url: $url,
+            thumbnail: $thumb,
+            title: $title,
+            caption: "Another certified internet classic",
+            media_type: "video",
+            status: "found",
+            message: ("Watch: [" + $title + "](" + $url + ")")
+          }'
+      else
+        jq -n '{
+          url: "",
+          thumbnail: "",
+          title: "No Cat Video Found",
+          caption: "The cats are hiding today...",
+          media_type: "video",
+          status: "not_found",
+          message: "Could not find a cat video. Try a different query."
+        }'
+      fi
+    dependsOn:
+      - search
+signal:
+  title: Cat Video Finder
+  template: widget
+  mapping: {}
+  size: 2x1
+  accent: orange
+outputWidget:
+  type: ai-template
+  template: |
+    {{#if outputs.thumbnail}}
+    <div style="max-width:560px;font-family:system-ui,sans-serif;">
+      <a href="{{outputs.url}}" target="_blank" rel="noopener" style="display:block;position:relative;padding-bottom:56.25%;height:0;overflow:hidden;border-radius:12px;box-shadow:0 4px 12px rgba(0,0,0,0.15);text-decoration:none;">
+        <img src="{{outputs.thumbnail}}" alt="{{outputs.title}}" style="position:absolute;top:0;left:0;width:100%;height:100%;object-fit:cover;" />
+        <span style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:68px;height:48px;background:rgba(0,0,0,0.75);border-radius:12px;display:flex;align-items:center;justify-content:center;color:white;font-size:1.5rem;">▶</span>
+      </a>
+      <div style="margin-top:12px;">
+        <h3 style="margin:0 0 4px 0;font-size:1.1rem;">{{outputs.title}}</h3>
+        <p style="margin:0;color:#666;font-size:0.9rem;font-style:italic;">{{outputs.caption}}</p>
+      </div>
+      <div style="margin-top:8px;">
+        <a href="{{outputs.url}}" target="_blank" rel="noopener" style="display:inline-block;padding:8px 16px;background:#ff4500;color:white;border-radius:6px;text-decoration:none;font-size:0.85rem;font-weight:600;">▶ Watch on YouTube</a>
+      </div>
+    </div>
+    {{/if}}
+    {{#unless outputs.url}}
+    <div style="padding:24px;text-align:center;font-family:system-ui,sans-serif;color:#666;">
+      <p style="font-size:1.2rem;">🙉 {{outputs.title}}</p>
+      <p>{{outputs.message}}</p>
+    </div>
+    {{/unless}}
+  controls:
+    - type: replay
+      label: Find another
+      inputs:
+        - SEARCH_QUERY
+

--- a/agents/examples/vimeo-staff-picks.yaml
+++ b/agents/examples/vimeo-staff-picks.yaml
@@ -1,0 +1,98 @@
+# Vimeo Staff Picks — recent picks rendered as embedded players.
+#
+# Fetches the public Vimeo Staff Picks RSS feed and renders the latest
+# entries as inline players using the `ai-template` widget. Tests the
+# new iframe allowlist (player.vimeo.com is on it), {{#each}} iteration,
+# and the replay control.
+#
+# Run:
+#   sua workflow run vimeo-staff-picks
+#   sua workflow run vimeo-staff-picks --input COUNT=2
+
+id: vimeo-staff-picks
+name: Vimeo Staff Picks
+description: "Recent Vimeo Staff Picks rendered as embedded players. Tests ai-template + iframe + #each + replay."
+status: active
+source: local
+mcp: false
+version: 2
+inputs:
+  COUNT:
+    type: number
+    default: 4
+    description: Number of staff picks to show (1-10)
+outputs:
+  videos:
+    type: array
+    description: List of {id, embed_src, title, url, thumbnail}
+  fetched_at:
+    type: string
+    description: Date the feed was fetched
+nodes:
+  - id: fetch
+    type: shell
+    command: |
+      set -e
+      RAW=$(curl -sf -A "Mozilla/5.0 sua-agent" "https://vimeo.com/channels/staffpicks/videos/rss")
+      if [ -z "$RAW" ]; then
+        echo "Failed to fetch Vimeo Staff Picks RSS" >&2
+        exit 1
+      fi
+      # Slice items, take COUNT, parse with python (xml is fragile from shell).
+      echo "$RAW" | python3 -c '
+      import sys, re, json, html, os
+      raw = sys.stdin.read()
+      count = int(os.environ.get("COUNT", "4"))
+      items = re.findall(r"<item>(.*?)</item>", raw, re.DOTALL)[:count]
+      videos = []
+      for it in items:
+          title = re.search(r"<title>(.*?)</title>", it, re.DOTALL)
+          link = re.search(r"<link>(.*?)</link>", it, re.DOTALL)
+          player = re.search(r"<media:player url=\"([^\"]+)\"", it)
+          thumb = re.search(r"<media:thumbnail[^>]*url=\"([^\"]+)\"", it)
+          if not (title and link and player):
+              continue
+          embed_src = player.group(1)
+          # ID is the path segment after /video/.
+          mid = re.search(r"/video/(\d+)", embed_src)
+          videos.append({
+              "id": mid.group(1) if mid else "",
+              "embed_src": embed_src,
+              "title": html.unescape(title.group(1)),
+              "url": link.group(1),
+              "thumbnail": thumb.group(1) if thumb else "",
+          })
+      from datetime import date
+      print(json.dumps({"videos": videos, "fetched_at": date.today().isoformat()}))
+      '
+    timeout: 20
+signal:
+  title: Vimeo Staff Picks
+  template: text-headline
+  mapping:
+    headline: fetched_at
+    body: fetched_at
+  size: 2x1
+  accent: blue
+outputWidget:
+  type: ai-template
+  prompt: Render each Vimeo staff pick as an embedded player card with the title above.
+  template: |
+    <div style="display:grid;gap:16px;font-family:system-ui,sans-serif;">
+      {{#each outputs.videos as v}}
+      <div>
+        <h3 style="margin:0 0 8px 0;font-size:1rem;font-weight:600;">{{v.title}}</h3>
+        <div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;border-radius:10px;background:#000;box-shadow:0 2px 8px rgba(0,0,0,0.12);">
+          <iframe src="{{v.embed_src}}" style="position:absolute;top:0;left:0;width:100%;height:100%;border:none;" allowfullscreen></iframe>
+        </div>
+        <a href="{{v.url}}" target="_blank" rel="noopener" style="display:inline-block;margin-top:6px;font-size:0.85rem;color:#1ab7ea;text-decoration:none;">Open on Vimeo →</a>
+      </div>
+      {{/each}}
+      {{#unless outputs.videos}}
+      <p style="color:#666;font-style:italic;">No staff picks fetched.</p>
+      {{/unless}}
+    </div>
+  controls:
+    - type: replay
+      label: Refresh picks
+

--- a/agents/examples/weather-forecast.yaml
+++ b/agents/examples/weather-forecast.yaml
@@ -1,0 +1,213 @@
+# Weather Forecast — current conditions + 7-day outlook with view-switch,
+# field-toggle, and replay controls.
+#
+# Stress-tests the `dashboard` widget controls: a view-switch flips
+# between "today" (hero metrics + extras) and "week" (7-day list); a
+# field-toggle hides/shows the secondary metrics (humidity, wind, UV,
+# precipitation, sunrise/sunset); a replay control re-runs for a
+# different city without leaving the page.
+#
+# Zero LLM cost — wttr.in JSON parsed via shell + python.
+#
+# Run:
+#   sua workflow run weather-forecast
+#   sua workflow run weather-forecast --input LOCATION="Austin TX"
+#   sua workflow run weather-forecast --input LOCATION=90210
+
+id: weather-forecast
+name: Weather Forecast
+description: Live weather + 7-day forecast with view-switch (today/week), field-toggle (extras), and replay (different city). Tests dashboard widget controls.
+status: active
+source: local
+mcp: false
+version: 4
+inputs:
+  LOCATION:
+    type: string
+    default: Seattle
+    description: City name (e.g. "Austin"), city + state (e.g. "Austin TX"), or zip code (e.g. 90210).
+outputs:
+  temperature:
+    type: string
+  feels_like:
+    type: string
+  condition:
+    type: string
+  humidity:
+    type: string
+  wind:
+    type: string
+  uv_index:
+    type: string
+  precipitation_chance:
+    type: string
+  sunrise:
+    type: string
+  sunset:
+    type: string
+  location:
+    type: string
+  day_0:
+    type: string
+  day_1:
+    type: string
+  day_2:
+    type: string
+  day_3:
+    type: string
+  day_4:
+    type: string
+  day_5:
+    type: string
+  day_6:
+    type: string
+nodes:
+  - id: fetch
+    type: shell
+    command: |
+      set -e
+      CLEAN=$(echo "$LOCATION" | sed 's/,//g' | sed 's/ /+/g')
+      RAW=$(curl -sf --max-time 15 "https://wttr.in/${CLEAN}?format=j1")
+      if [ -z "$RAW" ]; then
+        echo "wttr.in returned empty for $LOCATION" >&2
+        exit 1
+      fi
+      RAWFILE=$(mktemp)
+      printf '%s' "$RAW" > "$RAWFILE"
+      export RAWFILE
+      python3 << 'PYEOF'
+      import os, json
+      from datetime import datetime
+      with open(os.environ["RAWFILE"]) as f:
+          d = json.load(f)
+      cur = d["current_condition"][0]
+      area = d["nearest_area"][0]
+      astro_today = d["weather"][0]["astronomy"][0]
+      hourly_today = d["weather"][0]["hourly"]
+      precip_chance = max((int(h.get("chanceofrain", "0")) for h in hourly_today), default=0)
+      out = {
+          "temperature": cur["temp_F"] + "°F",
+          "feels_like": cur["FeelsLikeF"] + "°F",
+          "condition": cur["weatherDesc"][0]["value"],
+          "humidity": cur["humidity"] + "%",
+          "wind": cur["windspeedMiles"] + " mph " + cur["winddir16Point"],
+          "uv_index": cur["uvIndex"],
+          "precipitation_chance": str(precip_chance) + "%",
+          "sunrise": astro_today["sunrise"],
+          "sunset": astro_today["sunset"],
+          "location": area["areaName"][0]["value"] + ", " + area["region"][0]["value"],
+      }
+      for i, day in enumerate(d["weather"][:7]):
+          date = datetime.strptime(day["date"], "%Y-%m-%d").strftime("%a %b %-d")
+          desc = day["hourly"][len(day["hourly"]) // 2]["weatherDesc"][0]["value"]
+          out["day_" + str(i)] = date + " — H " + day["maxtempF"] + "° L " + day["mintempF"] + "° — " + desc
+      for i in range(7):
+          out.setdefault("day_" + str(i), "")
+      print(json.dumps(out))
+      PYEOF
+      rm -f "$RAWFILE"
+    timeout: 25
+signal:
+  title: Weather
+  template: text-headline
+  mapping:
+    headline: temperature
+    body: condition
+  size: 2x1
+  accent: blue
+outputWidget:
+  type: dashboard
+  fields:
+    - name: temperature
+      label: Temperature
+      type: metric
+    - name: condition
+      label: Condition
+      type: badge
+    - name: feels_like
+      label: Feels like
+      type: stat
+    - name: humidity
+      label: Humidity
+      type: stat
+    - name: wind
+      label: Wind
+      type: stat
+    - name: uv_index
+      label: UV Index
+      type: stat
+    - name: precipitation_chance
+      label: Precip chance
+      type: stat
+    - name: sunrise
+      label: Sunrise
+      type: stat
+    - name: sunset
+      label: Sunset
+      type: stat
+    - name: location
+      label: Location
+      type: text
+    - name: day_0
+      label: Today
+      type: stat
+    - name: day_1
+      label: Day 2
+      type: stat
+    - name: day_2
+      label: Day 3
+      type: stat
+    - name: day_3
+      label: Day 4
+      type: stat
+    - name: day_4
+      label: Day 5
+      type: stat
+    - name: day_5
+      label: Day 6
+      type: stat
+    - name: day_6
+      label: Day 7
+      type: stat
+  controls:
+    - type: view-switch
+      label: Range
+      views:
+        - id: today
+          fields:
+            - temperature
+            - condition
+            - feels_like
+            - humidity
+            - wind
+            - uv_index
+            - precipitation_chance
+            - sunrise
+            - sunset
+            - location
+        - id: week
+          fields:
+            - day_0
+            - day_1
+            - day_2
+            - day_3
+            - day_4
+            - day_5
+            - day_6
+            - location
+      default: today
+    - type: field-toggle
+      label: Show extras
+      fields:
+        - humidity
+        - wind
+        - uv_index
+        - precipitation_chance
+        - sunrise
+        - sunset
+      default: hidden
+    - type: replay
+      label: Different city
+      inputs:
+        - LOCATION
+


### PR DESCRIPTION
## Summary

Three new example agents that exercise the ai-template widget capabilities shipped in #191, #194, #197, #198. A coverage survey of `agents/examples/*.yaml` found zero examples used any of: `replay`, `field-toggle`, `view-switch`, `{{#if}}`, `{{#unless}}`, `{{#each}}`, or `<iframe>` from the host allowlist. These three close the gap.

| Agent | Widget | Capabilities |
|---|---|---|
| `vimeo-staff-picks` | ai-template | iframe (player.vimeo.com), `{{#each}}`, replay |
| `weather-forecast` | dashboard | view-switch (today/week), field-toggle (extras), replay |
| `cat-video-finder` | ai-template | `{{#if}}`, `{{#unless}}`, replay (with input-tweak) |

## Test plan
- [x] `npm test` — 977 passing
- [x] `npm run build` clean
- [x] Live dogfood: each agent runs successfully against the local daemon
- [x] `?wv=week` flips the weather forecast to the 7-day list
- [x] `?wh=` reveals the extras (humidity, wind, UV, precip, sunrise, sunset)
- [x] Vimeo iframes load with the YouTube poster + center play button
- [x] cat-video facade renders thumbnail + play overlay; click opens YouTube
- [ ] Reviewer: install via `sua examples sync` (or equivalent), verify each renders cleanly in their own dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)