### PR TITLE
feat(dashboard): browse + install widget packs (widget-packs PR 3/5)

### DIFF
--- a/.changeset/packs-browse-ui.md
+++ b/.changeset/packs-browse-ui.md
@@ -1,0 +1,34 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Browse and install widget packs from the dashboard (widget-packs PR 3/5).
+
+New routes:
+
+- **`GET /packs`** — grid of all registered packs, split into Installed
+  and Available sections. Cards show name, description, version, source,
+  dashboard/agent counts.
+- **`GET /packs/:id`** — pack detail with manifest summary (dashboards
+  by name + section count, agent ids) and an Install or Uninstall button.
+- **`POST /packs/:id/install`** / **`POST /packs/:id/uninstall`** — call
+  the installer from PR 2; redirect back to the detail page with a flash
+  banner reporting what changed.
+- **"Packs" entry in the top nav**, between Pulse and Settings.
+
+Plus a "clear-the-slate" pair on Pulse:
+
+- **`POST /pulse/hide-all`** — bulk-flip `pulseVisible=false` on every
+  agent that has a signal block. Use case: "I want to install a pack
+  and only see those tiles". Reversible.
+- **`POST /pulse/show-all`** — restores everything that was hidden.
+- **"Hide all" button** appears on the Pulse header when at least one
+  signal is visible; flips to "Show all" when nothing is visible but
+  hidden tiles exist.
+
+5 new route tests; full suite 1022/1022 green. Live smoke confirms
+install/uninstall round-trip + bulk hide/show.

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -45,6 +45,7 @@ import { settingsMcpRouter } from './routes/settings-mcp.js';
 import { helpRouter } from './routes/help.js';
 import { versionsRouter } from './routes/versions.js';
 import { pulseRouter } from './routes/pulse.js';
+import { packsRouter } from './routes/packs.js';
 
 export interface StartDashboardOptions {
   port: number;
@@ -198,6 +199,7 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   app.use(toolsRouter);
   app.use(nodesRouter);
   app.use(pulseRouter);
+  app.use(packsRouter);
 
   // Catch-all 404 for authenticated routes.
   app.use((_req, res) => {

--- a/packages/dashboard/src/routes/packs.test.ts
+++ b/packages/dashboard/src/routes/packs.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AgentStore,
+  DashboardsStore,
+  LocalProvider,
+  MemorySecretsStore,
+  PacksStore,
+  RunStore,
+  buildLoopbackAllowlist,
+  loadAgents,
+  type PackManifest,
+} from '@some-useful-agents/core';
+import { buildDashboardApp } from '../index.js';
+import type { DashboardContext } from '../context.js';
+import { SESSION_COOKIE } from '../auth-middleware.js';
+import { MemorySecretsSession } from '../secrets-session.js';
+
+const TOKEN = 'a'.repeat(64);
+const PORT = 3998;
+
+let dir: string;
+let provider: LocalProvider;
+let runStore: RunStore;
+let agentStore: AgentStore;
+let packsStore: PacksStore;
+let dashboardsStore: DashboardsStore;
+
+async function makeApp() {
+  dir = mkdtempSync(join(tmpdir(), 'sua-packs-routes-'));
+  const dbPath = join(dir, 'runs.db');
+  const agentsDir = join(dir, 'agents', 'local');
+  mkdirSync(agentsDir, { recursive: true });
+  writeFileSync(join(agentsDir, 'hello.yaml'), 'name: hello\ntype: shell\ncommand: echo hi\n');
+
+  const secretsStore = new MemorySecretsStore();
+  runStore = new RunStore(dbPath);
+  agentStore = new AgentStore(dbPath);
+  packsStore = new PacksStore(dbPath);
+  dashboardsStore = new DashboardsStore(dbPath);
+  provider = new LocalProvider(dbPath, secretsStore);
+  await provider.initialize();
+
+  const ctx: DashboardContext = {
+    token: TOKEN,
+    allowlist: buildLoopbackAllowlist(PORT),
+    port: PORT,
+    provider,
+    runStore,
+    agentStore,
+    loadAgents: () => loadAgents({ directories: [agentsDir] }),
+    secretsStore,
+    secretsSession: new MemorySecretsSession({ backing: secretsStore }),
+    tokenPath: join(dir, 'mcp-token'),
+    retentionDays: 30,
+    dbPath,
+    secretsPath: join(dir, 'secrets.enc'),
+    rotateToken: () => 'r'.repeat(64),
+    packsStore,
+    dashboardsStore,
+    allowUntrustedShell: new Set(),
+    activeRuns: new Map(),
+    dataDir: dir,
+    dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
+  };
+
+  return buildDashboardApp(ctx);
+}
+
+function manifest(): PackManifest {
+  return {
+    id: 'test-pack',
+    name: 'Test Pack',
+    version: '0.1.0',
+    description: 'A pack for testing.',
+    dashboards: [
+      { id: 'main', name: 'Main', sections: [{ title: 'Greetings', agentIds: ['hello'] }] },
+    ],
+  };
+}
+
+afterEach(async () => {
+  if (provider) {
+    const start = Date.now();
+    while ((provider as unknown as { running?: { size: number } }).running?.size && Date.now() - start < 2000) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    await provider.shutdown();
+  }
+  try { runStore?.close(); } catch { /* ignore */ }
+  try { agentStore?.close(); } catch { /* ignore */ }
+  try { packsStore?.close(); } catch { /* ignore */ }
+  try { dashboardsStore?.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('packs routes', () => {
+  it('GET /packs lists registered packs', async () => {
+    const app = await makeApp();
+    packsStore.upsertPack({ id: 'test-pack', name: 'Test Pack', version: '0.1.0', source: 'builtin', manifest: manifest() });
+    const res = await request(app).get('/packs').set('Host', `127.0.0.1:${PORT}`).set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Test Pack');
+    expect(res.text).toContain('Available');
+    expect(res.text).toContain('href="/packs/test-pack"');
+  });
+
+  it('GET /packs/:id renders detail with Install button', async () => {
+    const app = await makeApp();
+    packsStore.upsertPack({ id: 'test-pack', name: 'Test Pack', version: '0.1.0', source: 'builtin', manifest: manifest() });
+    const res = await request(app).get('/packs/test-pack').set('Host', `127.0.0.1:${PORT}`).set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('action="/packs/test-pack/install"');
+    expect(res.text).not.toContain('action="/packs/test-pack/uninstall"');
+    expect(res.text).toContain('Main'); // dashboard name visible
+  });
+
+  it('POST /packs/:id/install creates dashboards and flips Install → Uninstall', async () => {
+    const app = await makeApp();
+    packsStore.upsertPack({ id: 'test-pack', name: 'Test Pack', version: '0.1.0', source: 'builtin', manifest: manifest() });
+
+    const installRes = await request(app)
+      .post('/packs/test-pack/install')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(installRes.status).toBe(303);
+    expect(installRes.headers.location).toMatch(/\/packs\/test-pack\?ok=/);
+
+    expect(dashboardsStore.getDashboard('test-pack:main')).not.toBeNull();
+    expect(packsStore.getPack('test-pack')?.installedAt).not.toBeNull();
+
+    const detail = await request(app).get('/packs/test-pack').set('Host', `127.0.0.1:${PORT}`).set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(detail.text).toContain('action="/packs/test-pack/uninstall"');
+    expect(detail.text).not.toContain('action="/packs/test-pack/install"');
+  });
+
+  it('POST /packs/:id/uninstall removes dashboards but keeps agents', async () => {
+    const app = await makeApp();
+    packsStore.upsertPack({ id: 'test-pack', name: 'Test Pack', version: '0.1.0', source: 'builtin', manifest: manifest() });
+    await request(app).post('/packs/test-pack/install').set('Host', `127.0.0.1:${PORT}`).set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    const uninstallRes = await request(app)
+      .post('/packs/test-pack/uninstall')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(uninstallRes.status).toBe(303);
+    expect(uninstallRes.headers.location).toMatch(/\/packs\/test-pack\?ok=/);
+
+    expect(dashboardsStore.getDashboard('test-pack:main')).toBeNull();
+    expect(packsStore.getPack('test-pack')?.installedAt).toBeNull();
+  });
+
+  it('GET /packs/unknown 303s back to /packs', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/packs/nope').set('Host', `127.0.0.1:${PORT}`).set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toBe('/packs');
+  });
+});

--- a/packages/dashboard/src/routes/packs.ts
+++ b/packages/dashboard/src/routes/packs.ts
@@ -1,0 +1,93 @@
+/**
+ * Routes for `/packs` — browse, view, install, uninstall widget packs.
+ *
+ * Built on the PacksStore + DashboardsStore from PR 1 and the
+ * installPack / uninstallPack orchestration from PR 2. The pack
+ * registry is auto-populated by the daemon's loadBuiltinPacks call;
+ * users see and act on those packs here.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { installPack, uninstallPack } from '@some-useful-agents/core';
+import { getContext } from '../context.js';
+import { renderPacksList, renderPackDetail } from '../views/packs.js';
+
+export const packsRouter: Router = Router();
+
+packsRouter.get('/packs', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.packsStore) {
+    // Stores not initialised (e.g. test harness skipped them). Render an
+    // empty list rather than 500.
+    res.type('html').send(renderPacksList({ packs: [] }));
+    return;
+  }
+  const flash = parseFlash(req);
+  res.type('html').send(renderPacksList({ packs: ctx.packsStore.listPacks(), flash }));
+});
+
+packsRouter.get('/packs/:id', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.packsStore) {
+    res.status(404).redirect(303, '/packs');
+    return;
+  }
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const pack = ctx.packsStore.getPack(id);
+  if (!pack) {
+    res.status(404).redirect(303, '/packs');
+    return;
+  }
+  const flash = parseFlash(req);
+  res.type('html').send(renderPackDetail({ pack, flash }));
+});
+
+packsRouter.post('/packs/:id/install', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.packsStore || !ctx.dashboardsStore) {
+    res.status(503).redirect(303, '/packs');
+    return;
+  }
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  try {
+    const result = installPack(id, {
+      packsStore: ctx.packsStore,
+      dashboardsStore: ctx.dashboardsStore,
+      agentStore: ctx.agentStore,
+    });
+    const parts: string[] = [];
+    if (result.dashboardsCreated.length) parts.push(`${result.dashboardsCreated.length} dashboard${result.dashboardsCreated.length === 1 ? '' : 's'}`);
+    if (result.agentsCreated.length) parts.push(`${result.agentsCreated.length} agent${result.agentsCreated.length === 1 ? '' : 's'}`);
+    const detail = parts.length ? ` (${parts.join(', ')})` : '';
+    res.redirect(303, `/packs/${encodeURIComponent(id)}?ok=${encodeURIComponent('Installed' + detail + '.')}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/packs/${encodeURIComponent(id)}?error=${encodeURIComponent('Install failed: ' + msg)}`);
+  }
+});
+
+packsRouter.post('/packs/:id/uninstall', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.packsStore || !ctx.dashboardsStore) {
+    res.status(503).redirect(303, '/packs');
+    return;
+  }
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  try {
+    const result = uninstallPack(id, {
+      packsStore: ctx.packsStore,
+      dashboardsStore: ctx.dashboardsStore,
+    });
+    res.redirect(303, `/packs/${encodeURIComponent(id)}?ok=${encodeURIComponent(`Uninstalled (${result.dashboardsRemoved} dashboard${result.dashboardsRemoved === 1 ? '' : 's'} removed; agents kept).`)}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/packs/${encodeURIComponent(id)}?error=${encodeURIComponent('Uninstall failed: ' + msg)}`);
+  }
+});
+
+function parseFlash(req: Request): { kind: 'ok' | 'error' | 'info'; message: string } | undefined {
+  if (typeof req.query.ok === 'string') return { kind: 'ok', message: req.query.ok };
+  if (typeof req.query.error === 'string') return { kind: 'error', message: req.query.error };
+  if (typeof req.query.info === 'string') return { kind: 'info', message: req.query.info };
+  return undefined;
+}

--- a/packages/dashboard/src/routes/pulse.ts
+++ b/packages/dashboard/src/routes/pulse.ts
@@ -191,12 +191,21 @@ pulseRouter.get('/pulse', (req: Request, res: Response) => {
     }
   }
 
+  const flash = parsePulseFlash(req);
   res.type('html').send(renderPulsePage({
     systemTiles,
     tiles,
     hiddenTiles,
+    flash,
   }));
 });
+
+function parsePulseFlash(req: Request): { kind: 'ok' | 'error' | 'info'; message: string } | undefined {
+  if (typeof req.query.ok === 'string') return { kind: 'ok', message: req.query.ok };
+  if (typeof req.query.error === 'string') return { kind: 'error', message: req.query.error };
+  if (typeof req.query.info === 'string') return { kind: 'info', message: req.query.info };
+  return undefined;
+}
 
 pulseRouter.post('/agents/:id/signal/toggle', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
@@ -276,6 +285,43 @@ pulseRouter.post('/agents/:id/signal', (req: Request, res: Response) => {
 });
 
 // ── Tile fragment (for auto-refresh polling) ────────────────────────────
+
+/**
+ * POST /pulse/hide-all — bulk-flip pulseVisible=false on every agent that
+ * has a signal block AND isn't already hidden. Use case: "clear the slate
+ * before installing a pack so only its dashboards show through". Reversible
+ * via `/pulse/show-all` or per-agent toggle.
+ */
+pulseRouter.post('/pulse/hide-all', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  let hidden = 0;
+  for (const agent of ctx.agentStore.listAgents()) {
+    if (!agent.signal) continue;
+    const alreadyHidden = agent.pulseVisible === false
+      || (agent.pulseVisible === undefined && agent.signal.hidden === true);
+    if (alreadyHidden) continue;
+    ctx.agentStore.updateAgentMeta(agent.id, { pulseVisible: false });
+    hidden++;
+  }
+  res.redirect(303, `/pulse?ok=${encodeURIComponent(`Hid ${hidden} signal${hidden === 1 ? '' : 's'} from Pulse.`)}`);
+});
+
+/**
+ * POST /pulse/show-all — counterpart to hide-all. Sets pulseVisible=true
+ * on every agent that has a signal block. Useful after a "clear and
+ * curate" cycle if the user changes their mind.
+ */
+pulseRouter.post('/pulse/show-all', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  let shown = 0;
+  for (const agent of ctx.agentStore.listAgents()) {
+    if (!agent.signal) continue;
+    if (agent.pulseVisible === true) continue;
+    ctx.agentStore.updateAgentMeta(agent.id, { pulseVisible: true });
+    shown++;
+  }
+  res.redirect(303, `/pulse?ok=${encodeURIComponent(`Restored ${shown} signal${shown === 1 ? '' : 's'} to Pulse.`)}`);
+});
 
 pulseRouter.get('/pulse/tile/:id', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -13,8 +13,8 @@ import { footer } from './footer.js';
 
 export interface LayoutOptions {
   title: string;
-  /** Highlight in the nav (one of: agents, tools, runs, pulse, settings, help). */
-  activeNav?: 'agents' | 'tools' | 'nodes' | 'runs' | 'pulse' | 'settings' | 'help';
+  /** Highlight in the nav (one of: agents, tools, runs, pulse, packs, settings, help). */
+  activeNav?: 'agents' | 'tools' | 'nodes' | 'runs' | 'pulse' | 'packs' | 'settings' | 'help';
   /** Flash banner shown at the top of the body (errors from prior actions). */
   flash?: { kind: 'error' | 'info' | 'ok'; message: string };
   /** Widen the main column (for screens with 2-col layouts). */
@@ -56,6 +56,7 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
     <a href="/nodes" class="${opts.activeNav === 'nodes' ? 'is-active' : ''}">Nodes</a>
     <a href="/runs" class="${opts.activeNav === 'runs' ? 'is-active' : ''}">Runs</a>
     <a href="/pulse" class="${opts.activeNav === 'pulse' ? 'is-active' : ''}">Pulse</a>
+    <a href="/packs" class="${opts.activeNav === 'packs' ? 'is-active' : ''}">Packs</a>
     <a href="/settings" class="${opts.activeNav === 'settings' ? 'is-active' : ''}">Settings</a>
     <a href="/help" class="${opts.activeNav === 'help' ? 'is-active' : ''}">Help</a>
   </nav>

--- a/packages/dashboard/src/views/packs.ts
+++ b/packages/dashboard/src/views/packs.ts
@@ -1,0 +1,143 @@
+import type { Pack } from '@some-useful-agents/core';
+import { html, render } from './html.js';
+import { layout } from './layout.js';
+import { pageHeader } from './page-header.js';
+
+/**
+ * Render `/packs` — the browse-all-packs page. Cards split into two
+ * sections: installed first, then available. Empty-state when nothing
+ * is registered (the daemon hasn't found any built-in packs yet).
+ */
+export function renderPacksList(args: { packs: Pack[]; flash?: { kind: 'ok' | 'error' | 'info'; message: string } }): string {
+  const installed = args.packs.filter((p) => p.installedAt !== null);
+  const available = args.packs.filter((p) => p.installedAt === null);
+
+  const card = (p: Pack) => {
+    const dashboardCount = p.manifest.dashboards?.length ?? 0;
+    const agentCount = p.manifest.agents?.length ?? 0;
+    const stateBadge = p.installedAt
+      ? html`<span class="badge badge--ok">Installed</span>`
+      : html`<span class="badge dim">Available</span>`;
+    return html`
+      <a href="/packs/${encodeURIComponent(p.id)}" class="card" style="display: flex; flex-direction: column; gap: var(--space-2); text-decoration: none; color: inherit;">
+        <div style="display: flex; align-items: baseline; justify-content: space-between; gap: var(--space-2);">
+          <h3 style="margin: 0; font-size: var(--font-size-md); font-weight: var(--weight-semibold);">${p.name}</h3>
+          ${stateBadge}
+        </div>
+        ${p.description
+          ? html`<p style="margin: 0; color: var(--color-text-muted); font-size: var(--font-size-sm); line-height: 1.4;">${p.description}</p>`
+          : html``}
+        <div style="display: flex; gap: var(--space-3); font-size: var(--font-size-xs); color: var(--color-text-muted); margin-top: auto;">
+          <span>v${p.version}</span>
+          <span>${String(dashboardCount)} dashboard${dashboardCount === 1 ? '' : 's'}</span>
+          <span>${String(agentCount)} agent${agentCount === 1 ? '' : 's'}</span>
+          <span class="dim" style="margin-left: auto;">${p.source}</span>
+        </div>
+      </a>
+    `;
+  };
+
+  const section = (title: string, packs: Pack[]) => {
+    if (!packs.length) return html``;
+    return html`
+      <section style="margin-bottom: var(--space-5);">
+        <h2 style="margin: 0 0 var(--space-3) 0; font-size: var(--font-size-md); font-weight: var(--weight-semibold);">${title} <span class="dim">(${String(packs.length)})</span></h2>
+        <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: var(--space-3);">
+          ${packs.map(card)}
+        </div>
+      </section>
+    `;
+  };
+
+  const empty = args.packs.length === 0
+    ? html`<p class="dim" style="padding: var(--space-4); text-align: center;">No packs registered yet. Built-in packs are loaded from <code>packages/core/packs/*.yaml</code> on daemon start.</p>`
+    : html``;
+
+  const body = html`
+    ${pageHeader({
+      title: 'Packs',
+      description: 'Curated bundles of agents and dashboards. Install a pack to register its dashboards and contributed agents in one step.',
+    })}
+    ${section('Installed', installed)}
+    ${section('Available', available)}
+    ${empty}
+  `;
+
+  return render(layout({ title: 'Packs', activeNav: 'packs' as 'packs', flash: args.flash }, body));
+}
+
+/**
+ * Render `/packs/:id` — pack detail. Shows manifest contents and the
+ * Install or Uninstall action depending on current state.
+ */
+export function renderPackDetail(args: { pack: Pack; flash?: { kind: 'ok' | 'error' | 'info'; message: string } }): string {
+  const p = args.pack;
+  const installed = p.installedAt !== null;
+  const installedAt = p.installedAt ? new Date(p.installedAt).toISOString() : null;
+
+  const actionForm = installed
+    ? html`
+        <form method="POST" action="/packs/${encodeURIComponent(p.id)}/uninstall" style="display: inline;">
+          <button type="submit" class="btn btn--ghost">Uninstall</button>
+        </form>
+      `
+    : html`
+        <form method="POST" action="/packs/${encodeURIComponent(p.id)}/install" style="display: inline;">
+          <button type="submit" class="btn btn--primary">Install</button>
+        </form>
+      `;
+
+  const dashboardsBlock = p.manifest.dashboards?.length
+    ? html`
+        <section style="margin-top: var(--space-4);">
+          <h2 style="margin: 0 0 var(--space-2) 0; font-size: var(--font-size-md); font-weight: var(--weight-semibold);">Dashboards</h2>
+          <ul style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: var(--space-2);">
+            ${p.manifest.dashboards.map((d) => {
+              const sectionLabels = d.sections.map((s) => `${s.title} (${s.agentIds.length})`).join(' · ');
+              return html`
+                <li class="card" style="padding: var(--space-3);">
+                  <div style="font-weight: var(--weight-semibold);">${d.name}</div>
+                  <div class="dim" style="font-size: var(--font-size-sm);">${sectionLabels}</div>
+                </li>
+              `;
+            })}
+          </ul>
+        </section>
+      `
+    : html``;
+
+  const agentsBlock = p.manifest.agents?.length
+    ? html`
+        <section style="margin-top: var(--space-4);">
+          <h2 style="margin: 0 0 var(--space-2) 0; font-size: var(--font-size-md); font-weight: var(--weight-semibold);">Agents</h2>
+          <ul style="list-style: none; padding: 0; margin: 0; display: flex; flex-wrap: wrap; gap: var(--space-2);">
+            ${p.manifest.agents.map((a) => html`<li><code style="background: var(--color-surface-raised); padding: var(--space-1) var(--space-2); border-radius: var(--radius-sm);">${a.id}</code></li>`)}
+          </ul>
+          <p class="dim" style="font-size: var(--font-size-sm); margin: var(--space-2) 0 0 0;">Install creates any agents not already present (reference-only — uninstall keeps them).</p>
+        </section>
+      `
+    : html``;
+
+  const body = html`
+    ${pageHeader({
+      title: p.name,
+      back: { href: '/packs', label: 'Back to packs' },
+      description: p.description ?? undefined,
+    })}
+    <div class="card" style="display: flex; flex-direction: column; gap: var(--space-3);">
+      <div style="display: flex; gap: var(--space-3); flex-wrap: wrap; align-items: baseline;">
+        ${installed
+          ? html`<span class="badge badge--ok">Installed${installedAt ? html` · ${installedAt}` : html``}</span>`
+          : html`<span class="badge dim">Available</span>`}
+        <span class="dim" style="font-size: var(--font-size-sm);">v${p.version}</span>
+        <span class="dim" style="font-size: var(--font-size-sm);">source: ${p.source}</span>
+        ${p.author ? html`<span class="dim" style="font-size: var(--font-size-sm);">by ${p.author}</span>` : html``}
+        <div style="margin-left: auto;">${actionForm}</div>
+      </div>
+    </div>
+    ${dashboardsBlock}
+    ${agentsBlock}
+  `;
+
+  return render(layout({ title: `${p.name} · Packs`, activeNav: 'packs' as 'packs', flash: args.flash }, body));
+}

--- a/packages/dashboard/src/views/pulse-types.ts
+++ b/packages/dashboard/src/views/pulse-types.ts
@@ -24,6 +24,8 @@ export interface PulsePageInput {
   systemTiles: PulseTile[];
   tiles: PulseTile[];
   hiddenTiles: PulseTile[];
+  /** Optional one-shot banner from a redirect (?ok=… / ?error=…). */
+  flash?: { kind: 'ok' | 'error' | 'info'; message: string };
 }
 
 /** Signature for the tile wrapper function, passed to renderers. */

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -143,6 +143,16 @@ export function renderPulsePage(input: PulsePageInput): string {
         ${String(allTileCount)} signal${allTileCount !== 1 ? 's' : ''}${hiddenCount > 0 ? html`, ${String(hiddenCount)} hidden` : html``}
       </span>
       <div style="margin-left: auto; display: flex; gap: var(--space-2);">
+        ${tiles.length > 0 ? html`
+          <form method="POST" action="/pulse/hide-all" style="margin: 0; display: inline;" onsubmit="return confirm('Hide all ${String(tiles.length)} signal${tiles.length !== 1 ? 's' : ''} from Pulse? They\\'ll move to the hidden section and can be restored individually.');">
+            <button type="submit" class="btn btn--ghost btn--sm" title="Move every visible tile to the hidden section. Useful before installing packs.">Hide all</button>
+          </form>
+        ` : html``}
+        ${hiddenCount > 0 && tiles.length === 0 ? html`
+          <form method="POST" action="/pulse/show-all" style="margin: 0; display: inline;">
+            <button type="submit" class="btn btn--ghost btn--sm">Show all</button>
+          </form>
+        ` : html``}
         <button type="button" class="btn btn--ghost btn--sm" id="pulse-edit-toggle">\u270E Edit layout</button>
         <button type="button" class="btn btn--ghost btn--sm" id="pulse-add-container" style="display: none;">+ Add group</button>
       </div>
@@ -178,5 +188,5 @@ export function renderPulsePage(input: PulsePageInput): string {
     ${unsafeHtml(`<script type="application/json" id="pulse-template-registry">${JSON.stringify(TEMPLATE_REGISTRY)}</script>`)}
   `;
 
-  return render(layout({ title: 'Pulse', activeNav: 'pulse' }, body));
+  return render(layout({ title: 'Pulse', activeNav: 'pulse', flash: input.flash }, body));
 }


### PR DESCRIPTION
## Summary

PR 3 of 5 in the [widget-packs series](https://github.com/gregmeyer/some-useful-agents/pull/200). Stacked on #201; **target this PR's base to \`feat/pack-manifest-and-starter-stacked\`** until #200 + #201 land.

### Packs UI
- **\`GET /packs\`** — grid of all packs, split into Installed and Available.
- **\`GET /packs/:id\`** — detail view (dashboards by name, agent ids), Install or Uninstall button.
- **\`POST /packs/:id/install\`** / **\`POST /packs/:id/uninstall\`** — call PR 2's installPack/uninstallPack; redirect with flash banner.
- **"Packs" entry in the top nav**, between Pulse and Settings.

### Clear-the-slate (responding to in-flight feedback)
The user asked for a way to clear existing Pulse widgets so packs can drive curation. Two new bulk endpoints, plus a button on Pulse:

- **\`POST /pulse/hide-all\`** — bulk \`pulseVisible=false\` on every agent with a signal block.
- **\`POST /pulse/show-all\`** — reverses it.
- **"Hide all" / "Show all" button** on the Pulse header (toggles based on current state).

The Default Dashboard in PR 4 will key off \`pulseVisible\`, so this gives users a concrete "clear → install pack → see only those tiles" workflow even before PR 4 lands.

## Test plan
- [x] 5 new supertest cases for the packs routes (list, detail, install, uninstall, 404)
- [x] \`npm test\` — 1022/1022 passing
- [x] \`npm run build\` clean
- [x] Live smoke: install Starter pack → 2 dashboards created; uninstall → dashboards removed, agents kept
- [x] Live smoke: hide-all flipped 24 signals; show-all restored them
- [ ] Reviewer: tap through \`/packs\` in the browser to confirm the visual layout reads well

## What's next

- **PR 4:** \`/dashboards/:id\` rendering; \`/pulse\` becomes the Default Dashboard with a dropdown to pack dashboards.
- **PR 5:** dashboard editor (reuse the existing \`widget-layout.js.ts\` drag-drop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)