### PR TITLE
feat(dashboard): dashboard editor — create, customise, reorder (widget-packs PR 5/5)

### DIFF
--- a/.changeset/dashboards-editor.md
+++ b/.changeset/dashboards-editor.md
@@ -1,0 +1,41 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Dashboard editor — create, customise, reorder (widget-packs PR 5/5).
+
+Closes the widget-packs architecture series. New surfaces:
+
+- **`GET /dashboards/:id/edit`** — editor for any stored dashboard.
+  Each section gets a rename input + up/down arrows + delete; each
+  tile gets up/down arrows + delete; an "Add tile" dropdown lists
+  agents not already in the section; an "Add a section" form at the
+  bottom; "Delete dashboard" for user-created dashboards.
+- **`POST /dashboards`** — create a user dashboard from the dropdown.
+  The dashboards dropdown gained a "New dashboard name" input that
+  POSTs here; redirects to the new dashboard's editor.
+- **Action endpoints** — `POST /dashboards/:id/sections`,
+  `/sections/:idx/{rename,delete,move}`,
+  `/sections/:idx/tiles`,
+  `/sections/:idx/tiles/:tileIdx/{delete,move}`,
+  `/dashboards/:id/delete`. All form-POST + 303-redirect — no JS.
+- **"Edit" button** on every dashboard view page (top-right of the
+  header strip).
+- **Pack-owned dashboards are editable** but can't be deleted directly
+  (uninstall the pack instead). User-created dashboards can be deleted.
+- The Default Dashboard backing `/pulse` stays non-editable — it's
+  auto-derived from `pulseVisible`, so per-agent toggles are the
+  edit affordance there (already exists via the existing × button).
+
+Drag-drop reorder is intentionally deferred. The existing
+`widget-layout.js.ts` has the bones for it (currently localStorage-only);
+swapping its persistence layer to call this PR's `/sections/:idx/move`
+endpoints is a clean follow-up.
+
+11 new supertest cases covering every action endpoint; full suite
+1038/1038 green. Live smoke: created "Morning Briefing" → added
+Weather section → added weather-forecast tile via the editor.

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -47,6 +47,7 @@ import { versionsRouter } from './routes/versions.js';
 import { pulseRouter } from './routes/pulse.js';
 import { packsRouter } from './routes/packs.js';
 import { dashboardsRouter } from './routes/dashboards.js';
+import { dashboardsEditRouter } from './routes/dashboards-edit.js';
 
 export interface StartDashboardOptions {
   port: number;
@@ -201,6 +202,7 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   app.use(nodesRouter);
   app.use(pulseRouter);
   app.use(packsRouter);
+  app.use(dashboardsEditRouter);
   app.use(dashboardsRouter);
 
   // Catch-all 404 for authenticated routes.

--- a/packages/dashboard/src/routes/dashboards-edit.test.ts
+++ b/packages/dashboard/src/routes/dashboards-edit.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import request from 'supertest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AgentStore,
+  DashboardsStore,
+  LocalProvider,
+  MemorySecretsStore,
+  PacksStore,
+  RunStore,
+  buildLoopbackAllowlist,
+  loadAgents,
+} from '@some-useful-agents/core';
+import { buildDashboardApp } from '../index.js';
+import type { DashboardContext } from '../context.js';
+import { SESSION_COOKIE } from '../auth-middleware.js';
+import { MemorySecretsSession } from '../secrets-session.js';
+
+const TOKEN = 'a'.repeat(64);
+const PORT = 3996;
+const COOKIE = `${SESSION_COOKIE}=${TOKEN}`;
+
+let dir: string;
+let provider: LocalProvider;
+let runStore: RunStore;
+let agentStore: AgentStore;
+let packsStore: PacksStore;
+let dashboardsStore: DashboardsStore;
+
+async function makeApp() {
+  dir = mkdtempSync(join(tmpdir(), 'sua-dashboards-edit-'));
+  const dbPath = join(dir, 'runs.db');
+  const agentsDir = join(dir, 'agents', 'local');
+  mkdirSync(agentsDir, { recursive: true });
+
+  const secretsStore = new MemorySecretsStore();
+  runStore = new RunStore(dbPath);
+  agentStore = new AgentStore(dbPath);
+  packsStore = new PacksStore(dbPath);
+  dashboardsStore = new DashboardsStore(dbPath);
+  provider = new LocalProvider(dbPath, secretsStore);
+  await provider.initialize();
+
+  // Two signal-bearing agents to test add-tile.
+  for (const id of ['hello', 'world']) {
+    agentStore.createAgent({
+      id,
+      name: id,
+      status: 'active',
+      source: 'local',
+      mcp: false,
+      nodes: [{ id: 'n', type: 'shell', command: 'echo x', dependsOn: [] }],
+      signal: { title: id, template: 'text-headline', mapping: { headline: 'h' } },
+    }, 'cli');
+  }
+
+  const ctx: DashboardContext = {
+    token: TOKEN,
+    allowlist: buildLoopbackAllowlist(PORT),
+    port: PORT,
+    provider,
+    runStore,
+    agentStore,
+    loadAgents: () => loadAgents({ directories: [agentsDir] }),
+    secretsStore,
+    secretsSession: new MemorySecretsSession({ backing: secretsStore }),
+    tokenPath: join(dir, 'mcp-token'),
+    retentionDays: 30,
+    dbPath,
+    secretsPath: join(dir, 'secrets.enc'),
+    rotateToken: () => 'r'.repeat(64),
+    packsStore,
+    dashboardsStore,
+    allowUntrustedShell: new Set(),
+    activeRuns: new Map(),
+    dataDir: dir,
+    dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
+  };
+
+  return buildDashboardApp(ctx);
+}
+
+afterEach(async () => {
+  if (provider) {
+    const start = Date.now();
+    while ((provider as unknown as { running?: { size: number } }).running?.size && Date.now() - start < 2000) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    await provider.shutdown();
+  }
+  try { runStore?.close(); } catch { /* ignore */ }
+  try { agentStore?.close(); } catch { /* ignore */ }
+  try { packsStore?.close(); } catch { /* ignore */ }
+  try { dashboardsStore?.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+function seed(): { id: string } {
+  const id = 'user:test';
+  dashboardsStore.upsertDashboard({
+    id, packId: null, name: 'Test',
+    layout: { sections: [{ title: 'A', agentIds: ['hello'] }] },
+  });
+  return { id };
+}
+
+describe('dashboards editor', () => {
+  it('GET /dashboards/:id/edit renders the editor with section + tile rows', async () => {
+    const app = await makeApp();
+    seed();
+    const res = await request(app).get('/dashboards/user:test/edit')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('value="A"');
+    expect(res.text).toContain('hello');
+    expect(res.text).toContain('action="/dashboards/user%3Atest/sections"');
+  });
+
+  it('POST /dashboards creates a user dashboard and redirects to edit', async () => {
+    const app = await makeApp();
+    const res = await request(app).post('/dashboards')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .type('form').send({ name: 'My Dash' });
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/\/dashboards\/user%3Amy-dash\/edit/);
+    expect(dashboardsStore.getDashboard('user:my-dash')?.name).toBe('My Dash');
+  });
+
+  it('POST /sections appends a section', async () => {
+    const app = await makeApp();
+    const { id } = seed();
+    const res = await request(app).post(`/dashboards/${id}/sections`)
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .type('form').send({ title: 'B' });
+    expect(res.status).toBe(303);
+    expect(dashboardsStore.getDashboard(id)?.layout.sections.map((s) => s.title)).toEqual(['A', 'B']);
+  });
+
+  it('POST /sections/:idx/rename updates title', async () => {
+    const app = await makeApp();
+    const { id } = seed();
+    await request(app).post(`/dashboards/${id}/sections/0/rename`)
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .type('form').send({ title: 'Renamed' });
+    expect(dashboardsStore.getDashboard(id)?.layout.sections[0].title).toBe('Renamed');
+  });
+
+  it('POST /sections/:idx/delete removes the section', async () => {
+    const app = await makeApp();
+    const { id } = seed();
+    await request(app).post(`/dashboards/${id}/sections/0/delete`)
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(dashboardsStore.getDashboard(id)?.layout.sections).toEqual([]);
+  });
+
+  it('POST /sections/:idx/move?dir=down swaps with the next section', async () => {
+    const app = await makeApp();
+    const { id } = seed();
+    dashboardsStore.upsertDashboard({
+      id, packId: null, name: 'Test',
+      layout: { sections: [{ title: 'A', agentIds: [] }, { title: 'B', agentIds: [] }] },
+    });
+    await request(app).post(`/dashboards/${id}/sections/0/move?dir=down`)
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(dashboardsStore.getDashboard(id)?.layout.sections.map((s) => s.title)).toEqual(['B', 'A']);
+  });
+
+  it('POST /sections/:idx/tiles adds an agent', async () => {
+    const app = await makeApp();
+    const { id } = seed();
+    await request(app).post(`/dashboards/${id}/sections/0/tiles`)
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .type('form').send({ agentId: 'world' });
+    expect(dashboardsStore.getDashboard(id)?.layout.sections[0].agentIds).toEqual(['hello', 'world']);
+  });
+
+  it('POST /sections/:idx/tiles/:tileIdx/delete removes a tile', async () => {
+    const app = await makeApp();
+    const { id } = seed();
+    await request(app).post(`/dashboards/${id}/sections/0/tiles/0/delete`)
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(dashboardsStore.getDashboard(id)?.layout.sections[0].agentIds).toEqual([]);
+  });
+
+  it('POST /sections/:idx/tiles/:tileIdx/move swaps adjacent tiles', async () => {
+    const app = await makeApp();
+    const { id } = seed();
+    dashboardsStore.upsertDashboard({
+      id, packId: null, name: 'Test',
+      layout: { sections: [{ title: 'A', agentIds: ['hello', 'world'] }] },
+    });
+    await request(app).post(`/dashboards/${id}/sections/0/tiles/1/move?dir=up`)
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(dashboardsStore.getDashboard(id)?.layout.sections[0].agentIds).toEqual(['world', 'hello']);
+  });
+
+  it('POST /dashboards/:id/delete removes a user dashboard', async () => {
+    const app = await makeApp();
+    const { id } = seed();
+    const res = await request(app).post(`/dashboards/${id}/delete`)
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(303);
+    expect(dashboardsStore.getDashboard(id)).toBeNull();
+  });
+
+  it('POST /dashboards/:id/delete refuses to delete a pack-owned dashboard', async () => {
+    const app = await makeApp();
+    dashboardsStore.upsertDashboard({
+      id: 'starter:main', packId: 'starter', name: 'Main',
+      layout: { sections: [] },
+    });
+    const res = await request(app).post('/dashboards/starter:main/delete')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/error=/);
+    expect(dashboardsStore.getDashboard('starter:main')).not.toBeNull();
+  });
+});

--- a/packages/dashboard/src/routes/dashboards-edit.ts
+++ b/packages/dashboard/src/routes/dashboards-edit.ts
@@ -1,0 +1,254 @@
+/**
+ * Editor routes for stored dashboards.
+ *
+ * Each action mutates the layout via DashboardsStore.updateLayout and
+ * 303s back to the editor. No JS, no batching — every click is one
+ * server round-trip.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import type { DashboardLayout, DashboardSection } from '@some-useful-agents/core';
+import { getContext } from '../context.js';
+import { renderDashboardEditPage } from '../views/dashboard-edit.js';
+
+export const dashboardsEditRouter: Router = Router();
+
+const DASHBOARD_ID_RE = /^[a-z0-9][a-z0-9:_-]*$/;
+
+dashboardsEditRouter.get('/dashboards/:id/edit', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.dashboardsStore) {
+    res.status(404).type('html').send('<p>Dashboards store unavailable. <a href="/pulse">Back</a></p>');
+    return;
+  }
+  const id = pickId(req);
+  const dashboard = ctx.dashboardsStore.getDashboard(id);
+  if (!dashboard) {
+    res.status(404).type('html').send(`<p>No dashboard with id "${id}". <a href="/packs">Browse packs</a></p>`);
+    return;
+  }
+  // Only signal-bearing agents can render as Pulse tiles. Filter so the
+  // add-tile dropdown doesn't surface agents that would render empty.
+  const signalAgents = ctx.agentStore.listAgents().filter((a) => a.signal);
+  res.type('html').send(renderDashboardEditPage({
+    dashboard,
+    signalAgents,
+    flash: parseFlash(req),
+  }));
+});
+
+// ── Layout mutations (one redirect per action) ─────────────────────────────
+
+dashboardsEditRouter.post('/dashboards/:id/sections', (req: Request, res: Response) => {
+  withDashboard(req, res, (id, dashboard, ctx) => {
+    const title = pickString(req.body, 'title');
+    if (!title) return redirectErr(res, id, 'Section title is required.');
+    const sections = [...dashboard.layout.sections, { title, agentIds: [] }];
+    ctx.dashboardsStore!.updateLayout(id, { sections });
+    redirectOk(res, id, `Added section "${title}".`);
+  });
+});
+
+dashboardsEditRouter.post('/dashboards/:id/sections/:idx/rename', (req: Request, res: Response) => {
+  withDashboard(req, res, (id, dashboard, ctx) => {
+    const idx = parseInt(pickParam(req, 'idx'), 10);
+    const title = pickString(req.body, 'title');
+    if (!title) return redirectErr(res, id, 'Title is required.');
+    const sections = mutateSections(dashboard.layout, (arr) => {
+      if (!arr[idx]) throw new Error('Section index out of range.');
+      arr[idx] = { ...arr[idx], title };
+    });
+    ctx.dashboardsStore!.updateLayout(id, { sections });
+    redirectOk(res, id, `Renamed.`);
+  });
+});
+
+dashboardsEditRouter.post('/dashboards/:id/sections/:idx/delete', (req: Request, res: Response) => {
+  withDashboard(req, res, (id, dashboard, ctx) => {
+    const idx = parseInt(pickParam(req, 'idx'), 10);
+    const sections = mutateSections(dashboard.layout, (arr) => {
+      if (!arr[idx]) throw new Error('Section index out of range.');
+      arr.splice(idx, 1);
+    });
+    ctx.dashboardsStore!.updateLayout(id, { sections });
+    redirectOk(res, id, `Section removed.`);
+  });
+});
+
+dashboardsEditRouter.post('/dashboards/:id/sections/:idx/move', (req: Request, res: Response) => {
+  withDashboard(req, res, (id, dashboard, ctx) => {
+    const idx = parseInt(pickParam(req, 'idx'), 10);
+    const dir = req.query.dir === 'down' ? 'down' : 'up';
+    const sections = mutateSections(dashboard.layout, (arr) => {
+      if (!arr[idx]) throw new Error('Section index out of range.');
+      const target = dir === 'up' ? idx - 1 : idx + 1;
+      if (target < 0 || target >= arr.length) return;
+      [arr[idx], arr[target]] = [arr[target], arr[idx]];
+    });
+    ctx.dashboardsStore!.updateLayout(id, { sections });
+    redirectOk(res, id, `Section moved ${dir}.`);
+  });
+});
+
+dashboardsEditRouter.post('/dashboards/:id/sections/:idx/tiles', (req: Request, res: Response) => {
+  withDashboard(req, res, (id, dashboard, ctx) => {
+    const idx = parseInt(pickParam(req, 'idx'), 10);
+    const agentId = pickString(req.body, 'agentId');
+    if (!agentId) return redirectErr(res, id, 'agentId is required.');
+    const sections = mutateSections(dashboard.layout, (arr) => {
+      if (!arr[idx]) throw new Error('Section index out of range.');
+      if (arr[idx].agentIds.includes(agentId)) return; // already there
+      arr[idx] = { ...arr[idx], agentIds: [...arr[idx].agentIds, agentId] };
+    });
+    ctx.dashboardsStore!.updateLayout(id, { sections });
+    redirectOk(res, id, `Added "${agentId}".`);
+  });
+});
+
+dashboardsEditRouter.post('/dashboards/:id/sections/:idx/tiles/:tileIdx/delete', (req: Request, res: Response) => {
+  withDashboard(req, res, (id, dashboard, ctx) => {
+    const idx = parseInt(pickParam(req, 'idx'), 10);
+    const tileIdx = parseInt(pickParam(req, 'tileIdx'), 10);
+    const sections = mutateSections(dashboard.layout, (arr) => {
+      if (!arr[idx] || !arr[idx].agentIds[tileIdx]) throw new Error('Tile index out of range.');
+      const agentIds = [...arr[idx].agentIds];
+      agentIds.splice(tileIdx, 1);
+      arr[idx] = { ...arr[idx], agentIds };
+    });
+    ctx.dashboardsStore!.updateLayout(id, { sections });
+    redirectOk(res, id, `Tile removed.`);
+  });
+});
+
+dashboardsEditRouter.post('/dashboards/:id/sections/:idx/tiles/:tileIdx/move', (req: Request, res: Response) => {
+  withDashboard(req, res, (id, dashboard, ctx) => {
+    const idx = parseInt(pickParam(req, 'idx'), 10);
+    const tileIdx = parseInt(pickParam(req, 'tileIdx'), 10);
+    const dir = req.query.dir === 'down' ? 'down' : 'up';
+    const sections = mutateSections(dashboard.layout, (arr) => {
+      if (!arr[idx] || !arr[idx].agentIds[tileIdx]) throw new Error('Tile index out of range.');
+      const agentIds = [...arr[idx].agentIds];
+      const target = dir === 'up' ? tileIdx - 1 : tileIdx + 1;
+      if (target < 0 || target >= agentIds.length) return;
+      [agentIds[tileIdx], agentIds[target]] = [agentIds[target], agentIds[tileIdx]];
+      arr[idx] = { ...arr[idx], agentIds };
+    });
+    ctx.dashboardsStore!.updateLayout(id, { sections });
+    redirectOk(res, id, `Tile moved ${dir}.`);
+  });
+});
+
+dashboardsEditRouter.post('/dashboards/:id/delete', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.dashboardsStore) {
+    res.status(404).redirect(303, '/pulse');
+    return;
+  }
+  const id = pickId(req);
+  const dashboard = ctx.dashboardsStore.getDashboard(id);
+  if (!dashboard) {
+    res.status(404).redirect(303, '/pulse');
+    return;
+  }
+  if (dashboard.packId !== null) {
+    res.redirect(303, `/dashboards/${encodeURIComponent(id)}/edit?error=${encodeURIComponent('Pack-owned dashboards can\'t be deleted directly. Uninstall the pack instead.')}`);
+    return;
+  }
+  ctx.dashboardsStore.deleteDashboard(id);
+  res.redirect(303, '/pulse?ok=Dashboard+deleted.');
+});
+
+// ── Create new user dashboard ──────────────────────────────────────────────
+
+dashboardsEditRouter.post('/dashboards', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.dashboardsStore) {
+    res.redirect(303, '/pulse?error=Dashboards+store+unavailable.');
+    return;
+  }
+  const name = pickString(req.body, 'name');
+  if (!name) {
+    res.redirect(303, '/pulse?error=Dashboard+name+is+required.');
+    return;
+  }
+  // Generate a slug; collision-resistant via timestamp suffix if needed.
+  const baseSlug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 40) || 'dashboard';
+  let id = `user:${baseSlug}`;
+  if (ctx.dashboardsStore.getDashboard(id)) {
+    id = `user:${baseSlug}-${Date.now().toString(36)}`;
+  }
+  ctx.dashboardsStore.upsertDashboard({ id, packId: null, name, layout: { sections: [] } });
+  res.redirect(303, `/dashboards/${encodeURIComponent(id)}/edit?ok=Dashboard+created.`);
+});
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function withDashboard(
+  req: Request,
+  res: Response,
+  fn: (
+    id: string,
+    dashboard: NonNullable<ReturnType<NonNullable<ReturnType<typeof getContext>['dashboardsStore']>['getDashboard']>>,
+    ctx: ReturnType<typeof getContext>,
+  ) => void,
+): void {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.dashboardsStore) {
+    res.status(503).redirect(303, '/pulse');
+    return;
+  }
+  const id = pickId(req);
+  const dashboard = ctx.dashboardsStore.getDashboard(id);
+  if (!dashboard) {
+    res.status(404).redirect(303, '/pulse');
+    return;
+  }
+  try {
+    fn(id, dashboard, ctx);
+  } catch (err) {
+    redirectErr(res, id, err instanceof Error ? err.message : String(err));
+  }
+}
+
+function mutateSections(
+  layout: DashboardLayout,
+  fn: (arr: DashboardSection[]) => void,
+): DashboardSection[] {
+  const arr = layout.sections.map((s) => ({ ...s, agentIds: [...s.agentIds] }));
+  fn(arr);
+  return arr;
+}
+
+function pickId(req: Request): string {
+  const raw = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  if (!DASHBOARD_ID_RE.test(raw)) {
+    throw new Error(`Invalid dashboard id: ${raw}`);
+  }
+  return raw;
+}
+
+function pickParam(req: Request, name: string): string {
+  const raw = req.params[name];
+  return Array.isArray(raw) ? raw[0] : (raw ?? '');
+}
+
+function pickString(body: unknown, name: string): string {
+  if (!body || typeof body !== 'object') return '';
+  const v = (body as Record<string, unknown>)[name];
+  return typeof v === 'string' ? v.trim() : '';
+}
+
+function redirectOk(res: Response, id: string, message: string): void {
+  res.redirect(303, `/dashboards/${encodeURIComponent(id)}/edit?ok=${encodeURIComponent(message)}`);
+}
+
+function redirectErr(res: Response, id: string, message: string): void {
+  res.redirect(303, `/dashboards/${encodeURIComponent(id)}/edit?error=${encodeURIComponent(message)}`);
+}
+
+function parseFlash(req: Request): { kind: 'ok' | 'error' | 'info'; message: string } | undefined {
+  if (typeof req.query.ok === 'string') return { kind: 'ok', message: req.query.ok };
+  if (typeof req.query.error === 'string') return { kind: 'error', message: req.query.error };
+  if (typeof req.query.info === 'string') return { kind: 'info', message: req.query.info };
+  return undefined;
+}

--- a/packages/dashboard/src/views/dashboard-edit.ts
+++ b/packages/dashboard/src/views/dashboard-edit.ts
@@ -1,0 +1,139 @@
+/**
+ * Editor for a stored dashboard at /dashboards/:id/edit.
+ *
+ * Server-rendered, no JS. Every action (add/remove/move/rename) is a
+ * tiny form POST that 303s back to /edit. Drag-drop is intentionally
+ * deferred to a follow-up; up/down arrows are easier to test and
+ * harder to misuse than client-side reorder.
+ *
+ * The Default Dashboard backing /pulse is auto-derived from
+ * pulseVisible and has no row in the dashboards table, so it's
+ * non-editable here by construction. Pack-owned and user-created
+ * dashboards both editable; renaming a pack-owned dashboard or
+ * removing tiles is fine — the changes persist independent of
+ * whether the pack is reinstalled later.
+ */
+
+import type { Agent, Dashboard } from '@some-useful-agents/core';
+import { html, render, type SafeHtml } from './html.js';
+import { layout } from './layout.js';
+import { pageHeader } from './page-header.js';
+
+export interface RenderDashboardEditInput {
+  dashboard: Dashboard;
+  /**
+   * Agents available to add to sections. Filtered to those with a
+   * `signal` block (only signal-bearing agents render as Pulse tiles).
+   */
+  signalAgents: Agent[];
+  flash?: { kind: 'ok' | 'error' | 'info'; message: string };
+}
+
+export function renderDashboardEditPage(input: RenderDashboardEditInput): string {
+  const d = input.dashboard;
+  const sections = d.layout.sections;
+
+  const body = html`
+    ${pageHeader({
+      title: `Edit · ${d.name}`,
+      back: { href: `/dashboards/${encodeURIComponent(d.id)}`, label: 'Done editing' },
+      description: d.packId
+        ? `Pack-owned (${d.packId}). Edits persist; reinstalling the pack would reset to the manifest's layout.`
+        : 'User-created dashboard.',
+    })}
+
+    <div style="display: flex; gap: var(--space-2); margin-bottom: var(--space-4);">
+      <a class="btn btn--ghost" href="/dashboards/${encodeURIComponent(d.id)}">View</a>
+      ${d.packId === null ? html`
+        <form method="POST" action="/dashboards/${encodeURIComponent(d.id)}/delete" style="margin: 0; display: inline;" onsubmit="return confirm('Delete this dashboard? This cannot be undone.');">
+          <button type="submit" class="btn btn--ghost">Delete dashboard</button>
+        </form>
+      ` : html``}
+    </div>
+
+    ${sections.length === 0 ? html`<p class="dim" style="padding: var(--space-3) 0;">No sections yet. Add one below to get started.</p>` : html``}
+
+    ${sections.map((s, idx) => renderSectionEditor(d, s, idx, sections.length, input.signalAgents)) as unknown as SafeHtml[]}
+
+    <section class="card" style="margin-top: var(--space-4); padding: var(--space-3);">
+      <h3 style="margin: 0 0 var(--space-2) 0; font-size: var(--font-size-md);">Add a section</h3>
+      <form method="POST" action="/dashboards/${encodeURIComponent(d.id)}/sections" style="display: flex; gap: var(--space-2);">
+        <input type="text" name="title" placeholder="Section title" required style="flex: 1; padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); background: var(--color-surface); color: var(--color-text);">
+        <button type="submit" class="btn btn--primary">Add</button>
+      </form>
+    </section>
+  `;
+
+  return render(layout({
+    title: `Edit ${d.name}`,
+    activeNav: 'pulse',
+    flash: input.flash,
+  }, body));
+}
+
+function renderSectionEditor(
+  d: Dashboard,
+  section: { title: string; agentIds: string[] },
+  idx: number,
+  total: number,
+  signalAgents: Agent[],
+): SafeHtml {
+  const isFirst = idx === 0;
+  const isLast = idx === total - 1;
+  const dashId = encodeURIComponent(d.id);
+
+  // Agents already in this section are removed from the add-tile dropdown.
+  const inSection = new Set(section.agentIds);
+  const addable = signalAgents.filter((a) => !inSection.has(a.id));
+
+  return html`
+    <section class="card" style="margin-bottom: var(--space-3); padding: var(--space-3);">
+      <div style="display: flex; align-items: center; gap: var(--space-2); margin-bottom: var(--space-3);">
+        <form method="POST" action="/dashboards/${dashId}/sections/${String(idx)}/rename" style="display: flex; gap: var(--space-1); flex: 1;">
+          <input type="text" name="title" value="${section.title}" required style="flex: 1; padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border); border-radius: var(--radius-sm); background: var(--color-surface); color: var(--color-text); font-weight: var(--weight-semibold);">
+          <button type="submit" class="btn btn--ghost btn--sm">Rename</button>
+        </form>
+        <form method="POST" action="/dashboards/${dashId}/sections/${String(idx)}/move?dir=up" style="margin: 0;">
+          <button type="submit" class="btn btn--ghost btn--sm" ${isFirst ? 'disabled' : ''} title="Move section up">↑</button>
+        </form>
+        <form method="POST" action="/dashboards/${dashId}/sections/${String(idx)}/move?dir=down" style="margin: 0;">
+          <button type="submit" class="btn btn--ghost btn--sm" ${isLast ? 'disabled' : ''} title="Move section down">↓</button>
+        </form>
+        <form method="POST" action="/dashboards/${dashId}/sections/${String(idx)}/delete" style="margin: 0;" onsubmit="return confirm('Remove this section and all its tiles?');">
+          <button type="submit" class="btn btn--ghost btn--sm" title="Remove section">×</button>
+        </form>
+      </div>
+
+      ${section.agentIds.length === 0
+        ? html`<p class="dim" style="font-size: var(--font-size-sm); margin: 0 0 var(--space-2) 0;">No tiles in this section yet.</p>`
+        : html`
+          <ul style="list-style: none; padding: 0; margin: 0 0 var(--space-2) 0; display: flex; flex-direction: column; gap: var(--space-1);">
+            ${section.agentIds.map((agentId, tileIdx) => html`
+              <li style="display: flex; align-items: center; gap: var(--space-2); padding: var(--space-2); background: var(--color-surface-raised); border-radius: var(--radius-sm);">
+                <code style="flex: 1; font-size: var(--font-size-sm);">${agentId}</code>
+                <form method="POST" action="/dashboards/${dashId}/sections/${String(idx)}/tiles/${String(tileIdx)}/move?dir=up" style="margin: 0;">
+                  <button type="submit" class="btn btn--ghost btn--sm" ${tileIdx === 0 ? 'disabled' : ''} title="Move tile up">↑</button>
+                </form>
+                <form method="POST" action="/dashboards/${dashId}/sections/${String(idx)}/tiles/${String(tileIdx)}/move?dir=down" style="margin: 0;">
+                  <button type="submit" class="btn btn--ghost btn--sm" ${tileIdx === section.agentIds.length - 1 ? 'disabled' : ''} title="Move tile down">↓</button>
+                </form>
+                <form method="POST" action="/dashboards/${dashId}/sections/${String(idx)}/tiles/${String(tileIdx)}/delete" style="margin: 0;">
+                  <button type="submit" class="btn btn--ghost btn--sm" title="Remove tile">×</button>
+                </form>
+              </li>
+            `) as unknown as SafeHtml[]}
+          </ul>
+        `}
+
+      ${addable.length > 0 ? html`
+        <form method="POST" action="/dashboards/${dashId}/sections/${String(idx)}/tiles" style="display: flex; gap: var(--space-2); margin-top: var(--space-2);">
+          <select name="agentId" required style="flex: 1; padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border); border-radius: var(--radius-sm); background: var(--color-surface); color: var(--color-text);">
+            <option value="">Add an agent…</option>
+            ${addable.map((a) => html`<option value="${a.id}">${a.name} (${a.id})</option>`) as unknown as SafeHtml[]}
+          </select>
+          <button type="submit" class="btn btn--ghost btn--sm">Add tile</button>
+        </form>
+      ` : html`<p class="dim" style="font-size: var(--font-size-xs); margin: var(--space-2) 0 0 0;">All available agents are already in this section.</p>`}
+    </section>
+  `;
+}

--- a/packages/dashboard/src/views/dashboards-dropdown.ts
+++ b/packages/dashboard/src/views/dashboards-dropdown.ts
@@ -62,8 +62,12 @@ export function renderDashboardsDropdown(args: {
             </a>
           `;
         })}
-        <a href="/packs" style="display: flex; padding: var(--space-2) var(--space-3); text-decoration: none; color: var(--color-text-muted); font-size: var(--font-size-sm); border-top: 1px solid var(--color-border); margin-top: var(--space-1); padding-top: var(--space-2);">
-          + Install more from Packs
+        <form method="POST" action="/dashboards" style="display: flex; gap: var(--space-1); padding: var(--space-2) var(--space-3); border-top: 1px solid var(--color-border); margin-top: var(--space-1); padding-top: var(--space-2);">
+          <input type="text" name="name" placeholder="New dashboard name" required style="flex: 1; padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border); border-radius: var(--radius-sm); background: var(--color-surface); color: var(--color-text); font-size: var(--font-size-xs);">
+          <button type="submit" class="btn btn--ghost btn--sm" style="font-size: var(--font-size-xs);">Create</button>
+        </form>
+        <a href="/packs" style="display: flex; padding: var(--space-2) var(--space-3); text-decoration: none; color: var(--color-text-muted); font-size: var(--font-size-sm);">
+          + Install from Packs
         </a>
       </div>
     </details>

--- a/packages/dashboard/src/views/dashboards.ts
+++ b/packages/dashboard/src/views/dashboards.ts
@@ -54,6 +54,7 @@ export function renderDashboardPage(input: RenderDashboardPageInput): string {
         ${totalMissing > 0 ? html`, ${String(totalMissing)} missing` : html``}
         · ${sourceLabel}
       </span>
+      <a class="btn btn--ghost btn--sm" href="/dashboards/${encodeURIComponent(input.dashboard.id)}/edit" style="margin-left: auto;">Edit</a>
     </div>
 
     ${pageHeader({


### PR DESCRIPTION
## Summary

Final PR in the [widget-packs series](https://github.com/gregmeyer/some-useful-agents/pull/200). Adds the editor surface so users can create, customise, and tear down dashboards.

### Editor (\`/dashboards/:id/edit\`)
Each section gets:
- a rename input
- ↑ / ↓ arrows to reorder
- × to remove (with confirm)
- an "Add tile" dropdown listing agents not already in the section
- per-tile ↑ / ↓ / × controls

Plus an "Add a section" form at the bottom and a "Delete dashboard" button (user-created dashboards only). All actions are form POSTs that 303 back to the editor — no JS, no batching, every change atomic.

### Create flow
The dashboards dropdown (introduced in PR 4) gained a "New dashboard name" input that POSTs to \`POST /dashboards\` and redirects to the editor for the new dashboard. Slug is derived from the name; collisions get a timestamp suffix.

### Edit affordances
- "Edit" button on every dashboard view page (top-right of the header).
- Pack-owned dashboards are editable (rename, reorder, add/remove tiles) but **not deletable** — uninstall the pack instead.
- The Default Dashboard at \`/pulse\` stays non-editable here; it's auto-derived from \`pulseVisible\`, and the existing per-tile × already serves as the edit affordance.

### Action endpoints
\`\`\`
POST /dashboards                                          — create user dashboard
POST /dashboards/:id/sections                             — add section
POST /dashboards/:id/sections/:idx/rename                 — rename section
POST /dashboards/:id/sections/:idx/delete                 — remove section
POST /dashboards/:id/sections/:idx/move?dir=up|down       — reorder section
POST /dashboards/:id/sections/:idx/tiles                  — add tile
POST /dashboards/:id/sections/:idx/tiles/:tileIdx/delete  — remove tile
POST /dashboards/:id/sections/:idx/tiles/:tileIdx/move    — reorder tile
POST /dashboards/:id/delete                               — delete user dashboard
\`\`\`

## Out of scope (deliberate)
- **Drag-drop reorder** — up/down arrows are easier to test and don't need JS. The existing \`widget-layout.js.ts\` has drag-drop bones (currently localStorage-only); adapting its persistence to call these new \`/move\` endpoints is a self-contained follow-up.
- **"Pin to dashboard" button on agent pages** — same shape as add-tile; can ride on top of \`POST /sections/:idx/tiles\` later.

## Test plan
- [x] 11 new supertest cases (one per action + 2 edge cases — pack-owned delete refusal, slug generation)
- [x] \`npm test\` — 1038/1038 passing
- [x] \`npm run build\` clean
- [x] Live smoke: created "Morning Briefing" → added Weather section → added weather-forecast tile via the editor
- [ ] Reviewer: tap through \`/dashboards/<any-pack-dashboard>/edit\` to confirm the layout reads well

🤖 Generated with [Claude Code](https://claude.com/claude-code)