### PR TITLE
feat(core): pack manifest + Starter pack (widget-packs PR 2/5)

### DIFF
--- a/.changeset/pack-manifest-and-starter.md
+++ b/.changeset/pack-manifest-and-starter.md
@@ -1,0 +1,41 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Pack manifest format + first built-in Starter pack (widget-packs PR 2/5).
+
+Builds on PR 1's stores. New modules in `packages/core`:
+
+- **`pack-schema.ts`** — Zod schema for the pack manifest YAML format.
+  Validates pack id, semver version, dashboard structure, and the
+  `yaml` / `yamlPath` mutual exclusion on agent refs.
+- **`pack-loader.ts`** — discovers `packages/core/packs/*.yaml` on
+  daemon start, validates each, resolves `yamlPath` agent refs against
+  the manifest's directory, and upserts into `PacksStore` as
+  `source = 'builtin'`. Idempotent: reload preserves `installed_at`,
+  so a manifest version bump doesn't toggle install state. Failures on
+  individual files are skipped (returned in `result.skipped`) so one
+  broken pack doesn't gate the rest.
+- **`pack-installer.ts`** — `installPack(packId, ctx)` and
+  `uninstallPack(packId, ctx)` orchestrate across PacksStore +
+  DashboardsStore + AgentStore (the latter optional). Reference-only
+  ownership: install upserts missing agents from embedded YAML;
+  uninstall removes only the dashboards.
+- **`packages/core/packs/starter.yaml`** — first built-in pack. Bundles
+  the three dogfood agents from #199 (vimeo-staff-picks +
+  weather-forecast + cat-video-finder) into two dashboards (Media +
+  Weather). Auto-registers on daemon start; visible in PR 3's UI.
+
+Daemon startup (`packages/dashboard/src/index.ts`) now calls
+`loadBuiltinPacks(packsStore, defaultBuiltinPacksDir())` immediately
+after PacksStore init. Best-effort — failures don't block the
+dashboard from coming up.
+
+Added `packs/` to `packages/core/package.json`'s `files` array so the
+bundled manifest ships with the npm package.
+
+22 new unit tests; full suite 1017/1017 green.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,7 @@
   },
   "files": [
     "dist",
+    "packs",
     "README.md",
     "LICENSE"
   ],

--- a/packages/core/packs/starter.yaml
+++ b/packages/core/packs/starter.yaml
@@ -1,0 +1,35 @@
+# Starter pack — a guided tour of the new ai-template widget capabilities.
+#
+# Bundles the three dogfood agents shipped in #199, organised into two
+# dashboards (Media + Weather). Installing this pack creates the agents
+# (if missing) and registers the two dashboards under /dashboards/<id>.
+# Uninstalling removes the dashboards but keeps the agents.
+
+id: starter
+name: Starter
+description: A guided tour of the new ai-template widget capabilities.
+version: 0.1.0
+author: some-useful-agents
+
+agents:
+  - id: vimeo-staff-picks
+    yamlPath: ../../../agents/examples/vimeo-staff-picks.yaml
+  - id: weather-forecast
+    yamlPath: ../../../agents/examples/weather-forecast.yaml
+  - id: cat-video-finder
+    yamlPath: ../../../agents/examples/cat-video-finder.yaml
+
+dashboards:
+  - id: media
+    name: Media
+    sections:
+      - title: Video
+        agentIds:
+          - vimeo-staff-picks
+          - cat-video-finder
+  - id: weather
+    name: Weather
+    sections:
+      - title: Forecast
+        agentIds:
+          - weather-forecast

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -65,6 +65,23 @@ export {
   type DashboardLayout,
 } from './dashboards-store.js';
 export {
+  packManifestSchema,
+  type PackManifestInput,
+  type PackManifestParsed,
+} from './pack-schema.js';
+export {
+  loadBuiltinPacks,
+  defaultBuiltinPacksDir,
+  type LoadBuiltinPacksResult,
+} from './pack-loader.js';
+export {
+  installPack,
+  uninstallPack,
+  type PackInstallContext,
+  type PackInstallResult,
+  type PackUninstallResult,
+} from './pack-installer.js';
+export {
   getBuiltinTool,
   listBuiltinTools,
   isBuiltinTool,

--- a/packages/core/src/pack-installer.test.ts
+++ b/packages/core/src/pack-installer.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { PacksStore, type PackManifest } from './packs-store.js';
+import { DashboardsStore } from './dashboards-store.js';
+import { AgentStore } from './agent-store.js';
+import { installPack, uninstallPack } from './pack-installer.js';
+
+let dir: string;
+let db: DatabaseSync;
+let packs: PacksStore;
+let dashboards: DashboardsStore;
+let agents: AgentStore;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'sua-pack-installer-'));
+  db = new DatabaseSync(join(dir, 'runs.db'));
+  packs = PacksStore.fromHandle(db);
+  dashboards = DashboardsStore.fromHandle(db);
+  agents = AgentStore.fromHandle(db);
+});
+
+afterEach(() => {
+  try { db.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+const SAMPLE_AGENT_YAML = `id: hello
+name: Hello
+status: active
+source: local
+mcp: false
+nodes:
+  - id: greet
+    type: shell
+    command: echo hi
+`;
+
+function manifestWithAgents(): PackManifest {
+  return {
+    id: 'starter',
+    name: 'Starter',
+    version: '0.1.0',
+    agents: [{ id: 'hello', yaml: SAMPLE_AGENT_YAML }],
+    dashboards: [
+      {
+        id: 'main',
+        name: 'Main',
+        sections: [{ title: 'Greetings', agentIds: ['hello'] }],
+      },
+    ],
+  };
+}
+
+describe('installPack', () => {
+  it('creates dashboards from the manifest and marks installed', () => {
+    packs.upsertPack({ id: 'starter', name: 'Starter', version: '0.1.0', source: 'builtin', manifest: manifestWithAgents() });
+    const result = installPack('starter', { packsStore: packs, dashboardsStore: dashboards, agentStore: agents });
+    expect(result.dashboardsCreated).toEqual(['starter:main']);
+    expect(result.agentsCreated).toEqual(['hello']);
+    expect(packs.getPack('starter')?.installedAt).not.toBeNull();
+    expect(dashboards.getDashboard('starter:main')?.layout.sections[0].agentIds).toEqual(['hello']);
+    expect(agents.getAgent('hello')).not.toBeNull();
+  });
+
+  it('skips agents that already exist', () => {
+    // Pre-create the agent.
+    packs.upsertPack({ id: 'starter', name: 'Starter', version: '0.1.0', source: 'builtin', manifest: manifestWithAgents() });
+    installPack('starter', { packsStore: packs, dashboardsStore: dashboards, agentStore: agents });
+    // Reinstall — the agent already exists from the first run.
+    const result = installPack('starter', { packsStore: packs, dashboardsStore: dashboards, agentStore: agents });
+    expect(result.agentsCreated).toEqual([]);
+    expect(result.agentsSkipped).toEqual(['hello']);
+  });
+
+  it('only creates dashboards when no agentStore is provided', () => {
+    packs.upsertPack({ id: 'starter', name: 'Starter', version: '0.1.0', source: 'builtin', manifest: manifestWithAgents() });
+    const result = installPack('starter', { packsStore: packs, dashboardsStore: dashboards });
+    expect(result.dashboardsCreated).toEqual(['starter:main']);
+    expect(result.agentsCreated).toEqual([]);
+    // Agent ref skipped because no agent store to install into.
+    expect(result.agentsSkipped).toEqual(['hello']);
+  });
+
+  it('throws on unknown pack', () => {
+    expect(() => installPack('nope', { packsStore: packs, dashboardsStore: dashboards })).toThrow(/No pack registered/);
+  });
+
+  it('throws when an embedded agent YAML id mismatches the ref id', () => {
+    packs.upsertPack({
+      id: 'p', name: 'P', version: '0.1.0', source: 'builtin',
+      manifest: {
+        id: 'p', name: 'P', version: '0.1.0',
+        agents: [{ id: 'wrong-id', yaml: SAMPLE_AGENT_YAML }],
+        dashboards: [{ id: 'd', name: 'D', sections: [{ title: 'T', agentIds: ['hello'] }] }],
+      },
+    });
+    expect(() =>
+      installPack('p', { packsStore: packs, dashboardsStore: dashboards, agentStore: agents }),
+    ).toThrow(/does not match YAML id/);
+  });
+
+  it('reinstall refreshes dashboards from the latest manifest', () => {
+    packs.upsertPack({ id: 'starter', name: 'Starter', version: '0.1.0', source: 'builtin', manifest: manifestWithAgents() });
+    installPack('starter', { packsStore: packs, dashboardsStore: dashboards, agentStore: agents });
+
+    // Change the dashboard layout in the manifest, re-upsert, reinstall.
+    const updated = manifestWithAgents();
+    updated.dashboards![0].sections.push({ title: 'Extras', agentIds: ['hello'] });
+    packs.upsertPack({ id: 'starter', name: 'Starter', version: '0.1.0', source: 'builtin', manifest: updated });
+    installPack('starter', { packsStore: packs, dashboardsStore: dashboards, agentStore: agents });
+
+    expect(dashboards.getDashboard('starter:main')?.layout.sections).toHaveLength(2);
+  });
+});
+
+describe('uninstallPack', () => {
+  it('removes dashboards but keeps agents', () => {
+    packs.upsertPack({ id: 'starter', name: 'Starter', version: '0.1.0', source: 'builtin', manifest: manifestWithAgents() });
+    installPack('starter', { packsStore: packs, dashboardsStore: dashboards, agentStore: agents });
+    expect(dashboards.getDashboard('starter:main')).not.toBeNull();
+    expect(agents.getAgent('hello')).not.toBeNull();
+
+    const result = uninstallPack('starter', { packsStore: packs, dashboardsStore: dashboards, agentStore: agents });
+    expect(result.dashboardsRemoved).toBe(1);
+    expect(dashboards.getDashboard('starter:main')).toBeNull();
+    expect(packs.getPack('starter')?.installedAt).toBeNull();
+    expect(agents.getAgent('hello')).not.toBeNull();
+  });
+
+  it('is idempotent', () => {
+    packs.upsertPack({ id: 'starter', name: 'Starter', version: '0.1.0', source: 'builtin', manifest: manifestWithAgents() });
+    expect(() => uninstallPack('starter', { packsStore: packs, dashboardsStore: dashboards })).not.toThrow();
+    expect(() => uninstallPack('starter', { packsStore: packs, dashboardsStore: dashboards })).not.toThrow();
+  });
+});

--- a/packages/core/src/pack-installer.ts
+++ b/packages/core/src/pack-installer.ts
@@ -1,0 +1,104 @@
+/**
+ * Pack install / uninstall orchestration.
+ *
+ * Operates on top of the three stores (PacksStore, DashboardsStore,
+ * AgentStore) without coupling them to each other. Install creates
+ * dashboards from the manifest and upserts any missing agents from
+ * the embedded YAML; uninstall removes the dashboards but leaves the
+ * agents intact (reference-only ownership model).
+ */
+
+import type { PacksStore } from './packs-store.js';
+import type { DashboardsStore } from './dashboards-store.js';
+import type { AgentStore } from './agent-store.js';
+import { parseAgent } from './agent-yaml.js';
+
+export interface PackInstallContext {
+  packsStore: PacksStore;
+  dashboardsStore: DashboardsStore;
+  /**
+   * Optional. When provided, install will upsert any agent listed in the
+   * pack manifest's `agents:` block whose YAML is embedded and whose id
+   * isn't already in AgentStore. Without it, install only creates
+   * dashboards; missing agents will render as empty tiles until the user
+   * installs them separately.
+   */
+  agentStore?: AgentStore;
+}
+
+export interface PackInstallResult {
+  packId: string;
+  dashboardsCreated: string[];
+  agentsCreated: string[];
+  agentsSkipped: string[];
+}
+
+/**
+ * Install a registered pack. Idempotent — re-running on an installed
+ * pack refreshes the dashboards from the current manifest.
+ */
+export function installPack(packId: string, ctx: PackInstallContext): PackInstallResult {
+  const pack = ctx.packsStore.getPack(packId);
+  if (!pack) throw new Error(`No pack registered with id "${packId}"`);
+  const manifest = pack.manifest;
+
+  const agentsCreated: string[] = [];
+  const agentsSkipped: string[] = [];
+  for (const ref of manifest.agents ?? []) {
+    if (!ctx.agentStore) {
+      // No store to install into — record the ref as skipped so the caller
+      // sees what agents the pack expected to find.
+      agentsSkipped.push(ref.id);
+      continue;
+    }
+    if (ctx.agentStore.getAgent(ref.id)) {
+      agentsSkipped.push(ref.id);
+      continue;
+    }
+    if (!ref.yaml) {
+      // Id-only refs (no embedded YAML) can't be auto-installed.
+      agentsSkipped.push(ref.id);
+      continue;
+    }
+    const agent = parseAgent(ref.yaml);
+    if (agent.id !== ref.id) {
+      throw new Error(`Pack "${packId}" agent ref id "${ref.id}" does not match YAML id "${agent.id}"`);
+    }
+    const { version: _v, ...agentNoVersion } = agent;
+    void _v;
+    ctx.agentStore.upsertAgent(agentNoVersion, 'import', `Installed via pack "${packId}"`);
+    agentsCreated.push(ref.id);
+  }
+
+  const dashboardsCreated: string[] = [];
+  for (const dash of manifest.dashboards ?? []) {
+    const namespacedId = `${packId}:${dash.id}`;
+    ctx.dashboardsStore.upsertDashboard({
+      id: namespacedId,
+      packId,
+      name: dash.name,
+      layout: { sections: dash.sections },
+    });
+    dashboardsCreated.push(namespacedId);
+  }
+
+  ctx.packsStore.markInstalled(packId);
+  return { packId, dashboardsCreated, agentsCreated, agentsSkipped };
+}
+
+export interface PackUninstallResult {
+  packId: string;
+  dashboardsRemoved: number;
+}
+
+/**
+ * Uninstall a pack. Removes its dashboards, marks the pack as
+ * uninstalled, and leaves any agents the pack contributed alone
+ * (reference-only ownership). Idempotent — re-running on an
+ * uninstalled pack is a no-op.
+ */
+export function uninstallPack(packId: string, ctx: PackInstallContext): PackUninstallResult {
+  const dashboardsRemoved = ctx.dashboardsStore.deleteByPack(packId);
+  ctx.packsStore.markUninstalled(packId);
+  return { packId, dashboardsRemoved };
+}

--- a/packages/core/src/pack-loader.test.ts
+++ b/packages/core/src/pack-loader.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadBuiltinPacks } from './pack-loader.js';
+import { PacksStore } from './packs-store.js';
+
+let dir: string;
+let packsDir: string;
+let store: PacksStore;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'sua-pack-loader-'));
+  packsDir = join(dir, 'packs');
+  mkdirSync(packsDir);
+  store = new PacksStore(join(dir, 'runs.db'));
+});
+
+afterEach(() => {
+  try { store.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+function writeManifest(filename: string, contents: string): void {
+  writeFileSync(join(packsDir, filename), contents);
+}
+
+describe('loadBuiltinPacks', () => {
+  it('returns empty result when packs directory is missing', () => {
+    const result = loadBuiltinPacks(store, join(dir, 'does-not-exist'));
+    expect(result.registered).toEqual([]);
+    expect(result.skipped).toEqual([]);
+  });
+
+  it('registers a valid manifest as builtin source', () => {
+    writeManifest('starter.yaml', `
+id: starter
+name: Starter
+version: 0.1.0
+dashboards:
+  - id: media
+    name: Media
+    sections:
+      - title: Video
+        agentIds: [a]
+`);
+    const result = loadBuiltinPacks(store, packsDir);
+    expect(result.registered).toEqual(['starter']);
+    const pack = store.getPack('starter');
+    expect(pack?.source).toBe('builtin');
+    expect(pack?.installedAt).toBeNull();
+  });
+
+  it('inlines yamlPath agent refs', () => {
+    writeFileSync(join(dir, 'agent-a.yaml'), 'id: a\nname: A\n');
+    writeManifest('p.yaml', `
+id: p
+name: P
+version: 0.1.0
+agents:
+  - id: a
+    yamlPath: ../agent-a.yaml
+dashboards:
+  - id: d
+    name: D
+    sections:
+      - title: T
+        agentIds: [a]
+`);
+    loadBuiltinPacks(store, packsDir);
+    const pack = store.getPack('p');
+    expect(pack?.manifest.agents?.[0].yaml).toBe('id: a\nname: A\n');
+    // yamlPath is dropped from the stored form (inlined into yaml).
+    expect((pack?.manifest.agents?.[0] as { yamlPath?: string }).yamlPath).toBeUndefined();
+  });
+
+  it('skips manifests that fail validation but registers the rest', () => {
+    writeManifest('good.yaml', `
+id: good
+name: Good
+version: 0.1.0
+dashboards:
+  - id: d
+    name: D
+    sections:
+      - title: T
+        agentIds: [a]
+`);
+    writeManifest('bad.yaml', `
+id: BAD
+name: Bad
+version: not-semver
+`);
+    const result = loadBuiltinPacks(store, packsDir);
+    expect(result.registered).toEqual(['good']);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].file).toBe('bad.yaml');
+  });
+
+  it('preserves installed_at across reload (idempotent)', () => {
+    writeManifest('starter.yaml', `
+id: starter
+name: Starter
+version: 0.1.0
+dashboards:
+  - id: d
+    name: D
+    sections:
+      - title: T
+        agentIds: [a]
+`);
+    loadBuiltinPacks(store, packsDir);
+    store.markInstalled('starter');
+    const before = store.getPack('starter');
+
+    // Bump the version in the manifest and reload.
+    writeManifest('starter.yaml', `
+id: starter
+name: Starter
+version: 0.2.0
+dashboards:
+  - id: d
+    name: D
+    sections:
+      - title: T
+        agentIds: [a]
+`);
+    loadBuiltinPacks(store, packsDir);
+
+    const after = store.getPack('starter');
+    expect(after?.version).toBe('0.2.0');
+    expect(after?.installedAt).toBe(before?.installedAt);
+  });
+
+  it('throws (and skips) on a yamlPath that does not exist', () => {
+    writeManifest('p.yaml', `
+id: p
+name: P
+version: 0.1.0
+agents:
+  - id: a
+    yamlPath: ./does-not-exist.yaml
+`);
+    const result = loadBuiltinPacks(store, packsDir);
+    expect(result.registered).toEqual([]);
+    expect(result.skipped[0].reason).toMatch(/not found/);
+  });
+});

--- a/packages/core/src/pack-loader.ts
+++ b/packages/core/src/pack-loader.ts
@@ -1,0 +1,104 @@
+/**
+ * Built-in pack discovery + registration.
+ *
+ * On daemon start, the loader scans `packages/core/packs/*.yaml`, parses
+ * each manifest, resolves any `yamlPath` agent refs against the manifest
+ * file's directory, and upserts the result into PacksStore as
+ * `source = 'builtin'`. Idempotent — re-running on each daemon start
+ * picks up version/manifest changes without toggling install state
+ * (PacksStore.upsertPack preserves installed_at).
+ *
+ * Note: the loader registers packs but does NOT install them. Users
+ * decide what to install via `/packs` (PR 3) or `installPack()` directly.
+ */
+
+import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+import { packManifestSchema, type PackManifestParsed } from './pack-schema.js';
+import type { PacksStore, PackManifest, PackAgentRef } from './packs-store.js';
+
+/**
+ * Default location of bundled packs relative to this loader file.
+ *
+ * In repo: `packages/core/src/pack-loader.ts` is compiled to
+ * `packages/core/dist/pack-loader.js`. The packs dir lives at
+ * `packages/core/packs/`, i.e. one level up from `dist/`.
+ *
+ * In an npm install: same shape — `dist/` and `packs/` are siblings
+ * under `node_modules/@some-useful-agents/core/`.
+ */
+export function defaultBuiltinPacksDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '..', 'packs');
+}
+
+export interface LoadBuiltinPacksResult {
+  registered: string[];
+  skipped: Array<{ file: string; reason: string }>;
+}
+
+/**
+ * Read every `*.yaml` in `packsDir`, validate, resolve yamlPath refs, and
+ * upsert into the store. Failures on individual files are skipped (logged
+ * via the returned `skipped` array) so one broken pack doesn't gate the
+ * rest. Returns the ids of packs successfully registered.
+ */
+export function loadBuiltinPacks(
+  packsStore: PacksStore,
+  packsDir: string,
+): LoadBuiltinPacksResult {
+  const result: LoadBuiltinPacksResult = { registered: [], skipped: [] };
+  if (!existsSync(packsDir) || !statSync(packsDir).isDirectory()) return result;
+
+  const files = readdirSync(packsDir).filter((f) => f.endsWith('.yaml'));
+  for (const file of files) {
+    const fullPath = join(packsDir, file);
+    try {
+      const raw = readFileSync(fullPath, 'utf-8');
+      const parsed = parseYaml(raw) as unknown;
+      const manifest = packManifestSchema.parse(parsed);
+      const inlined = inlineAgentYamlRefs(manifest, dirname(fullPath));
+      packsStore.upsertPack({
+        id: inlined.id,
+        name: inlined.name,
+        description: inlined.description ?? null,
+        version: inlined.version,
+        author: inlined.author ?? null,
+        source: 'builtin',
+        manifest: inlined,
+      });
+      result.registered.push(inlined.id);
+    } catch (err) {
+      result.skipped.push({
+        file,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return result;
+}
+
+/**
+ * Replace any `yamlPath` agent refs in the manifest with the file's
+ * contents under `yaml`. Throws if a referenced file is missing —
+ * a built-in pack with a dangling reference is a build/release bug.
+ */
+function inlineAgentYamlRefs(manifest: PackManifestParsed, baseDir: string): PackManifest {
+  const agents: PackAgentRef[] | undefined = manifest.agents?.map((a) => {
+    if (a.yamlPath) {
+      const abs = resolve(baseDir, a.yamlPath);
+      if (!existsSync(abs)) {
+        throw new Error(`Agent ref "${a.id}" → yamlPath "${a.yamlPath}" not found at ${abs}`);
+      }
+      const yaml = readFileSync(abs, 'utf-8');
+      return { id: a.id, yaml };
+    }
+    return { id: a.id, yaml: a.yaml };
+  });
+  return {
+    ...manifest,
+    agents,
+  };
+}

--- a/packages/core/src/pack-schema.test.ts
+++ b/packages/core/src/pack-schema.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { packManifestSchema } from './pack-schema.js';
+
+describe('packManifestSchema', () => {
+  it('accepts a minimal pack with only dashboards', () => {
+    const m = packManifestSchema.parse({
+      id: 'starter',
+      name: 'Starter',
+      version: '0.1.0',
+      dashboards: [{ id: 'media', name: 'Media', sections: [{ title: 'Video', agentIds: ['x'] }] }],
+    });
+    expect(m.id).toBe('starter');
+    expect(m.dashboards).toHaveLength(1);
+  });
+
+  it('accepts a pack with only agents', () => {
+    const m = packManifestSchema.parse({
+      id: 'tools',
+      name: 'Tools',
+      version: '0.1.0',
+      agents: [{ id: 'a', yaml: 'id: a\nname: A\n…' }],
+    });
+    expect(m.agents).toHaveLength(1);
+  });
+
+  it('rejects a pack with neither agents nor dashboards', () => {
+    expect(() => packManifestSchema.parse({
+      id: 'empty', name: 'Empty', version: '0.1.0',
+    })).toThrow(/at least one agent or one dashboard/);
+  });
+
+  it('rejects pack id with uppercase', () => {
+    expect(() => packManifestSchema.parse({
+      id: 'StarterPack', name: 'X', version: '0.1.0',
+      dashboards: [{ id: 'd', name: 'D', sections: [{ title: 'T', agentIds: ['a'] }] }],
+    })).toThrow(/lowercase/);
+  });
+
+  it('rejects non-semver version', () => {
+    expect(() => packManifestSchema.parse({
+      id: 'x', name: 'X', version: 'v1',
+      dashboards: [{ id: 'd', name: 'D', sections: [{ title: 'T', agentIds: ['a'] }] }],
+    })).toThrow(/semver/);
+  });
+
+  it('rejects empty section agentIds', () => {
+    expect(() => packManifestSchema.parse({
+      id: 'x', name: 'X', version: '0.1.0',
+      dashboards: [{ id: 'd', name: 'D', sections: [{ title: 'T', agentIds: [] }] }],
+    })).toThrow(/at least one agent/);
+  });
+
+  it('rejects an agent ref with both yaml and yamlPath', () => {
+    expect(() => packManifestSchema.parse({
+      id: 'x', name: 'X', version: '0.1.0',
+      agents: [{ id: 'a', yaml: 'foo', yamlPath: 'bar' }],
+    })).toThrow(/yaml or yamlPath/);
+  });
+
+  it('accepts an agent ref with id only (no yaml inline)', () => {
+    const m = packManifestSchema.parse({
+      id: 'x', name: 'X', version: '0.1.0',
+      agents: [{ id: 'a' }],
+    });
+    expect(m.agents?.[0].id).toBe('a');
+  });
+});

--- a/packages/core/src/pack-schema.ts
+++ b/packages/core/src/pack-schema.ts
@@ -1,0 +1,55 @@
+/**
+ * Zod schema for the widget pack manifest YAML format.
+ *
+ * Packs ship as YAML files in `packages/core/packs/<id>.yaml` (built-in)
+ * or anywhere a user wants to author one (user/exported). The loader
+ * validates the YAML against this schema before registering.
+ *
+ * Two forms accepted for agent refs:
+ *  - `yaml: "<inline string>"` — full YAML embedded in the manifest
+ *  - `yamlPath: "relative/path/to/agent.yaml"` — resolved by the loader
+ *    against the manifest file's directory; the file is read and inlined
+ *    into `yaml` before the manifest is stored. Either form, never both.
+ */
+
+import { z } from 'zod';
+
+const PACK_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+const DASHBOARD_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+const SEMVER_RE = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
+
+const sectionSchema = z.object({
+  title: z.string().min(1),
+  agentIds: z.array(z.string().min(1)).min(1, 'A section must list at least one agent.'),
+});
+
+const dashboardSchema = z.object({
+  id: z.string().regex(DASHBOARD_ID_RE, 'Dashboard ids: lowercase letters/digits/hyphens, starting alnum.'),
+  name: z.string().min(1),
+  sections: z.array(sectionSchema).min(1, 'A dashboard needs at least one section.'),
+});
+
+const agentRefSchema = z.object({
+  id: z.string().min(1),
+  yaml: z.string().min(1).optional(),
+  yamlPath: z.string().min(1).optional(),
+}).refine(
+  (a) => !(a.yaml && a.yamlPath),
+  { message: 'Specify either yaml or yamlPath, not both.' },
+);
+
+export const packManifestSchema = z.object({
+  id: z.string().regex(PACK_ID_RE, 'Pack ids: lowercase letters/digits/hyphens, starting alnum.'),
+  name: z.string().min(1),
+  description: z.string().optional(),
+  version: z.string().regex(SEMVER_RE, 'version must be semver (e.g. 0.1.0).'),
+  author: z.string().optional(),
+  agents: z.array(agentRefSchema).optional(),
+  dashboards: z.array(dashboardSchema).optional(),
+}).refine(
+  (m) => (m.agents?.length ?? 0) > 0 || (m.dashboards?.length ?? 0) > 0,
+  { message: 'A pack must contribute at least one agent or one dashboard.' },
+);
+
+export type PackManifestInput = z.input<typeof packManifestSchema>;
+export type PackManifestParsed = z.output<typeof packManifestSchema>;

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -8,6 +8,8 @@ import {
   ToolStore,
   PacksStore,
   DashboardsStore,
+  loadBuiltinPacks,
+  defaultBuiltinPacksDir,
   VariablesStore,
   EncryptedFileStore,
   loadAgents,
@@ -249,6 +251,13 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
   try {
     packsStore = new PacksStore(opts.dbPath);
     dashboardsStore = new DashboardsStore(opts.dbPath);
+    // Discover and register bundled packs. Idempotent — re-running on each
+    // restart picks up version/manifest changes without toggling install state.
+    // Failures here are non-fatal: a broken pack manifest shouldn't gate the
+    // dashboard from coming up.
+    try {
+      loadBuiltinPacks(packsStore, defaultBuiltinPacksDir());
+    } catch { /* ignore — packs discovery is best-effort */ }
   } catch {
     // Non-fatal: packs/dashboards surface stays absent until later PRs
     // wire routes that depend on these stores.


### PR DESCRIPTION
## Summary

PR 2 of 5 in the [widget-packs series](https://github.com/gregmeyer/some-useful-agents/pull/200). Stacked on #200; **target this PR's base to \`feat/packs-and-dashboards-stores\`** until #200 lands.

Adds the manifest format, the auto-discovery loader, the install/uninstall orchestration, and the first built-in pack.

- **\`pack-schema.ts\`** — Zod manifest schema (id, semver, dashboards, agent refs).
- **\`pack-loader.ts\`** — scans \`packages/core/packs/*.yaml\` on daemon start, validates, resolves \`yamlPath\` agent refs, upserts as \`source = 'builtin'\`. Idempotent across daemon restarts.
- **\`pack-installer.ts\`** — \`installPack\` / \`uninstallPack\` orchestration. Reference-only ownership: install upserts missing agents from embedded YAML; uninstall removes only the dashboards.
- **\`packages/core/packs/starter.yaml\`** — first built-in pack. Bundles vimeo-staff-picks + weather-forecast + cat-video-finder into two dashboards (Media + Weather). Auto-registers on boot.

Daemon now calls \`loadBuiltinPacks(packsStore, defaultBuiltinPacksDir())\` after PacksStore init. Best-effort — broken manifests don't gate the dashboard.

## Live smoke

After restart:
\`\`\`
$ sqlite3 data/runs.db "SELECT id, name, source, version, installed_at FROM packs;"
starter|Starter|builtin|0.1.0|     ← installed_at NULL = available, not yet installed
\`\`\`

## What's next

- **PR 3:** \`/packs\` browse + install UI (Install button calls \`installPack\`, \`/agents/<created-id>\` becomes accessible).
- **PR 4:** \`/dashboards/<id>\` rendering; \`/pulse\` becomes the Default Dashboard.
- **PR 5:** dashboard editor.

## Test plan
- [x] 22 new unit tests (schema, loader idempotency, install/uninstall round-trips)
- [x] \`npm test\` — 1017/1017 passing
- [x] \`npm run build\` clean
- [x] Live smoke: daemon restart auto-registers Starter pack
- [ ] Reviewer: confirm the \`packs/\` dir shipping via \`package.json\` files[] is the right call vs copying into \`dist/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)