### PR TITLE
feat(widget-packs): re-stack PRs 2-4 onto main (#201, #202, #203 went to wrong base)

### DIFF
--- a/.changeset/dashboards-render.md
+++ b/.changeset/dashboards-render.md
@@ -1,0 +1,27 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Render pack dashboards + add a switcher dropdown (widget-packs PR 4/5).
+
+- **`GET /dashboards/:id`** renders any installed dashboard via the
+  existing Pulse tile machinery. Unknown agents render as muted
+  placeholder cards so the user knows what's missing.
+- **Dashboards dropdown** above the Pulse header (and on each
+  dashboard page) lists Default + every installed dashboard, plus a
+  link to `/packs` to install more. Server-rendered `<details>` —
+  no JS. Hidden when only the Default option exists (avoids noise).
+- **Pulse stays at `/pulse`** as the "Default Dashboard" — its
+  visible tiles are still the agents with `pulseVisible !== false`,
+  computed on each request (no rows in the dashboards table).
+- Refactor: extracted `buildPulseTile` from `routes/pulse.ts` to a
+  new `views/pulse-tile-builder.ts` so the dashboards route can
+  build identical tiles without cross-route imports.
+
+5 new supertest cases; full suite 1027/1027 green. Live smoke:
+install Starter pack → switch via dropdown to /dashboards/starter:media
+→ Vimeo + cat-video tiles render in their "Video" section.

--- a/.changeset/pack-manifest-and-starter.md
+++ b/.changeset/pack-manifest-and-starter.md
@@ -1,0 +1,41 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Pack manifest format + first built-in Starter pack (widget-packs PR 2/5).
+
+Builds on PR 1's stores. New modules in `packages/core`:
+
+- **`pack-schema.ts`** — Zod schema for the pack manifest YAML format.
+  Validates pack id, semver version, dashboard structure, and the
+  `yaml` / `yamlPath` mutual exclusion on agent refs.
+- **`pack-loader.ts`** — discovers `packages/core/packs/*.yaml` on
+  daemon start, validates each, resolves `yamlPath` agent refs against
+  the manifest's directory, and upserts into `PacksStore` as
+  `source = 'builtin'`. Idempotent: reload preserves `installed_at`,
+  so a manifest version bump doesn't toggle install state. Failures on
+  individual files are skipped (returned in `result.skipped`) so one
+  broken pack doesn't gate the rest.
+- **`pack-installer.ts`** — `installPack(packId, ctx)` and
+  `uninstallPack(packId, ctx)` orchestrate across PacksStore +
+  DashboardsStore + AgentStore (the latter optional). Reference-only
+  ownership: install upserts missing agents from embedded YAML;
+  uninstall removes only the dashboards.
+- **`packages/core/packs/starter.yaml`** — first built-in pack. Bundles
+  the three dogfood agents from #199 (vimeo-staff-picks +
+  weather-forecast + cat-video-finder) into two dashboards (Media +
+  Weather). Auto-registers on daemon start; visible in PR 3's UI.
+
+Daemon startup (`packages/dashboard/src/index.ts`) now calls
+`loadBuiltinPacks(packsStore, defaultBuiltinPacksDir())` immediately
+after PacksStore init. Best-effort — failures don't block the
+dashboard from coming up.
+
+Added `packs/` to `packages/core/package.json`'s `files` array so the
+bundled manifest ships with the npm package.
+
+22 new unit tests; full suite 1017/1017 green.

--- a/.changeset/packs-browse-ui.md
+++ b/.changeset/packs-browse-ui.md
@@ -1,0 +1,34 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Browse and install widget packs from the dashboard (widget-packs PR 3/5).
+
+New routes:
+
+- **`GET /packs`** — grid of all registered packs, split into Installed
+  and Available sections. Cards show name, description, version, source,
+  dashboard/agent counts.
+- **`GET /packs/:id`** — pack detail with manifest summary (dashboards
+  by name + section count, agent ids) and an Install or Uninstall button.
+- **`POST /packs/:id/install`** / **`POST /packs/:id/uninstall`** — call
+  the installer from PR 2; redirect back to the detail page with a flash
+  banner reporting what changed.
+- **"Packs" entry in the top nav**, between Pulse and Settings.
+
+Plus a "clear-the-slate" pair on Pulse:
+
+- **`POST /pulse/hide-all`** — bulk-flip `pulseVisible=false` on every
+  agent that has a signal block. Use case: "I want to install a pack
+  and only see those tiles". Reversible.
+- **`POST /pulse/show-all`** — restores everything that was hidden.
+- **"Hide all" button** appears on the Pulse header when at least one
+  signal is visible; flips to "Show all" when nothing is visible but
+  hidden tiles exist.
+
+5 new route tests; full suite 1022/1022 green. Live smoke confirms
+install/uninstall round-trip + bulk hide/show.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,7 @@
   },
   "files": [
     "dist",
+    "packs",
     "README.md",
     "LICENSE"
   ],

--- a/packages/core/packs/starter.yaml
+++ b/packages/core/packs/starter.yaml
@@ -1,0 +1,35 @@
+# Starter pack — a guided tour of the new ai-template widget capabilities.
+#
+# Bundles the three dogfood agents shipped in #199, organised into two
+# dashboards (Media + Weather). Installing this pack creates the agents
+# (if missing) and registers the two dashboards under /dashboards/<id>.
+# Uninstalling removes the dashboards but keeps the agents.
+
+id: starter
+name: Starter
+description: A guided tour of the new ai-template widget capabilities.
+version: 0.1.0
+author: some-useful-agents
+
+agents:
+  - id: vimeo-staff-picks
+    yamlPath: ../../../agents/examples/vimeo-staff-picks.yaml
+  - id: weather-forecast
+    yamlPath: ../../../agents/examples/weather-forecast.yaml
+  - id: cat-video-finder
+    yamlPath: ../../../agents/examples/cat-video-finder.yaml
+
+dashboards:
+  - id: media
+    name: Media
+    sections:
+      - title: Video
+        agentIds:
+          - vimeo-staff-picks
+          - cat-video-finder
+  - id: weather
+    name: Weather
+    sections:
+      - title: Forecast
+        agentIds:
+          - weather-forecast

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -65,6 +65,23 @@ export {
   type DashboardLayout,
 } from './dashboards-store.js';
 export {
+  packManifestSchema,
+  type PackManifestInput,
+  type PackManifestParsed,
+} from './pack-schema.js';
+export {
+  loadBuiltinPacks,
+  defaultBuiltinPacksDir,
+  type LoadBuiltinPacksResult,
+} from './pack-loader.js';
+export {
+  installPack,
+  uninstallPack,
+  type PackInstallContext,
+  type PackInstallResult,
+  type PackUninstallResult,
+} from './pack-installer.js';
+export {
   getBuiltinTool,
   listBuiltinTools,
   isBuiltinTool,

--- a/packages/core/src/pack-installer.test.ts
+++ b/packages/core/src/pack-installer.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { PacksStore, type PackManifest } from './packs-store.js';
+import { DashboardsStore } from './dashboards-store.js';
+import { AgentStore } from './agent-store.js';
+import { installPack, uninstallPack } from './pack-installer.js';
+
+let dir: string;
+let db: DatabaseSync;
+let packs: PacksStore;
+let dashboards: DashboardsStore;
+let agents: AgentStore;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'sua-pack-installer-'));
+  db = new DatabaseSync(join(dir, 'runs.db'));
+  packs = PacksStore.fromHandle(db);
+  dashboards = DashboardsStore.fromHandle(db);
+  agents = AgentStore.fromHandle(db);
+});
+
+afterEach(() => {
+  try { db.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+const SAMPLE_AGENT_YAML = `id: hello
+name: Hello
+status: active
+source: local
+mcp: false
+nodes:
+  - id: greet
+    type: shell
+    command: echo hi
+`;
+
+function manifestWithAgents(): PackManifest {
+  return {
+    id: 'starter',
+    name: 'Starter',
+    version: '0.1.0',
+    agents: [{ id: 'hello', yaml: SAMPLE_AGENT_YAML }],
+    dashboards: [
+      {
+        id: 'main',
+        name: 'Main',
+        sections: [{ title: 'Greetings', agentIds: ['hello'] }],
+      },
+    ],
+  };
+}
+
+describe('installPack', () => {
+  it('creates dashboards from the manifest and marks installed', () => {
+    packs.upsertPack({ id: 'starter', name: 'Starter', version: '0.1.0', source: 'builtin', manifest: manifestWithAgents() });
+    const result = installPack('starter', { packsStore: packs, dashboardsStore: dashboards, agentStore: agents });
+    expect(result.dashboardsCreated).toEqual(['starter:main']);
+    expect(result.agentsCreated).toEqual(['hello']);
+    expect(packs.getPack('starter')?.installedAt).not.toBeNull();
+    expect(dashboards.getDashboard('starter:main')?.layout.sections[0].agentIds).toEqual(['hello']);
+    expect(agents.getAgent('hello')).not.toBeNull();
+  });
+
+  it('skips agents that already exist', () => {
+    // Pre-create the agent.
+    packs.upsertPack({ id: 'starter', name: 'Starter', version: '0.1.0', source: 'builtin', manifest: manifestWithAgents() });
+    installPack('starter', { packsStore: packs, dashboardsStore: dashboards, agentStore: agents });
+    // Reinstall — the agent already exists from the first run.
+    const result = installPack('starter', { packsStore: packs, dashboardsStore: dashboards, agentStore: agents });
+    expect(result.agentsCreated).toEqual([]);
+    expect(result.agentsSkipped).toEqual(['hello']);
+  });
+
+  it('only creates dashboards when no agentStore is provided', () => {
+    packs.upsertPack({ id: 'starter', name: 'Starter', version: '0.1.0', source: 'builtin', manifest: manifestWithAgents() });
+    const result = installPack('starter', { packsStore: packs, dashboardsStore: dashboards });
+    expect(result.dashboardsCreated).toEqual(['starter:main']);
+    expect(result.agentsCreated).toEqual([]);
+    // Agent ref skipped because no agent store to install into.
+    expect(result.agentsSkipped).toEqual(['hello']);
+  });
+
+  it('throws on unknown pack', () => {
+    expect(() => installPack('nope', { packsStore: packs, dashboardsStore: dashboards })).toThrow(/No pack registered/);
+  });
+
+  it('throws when an embedded agent YAML id mismatches the ref id', () => {
+    packs.upsertPack({
+      id: 'p', name: 'P', version: '0.1.0', source: 'builtin',
+      manifest: {
+        id: 'p', name: 'P', version: '0.1.0',
+        agents: [{ id: 'wrong-id', yaml: SAMPLE_AGENT_YAML }],
+        dashboards: [{ id: 'd', name: 'D', sections: [{ title: 'T', agentIds: ['hello'] }] }],
+      },
+    });
+    expect(() =>
+      installPack('p', { packsStore: packs, dashboardsStore: dashboards, agentStore: agents }),
+    ).toThrow(/does not match YAML id/);
+  });
+
+  it('reinstall refreshes dashboards from the latest manifest', () => {
+    packs.upsertPack({ id: 'starter', name: 'Starter', version: '0.1.0', source: 'builtin', manifest: manifestWithAgents() });
+    installPack('starter', { packsStore: packs, dashboardsStore: dashboards, agentStore: agents });
+
+    // Change the dashboard layout in the manifest, re-upsert, reinstall.
+    const updated = manifestWithAgents();
+    updated.dashboards![0].sections.push({ title: 'Extras', agentIds: ['hello'] });
+    packs.upsertPack({ id: 'starter', name: 'Starter', version: '0.1.0', source: 'builtin', manifest: updated });
+    installPack('starter', { packsStore: packs, dashboardsStore: dashboards, agentStore: agents });
+
+    expect(dashboards.getDashboard('starter:main')?.layout.sections).toHaveLength(2);
+  });
+});
+
+describe('uninstallPack', () => {
+  it('removes dashboards but keeps agents', () => {
+    packs.upsertPack({ id: 'starter', name: 'Starter', version: '0.1.0', source: 'builtin', manifest: manifestWithAgents() });
+    installPack('starter', { packsStore: packs, dashboardsStore: dashboards, agentStore: agents });
+    expect(dashboards.getDashboard('starter:main')).not.toBeNull();
+    expect(agents.getAgent('hello')).not.toBeNull();
+
+    const result = uninstallPack('starter', { packsStore: packs, dashboardsStore: dashboards, agentStore: agents });
+    expect(result.dashboardsRemoved).toBe(1);
+    expect(dashboards.getDashboard('starter:main')).toBeNull();
+    expect(packs.getPack('starter')?.installedAt).toBeNull();
+    expect(agents.getAgent('hello')).not.toBeNull();
+  });
+
+  it('is idempotent', () => {
+    packs.upsertPack({ id: 'starter', name: 'Starter', version: '0.1.0', source: 'builtin', manifest: manifestWithAgents() });
+    expect(() => uninstallPack('starter', { packsStore: packs, dashboardsStore: dashboards })).not.toThrow();
+    expect(() => uninstallPack('starter', { packsStore: packs, dashboardsStore: dashboards })).not.toThrow();
+  });
+});

--- a/packages/core/src/pack-installer.ts
+++ b/packages/core/src/pack-installer.ts
@@ -1,0 +1,104 @@
+/**
+ * Pack install / uninstall orchestration.
+ *
+ * Operates on top of the three stores (PacksStore, DashboardsStore,
+ * AgentStore) without coupling them to each other. Install creates
+ * dashboards from the manifest and upserts any missing agents from
+ * the embedded YAML; uninstall removes the dashboards but leaves the
+ * agents intact (reference-only ownership model).
+ */
+
+import type { PacksStore } from './packs-store.js';
+import type { DashboardsStore } from './dashboards-store.js';
+import type { AgentStore } from './agent-store.js';
+import { parseAgent } from './agent-yaml.js';
+
+export interface PackInstallContext {
+  packsStore: PacksStore;
+  dashboardsStore: DashboardsStore;
+  /**
+   * Optional. When provided, install will upsert any agent listed in the
+   * pack manifest's `agents:` block whose YAML is embedded and whose id
+   * isn't already in AgentStore. Without it, install only creates
+   * dashboards; missing agents will render as empty tiles until the user
+   * installs them separately.
+   */
+  agentStore?: AgentStore;
+}
+
+export interface PackInstallResult {
+  packId: string;
+  dashboardsCreated: string[];
+  agentsCreated: string[];
+  agentsSkipped: string[];
+}
+
+/**
+ * Install a registered pack. Idempotent — re-running on an installed
+ * pack refreshes the dashboards from the current manifest.
+ */
+export function installPack(packId: string, ctx: PackInstallContext): PackInstallResult {
+  const pack = ctx.packsStore.getPack(packId);
+  if (!pack) throw new Error(`No pack registered with id "${packId}"`);
+  const manifest = pack.manifest;
+
+  const agentsCreated: string[] = [];
+  const agentsSkipped: string[] = [];
+  for (const ref of manifest.agents ?? []) {
+    if (!ctx.agentStore) {
+      // No store to install into — record the ref as skipped so the caller
+      // sees what agents the pack expected to find.
+      agentsSkipped.push(ref.id);
+      continue;
+    }
+    if (ctx.agentStore.getAgent(ref.id)) {
+      agentsSkipped.push(ref.id);
+      continue;
+    }
+    if (!ref.yaml) {
+      // Id-only refs (no embedded YAML) can't be auto-installed.
+      agentsSkipped.push(ref.id);
+      continue;
+    }
+    const agent = parseAgent(ref.yaml);
+    if (agent.id !== ref.id) {
+      throw new Error(`Pack "${packId}" agent ref id "${ref.id}" does not match YAML id "${agent.id}"`);
+    }
+    const { version: _v, ...agentNoVersion } = agent;
+    void _v;
+    ctx.agentStore.upsertAgent(agentNoVersion, 'import', `Installed via pack "${packId}"`);
+    agentsCreated.push(ref.id);
+  }
+
+  const dashboardsCreated: string[] = [];
+  for (const dash of manifest.dashboards ?? []) {
+    const namespacedId = `${packId}:${dash.id}`;
+    ctx.dashboardsStore.upsertDashboard({
+      id: namespacedId,
+      packId,
+      name: dash.name,
+      layout: { sections: dash.sections },
+    });
+    dashboardsCreated.push(namespacedId);
+  }
+
+  ctx.packsStore.markInstalled(packId);
+  return { packId, dashboardsCreated, agentsCreated, agentsSkipped };
+}
+
+export interface PackUninstallResult {
+  packId: string;
+  dashboardsRemoved: number;
+}
+
+/**
+ * Uninstall a pack. Removes its dashboards, marks the pack as
+ * uninstalled, and leaves any agents the pack contributed alone
+ * (reference-only ownership). Idempotent — re-running on an
+ * uninstalled pack is a no-op.
+ */
+export function uninstallPack(packId: string, ctx: PackInstallContext): PackUninstallResult {
+  const dashboardsRemoved = ctx.dashboardsStore.deleteByPack(packId);
+  ctx.packsStore.markUninstalled(packId);
+  return { packId, dashboardsRemoved };
+}

--- a/packages/core/src/pack-loader.test.ts
+++ b/packages/core/src/pack-loader.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadBuiltinPacks } from './pack-loader.js';
+import { PacksStore } from './packs-store.js';
+
+let dir: string;
+let packsDir: string;
+let store: PacksStore;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'sua-pack-loader-'));
+  packsDir = join(dir, 'packs');
+  mkdirSync(packsDir);
+  store = new PacksStore(join(dir, 'runs.db'));
+});
+
+afterEach(() => {
+  try { store.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+function writeManifest(filename: string, contents: string): void {
+  writeFileSync(join(packsDir, filename), contents);
+}
+
+describe('loadBuiltinPacks', () => {
+  it('returns empty result when packs directory is missing', () => {
+    const result = loadBuiltinPacks(store, join(dir, 'does-not-exist'));
+    expect(result.registered).toEqual([]);
+    expect(result.skipped).toEqual([]);
+  });
+
+  it('registers a valid manifest as builtin source', () => {
+    writeManifest('starter.yaml', `
+id: starter
+name: Starter
+version: 0.1.0
+dashboards:
+  - id: media
+    name: Media
+    sections:
+      - title: Video
+        agentIds: [a]
+`);
+    const result = loadBuiltinPacks(store, packsDir);
+    expect(result.registered).toEqual(['starter']);
+    const pack = store.getPack('starter');
+    expect(pack?.source).toBe('builtin');
+    expect(pack?.installedAt).toBeNull();
+  });
+
+  it('inlines yamlPath agent refs', () => {
+    writeFileSync(join(dir, 'agent-a.yaml'), 'id: a\nname: A\n');
+    writeManifest('p.yaml', `
+id: p
+name: P
+version: 0.1.0
+agents:
+  - id: a
+    yamlPath: ../agent-a.yaml
+dashboards:
+  - id: d
+    name: D
+    sections:
+      - title: T
+        agentIds: [a]
+`);
+    loadBuiltinPacks(store, packsDir);
+    const pack = store.getPack('p');
+    expect(pack?.manifest.agents?.[0].yaml).toBe('id: a\nname: A\n');
+    // yamlPath is dropped from the stored form (inlined into yaml).
+    expect((pack?.manifest.agents?.[0] as { yamlPath?: string }).yamlPath).toBeUndefined();
+  });
+
+  it('skips manifests that fail validation but registers the rest', () => {
+    writeManifest('good.yaml', `
+id: good
+name: Good
+version: 0.1.0
+dashboards:
+  - id: d
+    name: D
+    sections:
+      - title: T
+        agentIds: [a]
+`);
+    writeManifest('bad.yaml', `
+id: BAD
+name: Bad
+version: not-semver
+`);
+    const result = loadBuiltinPacks(store, packsDir);
+    expect(result.registered).toEqual(['good']);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].file).toBe('bad.yaml');
+  });
+
+  it('preserves installed_at across reload (idempotent)', () => {
+    writeManifest('starter.yaml', `
+id: starter
+name: Starter
+version: 0.1.0
+dashboards:
+  - id: d
+    name: D
+    sections:
+      - title: T
+        agentIds: [a]
+`);
+    loadBuiltinPacks(store, packsDir);
+    store.markInstalled('starter');
+    const before = store.getPack('starter');
+
+    // Bump the version in the manifest and reload.
+    writeManifest('starter.yaml', `
+id: starter
+name: Starter
+version: 0.2.0
+dashboards:
+  - id: d
+    name: D
+    sections:
+      - title: T
+        agentIds: [a]
+`);
+    loadBuiltinPacks(store, packsDir);
+
+    const after = store.getPack('starter');
+    expect(after?.version).toBe('0.2.0');
+    expect(after?.installedAt).toBe(before?.installedAt);
+  });
+
+  it('throws (and skips) on a yamlPath that does not exist', () => {
+    writeManifest('p.yaml', `
+id: p
+name: P
+version: 0.1.0
+agents:
+  - id: a
+    yamlPath: ./does-not-exist.yaml
+`);
+    const result = loadBuiltinPacks(store, packsDir);
+    expect(result.registered).toEqual([]);
+    expect(result.skipped[0].reason).toMatch(/not found/);
+  });
+});

--- a/packages/core/src/pack-loader.ts
+++ b/packages/core/src/pack-loader.ts
@@ -1,0 +1,104 @@
+/**
+ * Built-in pack discovery + registration.
+ *
+ * On daemon start, the loader scans `packages/core/packs/*.yaml`, parses
+ * each manifest, resolves any `yamlPath` agent refs against the manifest
+ * file's directory, and upserts the result into PacksStore as
+ * `source = 'builtin'`. Idempotent — re-running on each daemon start
+ * picks up version/manifest changes without toggling install state
+ * (PacksStore.upsertPack preserves installed_at).
+ *
+ * Note: the loader registers packs but does NOT install them. Users
+ * decide what to install via `/packs` (PR 3) or `installPack()` directly.
+ */
+
+import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+import { packManifestSchema, type PackManifestParsed } from './pack-schema.js';
+import type { PacksStore, PackManifest, PackAgentRef } from './packs-store.js';
+
+/**
+ * Default location of bundled packs relative to this loader file.
+ *
+ * In repo: `packages/core/src/pack-loader.ts` is compiled to
+ * `packages/core/dist/pack-loader.js`. The packs dir lives at
+ * `packages/core/packs/`, i.e. one level up from `dist/`.
+ *
+ * In an npm install: same shape — `dist/` and `packs/` are siblings
+ * under `node_modules/@some-useful-agents/core/`.
+ */
+export function defaultBuiltinPacksDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '..', 'packs');
+}
+
+export interface LoadBuiltinPacksResult {
+  registered: string[];
+  skipped: Array<{ file: string; reason: string }>;
+}
+
+/**
+ * Read every `*.yaml` in `packsDir`, validate, resolve yamlPath refs, and
+ * upsert into the store. Failures on individual files are skipped (logged
+ * via the returned `skipped` array) so one broken pack doesn't gate the
+ * rest. Returns the ids of packs successfully registered.
+ */
+export function loadBuiltinPacks(
+  packsStore: PacksStore,
+  packsDir: string,
+): LoadBuiltinPacksResult {
+  const result: LoadBuiltinPacksResult = { registered: [], skipped: [] };
+  if (!existsSync(packsDir) || !statSync(packsDir).isDirectory()) return result;
+
+  const files = readdirSync(packsDir).filter((f) => f.endsWith('.yaml'));
+  for (const file of files) {
+    const fullPath = join(packsDir, file);
+    try {
+      const raw = readFileSync(fullPath, 'utf-8');
+      const parsed = parseYaml(raw) as unknown;
+      const manifest = packManifestSchema.parse(parsed);
+      const inlined = inlineAgentYamlRefs(manifest, dirname(fullPath));
+      packsStore.upsertPack({
+        id: inlined.id,
+        name: inlined.name,
+        description: inlined.description ?? null,
+        version: inlined.version,
+        author: inlined.author ?? null,
+        source: 'builtin',
+        manifest: inlined,
+      });
+      result.registered.push(inlined.id);
+    } catch (err) {
+      result.skipped.push({
+        file,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return result;
+}
+
+/**
+ * Replace any `yamlPath` agent refs in the manifest with the file's
+ * contents under `yaml`. Throws if a referenced file is missing —
+ * a built-in pack with a dangling reference is a build/release bug.
+ */
+function inlineAgentYamlRefs(manifest: PackManifestParsed, baseDir: string): PackManifest {
+  const agents: PackAgentRef[] | undefined = manifest.agents?.map((a) => {
+    if (a.yamlPath) {
+      const abs = resolve(baseDir, a.yamlPath);
+      if (!existsSync(abs)) {
+        throw new Error(`Agent ref "${a.id}" → yamlPath "${a.yamlPath}" not found at ${abs}`);
+      }
+      const yaml = readFileSync(abs, 'utf-8');
+      return { id: a.id, yaml };
+    }
+    return { id: a.id, yaml: a.yaml };
+  });
+  return {
+    ...manifest,
+    agents,
+  };
+}

--- a/packages/core/src/pack-schema.test.ts
+++ b/packages/core/src/pack-schema.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { packManifestSchema } from './pack-schema.js';
+
+describe('packManifestSchema', () => {
+  it('accepts a minimal pack with only dashboards', () => {
+    const m = packManifestSchema.parse({
+      id: 'starter',
+      name: 'Starter',
+      version: '0.1.0',
+      dashboards: [{ id: 'media', name: 'Media', sections: [{ title: 'Video', agentIds: ['x'] }] }],
+    });
+    expect(m.id).toBe('starter');
+    expect(m.dashboards).toHaveLength(1);
+  });
+
+  it('accepts a pack with only agents', () => {
+    const m = packManifestSchema.parse({
+      id: 'tools',
+      name: 'Tools',
+      version: '0.1.0',
+      agents: [{ id: 'a', yaml: 'id: a\nname: A\n…' }],
+    });
+    expect(m.agents).toHaveLength(1);
+  });
+
+  it('rejects a pack with neither agents nor dashboards', () => {
+    expect(() => packManifestSchema.parse({
+      id: 'empty', name: 'Empty', version: '0.1.0',
+    })).toThrow(/at least one agent or one dashboard/);
+  });
+
+  it('rejects pack id with uppercase', () => {
+    expect(() => packManifestSchema.parse({
+      id: 'StarterPack', name: 'X', version: '0.1.0',
+      dashboards: [{ id: 'd', name: 'D', sections: [{ title: 'T', agentIds: ['a'] }] }],
+    })).toThrow(/lowercase/);
+  });
+
+  it('rejects non-semver version', () => {
+    expect(() => packManifestSchema.parse({
+      id: 'x', name: 'X', version: 'v1',
+      dashboards: [{ id: 'd', name: 'D', sections: [{ title: 'T', agentIds: ['a'] }] }],
+    })).toThrow(/semver/);
+  });
+
+  it('rejects empty section agentIds', () => {
+    expect(() => packManifestSchema.parse({
+      id: 'x', name: 'X', version: '0.1.0',
+      dashboards: [{ id: 'd', name: 'D', sections: [{ title: 'T', agentIds: [] }] }],
+    })).toThrow(/at least one agent/);
+  });
+
+  it('rejects an agent ref with both yaml and yamlPath', () => {
+    expect(() => packManifestSchema.parse({
+      id: 'x', name: 'X', version: '0.1.0',
+      agents: [{ id: 'a', yaml: 'foo', yamlPath: 'bar' }],
+    })).toThrow(/yaml or yamlPath/);
+  });
+
+  it('accepts an agent ref with id only (no yaml inline)', () => {
+    const m = packManifestSchema.parse({
+      id: 'x', name: 'X', version: '0.1.0',
+      agents: [{ id: 'a' }],
+    });
+    expect(m.agents?.[0].id).toBe('a');
+  });
+});

--- a/packages/core/src/pack-schema.ts
+++ b/packages/core/src/pack-schema.ts
@@ -1,0 +1,55 @@
+/**
+ * Zod schema for the widget pack manifest YAML format.
+ *
+ * Packs ship as YAML files in `packages/core/packs/<id>.yaml` (built-in)
+ * or anywhere a user wants to author one (user/exported). The loader
+ * validates the YAML against this schema before registering.
+ *
+ * Two forms accepted for agent refs:
+ *  - `yaml: "<inline string>"` — full YAML embedded in the manifest
+ *  - `yamlPath: "relative/path/to/agent.yaml"` — resolved by the loader
+ *    against the manifest file's directory; the file is read and inlined
+ *    into `yaml` before the manifest is stored. Either form, never both.
+ */
+
+import { z } from 'zod';
+
+const PACK_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+const DASHBOARD_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+const SEMVER_RE = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
+
+const sectionSchema = z.object({
+  title: z.string().min(1),
+  agentIds: z.array(z.string().min(1)).min(1, 'A section must list at least one agent.'),
+});
+
+const dashboardSchema = z.object({
+  id: z.string().regex(DASHBOARD_ID_RE, 'Dashboard ids: lowercase letters/digits/hyphens, starting alnum.'),
+  name: z.string().min(1),
+  sections: z.array(sectionSchema).min(1, 'A dashboard needs at least one section.'),
+});
+
+const agentRefSchema = z.object({
+  id: z.string().min(1),
+  yaml: z.string().min(1).optional(),
+  yamlPath: z.string().min(1).optional(),
+}).refine(
+  (a) => !(a.yaml && a.yamlPath),
+  { message: 'Specify either yaml or yamlPath, not both.' },
+);
+
+export const packManifestSchema = z.object({
+  id: z.string().regex(PACK_ID_RE, 'Pack ids: lowercase letters/digits/hyphens, starting alnum.'),
+  name: z.string().min(1),
+  description: z.string().optional(),
+  version: z.string().regex(SEMVER_RE, 'version must be semver (e.g. 0.1.0).'),
+  author: z.string().optional(),
+  agents: z.array(agentRefSchema).optional(),
+  dashboards: z.array(dashboardSchema).optional(),
+}).refine(
+  (m) => (m.agents?.length ?? 0) > 0 || (m.dashboards?.length ?? 0) > 0,
+  { message: 'A pack must contribute at least one agent or one dashboard.' },
+);
+
+export type PackManifestInput = z.input<typeof packManifestSchema>;
+export type PackManifestParsed = z.output<typeof packManifestSchema>;

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -45,6 +45,7 @@ import { settingsMcpRouter } from './routes/settings-mcp.js';
 import { helpRouter } from './routes/help.js';
 import { versionsRouter } from './routes/versions.js';
 import { pulseRouter } from './routes/pulse.js';
+import { packsRouter } from './routes/packs.js';
 
 export interface StartDashboardOptions {
   port: number;
@@ -198,6 +199,7 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   app.use(toolsRouter);
   app.use(nodesRouter);
   app.use(pulseRouter);
+  app.use(packsRouter);
 
   // Catch-all 404 for authenticated routes.
   app.use((_req, res) => {

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -46,6 +46,7 @@ import { helpRouter } from './routes/help.js';
 import { versionsRouter } from './routes/versions.js';
 import { pulseRouter } from './routes/pulse.js';
 import { packsRouter } from './routes/packs.js';
+import { dashboardsRouter } from './routes/dashboards.js';
 
 export interface StartDashboardOptions {
   port: number;
@@ -200,6 +201,7 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   app.use(nodesRouter);
   app.use(pulseRouter);
   app.use(packsRouter);
+  app.use(dashboardsRouter);
 
   // Catch-all 404 for authenticated routes.
   app.use((_req, res) => {

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -8,6 +8,8 @@ import {
   ToolStore,
   PacksStore,
   DashboardsStore,
+  loadBuiltinPacks,
+  defaultBuiltinPacksDir,
   VariablesStore,
   EncryptedFileStore,
   loadAgents,
@@ -249,6 +251,13 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
   try {
     packsStore = new PacksStore(opts.dbPath);
     dashboardsStore = new DashboardsStore(opts.dbPath);
+    // Discover and register bundled packs. Idempotent — re-running on each
+    // restart picks up version/manifest changes without toggling install state.
+    // Failures here are non-fatal: a broken pack manifest shouldn't gate the
+    // dashboard from coming up.
+    try {
+      loadBuiltinPacks(packsStore, defaultBuiltinPacksDir());
+    } catch { /* ignore — packs discovery is best-effort */ }
   } catch {
     // Non-fatal: packs/dashboards surface stays absent until later PRs
     // wire routes that depend on these stores.

--- a/packages/dashboard/src/routes/dashboards.test.ts
+++ b/packages/dashboard/src/routes/dashboards.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import request from 'supertest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AgentStore,
+  DashboardsStore,
+  LocalProvider,
+  MemorySecretsStore,
+  PacksStore,
+  RunStore,
+  buildLoopbackAllowlist,
+  loadAgents,
+} from '@some-useful-agents/core';
+import { buildDashboardApp } from '../index.js';
+import type { DashboardContext } from '../context.js';
+import { SESSION_COOKIE } from '../auth-middleware.js';
+import { MemorySecretsSession } from '../secrets-session.js';
+
+const TOKEN = 'a'.repeat(64);
+const PORT = 3997;
+
+let dir: string;
+let provider: LocalProvider;
+let runStore: RunStore;
+let agentStore: AgentStore;
+let packsStore: PacksStore;
+let dashboardsStore: DashboardsStore;
+
+async function makeApp() {
+  dir = mkdtempSync(join(tmpdir(), 'sua-dashboards-routes-'));
+  const dbPath = join(dir, 'runs.db');
+  const agentsDir = join(dir, 'agents', 'local');
+  mkdirSync(agentsDir, { recursive: true });
+
+  const secretsStore = new MemorySecretsStore();
+  runStore = new RunStore(dbPath);
+  agentStore = new AgentStore(dbPath);
+  packsStore = new PacksStore(dbPath);
+  dashboardsStore = new DashboardsStore(dbPath);
+  provider = new LocalProvider(dbPath, secretsStore);
+  await provider.initialize();
+
+  // Install a tiny v2 agent with a signal so tile-building has something to do.
+  agentStore.createAgent({
+    id: 'hello',
+    name: 'Hello',
+    status: 'active',
+    source: 'local',
+    mcp: false,
+    nodes: [{ id: 'greet', type: 'shell', command: 'echo hi', dependsOn: [] }],
+    signal: { title: 'Hello', template: 'text-headline', mapping: { headline: 'greeting' } },
+  }, 'cli');
+
+  const ctx: DashboardContext = {
+    token: TOKEN,
+    allowlist: buildLoopbackAllowlist(PORT),
+    port: PORT,
+    provider,
+    runStore,
+    agentStore,
+    loadAgents: () => loadAgents({ directories: [agentsDir] }),
+    secretsStore,
+    secretsSession: new MemorySecretsSession({ backing: secretsStore }),
+    tokenPath: join(dir, 'mcp-token'),
+    retentionDays: 30,
+    dbPath,
+    secretsPath: join(dir, 'secrets.enc'),
+    rotateToken: () => 'r'.repeat(64),
+    packsStore,
+    dashboardsStore,
+    allowUntrustedShell: new Set(),
+    activeRuns: new Map(),
+    dataDir: dir,
+    dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
+  };
+
+  return buildDashboardApp(ctx);
+}
+
+afterEach(async () => {
+  if (provider) {
+    const start = Date.now();
+    while ((provider as unknown as { running?: { size: number } }).running?.size && Date.now() - start < 2000) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    await provider.shutdown();
+  }
+  try { runStore?.close(); } catch { /* ignore */ }
+  try { agentStore?.close(); } catch { /* ignore */ }
+  try { packsStore?.close(); } catch { /* ignore */ }
+  try { dashboardsStore?.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('dashboards routes', () => {
+  it('GET /dashboards/:id renders sections + tiles', async () => {
+    const app = await makeApp();
+    dashboardsStore.upsertDashboard({
+      id: 'starter:main',
+      packId: 'starter',
+      name: 'Main',
+      layout: { sections: [{ title: 'Greetings', agentIds: ['hello'] }] },
+    });
+    const res = await request(app)
+      .get('/dashboards/starter:main')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Main');
+    expect(res.text).toContain('Greetings');
+    expect(res.text).toContain('data-agent-id="hello"');
+    expect(res.text).toContain('from pack: starter');
+  });
+
+  it('renders missing-agent placeholders for ids the agent store doesn\'t know', async () => {
+    const app = await makeApp();
+    dashboardsStore.upsertDashboard({
+      id: 'd1',
+      packId: null,
+      name: 'D1',
+      layout: { sections: [{ title: 'Mixed', agentIds: ['hello', 'ghost-agent'] }] },
+    });
+    const res = await request(app)
+      .get('/dashboards/d1')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('data-agent-id="hello"');
+    expect(res.text).toContain('ghost-agent');
+    expect(res.text).toContain('not installed');
+  });
+
+  it('GET /dashboards/unknown 404s', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .get('/dashboards/nope')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('Pulse shows the dashboards dropdown when at least one dashboard is installed', async () => {
+    const app = await makeApp();
+    dashboardsStore.upsertDashboard({
+      id: 'starter:main',
+      packId: 'starter',
+      name: 'Main',
+      layout: { sections: [{ title: 'Greetings', agentIds: ['hello'] }] },
+    });
+    const res = await request(app)
+      .get('/pulse')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('class="dashboards-dropdown"');
+    expect(res.text).toContain('Default Dashboard');
+    expect(res.text).toContain('href="/dashboards/starter%3Amain"');
+  });
+
+  it('Pulse hides the dropdown when no dashboards exist (only Default would show — noise)', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .get('/pulse')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).not.toContain('class="dashboards-dropdown"');
+  });
+});

--- a/packages/dashboard/src/routes/dashboards.ts
+++ b/packages/dashboard/src/routes/dashboards.ts
@@ -1,0 +1,67 @@
+/**
+ * Routes for `/dashboards/:id` — render a stored dashboard.
+ *
+ * The Default Dashboard backing /pulse is NOT served from here; it
+ * stays in routes/pulse.ts (synthesised from pulseVisible). This
+ * router only handles named, persisted dashboards from
+ * DashboardsStore — pack-owned (e.g. "starter:media") or user-created
+ * (added via the editor in PR 5).
+ */
+
+import { Router, type Request, type Response } from 'express';
+import type { Agent, AgentSignal } from '@some-useful-agents/core';
+import { getContext } from '../context.js';
+import {
+  renderDashboardPage,
+  type DashboardSectionRender,
+} from '../views/dashboards.js';
+import { buildPulseTile } from '../views/pulse-tile-builder.js';
+
+export const dashboardsRouter: Router = Router();
+
+dashboardsRouter.get('/dashboards/:id', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.dashboardsStore) {
+    res.status(404).type('html').send('<p>Dashboards store unavailable. <a href="/pulse">Back to Pulse</a></p>');
+    return;
+  }
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const dashboard = ctx.dashboardsStore.getDashboard(id);
+  if (!dashboard) {
+    res.status(404).type('html').send(`<p>No dashboard with id "${id}". <a href="/packs">Browse packs</a></p>`);
+    return;
+  }
+
+  // Build tiles for each section. Agents that aren't installed render
+  // as muted placeholder cards so the user knows what's missing.
+  const sections: DashboardSectionRender[] = dashboard.layout.sections.map((s) => {
+    const tiles = [];
+    const missingAgentIds: string[] = [];
+    for (const agentId of s.agentIds) {
+      const agent = ctx.agentStore.getAgent(agentId);
+      if (!agent || !agent.signal) {
+        missingAgentIds.push(agentId);
+        continue;
+      }
+      tiles.push(buildPulseTile(agent as Agent & { signal: AgentSignal }, { runStore: ctx.runStore }));
+    }
+    return { title: s.title, tiles, missingAgentIds };
+  });
+
+  const installedDashboards = ctx.dashboardsStore.listDashboards();
+  const flash = parseFlash(req);
+
+  res.type('html').send(renderDashboardPage({
+    dashboard,
+    sections,
+    installedDashboards,
+    flash,
+  }));
+});
+
+function parseFlash(req: Request): { kind: 'ok' | 'error' | 'info'; message: string } | undefined {
+  if (typeof req.query.ok === 'string') return { kind: 'ok', message: req.query.ok };
+  if (typeof req.query.error === 'string') return { kind: 'error', message: req.query.error };
+  if (typeof req.query.info === 'string') return { kind: 'info', message: req.query.info };
+  return undefined;
+}

--- a/packages/dashboard/src/routes/packs.test.ts
+++ b/packages/dashboard/src/routes/packs.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AgentStore,
+  DashboardsStore,
+  LocalProvider,
+  MemorySecretsStore,
+  PacksStore,
+  RunStore,
+  buildLoopbackAllowlist,
+  loadAgents,
+  type PackManifest,
+} from '@some-useful-agents/core';
+import { buildDashboardApp } from '../index.js';
+import type { DashboardContext } from '../context.js';
+import { SESSION_COOKIE } from '../auth-middleware.js';
+import { MemorySecretsSession } from '../secrets-session.js';
+
+const TOKEN = 'a'.repeat(64);
+const PORT = 3998;
+
+let dir: string;
+let provider: LocalProvider;
+let runStore: RunStore;
+let agentStore: AgentStore;
+let packsStore: PacksStore;
+let dashboardsStore: DashboardsStore;
+
+async function makeApp() {
+  dir = mkdtempSync(join(tmpdir(), 'sua-packs-routes-'));
+  const dbPath = join(dir, 'runs.db');
+  const agentsDir = join(dir, 'agents', 'local');
+  mkdirSync(agentsDir, { recursive: true });
+  writeFileSync(join(agentsDir, 'hello.yaml'), 'name: hello\ntype: shell\ncommand: echo hi\n');
+
+  const secretsStore = new MemorySecretsStore();
+  runStore = new RunStore(dbPath);
+  agentStore = new AgentStore(dbPath);
+  packsStore = new PacksStore(dbPath);
+  dashboardsStore = new DashboardsStore(dbPath);
+  provider = new LocalProvider(dbPath, secretsStore);
+  await provider.initialize();
+
+  const ctx: DashboardContext = {
+    token: TOKEN,
+    allowlist: buildLoopbackAllowlist(PORT),
+    port: PORT,
+    provider,
+    runStore,
+    agentStore,
+    loadAgents: () => loadAgents({ directories: [agentsDir] }),
+    secretsStore,
+    secretsSession: new MemorySecretsSession({ backing: secretsStore }),
+    tokenPath: join(dir, 'mcp-token'),
+    retentionDays: 30,
+    dbPath,
+    secretsPath: join(dir, 'secrets.enc'),
+    rotateToken: () => 'r'.repeat(64),
+    packsStore,
+    dashboardsStore,
+    allowUntrustedShell: new Set(),
+    activeRuns: new Map(),
+    dataDir: dir,
+    dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
+  };
+
+  return buildDashboardApp(ctx);
+}
+
+function manifest(): PackManifest {
+  return {
+    id: 'test-pack',
+    name: 'Test Pack',
+    version: '0.1.0',
+    description: 'A pack for testing.',
+    dashboards: [
+      { id: 'main', name: 'Main', sections: [{ title: 'Greetings', agentIds: ['hello'] }] },
+    ],
+  };
+}
+
+afterEach(async () => {
+  if (provider) {
+    const start = Date.now();
+    while ((provider as unknown as { running?: { size: number } }).running?.size && Date.now() - start < 2000) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    await provider.shutdown();
+  }
+  try { runStore?.close(); } catch { /* ignore */ }
+  try { agentStore?.close(); } catch { /* ignore */ }
+  try { packsStore?.close(); } catch { /* ignore */ }
+  try { dashboardsStore?.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('packs routes', () => {
+  it('GET /packs lists registered packs', async () => {
+    const app = await makeApp();
+    packsStore.upsertPack({ id: 'test-pack', name: 'Test Pack', version: '0.1.0', source: 'builtin', manifest: manifest() });
+    const res = await request(app).get('/packs').set('Host', `127.0.0.1:${PORT}`).set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Test Pack');
+    expect(res.text).toContain('Available');
+    expect(res.text).toContain('href="/packs/test-pack"');
+  });
+
+  it('GET /packs/:id renders detail with Install button', async () => {
+    const app = await makeApp();
+    packsStore.upsertPack({ id: 'test-pack', name: 'Test Pack', version: '0.1.0', source: 'builtin', manifest: manifest() });
+    const res = await request(app).get('/packs/test-pack').set('Host', `127.0.0.1:${PORT}`).set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('action="/packs/test-pack/install"');
+    expect(res.text).not.toContain('action="/packs/test-pack/uninstall"');
+    expect(res.text).toContain('Main'); // dashboard name visible
+  });
+
+  it('POST /packs/:id/install creates dashboards and flips Install → Uninstall', async () => {
+    const app = await makeApp();
+    packsStore.upsertPack({ id: 'test-pack', name: 'Test Pack', version: '0.1.0', source: 'builtin', manifest: manifest() });
+
+    const installRes = await request(app)
+      .post('/packs/test-pack/install')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(installRes.status).toBe(303);
+    expect(installRes.headers.location).toMatch(/\/packs\/test-pack\?ok=/);
+
+    expect(dashboardsStore.getDashboard('test-pack:main')).not.toBeNull();
+    expect(packsStore.getPack('test-pack')?.installedAt).not.toBeNull();
+
+    const detail = await request(app).get('/packs/test-pack').set('Host', `127.0.0.1:${PORT}`).set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(detail.text).toContain('action="/packs/test-pack/uninstall"');
+    expect(detail.text).not.toContain('action="/packs/test-pack/install"');
+  });
+
+  it('POST /packs/:id/uninstall removes dashboards but keeps agents', async () => {
+    const app = await makeApp();
+    packsStore.upsertPack({ id: 'test-pack', name: 'Test Pack', version: '0.1.0', source: 'builtin', manifest: manifest() });
+    await request(app).post('/packs/test-pack/install').set('Host', `127.0.0.1:${PORT}`).set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    const uninstallRes = await request(app)
+      .post('/packs/test-pack/uninstall')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(uninstallRes.status).toBe(303);
+    expect(uninstallRes.headers.location).toMatch(/\/packs\/test-pack\?ok=/);
+
+    expect(dashboardsStore.getDashboard('test-pack:main')).toBeNull();
+    expect(packsStore.getPack('test-pack')?.installedAt).toBeNull();
+  });
+
+  it('GET /packs/unknown 303s back to /packs', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/packs/nope').set('Host', `127.0.0.1:${PORT}`).set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toBe('/packs');
+  });
+});

--- a/packages/dashboard/src/routes/packs.ts
+++ b/packages/dashboard/src/routes/packs.ts
@@ -1,0 +1,93 @@
+/**
+ * Routes for `/packs` — browse, view, install, uninstall widget packs.
+ *
+ * Built on the PacksStore + DashboardsStore from PR 1 and the
+ * installPack / uninstallPack orchestration from PR 2. The pack
+ * registry is auto-populated by the daemon's loadBuiltinPacks call;
+ * users see and act on those packs here.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { installPack, uninstallPack } from '@some-useful-agents/core';
+import { getContext } from '../context.js';
+import { renderPacksList, renderPackDetail } from '../views/packs.js';
+
+export const packsRouter: Router = Router();
+
+packsRouter.get('/packs', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.packsStore) {
+    // Stores not initialised (e.g. test harness skipped them). Render an
+    // empty list rather than 500.
+    res.type('html').send(renderPacksList({ packs: [] }));
+    return;
+  }
+  const flash = parseFlash(req);
+  res.type('html').send(renderPacksList({ packs: ctx.packsStore.listPacks(), flash }));
+});
+
+packsRouter.get('/packs/:id', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.packsStore) {
+    res.status(404).redirect(303, '/packs');
+    return;
+  }
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const pack = ctx.packsStore.getPack(id);
+  if (!pack) {
+    res.status(404).redirect(303, '/packs');
+    return;
+  }
+  const flash = parseFlash(req);
+  res.type('html').send(renderPackDetail({ pack, flash }));
+});
+
+packsRouter.post('/packs/:id/install', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.packsStore || !ctx.dashboardsStore) {
+    res.status(503).redirect(303, '/packs');
+    return;
+  }
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  try {
+    const result = installPack(id, {
+      packsStore: ctx.packsStore,
+      dashboardsStore: ctx.dashboardsStore,
+      agentStore: ctx.agentStore,
+    });
+    const parts: string[] = [];
+    if (result.dashboardsCreated.length) parts.push(`${result.dashboardsCreated.length} dashboard${result.dashboardsCreated.length === 1 ? '' : 's'}`);
+    if (result.agentsCreated.length) parts.push(`${result.agentsCreated.length} agent${result.agentsCreated.length === 1 ? '' : 's'}`);
+    const detail = parts.length ? ` (${parts.join(', ')})` : '';
+    res.redirect(303, `/packs/${encodeURIComponent(id)}?ok=${encodeURIComponent('Installed' + detail + '.')}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/packs/${encodeURIComponent(id)}?error=${encodeURIComponent('Install failed: ' + msg)}`);
+  }
+});
+
+packsRouter.post('/packs/:id/uninstall', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.packsStore || !ctx.dashboardsStore) {
+    res.status(503).redirect(303, '/packs');
+    return;
+  }
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  try {
+    const result = uninstallPack(id, {
+      packsStore: ctx.packsStore,
+      dashboardsStore: ctx.dashboardsStore,
+    });
+    res.redirect(303, `/packs/${encodeURIComponent(id)}?ok=${encodeURIComponent(`Uninstalled (${result.dashboardsRemoved} dashboard${result.dashboardsRemoved === 1 ? '' : 's'} removed; agents kept).`)}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/packs/${encodeURIComponent(id)}?error=${encodeURIComponent('Uninstall failed: ' + msg)}`);
+  }
+});
+
+function parseFlash(req: Request): { kind: 'ok' | 'error' | 'info'; message: string } | undefined {
+  if (typeof req.query.ok === 'string') return { kind: 'ok', message: req.query.ok };
+  if (typeof req.query.error === 'string') return { kind: 'error', message: req.query.error };
+  if (typeof req.query.info === 'string') return { kind: 'info', message: req.query.info };
+  return undefined;
+}

--- a/packages/dashboard/src/routes/pulse.ts
+++ b/packages/dashboard/src/routes/pulse.ts
@@ -5,7 +5,8 @@ import { join, resolve } from 'node:path';
 import { getContext } from '../context.js';
 import { renderPulsePage, tileWrap, type PulseTile } from '../views/pulse.js';
 import { renderTile } from '../views/pulse-renderers.js';
-import { normalizeSignal, extractMappedValues, TEMPLATE_REGISTRY } from '../views/pulse-templates.js';
+import { buildPulseTile } from '../views/pulse-tile-builder.js';
+import { normalizeSignal, TEMPLATE_REGISTRY } from '../views/pulse-templates.js';
 
 export const pulseRouter: Router = Router();
 
@@ -32,60 +33,7 @@ function autoImportSignalExamples(ctx: ReturnType<typeof getContext>): void {
 // ── Tile building ────────────────────────────────────────────────────────
 
 function buildTile(agent: Agent & { signal: AgentSignal }, ctx: ReturnType<typeof getContext>): PulseTile {
-  const signal = agent.signal;
-  let lastRun: Run | undefined;
-  let outputsJson: string | undefined;
-  let previousInputs: Record<string, string> | undefined;
-  try {
-    const runs = ctx.runStore.listRuns({ agentName: agent.id, status: 'completed', limit: 1 });
-    if (runs.length > 0) {
-      lastRun = runs[0];
-      const execs = ctx.runStore.listNodeExecutions(lastRun.id);
-      const lastExec = execs.filter((e) => e.status === 'completed').pop();
-      if (lastExec?.outputsJson) outputsJson = lastExec.outputsJson;
-
-      // Pre-fill the interactive widget form with the most recent run's
-      // input values so re-running with a tweaked prompt is one edit, not
-      // a full retype. Mirrors buildTabArgs in routes/agents/tabs.ts.
-      if (agent.outputWidget?.interactive && agent.inputs && execs.length > 0 && execs[0].inputsJson) {
-        try {
-          const allEnv = JSON.parse(execs[0].inputsJson) as Record<string, string>;
-          const inputNames = new Set(Object.keys(agent.inputs));
-          const picked: Record<string, string> = {};
-          for (const [k, v] of Object.entries(allEnv)) {
-            if (inputNames.has(k) && v !== '') picked[k] = v;
-          }
-          if (Object.keys(picked).length > 0) previousInputs = picked;
-        } catch { /* malformed inputsJson */ }
-      }
-    }
-  } catch { /* no runs */ }
-
-  const { mapping } = normalizeSignal(signal);
-  const slots = extractMappedValues(lastRun, mapping, outputsJson);
-
-  // Discover output field keys for the configure modal.
-  const outputFields: string[] = [];
-  const fieldSet = new Set<string>();
-  if (outputsJson) {
-    try {
-      const parsed = JSON.parse(outputsJson);
-      if (typeof parsed === 'object' && parsed !== null) {
-        for (const k of Object.keys(parsed)) fieldSet.add(k);
-      }
-    } catch { /* ignore */ }
-  }
-  if (lastRun?.result) {
-    try {
-      const parsed = JSON.parse(lastRun.result);
-      if (typeof parsed === 'object' && parsed !== null) {
-        for (const k of Object.keys(parsed)) fieldSet.add(k);
-      }
-    } catch { /* not JSON */ }
-  }
-  outputFields.push(...Array.from(fieldSet).sort());
-
-  return { agent, signal, lastRun, slots, outputFields, previousInputs };
+  return buildPulseTile(agent, { runStore: ctx.runStore });
 }
 
 // ── Virtual system tiles ─────────────────────────────────────────────────
@@ -192,11 +140,13 @@ pulseRouter.get('/pulse', (req: Request, res: Response) => {
   }
 
   const flash = parsePulseFlash(req);
+  const installedDashboards = ctx.dashboardsStore?.listDashboards() ?? [];
   res.type('html').send(renderPulsePage({
     systemTiles,
     tiles,
     hiddenTiles,
     flash,
+    installedDashboards,
   }));
 });
 

--- a/packages/dashboard/src/routes/pulse.ts
+++ b/packages/dashboard/src/routes/pulse.ts
@@ -191,12 +191,21 @@ pulseRouter.get('/pulse', (req: Request, res: Response) => {
     }
   }
 
+  const flash = parsePulseFlash(req);
   res.type('html').send(renderPulsePage({
     systemTiles,
     tiles,
     hiddenTiles,
+    flash,
   }));
 });
+
+function parsePulseFlash(req: Request): { kind: 'ok' | 'error' | 'info'; message: string } | undefined {
+  if (typeof req.query.ok === 'string') return { kind: 'ok', message: req.query.ok };
+  if (typeof req.query.error === 'string') return { kind: 'error', message: req.query.error };
+  if (typeof req.query.info === 'string') return { kind: 'info', message: req.query.info };
+  return undefined;
+}
 
 pulseRouter.post('/agents/:id/signal/toggle', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
@@ -276,6 +285,43 @@ pulseRouter.post('/agents/:id/signal', (req: Request, res: Response) => {
 });
 
 // ── Tile fragment (for auto-refresh polling) ────────────────────────────
+
+/**
+ * POST /pulse/hide-all — bulk-flip pulseVisible=false on every agent that
+ * has a signal block AND isn't already hidden. Use case: "clear the slate
+ * before installing a pack so only its dashboards show through". Reversible
+ * via `/pulse/show-all` or per-agent toggle.
+ */
+pulseRouter.post('/pulse/hide-all', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  let hidden = 0;
+  for (const agent of ctx.agentStore.listAgents()) {
+    if (!agent.signal) continue;
+    const alreadyHidden = agent.pulseVisible === false
+      || (agent.pulseVisible === undefined && agent.signal.hidden === true);
+    if (alreadyHidden) continue;
+    ctx.agentStore.updateAgentMeta(agent.id, { pulseVisible: false });
+    hidden++;
+  }
+  res.redirect(303, `/pulse?ok=${encodeURIComponent(`Hid ${hidden} signal${hidden === 1 ? '' : 's'} from Pulse.`)}`);
+});
+
+/**
+ * POST /pulse/show-all — counterpart to hide-all. Sets pulseVisible=true
+ * on every agent that has a signal block. Useful after a "clear and
+ * curate" cycle if the user changes their mind.
+ */
+pulseRouter.post('/pulse/show-all', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  let shown = 0;
+  for (const agent of ctx.agentStore.listAgents()) {
+    if (!agent.signal) continue;
+    if (agent.pulseVisible === true) continue;
+    ctx.agentStore.updateAgentMeta(agent.id, { pulseVisible: true });
+    shown++;
+  }
+  res.redirect(303, `/pulse?ok=${encodeURIComponent(`Restored ${shown} signal${shown === 1 ? '' : 's'} to Pulse.`)}`);
+});
 
 pulseRouter.get('/pulse/tile/:id', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);

--- a/packages/dashboard/src/views/dashboards-dropdown.ts
+++ b/packages/dashboard/src/views/dashboards-dropdown.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared dashboards dropdown — appears on /pulse and on /dashboards/:id.
+ * Server-rendered <details>/<summary> menu (no JS) with the active
+ * dashboard at the top and the others below as links.
+ */
+
+import type { Dashboard } from '@some-useful-agents/core';
+import { html, type SafeHtml } from './html.js';
+
+export interface DashboardOption {
+  /** Stable URL — '/pulse' for Default, '/dashboards/<id>' for installed packs. */
+  href: string;
+  label: string;
+  /** Optional secondary label (e.g. pack id) shown muted. */
+  hint?: string;
+}
+
+/**
+ * Build the option list. Default Dashboard is always first; pack-owned
+ * dashboards follow alphabetised by pack-id then dashboard name.
+ */
+export function buildDashboardOptions(installed: Dashboard[]): DashboardOption[] {
+  const opts: DashboardOption[] = [
+    { href: '/pulse', label: 'Default Dashboard', hint: 'pulseVisible' },
+  ];
+  const sorted = [...installed].sort((a, b) => {
+    const ap = a.packId ?? 'user';
+    const bp = b.packId ?? 'user';
+    if (ap !== bp) return ap.localeCompare(bp);
+    return a.name.localeCompare(b.name);
+  });
+  for (const d of sorted) {
+    opts.push({
+      href: `/dashboards/${encodeURIComponent(d.id)}`,
+      label: d.name,
+      hint: d.packId ?? 'user',
+    });
+  }
+  return opts;
+}
+
+/** Render the dropdown. `activeHref` matches one of the options' hrefs. */
+export function renderDashboardsDropdown(args: {
+  options: DashboardOption[];
+  activeHref: string;
+}): SafeHtml {
+  const active = args.options.find((o) => o.href === args.activeHref) ?? args.options[0];
+  return html`
+    <details class="dashboards-dropdown" style="position: relative;">
+      <summary style="list-style: none; cursor: pointer; padding: var(--space-1) var(--space-3); border: 1px solid var(--color-border); border-radius: var(--radius-sm); background: var(--color-surface); font-size: var(--font-size-sm); display: inline-flex; align-items: center; gap: var(--space-2);">
+        <span>${active.label}</span>
+        <span style="font-size: var(--font-size-xs); opacity: 0.6;">▾</span>
+      </summary>
+      <div style="position: absolute; top: 100%; left: 0; margin-top: var(--space-1); background: var(--color-surface-raised); border: 1px solid var(--color-border); border-radius: var(--radius-sm); box-shadow: 0 4px 12px rgba(0,0,0,0.15); min-width: 220px; z-index: 100; padding: var(--space-1); display: flex; flex-direction: column; gap: 1px;">
+        ${args.options.map((o) => {
+          const isActive = o.href === args.activeHref;
+          const bg = isActive ? 'background: var(--color-surface);' : '';
+          return html`
+            <a href="${o.href}" style="display: flex; justify-content: space-between; align-items: baseline; gap: var(--space-3); padding: var(--space-2) var(--space-3); text-decoration: none; color: inherit; border-radius: var(--radius-sm); ${bg}">
+              <span>${o.label}</span>
+              ${o.hint ? html`<span class="dim" style="font-size: var(--font-size-xs);">${o.hint}</span>` : html``}
+            </a>
+          `;
+        })}
+        <a href="/packs" style="display: flex; padding: var(--space-2) var(--space-3); text-decoration: none; color: var(--color-text-muted); font-size: var(--font-size-sm); border-top: 1px solid var(--color-border); margin-top: var(--space-1); padding-top: var(--space-2);">
+          + Install more from Packs
+        </a>
+      </div>
+    </details>
+  `;
+}

--- a/packages/dashboard/src/views/dashboards.ts
+++ b/packages/dashboard/src/views/dashboards.ts
@@ -1,0 +1,93 @@
+/**
+ * Render a single dashboard at /dashboards/:id.
+ *
+ * Reuses the Pulse tile rendering machinery (renderTile + tileWrap)
+ * so dashboards look identical to Pulse — the layout/sectioning is
+ * the only thing that differs. The "Default Dashboard" backing
+ * /pulse stays in routes/pulse.ts; this file is for named (pack or
+ * user) dashboards that came from DashboardsStore.
+ */
+
+import type { Dashboard } from '@some-useful-agents/core';
+import { html, render, type SafeHtml } from './html.js';
+import { layout } from './layout.js';
+import { pageHeader } from './page-header.js';
+import { renderTile } from './pulse-renderers.js';
+import { tileWrap, type PulseTile } from './pulse.js';
+import {
+  buildDashboardOptions,
+  renderDashboardsDropdown,
+  type DashboardOption,
+} from './dashboards-dropdown.js';
+
+export interface DashboardSectionRender {
+  title: string;
+  /** Tiles already built, in the order the section declares them. */
+  tiles: PulseTile[];
+  /** Agent ids referenced by the section that aren't installed (rendered as muted placeholders). */
+  missingAgentIds: string[];
+}
+
+export interface RenderDashboardPageInput {
+  dashboard: Dashboard;
+  sections: DashboardSectionRender[];
+  /** All installed dashboards, used to populate the dropdown. */
+  installedDashboards: Dashboard[];
+  flash?: { kind: 'ok' | 'error' | 'info'; message: string };
+}
+
+export function renderDashboardPage(input: RenderDashboardPageInput): string {
+  const options: DashboardOption[] = buildDashboardOptions(input.installedDashboards);
+  const activeHref = `/dashboards/${encodeURIComponent(input.dashboard.id)}`;
+  const dropdown = renderDashboardsDropdown({ options, activeHref });
+
+  const totalTiles = input.sections.reduce((n, s) => n + s.tiles.length, 0);
+  const totalMissing = input.sections.reduce((n, s) => n + s.missingAgentIds.length, 0);
+
+  const sourceLabel = input.dashboard.packId ? `from pack: ${input.dashboard.packId}` : 'user-created';
+
+  const body = html`
+    <div style="display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-4);">
+      ${dropdown}
+      <span class="dim" style="font-size: var(--font-size-sm);">
+        ${String(totalTiles)} tile${totalTiles === 1 ? '' : 's'}
+        ${totalMissing > 0 ? html`, ${String(totalMissing)} missing` : html``}
+        · ${sourceLabel}
+      </span>
+    </div>
+
+    ${pageHeader({
+      title: input.dashboard.name,
+      back: { href: '/packs', label: 'All packs' },
+    })}
+
+    ${input.sections.length === 0
+      ? html`<p class="dim" style="padding: var(--space-4); text-align: center;">No sections in this dashboard.</p>`
+      : input.sections.map((s) => renderSection(s)) as unknown as SafeHtml[]}
+  `;
+
+  return render(layout({
+    title: `${input.dashboard.name} · Dashboards`,
+    activeNav: 'pulse', // Dashboards live under the Pulse tab in nav
+    flash: input.flash,
+  }, body));
+}
+
+function renderSection(s: DashboardSectionRender): SafeHtml {
+  const isEmpty = s.tiles.length === 0 && s.missingAgentIds.length === 0;
+  if (isEmpty) return html``;
+  return html`
+    <section style="margin-bottom: var(--space-5);">
+      <h2 style="margin: 0 0 var(--space-3) 0; font-size: var(--font-size-md); font-weight: var(--weight-semibold);">${s.title}</h2>
+      <div class="pulse-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: var(--space-3);">
+        ${s.tiles.map((t) => renderTile(t, tileWrap)) as unknown as SafeHtml[]}
+        ${s.missingAgentIds.map((id) => html`
+          <div class="card dim" style="padding: var(--space-3); border: 1px dashed var(--color-border-strong);">
+            <div style="font-family: var(--font-mono); font-size: var(--font-size-sm);">${id}</div>
+            <div style="font-size: var(--font-size-xs);">not installed — install the pack or remove from the dashboard</div>
+          </div>
+        `) as unknown as SafeHtml[]}
+      </div>
+    </section>
+  `;
+}

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -13,8 +13,8 @@ import { footer } from './footer.js';
 
 export interface LayoutOptions {
   title: string;
-  /** Highlight in the nav (one of: agents, tools, runs, pulse, settings, help). */
-  activeNav?: 'agents' | 'tools' | 'nodes' | 'runs' | 'pulse' | 'settings' | 'help';
+  /** Highlight in the nav (one of: agents, tools, runs, pulse, packs, settings, help). */
+  activeNav?: 'agents' | 'tools' | 'nodes' | 'runs' | 'pulse' | 'packs' | 'settings' | 'help';
   /** Flash banner shown at the top of the body (errors from prior actions). */
   flash?: { kind: 'error' | 'info' | 'ok'; message: string };
   /** Widen the main column (for screens with 2-col layouts). */
@@ -56,6 +56,7 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
     <a href="/nodes" class="${opts.activeNav === 'nodes' ? 'is-active' : ''}">Nodes</a>
     <a href="/runs" class="${opts.activeNav === 'runs' ? 'is-active' : ''}">Runs</a>
     <a href="/pulse" class="${opts.activeNav === 'pulse' ? 'is-active' : ''}">Pulse</a>
+    <a href="/packs" class="${opts.activeNav === 'packs' ? 'is-active' : ''}">Packs</a>
     <a href="/settings" class="${opts.activeNav === 'settings' ? 'is-active' : ''}">Settings</a>
     <a href="/help" class="${opts.activeNav === 'help' ? 'is-active' : ''}">Help</a>
   </nav>

--- a/packages/dashboard/src/views/packs.ts
+++ b/packages/dashboard/src/views/packs.ts
@@ -1,0 +1,143 @@
+import type { Pack } from '@some-useful-agents/core';
+import { html, render } from './html.js';
+import { layout } from './layout.js';
+import { pageHeader } from './page-header.js';
+
+/**
+ * Render `/packs` — the browse-all-packs page. Cards split into two
+ * sections: installed first, then available. Empty-state when nothing
+ * is registered (the daemon hasn't found any built-in packs yet).
+ */
+export function renderPacksList(args: { packs: Pack[]; flash?: { kind: 'ok' | 'error' | 'info'; message: string } }): string {
+  const installed = args.packs.filter((p) => p.installedAt !== null);
+  const available = args.packs.filter((p) => p.installedAt === null);
+
+  const card = (p: Pack) => {
+    const dashboardCount = p.manifest.dashboards?.length ?? 0;
+    const agentCount = p.manifest.agents?.length ?? 0;
+    const stateBadge = p.installedAt
+      ? html`<span class="badge badge--ok">Installed</span>`
+      : html`<span class="badge dim">Available</span>`;
+    return html`
+      <a href="/packs/${encodeURIComponent(p.id)}" class="card" style="display: flex; flex-direction: column; gap: var(--space-2); text-decoration: none; color: inherit;">
+        <div style="display: flex; align-items: baseline; justify-content: space-between; gap: var(--space-2);">
+          <h3 style="margin: 0; font-size: var(--font-size-md); font-weight: var(--weight-semibold);">${p.name}</h3>
+          ${stateBadge}
+        </div>
+        ${p.description
+          ? html`<p style="margin: 0; color: var(--color-text-muted); font-size: var(--font-size-sm); line-height: 1.4;">${p.description}</p>`
+          : html``}
+        <div style="display: flex; gap: var(--space-3); font-size: var(--font-size-xs); color: var(--color-text-muted); margin-top: auto;">
+          <span>v${p.version}</span>
+          <span>${String(dashboardCount)} dashboard${dashboardCount === 1 ? '' : 's'}</span>
+          <span>${String(agentCount)} agent${agentCount === 1 ? '' : 's'}</span>
+          <span class="dim" style="margin-left: auto;">${p.source}</span>
+        </div>
+      </a>
+    `;
+  };
+
+  const section = (title: string, packs: Pack[]) => {
+    if (!packs.length) return html``;
+    return html`
+      <section style="margin-bottom: var(--space-5);">
+        <h2 style="margin: 0 0 var(--space-3) 0; font-size: var(--font-size-md); font-weight: var(--weight-semibold);">${title} <span class="dim">(${String(packs.length)})</span></h2>
+        <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: var(--space-3);">
+          ${packs.map(card)}
+        </div>
+      </section>
+    `;
+  };
+
+  const empty = args.packs.length === 0
+    ? html`<p class="dim" style="padding: var(--space-4); text-align: center;">No packs registered yet. Built-in packs are loaded from <code>packages/core/packs/*.yaml</code> on daemon start.</p>`
+    : html``;
+
+  const body = html`
+    ${pageHeader({
+      title: 'Packs',
+      description: 'Curated bundles of agents and dashboards. Install a pack to register its dashboards and contributed agents in one step.',
+    })}
+    ${section('Installed', installed)}
+    ${section('Available', available)}
+    ${empty}
+  `;
+
+  return render(layout({ title: 'Packs', activeNav: 'packs' as 'packs', flash: args.flash }, body));
+}
+
+/**
+ * Render `/packs/:id` — pack detail. Shows manifest contents and the
+ * Install or Uninstall action depending on current state.
+ */
+export function renderPackDetail(args: { pack: Pack; flash?: { kind: 'ok' | 'error' | 'info'; message: string } }): string {
+  const p = args.pack;
+  const installed = p.installedAt !== null;
+  const installedAt = p.installedAt ? new Date(p.installedAt).toISOString() : null;
+
+  const actionForm = installed
+    ? html`
+        <form method="POST" action="/packs/${encodeURIComponent(p.id)}/uninstall" style="display: inline;">
+          <button type="submit" class="btn btn--ghost">Uninstall</button>
+        </form>
+      `
+    : html`
+        <form method="POST" action="/packs/${encodeURIComponent(p.id)}/install" style="display: inline;">
+          <button type="submit" class="btn btn--primary">Install</button>
+        </form>
+      `;
+
+  const dashboardsBlock = p.manifest.dashboards?.length
+    ? html`
+        <section style="margin-top: var(--space-4);">
+          <h2 style="margin: 0 0 var(--space-2) 0; font-size: var(--font-size-md); font-weight: var(--weight-semibold);">Dashboards</h2>
+          <ul style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: var(--space-2);">
+            ${p.manifest.dashboards.map((d) => {
+              const sectionLabels = d.sections.map((s) => `${s.title} (${s.agentIds.length})`).join(' · ');
+              return html`
+                <li class="card" style="padding: var(--space-3);">
+                  <div style="font-weight: var(--weight-semibold);">${d.name}</div>
+                  <div class="dim" style="font-size: var(--font-size-sm);">${sectionLabels}</div>
+                </li>
+              `;
+            })}
+          </ul>
+        </section>
+      `
+    : html``;
+
+  const agentsBlock = p.manifest.agents?.length
+    ? html`
+        <section style="margin-top: var(--space-4);">
+          <h2 style="margin: 0 0 var(--space-2) 0; font-size: var(--font-size-md); font-weight: var(--weight-semibold);">Agents</h2>
+          <ul style="list-style: none; padding: 0; margin: 0; display: flex; flex-wrap: wrap; gap: var(--space-2);">
+            ${p.manifest.agents.map((a) => html`<li><code style="background: var(--color-surface-raised); padding: var(--space-1) var(--space-2); border-radius: var(--radius-sm);">${a.id}</code></li>`)}
+          </ul>
+          <p class="dim" style="font-size: var(--font-size-sm); margin: var(--space-2) 0 0 0;">Install creates any agents not already present (reference-only — uninstall keeps them).</p>
+        </section>
+      `
+    : html``;
+
+  const body = html`
+    ${pageHeader({
+      title: p.name,
+      back: { href: '/packs', label: 'Back to packs' },
+      description: p.description ?? undefined,
+    })}
+    <div class="card" style="display: flex; flex-direction: column; gap: var(--space-3);">
+      <div style="display: flex; gap: var(--space-3); flex-wrap: wrap; align-items: baseline;">
+        ${installed
+          ? html`<span class="badge badge--ok">Installed${installedAt ? html` · ${installedAt}` : html``}</span>`
+          : html`<span class="badge dim">Available</span>`}
+        <span class="dim" style="font-size: var(--font-size-sm);">v${p.version}</span>
+        <span class="dim" style="font-size: var(--font-size-sm);">source: ${p.source}</span>
+        ${p.author ? html`<span class="dim" style="font-size: var(--font-size-sm);">by ${p.author}</span>` : html``}
+        <div style="margin-left: auto;">${actionForm}</div>
+      </div>
+    </div>
+    ${dashboardsBlock}
+    ${agentsBlock}
+  `;
+
+  return render(layout({ title: `${p.name} · Packs`, activeNav: 'packs' as 'packs', flash: args.flash }, body));
+}

--- a/packages/dashboard/src/views/pulse-tile-builder.ts
+++ b/packages/dashboard/src/views/pulse-tile-builder.ts
@@ -1,0 +1,75 @@
+/**
+ * Build a PulseTile from an agent + run history.
+ *
+ * Extracted from routes/pulse.ts so other surfaces (the new
+ * /dashboards/:id route) can render the same tiles without
+ * cross-route imports. Tile rendering itself stays in
+ * pulse-renderers.ts.
+ */
+
+import type { Agent, AgentSignal, Run, RunStore } from '@some-useful-agents/core';
+import type { PulseTile } from './pulse-types.js';
+import { normalizeSignal, extractMappedValues } from './pulse-templates.js';
+
+export interface BuildTileDeps {
+  runStore: RunStore;
+}
+
+export function buildPulseTile(
+  agent: Agent & { signal: AgentSignal },
+  deps: BuildTileDeps,
+): PulseTile {
+  const signal = agent.signal;
+  let lastRun: Run | undefined;
+  let outputsJson: string | undefined;
+  let previousInputs: Record<string, string> | undefined;
+  try {
+    const runs = deps.runStore.listRuns({ agentName: agent.id, status: 'completed', limit: 1 });
+    if (runs.length > 0) {
+      lastRun = runs[0];
+      const execs = deps.runStore.listNodeExecutions(lastRun.id);
+      const lastExec = execs.filter((e) => e.status === 'completed').pop();
+      if (lastExec?.outputsJson) outputsJson = lastExec.outputsJson;
+
+      // Pre-fill the interactive widget form with the most recent run's
+      // input values (mirrors buildTile in routes/pulse.ts).
+      if (agent.outputWidget?.interactive && agent.inputs && execs.length > 0 && execs[0].inputsJson) {
+        try {
+          const allEnv = JSON.parse(execs[0].inputsJson) as Record<string, string>;
+          const inputNames = new Set(Object.keys(agent.inputs));
+          const picked: Record<string, string> = {};
+          for (const [k, v] of Object.entries(allEnv)) {
+            if (inputNames.has(k) && v !== '') picked[k] = v;
+          }
+          if (Object.keys(picked).length > 0) previousInputs = picked;
+        } catch { /* malformed inputsJson */ }
+      }
+    }
+  } catch { /* no runs */ }
+
+  const { mapping } = normalizeSignal(signal);
+  const slots = extractMappedValues(lastRun, mapping, outputsJson);
+
+  // Discover output field keys for the configure modal.
+  const outputFields: string[] = [];
+  const fieldSet = new Set<string>();
+  if (outputsJson) {
+    try {
+      const parsed = JSON.parse(outputsJson);
+      if (typeof parsed === 'object' && parsed !== null) {
+        for (const k of Object.keys(parsed)) fieldSet.add(k);
+      }
+    } catch { /* ignore */ }
+  }
+  if (lastRun?.result) {
+    try {
+      const parsed = JSON.parse(lastRun.result);
+      if (typeof parsed === 'object' && parsed !== null) {
+        for (const k of Object.keys(parsed)) fieldSet.add(k);
+      }
+    } catch { /* not JSON */ }
+  }
+  outputFields.push(...Array.from(fieldSet).sort());
+
+  return { agent, signal, lastRun, slots, outputFields, previousInputs };
+}

--- a/packages/dashboard/src/views/pulse-types.ts
+++ b/packages/dashboard/src/views/pulse-types.ts
@@ -24,6 +24,8 @@ export interface PulsePageInput {
   systemTiles: PulseTile[];
   tiles: PulseTile[];
   hiddenTiles: PulseTile[];
+  /** Optional one-shot banner from a redirect (?ok=… / ?error=…). */
+  flash?: { kind: 'ok' | 'error' | 'info'; message: string };
 }
 
 /** Signature for the tile wrapper function, passed to renderers. */

--- a/packages/dashboard/src/views/pulse-types.ts
+++ b/packages/dashboard/src/views/pulse-types.ts
@@ -26,6 +26,12 @@ export interface PulsePageInput {
   hiddenTiles: PulseTile[];
   /** Optional one-shot banner from a redirect (?ok=… / ?error=…). */
   flash?: { kind: 'ok' | 'error' | 'info'; message: string };
+  /**
+   * Installed dashboards (from DashboardsStore) used to populate the
+   * dashboards dropdown above the Pulse header. Empty/undefined when
+   * the dashboards store isn't wired (tests, older daemons).
+   */
+  installedDashboards?: import('@some-useful-agents/core').Dashboard[];
 }
 
 /** Signature for the tile wrapper function, passed to renderers. */

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -14,6 +14,7 @@ import { formatAge } from './components.js';
 import { normalizeSignal, TEMPLATE_REGISTRY } from './pulse-templates.js';
 import { esc } from './pulse-helpers.js';
 import { renderTile } from './pulse-renderers.js';
+import { buildDashboardOptions, renderDashboardsDropdown } from './dashboards-dropdown.js';
 export type { PulseTile, PulsePageInput, TileWrapFn } from './pulse-types.js';
 import type { PulseTile, PulsePageInput, TileWrapFn } from './pulse-types.js';
 
@@ -136,7 +137,17 @@ export function renderPulsePage(input: PulsePageInput): string {
 
   const doRenderTile = (tile: PulseTile) => renderTile(tile, tileWrap);
 
+  const dropdownOptions = buildDashboardOptions(input.installedDashboards ?? []);
+  // Only render the dropdown when there's more than just the Default
+  // entry — otherwise it's noise.
+  const dropdown = dropdownOptions.length > 1
+    ? renderDashboardsDropdown({ options: dropdownOptions, activeHref: '/pulse' })
+    : html``;
+
   const body = html`
+    ${dropdownOptions.length > 1
+      ? html`<div style="margin-bottom: var(--space-3);">${dropdown}</div>`
+      : html``}
     <div style="display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-6);">
       <h1 style="margin: 0;">Pulse</h1>
       <span style="font-size: var(--font-size-sm); color: var(--color-text-muted);">

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -143,6 +143,16 @@ export function renderPulsePage(input: PulsePageInput): string {
         ${String(allTileCount)} signal${allTileCount !== 1 ? 's' : ''}${hiddenCount > 0 ? html`, ${String(hiddenCount)} hidden` : html``}
       </span>
       <div style="margin-left: auto; display: flex; gap: var(--space-2);">
+        ${tiles.length > 0 ? html`
+          <form method="POST" action="/pulse/hide-all" style="margin: 0; display: inline;" onsubmit="return confirm('Hide all ${String(tiles.length)} signal${tiles.length !== 1 ? 's' : ''} from Pulse? They\\'ll move to the hidden section and can be restored individually.');">
+            <button type="submit" class="btn btn--ghost btn--sm" title="Move every visible tile to the hidden section. Useful before installing packs.">Hide all</button>
+          </form>
+        ` : html``}
+        ${hiddenCount > 0 && tiles.length === 0 ? html`
+          <form method="POST" action="/pulse/show-all" style="margin: 0; display: inline;">
+            <button type="submit" class="btn btn--ghost btn--sm">Show all</button>
+          </form>
+        ` : html``}
         <button type="button" class="btn btn--ghost btn--sm" id="pulse-edit-toggle">\u270E Edit layout</button>
         <button type="button" class="btn btn--ghost btn--sm" id="pulse-add-container" style="display: none;">+ Add group</button>
       </div>
@@ -178,5 +188,5 @@ export function renderPulsePage(input: PulsePageInput): string {
     ${unsafeHtml(`<script type="application/json" id="pulse-template-registry">${JSON.stringify(TEMPLATE_REGISTRY)}</script>`)}
   `;
 
-  return render(layout({ title: 'Pulse', activeNav: 'pulse' }, body));
+  return render(layout({ title: 'Pulse', activeNav: 'pulse', flash: input.flash }, body));
 }


### PR DESCRIPTION
## Summary

PRs #201, #202, and #203 from the widget-packs series got merged into their *stacked base branches* instead of into \`main\`. GitHub flagged them as MERGED but the commits never reached main. This PR re-stacks the same three commits cleanly on top of main.

The diffs are unchanged from the originals — same code, same tests, same changesets. Just correcting the GitHub state.

| Commit | What | Originally |
|---|---|---|
| \`4306a9f\` | pack manifest + Starter pack | #201 |
| \`a6b457d\` | browse + install widget packs UI + Pulse "Hide all" | #202 |
| \`ea1f57c\` | render pack dashboards + switcher dropdown | #203 |

## Why this happened

The original PRs were stacked: #201 targeted #200's branch, #202 targeted #201's branch, etc. Clicking GitHub's "Merge" on each one merged it into its base — which then auto-marked the PR as merged but never propagated to main. After #200 landed on main, the chain didn't auto-rebase.

## Test plan
- [x] Cherry-picked from the original branches; no edits
- [x] \`npm test\` — 1027/1027 passing on the re-stacked branch
- [x] \`npm run build\` clean
- [x] Live smoke (from prior PRs): install Starter → 2 dashboards → switch via dropdown → tiles render

## What's next (after this lands)

- **PR 5:** dashboard editor (drag-drop reorder, add/remove tiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)