### PR TITLE
feat(dashboard): render pack dashboards + switcher dropdown (widget-packs PR 4/5)

### DIFF
--- a/.changeset/dashboards-render.md
+++ b/.changeset/dashboards-render.md
@@ -1,0 +1,27 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Render pack dashboards + add a switcher dropdown (widget-packs PR 4/5).
+
+- **`GET /dashboards/:id`** renders any installed dashboard via the
+  existing Pulse tile machinery. Unknown agents render as muted
+  placeholder cards so the user knows what's missing.
+- **Dashboards dropdown** above the Pulse header (and on each
+  dashboard page) lists Default + every installed dashboard, plus a
+  link to `/packs` to install more. Server-rendered `<details>` —
+  no JS. Hidden when only the Default option exists (avoids noise).
+- **Pulse stays at `/pulse`** as the "Default Dashboard" — its
+  visible tiles are still the agents with `pulseVisible !== false`,
+  computed on each request (no rows in the dashboards table).
+- Refactor: extracted `buildPulseTile` from `routes/pulse.ts` to a
+  new `views/pulse-tile-builder.ts` so the dashboards route can
+  build identical tiles without cross-route imports.
+
+5 new supertest cases; full suite 1027/1027 green. Live smoke:
+install Starter pack → switch via dropdown to /dashboards/starter:media
+→ Vimeo + cat-video tiles render in their "Video" section.

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -46,6 +46,7 @@ import { helpRouter } from './routes/help.js';
 import { versionsRouter } from './routes/versions.js';
 import { pulseRouter } from './routes/pulse.js';
 import { packsRouter } from './routes/packs.js';
+import { dashboardsRouter } from './routes/dashboards.js';
 
 export interface StartDashboardOptions {
   port: number;
@@ -200,6 +201,7 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   app.use(nodesRouter);
   app.use(pulseRouter);
   app.use(packsRouter);
+  app.use(dashboardsRouter);
 
   // Catch-all 404 for authenticated routes.
   app.use((_req, res) => {

--- a/packages/dashboard/src/routes/dashboards.test.ts
+++ b/packages/dashboard/src/routes/dashboards.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import request from 'supertest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AgentStore,
+  DashboardsStore,
+  LocalProvider,
+  MemorySecretsStore,
+  PacksStore,
+  RunStore,
+  buildLoopbackAllowlist,
+  loadAgents,
+} from '@some-useful-agents/core';
+import { buildDashboardApp } from '../index.js';
+import type { DashboardContext } from '../context.js';
+import { SESSION_COOKIE } from '../auth-middleware.js';
+import { MemorySecretsSession } from '../secrets-session.js';
+
+const TOKEN = 'a'.repeat(64);
+const PORT = 3997;
+
+let dir: string;
+let provider: LocalProvider;
+let runStore: RunStore;
+let agentStore: AgentStore;
+let packsStore: PacksStore;
+let dashboardsStore: DashboardsStore;
+
+async function makeApp() {
+  dir = mkdtempSync(join(tmpdir(), 'sua-dashboards-routes-'));
+  const dbPath = join(dir, 'runs.db');
+  const agentsDir = join(dir, 'agents', 'local');
+  mkdirSync(agentsDir, { recursive: true });
+
+  const secretsStore = new MemorySecretsStore();
+  runStore = new RunStore(dbPath);
+  agentStore = new AgentStore(dbPath);
+  packsStore = new PacksStore(dbPath);
+  dashboardsStore = new DashboardsStore(dbPath);
+  provider = new LocalProvider(dbPath, secretsStore);
+  await provider.initialize();
+
+  // Install a tiny v2 agent with a signal so tile-building has something to do.
+  agentStore.createAgent({
+    id: 'hello',
+    name: 'Hello',
+    status: 'active',
+    source: 'local',
+    mcp: false,
+    nodes: [{ id: 'greet', type: 'shell', command: 'echo hi', dependsOn: [] }],
+    signal: { title: 'Hello', template: 'text-headline', mapping: { headline: 'greeting' } },
+  }, 'cli');
+
+  const ctx: DashboardContext = {
+    token: TOKEN,
+    allowlist: buildLoopbackAllowlist(PORT),
+    port: PORT,
+    provider,
+    runStore,
+    agentStore,
+    loadAgents: () => loadAgents({ directories: [agentsDir] }),
+    secretsStore,
+    secretsSession: new MemorySecretsSession({ backing: secretsStore }),
+    tokenPath: join(dir, 'mcp-token'),
+    retentionDays: 30,
+    dbPath,
+    secretsPath: join(dir, 'secrets.enc'),
+    rotateToken: () => 'r'.repeat(64),
+    packsStore,
+    dashboardsStore,
+    allowUntrustedShell: new Set(),
+    activeRuns: new Map(),
+    dataDir: dir,
+    dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
+  };
+
+  return buildDashboardApp(ctx);
+}
+
+afterEach(async () => {
+  if (provider) {
+    const start = Date.now();
+    while ((provider as unknown as { running?: { size: number } }).running?.size && Date.now() - start < 2000) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    await provider.shutdown();
+  }
+  try { runStore?.close(); } catch { /* ignore */ }
+  try { agentStore?.close(); } catch { /* ignore */ }
+  try { packsStore?.close(); } catch { /* ignore */ }
+  try { dashboardsStore?.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('dashboards routes', () => {
+  it('GET /dashboards/:id renders sections + tiles', async () => {
+    const app = await makeApp();
+    dashboardsStore.upsertDashboard({
+      id: 'starter:main',
+      packId: 'starter',
+      name: 'Main',
+      layout: { sections: [{ title: 'Greetings', agentIds: ['hello'] }] },
+    });
+    const res = await request(app)
+      .get('/dashboards/starter:main')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Main');
+    expect(res.text).toContain('Greetings');
+    expect(res.text).toContain('data-agent-id="hello"');
+    expect(res.text).toContain('from pack: starter');
+  });
+
+  it('renders missing-agent placeholders for ids the agent store doesn\'t know', async () => {
+    const app = await makeApp();
+    dashboardsStore.upsertDashboard({
+      id: 'd1',
+      packId: null,
+      name: 'D1',
+      layout: { sections: [{ title: 'Mixed', agentIds: ['hello', 'ghost-agent'] }] },
+    });
+    const res = await request(app)
+      .get('/dashboards/d1')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('data-agent-id="hello"');
+    expect(res.text).toContain('ghost-agent');
+    expect(res.text).toContain('not installed');
+  });
+
+  it('GET /dashboards/unknown 404s', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .get('/dashboards/nope')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('Pulse shows the dashboards dropdown when at least one dashboard is installed', async () => {
+    const app = await makeApp();
+    dashboardsStore.upsertDashboard({
+      id: 'starter:main',
+      packId: 'starter',
+      name: 'Main',
+      layout: { sections: [{ title: 'Greetings', agentIds: ['hello'] }] },
+    });
+    const res = await request(app)
+      .get('/pulse')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('class="dashboards-dropdown"');
+    expect(res.text).toContain('Default Dashboard');
+    expect(res.text).toContain('href="/dashboards/starter%3Amain"');
+  });
+
+  it('Pulse hides the dropdown when no dashboards exist (only Default would show — noise)', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .get('/pulse')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).not.toContain('class="dashboards-dropdown"');
+  });
+});

--- a/packages/dashboard/src/routes/dashboards.ts
+++ b/packages/dashboard/src/routes/dashboards.ts
@@ -1,0 +1,67 @@
+/**
+ * Routes for `/dashboards/:id` — render a stored dashboard.
+ *
+ * The Default Dashboard backing /pulse is NOT served from here; it
+ * stays in routes/pulse.ts (synthesised from pulseVisible). This
+ * router only handles named, persisted dashboards from
+ * DashboardsStore — pack-owned (e.g. "starter:media") or user-created
+ * (added via the editor in PR 5).
+ */
+
+import { Router, type Request, type Response } from 'express';
+import type { Agent, AgentSignal } from '@some-useful-agents/core';
+import { getContext } from '../context.js';
+import {
+  renderDashboardPage,
+  type DashboardSectionRender,
+} from '../views/dashboards.js';
+import { buildPulseTile } from '../views/pulse-tile-builder.js';
+
+export const dashboardsRouter: Router = Router();
+
+dashboardsRouter.get('/dashboards/:id', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.dashboardsStore) {
+    res.status(404).type('html').send('<p>Dashboards store unavailable. <a href="/pulse">Back to Pulse</a></p>');
+    return;
+  }
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const dashboard = ctx.dashboardsStore.getDashboard(id);
+  if (!dashboard) {
+    res.status(404).type('html').send(`<p>No dashboard with id "${id}". <a href="/packs">Browse packs</a></p>`);
+    return;
+  }
+
+  // Build tiles for each section. Agents that aren't installed render
+  // as muted placeholder cards so the user knows what's missing.
+  const sections: DashboardSectionRender[] = dashboard.layout.sections.map((s) => {
+    const tiles = [];
+    const missingAgentIds: string[] = [];
+    for (const agentId of s.agentIds) {
+      const agent = ctx.agentStore.getAgent(agentId);
+      if (!agent || !agent.signal) {
+        missingAgentIds.push(agentId);
+        continue;
+      }
+      tiles.push(buildPulseTile(agent as Agent & { signal: AgentSignal }, { runStore: ctx.runStore }));
+    }
+    return { title: s.title, tiles, missingAgentIds };
+  });
+
+  const installedDashboards = ctx.dashboardsStore.listDashboards();
+  const flash = parseFlash(req);
+
+  res.type('html').send(renderDashboardPage({
+    dashboard,
+    sections,
+    installedDashboards,
+    flash,
+  }));
+});
+
+function parseFlash(req: Request): { kind: 'ok' | 'error' | 'info'; message: string } | undefined {
+  if (typeof req.query.ok === 'string') return { kind: 'ok', message: req.query.ok };
+  if (typeof req.query.error === 'string') return { kind: 'error', message: req.query.error };
+  if (typeof req.query.info === 'string') return { kind: 'info', message: req.query.info };
+  return undefined;
+}

--- a/packages/dashboard/src/routes/pulse.ts
+++ b/packages/dashboard/src/routes/pulse.ts
@@ -5,7 +5,8 @@ import { join, resolve } from 'node:path';
 import { getContext } from '../context.js';
 import { renderPulsePage, tileWrap, type PulseTile } from '../views/pulse.js';
 import { renderTile } from '../views/pulse-renderers.js';
-import { normalizeSignal, extractMappedValues, TEMPLATE_REGISTRY } from '../views/pulse-templates.js';
+import { buildPulseTile } from '../views/pulse-tile-builder.js';
+import { normalizeSignal, TEMPLATE_REGISTRY } from '../views/pulse-templates.js';
 
 export const pulseRouter: Router = Router();
 
@@ -32,60 +33,7 @@ function autoImportSignalExamples(ctx: ReturnType<typeof getContext>): void {
 // ── Tile building ────────────────────────────────────────────────────────
 
 function buildTile(agent: Agent & { signal: AgentSignal }, ctx: ReturnType<typeof getContext>): PulseTile {
-  const signal = agent.signal;
-  let lastRun: Run | undefined;
-  let outputsJson: string | undefined;
-  let previousInputs: Record<string, string> | undefined;
-  try {
-    const runs = ctx.runStore.listRuns({ agentName: agent.id, status: 'completed', limit: 1 });
-    if (runs.length > 0) {
-      lastRun = runs[0];
-      const execs = ctx.runStore.listNodeExecutions(lastRun.id);
-      const lastExec = execs.filter((e) => e.status === 'completed').pop();
-      if (lastExec?.outputsJson) outputsJson = lastExec.outputsJson;
-
-      // Pre-fill the interactive widget form with the most recent run's
-      // input values so re-running with a tweaked prompt is one edit, not
-      // a full retype. Mirrors buildTabArgs in routes/agents/tabs.ts.
-      if (agent.outputWidget?.interactive && agent.inputs && execs.length > 0 && execs[0].inputsJson) {
-        try {
-          const allEnv = JSON.parse(execs[0].inputsJson) as Record<string, string>;
-          const inputNames = new Set(Object.keys(agent.inputs));
-          const picked: Record<string, string> = {};
-          for (const [k, v] of Object.entries(allEnv)) {
-            if (inputNames.has(k) && v !== '') picked[k] = v;
-          }
-          if (Object.keys(picked).length > 0) previousInputs = picked;
-        } catch { /* malformed inputsJson */ }
-      }
-    }
-  } catch { /* no runs */ }
-
-  const { mapping } = normalizeSignal(signal);
-  const slots = extractMappedValues(lastRun, mapping, outputsJson);
-
-  // Discover output field keys for the configure modal.
-  const outputFields: string[] = [];
-  const fieldSet = new Set<string>();
-  if (outputsJson) {
-    try {
-      const parsed = JSON.parse(outputsJson);
-      if (typeof parsed === 'object' && parsed !== null) {
-        for (const k of Object.keys(parsed)) fieldSet.add(k);
-      }
-    } catch { /* ignore */ }
-  }
-  if (lastRun?.result) {
-    try {
-      const parsed = JSON.parse(lastRun.result);
-      if (typeof parsed === 'object' && parsed !== null) {
-        for (const k of Object.keys(parsed)) fieldSet.add(k);
-      }
-    } catch { /* not JSON */ }
-  }
-  outputFields.push(...Array.from(fieldSet).sort());
-
-  return { agent, signal, lastRun, slots, outputFields, previousInputs };
+  return buildPulseTile(agent, { runStore: ctx.runStore });
 }
 
 // ── Virtual system tiles ─────────────────────────────────────────────────
@@ -192,11 +140,13 @@ pulseRouter.get('/pulse', (req: Request, res: Response) => {
   }
 
   const flash = parsePulseFlash(req);
+  const installedDashboards = ctx.dashboardsStore?.listDashboards() ?? [];
   res.type('html').send(renderPulsePage({
     systemTiles,
     tiles,
     hiddenTiles,
     flash,
+    installedDashboards,
   }));
 });
 

--- a/packages/dashboard/src/views/dashboards-dropdown.ts
+++ b/packages/dashboard/src/views/dashboards-dropdown.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared dashboards dropdown — appears on /pulse and on /dashboards/:id.
+ * Server-rendered <details>/<summary> menu (no JS) with the active
+ * dashboard at the top and the others below as links.
+ */
+
+import type { Dashboard } from '@some-useful-agents/core';
+import { html, type SafeHtml } from './html.js';
+
+export interface DashboardOption {
+  /** Stable URL — '/pulse' for Default, '/dashboards/<id>' for installed packs. */
+  href: string;
+  label: string;
+  /** Optional secondary label (e.g. pack id) shown muted. */
+  hint?: string;
+}
+
+/**
+ * Build the option list. Default Dashboard is always first; pack-owned
+ * dashboards follow alphabetised by pack-id then dashboard name.
+ */
+export function buildDashboardOptions(installed: Dashboard[]): DashboardOption[] {
+  const opts: DashboardOption[] = [
+    { href: '/pulse', label: 'Default Dashboard', hint: 'pulseVisible' },
+  ];
+  const sorted = [...installed].sort((a, b) => {
+    const ap = a.packId ?? 'user';
+    const bp = b.packId ?? 'user';
+    if (ap !== bp) return ap.localeCompare(bp);
+    return a.name.localeCompare(b.name);
+  });
+  for (const d of sorted) {
+    opts.push({
+      href: `/dashboards/${encodeURIComponent(d.id)}`,
+      label: d.name,
+      hint: d.packId ?? 'user',
+    });
+  }
+  return opts;
+}
+
+/** Render the dropdown. `activeHref` matches one of the options' hrefs. */
+export function renderDashboardsDropdown(args: {
+  options: DashboardOption[];
+  activeHref: string;
+}): SafeHtml {
+  const active = args.options.find((o) => o.href === args.activeHref) ?? args.options[0];
+  return html`
+    <details class="dashboards-dropdown" style="position: relative;">
+      <summary style="list-style: none; cursor: pointer; padding: var(--space-1) var(--space-3); border: 1px solid var(--color-border); border-radius: var(--radius-sm); background: var(--color-surface); font-size: var(--font-size-sm); display: inline-flex; align-items: center; gap: var(--space-2);">
+        <span>${active.label}</span>
+        <span style="font-size: var(--font-size-xs); opacity: 0.6;">▾</span>
+      </summary>
+      <div style="position: absolute; top: 100%; left: 0; margin-top: var(--space-1); background: var(--color-surface-raised); border: 1px solid var(--color-border); border-radius: var(--radius-sm); box-shadow: 0 4px 12px rgba(0,0,0,0.15); min-width: 220px; z-index: 100; padding: var(--space-1); display: flex; flex-direction: column; gap: 1px;">
+        ${args.options.map((o) => {
+          const isActive = o.href === args.activeHref;
+          const bg = isActive ? 'background: var(--color-surface);' : '';
+          return html`
+            <a href="${o.href}" style="display: flex; justify-content: space-between; align-items: baseline; gap: var(--space-3); padding: var(--space-2) var(--space-3); text-decoration: none; color: inherit; border-radius: var(--radius-sm); ${bg}">
+              <span>${o.label}</span>
+              ${o.hint ? html`<span class="dim" style="font-size: var(--font-size-xs);">${o.hint}</span>` : html``}
+            </a>
+          `;
+        })}
+        <a href="/packs" style="display: flex; padding: var(--space-2) var(--space-3); text-decoration: none; color: var(--color-text-muted); font-size: var(--font-size-sm); border-top: 1px solid var(--color-border); margin-top: var(--space-1); padding-top: var(--space-2);">
+          + Install more from Packs
+        </a>
+      </div>
+    </details>
+  `;
+}

--- a/packages/dashboard/src/views/dashboards.ts
+++ b/packages/dashboard/src/views/dashboards.ts
@@ -1,0 +1,93 @@
+/**
+ * Render a single dashboard at /dashboards/:id.
+ *
+ * Reuses the Pulse tile rendering machinery (renderTile + tileWrap)
+ * so dashboards look identical to Pulse — the layout/sectioning is
+ * the only thing that differs. The "Default Dashboard" backing
+ * /pulse stays in routes/pulse.ts; this file is for named (pack or
+ * user) dashboards that came from DashboardsStore.
+ */
+
+import type { Dashboard } from '@some-useful-agents/core';
+import { html, render, type SafeHtml } from './html.js';
+import { layout } from './layout.js';
+import { pageHeader } from './page-header.js';
+import { renderTile } from './pulse-renderers.js';
+import { tileWrap, type PulseTile } from './pulse.js';
+import {
+  buildDashboardOptions,
+  renderDashboardsDropdown,
+  type DashboardOption,
+} from './dashboards-dropdown.js';
+
+export interface DashboardSectionRender {
+  title: string;
+  /** Tiles already built, in the order the section declares them. */
+  tiles: PulseTile[];
+  /** Agent ids referenced by the section that aren't installed (rendered as muted placeholders). */
+  missingAgentIds: string[];
+}
+
+export interface RenderDashboardPageInput {
+  dashboard: Dashboard;
+  sections: DashboardSectionRender[];
+  /** All installed dashboards, used to populate the dropdown. */
+  installedDashboards: Dashboard[];
+  flash?: { kind: 'ok' | 'error' | 'info'; message: string };
+}
+
+export function renderDashboardPage(input: RenderDashboardPageInput): string {
+  const options: DashboardOption[] = buildDashboardOptions(input.installedDashboards);
+  const activeHref = `/dashboards/${encodeURIComponent(input.dashboard.id)}`;
+  const dropdown = renderDashboardsDropdown({ options, activeHref });
+
+  const totalTiles = input.sections.reduce((n, s) => n + s.tiles.length, 0);
+  const totalMissing = input.sections.reduce((n, s) => n + s.missingAgentIds.length, 0);
+
+  const sourceLabel = input.dashboard.packId ? `from pack: ${input.dashboard.packId}` : 'user-created';
+
+  const body = html`
+    <div style="display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-4);">
+      ${dropdown}
+      <span class="dim" style="font-size: var(--font-size-sm);">
+        ${String(totalTiles)} tile${totalTiles === 1 ? '' : 's'}
+        ${totalMissing > 0 ? html`, ${String(totalMissing)} missing` : html``}
+        · ${sourceLabel}
+      </span>
+    </div>
+
+    ${pageHeader({
+      title: input.dashboard.name,
+      back: { href: '/packs', label: 'All packs' },
+    })}
+
+    ${input.sections.length === 0
+      ? html`<p class="dim" style="padding: var(--space-4); text-align: center;">No sections in this dashboard.</p>`
+      : input.sections.map((s) => renderSection(s)) as unknown as SafeHtml[]}
+  `;
+
+  return render(layout({
+    title: `${input.dashboard.name} · Dashboards`,
+    activeNav: 'pulse', // Dashboards live under the Pulse tab in nav
+    flash: input.flash,
+  }, body));
+}
+
+function renderSection(s: DashboardSectionRender): SafeHtml {
+  const isEmpty = s.tiles.length === 0 && s.missingAgentIds.length === 0;
+  if (isEmpty) return html``;
+  return html`
+    <section style="margin-bottom: var(--space-5);">
+      <h2 style="margin: 0 0 var(--space-3) 0; font-size: var(--font-size-md); font-weight: var(--weight-semibold);">${s.title}</h2>
+      <div class="pulse-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: var(--space-3);">
+        ${s.tiles.map((t) => renderTile(t, tileWrap)) as unknown as SafeHtml[]}
+        ${s.missingAgentIds.map((id) => html`
+          <div class="card dim" style="padding: var(--space-3); border: 1px dashed var(--color-border-strong);">
+            <div style="font-family: var(--font-mono); font-size: var(--font-size-sm);">${id}</div>
+            <div style="font-size: var(--font-size-xs);">not installed — install the pack or remove from the dashboard</div>
+          </div>
+        `) as unknown as SafeHtml[]}
+      </div>
+    </section>
+  `;
+}

--- a/packages/dashboard/src/views/pulse-tile-builder.ts
+++ b/packages/dashboard/src/views/pulse-tile-builder.ts
@@ -1,0 +1,75 @@
+/**
+ * Build a PulseTile from an agent + run history.
+ *
+ * Extracted from routes/pulse.ts so other surfaces (the new
+ * /dashboards/:id route) can render the same tiles without
+ * cross-route imports. Tile rendering itself stays in
+ * pulse-renderers.ts.
+ */
+
+import type { Agent, AgentSignal, Run, RunStore } from '@some-useful-agents/core';
+import type { PulseTile } from './pulse-types.js';
+import { normalizeSignal, extractMappedValues } from './pulse-templates.js';
+
+export interface BuildTileDeps {
+  runStore: RunStore;
+}
+
+export function buildPulseTile(
+  agent: Agent & { signal: AgentSignal },
+  deps: BuildTileDeps,
+): PulseTile {
+  const signal = agent.signal;
+  let lastRun: Run | undefined;
+  let outputsJson: string | undefined;
+  let previousInputs: Record<string, string> | undefined;
+  try {
+    const runs = deps.runStore.listRuns({ agentName: agent.id, status: 'completed', limit: 1 });
+    if (runs.length > 0) {
+      lastRun = runs[0];
+      const execs = deps.runStore.listNodeExecutions(lastRun.id);
+      const lastExec = execs.filter((e) => e.status === 'completed').pop();
+      if (lastExec?.outputsJson) outputsJson = lastExec.outputsJson;
+
+      // Pre-fill the interactive widget form with the most recent run's
+      // input values (mirrors buildTile in routes/pulse.ts).
+      if (agent.outputWidget?.interactive && agent.inputs && execs.length > 0 && execs[0].inputsJson) {
+        try {
+          const allEnv = JSON.parse(execs[0].inputsJson) as Record<string, string>;
+          const inputNames = new Set(Object.keys(agent.inputs));
+          const picked: Record<string, string> = {};
+          for (const [k, v] of Object.entries(allEnv)) {
+            if (inputNames.has(k) && v !== '') picked[k] = v;
+          }
+          if (Object.keys(picked).length > 0) previousInputs = picked;
+        } catch { /* malformed inputsJson */ }
+      }
+    }
+  } catch { /* no runs */ }
+
+  const { mapping } = normalizeSignal(signal);
+  const slots = extractMappedValues(lastRun, mapping, outputsJson);
+
+  // Discover output field keys for the configure modal.
+  const outputFields: string[] = [];
+  const fieldSet = new Set<string>();
+  if (outputsJson) {
+    try {
+      const parsed = JSON.parse(outputsJson);
+      if (typeof parsed === 'object' && parsed !== null) {
+        for (const k of Object.keys(parsed)) fieldSet.add(k);
+      }
+    } catch { /* ignore */ }
+  }
+  if (lastRun?.result) {
+    try {
+      const parsed = JSON.parse(lastRun.result);
+      if (typeof parsed === 'object' && parsed !== null) {
+        for (const k of Object.keys(parsed)) fieldSet.add(k);
+      }
+    } catch { /* not JSON */ }
+  }
+  outputFields.push(...Array.from(fieldSet).sort());
+
+  return { agent, signal, lastRun, slots, outputFields, previousInputs };
+}

--- a/packages/dashboard/src/views/pulse-types.ts
+++ b/packages/dashboard/src/views/pulse-types.ts
@@ -26,6 +26,12 @@ export interface PulsePageInput {
   hiddenTiles: PulseTile[];
   /** Optional one-shot banner from a redirect (?ok=… / ?error=…). */
   flash?: { kind: 'ok' | 'error' | 'info'; message: string };
+  /**
+   * Installed dashboards (from DashboardsStore) used to populate the
+   * dashboards dropdown above the Pulse header. Empty/undefined when
+   * the dashboards store isn't wired (tests, older daemons).
+   */
+  installedDashboards?: import('@some-useful-agents/core').Dashboard[];
 }
 
 /** Signature for the tile wrapper function, passed to renderers. */

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -14,6 +14,7 @@ import { formatAge } from './components.js';
 import { normalizeSignal, TEMPLATE_REGISTRY } from './pulse-templates.js';
 import { esc } from './pulse-helpers.js';
 import { renderTile } from './pulse-renderers.js';
+import { buildDashboardOptions, renderDashboardsDropdown } from './dashboards-dropdown.js';
 export type { PulseTile, PulsePageInput, TileWrapFn } from './pulse-types.js';
 import type { PulseTile, PulsePageInput, TileWrapFn } from './pulse-types.js';
 
@@ -136,7 +137,17 @@ export function renderPulsePage(input: PulsePageInput): string {
 
   const doRenderTile = (tile: PulseTile) => renderTile(tile, tileWrap);
 
+  const dropdownOptions = buildDashboardOptions(input.installedDashboards ?? []);
+  // Only render the dropdown when there's more than just the Default
+  // entry — otherwise it's noise.
+  const dropdown = dropdownOptions.length > 1
+    ? renderDashboardsDropdown({ options: dropdownOptions, activeHref: '/pulse' })
+    : html``;
+
   const body = html`
+    ${dropdownOptions.length > 1
+      ? html`<div style="margin-bottom: var(--space-3);">${dropdown}</div>`
+      : html``}
     <div style="display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-6);">
       <h1 style="margin: 0;">Pulse</h1>
       <span style="font-size: var(--font-size-sm); color: var(--color-text-muted);">


### PR DESCRIPTION
## Summary

PR 4 of 5 in the [widget-packs series](https://github.com/gregmeyer/some-useful-agents/pull/200). Stacked on #202; **target this PR's base to \`feat/packs-browse-ui\`** until the rest land.

- **\`GET /dashboards/:id\`** renders any stored dashboard via the existing Pulse tile machinery (same look as /pulse). Unknown agent ids render as muted placeholder cards.
- **Dashboards dropdown** above the Pulse header and on each dashboard page. Lists Default + every installed dashboard, plus a "+ Install more from Packs" link. Server-rendered \`<details>\` — no JS. Hidden when only Default would appear (avoids noise).
- **Pulse stays at \`/pulse\`** as the conceptual "Default Dashboard." Visible tiles still come from \`pulseVisible\` (computed each request, no rows in the dashboards table).

### Refactor
Extracted \`buildPulseTile\` from \`routes/pulse.ts\` to a new \`views/pulse-tile-builder.ts\` so the new dashboards route can build identical tiles without cross-route imports. Pulse's existing render unchanged.

## Test plan
- [x] 5 new supertest cases (sections + tiles, missing-agent placeholders, 404, dropdown visibility on/off)
- [x] \`npm test\` — 1027/1027 passing
- [x] \`npm run build\` clean
- [x] Live smoke: install Starter pack → \`/dashboards/starter:media\` shows Vimeo + cat-video tiles in Media section; dropdown lists Default + Media + Weather

## What's next

- **PR 5:** dashboard editor — drag-drop reorder + add/remove tiles. Reuses existing \`widget-layout.js.ts\`; swaps localStorage for server persistence via DashboardsStore.updateLayout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)