### PR TITLE
feat(dashboard): styled 404 page

### DIFF
--- a/.changeset/styled-404-page.md
+++ b/.changeset/styled-404-page.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Styled 404 page that wraps the standard layout (topbar, theme toggle,
+suggestion cards) instead of the previous bare `<p>Not found</p>` scrap.
+
+The catch-all in `index.ts` and the unknown-id paths in the new
+dashboards routes now render `renderNotFoundPage`. Shows the requested
+path (HTML-escaped), an optional context message, and a card list of
+common destinations (Agents / Pulse / Packs / Runs).

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -206,8 +206,9 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   app.use(dashboardsRouter);
 
   // Catch-all 404 for authenticated routes.
-  app.use((_req, res) => {
-    res.status(404).type('html').send('<p>Not found. <a href="/agents">Back</a></p>');
+  app.use(async (req, res) => {
+    const { renderNotFoundPage } = await import('./views/not-found.js');
+    res.status(404).type('html').send(renderNotFoundPage({ path: req.originalUrl }));
   });
 
   return app;

--- a/packages/dashboard/src/routes/dashboards-edit.ts
+++ b/packages/dashboard/src/routes/dashboards-edit.ts
@@ -10,6 +10,7 @@ import { Router, type Request, type Response } from 'express';
 import type { DashboardLayout, DashboardSection } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 import { renderDashboardEditPage } from '../views/dashboard-edit.js';
+import { renderNotFoundPage } from '../views/not-found.js';
 
 export const dashboardsEditRouter: Router = Router();
 
@@ -18,13 +19,19 @@ const DASHBOARD_ID_RE = /^[a-z0-9][a-z0-9:_-]*$/;
 dashboardsEditRouter.get('/dashboards/:id/edit', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
   if (!ctx.dashboardsStore) {
-    res.status(404).type('html').send('<p>Dashboards store unavailable. <a href="/pulse">Back</a></p>');
+    res.status(404).type('html').send(renderNotFoundPage({
+      path: req.originalUrl,
+      message: 'Dashboards store unavailable.',
+    }));
     return;
   }
   const id = pickId(req);
   const dashboard = ctx.dashboardsStore.getDashboard(id);
   if (!dashboard) {
-    res.status(404).type('html').send(`<p>No dashboard with id "${id}". <a href="/packs">Browse packs</a></p>`);
+    res.status(404).type('html').send(renderNotFoundPage({
+      path: req.originalUrl,
+      message: `No dashboard with id "${id}".`,
+    }));
     return;
   }
   // Only signal-bearing agents can render as Pulse tiles. Filter so the

--- a/packages/dashboard/src/routes/dashboards.ts
+++ b/packages/dashboard/src/routes/dashboards.ts
@@ -16,19 +16,26 @@ import {
   type DashboardSectionRender,
 } from '../views/dashboards.js';
 import { buildPulseTile } from '../views/pulse-tile-builder.js';
+import { renderNotFoundPage } from '../views/not-found.js';
 
 export const dashboardsRouter: Router = Router();
 
 dashboardsRouter.get('/dashboards/:id', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
   if (!ctx.dashboardsStore) {
-    res.status(404).type('html').send('<p>Dashboards store unavailable. <a href="/pulse">Back to Pulse</a></p>');
+    res.status(404).type('html').send(renderNotFoundPage({
+      path: req.originalUrl,
+      message: 'Dashboards store unavailable.',
+    }));
     return;
   }
   const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
   const dashboard = ctx.dashboardsStore.getDashboard(id);
   if (!dashboard) {
-    res.status(404).type('html').send(`<p>No dashboard with id "${id}". <a href="/packs">Browse packs</a></p>`);
+    res.status(404).type('html').send(renderNotFoundPage({
+      path: req.originalUrl,
+      message: `No dashboard with id "${id}".`,
+    }));
     return;
   }
 

--- a/packages/dashboard/src/views/not-found.test.ts
+++ b/packages/dashboard/src/views/not-found.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import request from 'supertest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AgentStore,
+  DashboardsStore,
+  LocalProvider,
+  MemorySecretsStore,
+  PacksStore,
+  RunStore,
+  buildLoopbackAllowlist,
+  loadAgents,
+} from '@some-useful-agents/core';
+import { buildDashboardApp } from '../index.js';
+import type { DashboardContext } from '../context.js';
+import { SESSION_COOKIE } from '../auth-middleware.js';
+import { MemorySecretsSession } from '../secrets-session.js';
+import { renderNotFoundPage } from './not-found.js';
+
+const TOKEN = 'a'.repeat(64);
+const PORT = 3995;
+const COOKIE = `${SESSION_COOKIE}=${TOKEN}`;
+
+let dir: string;
+let provider: LocalProvider;
+let runStore: RunStore;
+let agentStore: AgentStore;
+
+async function makeApp() {
+  dir = mkdtempSync(join(tmpdir(), 'sua-not-found-'));
+  const dbPath = join(dir, 'runs.db');
+  const agentsDir = join(dir, 'agents', 'local');
+  mkdirSync(agentsDir, { recursive: true });
+
+  const secretsStore = new MemorySecretsStore();
+  runStore = new RunStore(dbPath);
+  agentStore = new AgentStore(dbPath);
+  const packsStore = new PacksStore(dbPath);
+  const dashboardsStore = new DashboardsStore(dbPath);
+  provider = new LocalProvider(dbPath, secretsStore);
+  await provider.initialize();
+
+  const ctx: DashboardContext = {
+    token: TOKEN,
+    allowlist: buildLoopbackAllowlist(PORT),
+    port: PORT,
+    provider,
+    runStore,
+    agentStore,
+    loadAgents: () => loadAgents({ directories: [agentsDir] }),
+    secretsStore,
+    secretsSession: new MemorySecretsSession({ backing: secretsStore }),
+    tokenPath: join(dir, 'mcp-token'),
+    retentionDays: 30,
+    dbPath,
+    secretsPath: join(dir, 'secrets.enc'),
+    rotateToken: () => 'r'.repeat(64),
+    packsStore,
+    dashboardsStore,
+    allowUntrustedShell: new Set(),
+    activeRuns: new Map(),
+    dataDir: dir,
+    dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
+  };
+
+  return buildDashboardApp(ctx);
+}
+
+afterEach(async () => {
+  if (provider) {
+    const start = Date.now();
+    while ((provider as unknown as { running?: { size: number } }).running?.size && Date.now() - start < 2000) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    await provider.shutdown();
+  }
+  try { runStore?.close(); } catch { /* ignore */ }
+  try { agentStore?.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('renderNotFoundPage', () => {
+  it('renders the 404 chrome with suggestions', () => {
+    const html = renderNotFoundPage({ path: '/no/such/path' });
+    expect(html).toContain('404');
+    expect(html).toContain('/no/such/path');
+    expect(html).toContain('href="/agents"');
+    expect(html).toContain('href="/pulse"');
+    expect(html).toContain('href="/packs"');
+    expect(html).toContain('topbar'); // wrapped in standard layout
+  });
+
+  it('uses the default message when none is provided', () => {
+    const html = renderNotFoundPage();
+    expect(html).toContain('doesn');
+  });
+
+  it('uses a custom message when provided', () => {
+    const html = renderNotFoundPage({ message: 'No dashboard with id "foo".' });
+    // HTML-escaped on render.
+    expect(html).toContain('No dashboard with id &quot;foo&quot;');
+  });
+});
+
+describe('catch-all 404 route', () => {
+  it('returns the styled 404 page for an unknown URL', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/this/route/does/not/exist')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE);
+    expect(res.status).toBe(404);
+    expect(res.text).toContain('404');
+    expect(res.text).toContain('/this/route/does/not/exist');
+    expect(res.text).toContain('href="/agents"');
+  });
+
+  it('GET /dashboards/:id with unknown id renders the 404 page (not raw HTML)', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/dashboards/nope')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE);
+    expect(res.status).toBe(404);
+    expect(res.text).toContain('No dashboard with id &quot;nope&quot;');
+    expect(res.text).toContain('topbar'); // styled, not bare <p>
+  });
+});

--- a/packages/dashboard/src/views/not-found.ts
+++ b/packages/dashboard/src/views/not-found.ts
@@ -1,0 +1,51 @@
+/**
+ * Styled 404 page. Replaces the bare `<p>Not found</p>` responses that
+ * had accumulated across routes. Wraps the standard layout (with topbar,
+ * theme toggle, etc.) so a missed URL still feels like part of the
+ * dashboard rather than a raw HTML scrap.
+ */
+
+import { html, render } from './html.js';
+import { layout } from './layout.js';
+
+export interface RenderNotFoundInput {
+  /** The path the user tried to reach (HTML-escaped before render). */
+  path?: string;
+  /**
+   * Short context string shown above the suggestions. Lets specific
+   * routes tailor the message ("No dashboard with id…", "Agent not
+   * found", etc.) while still using the same chrome.
+   */
+  message?: string;
+}
+
+const SUGGESTIONS: Array<{ href: string; label: string; hint: string }> = [
+  { href: '/agents', label: 'Agents', hint: 'Browse and run agents' },
+  { href: '/pulse', label: 'Pulse', hint: 'Live signal tiles' },
+  { href: '/packs', label: 'Packs', hint: 'Install curated dashboards' },
+  { href: '/runs', label: 'Runs', hint: 'Recent executions' },
+];
+
+export function renderNotFoundPage(input: RenderNotFoundInput = {}): string {
+  const path = input.path ?? '';
+  const message = input.message ?? 'The page you tried to reach doesn’t exist.';
+
+  const body = html`
+    <div style="max-width: 560px; margin: var(--space-6) auto; padding: var(--space-4);">
+      <div style="font-size: 4rem; font-weight: var(--weight-bold); line-height: 1; margin-bottom: var(--space-3); color: var(--color-text-muted);">404</div>
+      <h1 style="margin: 0 0 var(--space-3) 0; font-size: var(--font-size-lg);">${message}</h1>
+      ${path ? html`<p class="dim" style="margin: 0 0 var(--space-4) 0; font-family: var(--font-mono); font-size: var(--font-size-sm); word-break: break-all;">${path}</p>` : html``}
+
+      <div style="display: flex; flex-direction: column; gap: var(--space-2); margin-top: var(--space-5);">
+        ${SUGGESTIONS.map((s) => html`
+          <a href="${s.href}" class="card" style="display: flex; align-items: baseline; gap: var(--space-3); padding: var(--space-3); text-decoration: none; color: inherit;">
+            <span style="font-weight: var(--weight-semibold);">${s.label}</span>
+            <span class="dim" style="font-size: var(--font-size-sm);">${s.hint}</span>
+          </a>
+        `) as unknown as import('./html.js').SafeHtml[]}
+      </div>
+    </div>
+  `;
+
+  return render(layout({ title: 'Not found' }, body));
+}


### PR DESCRIPTION
## Summary

Replaces the bare \`<p>Not found</p>\` responses with a styled page that wraps the standard layout (topbar, theme toggle, suggestion cards). Used by the catch-all 404 and by the unknown-id paths in the dashboards routes added during the widget-packs series.

\`renderNotFoundPage({path, message})\` — both args optional. Path is HTML-escaped and shown in mono. Message slot lets routes tailor context (\`"No dashboard with id …"\`) without losing the chrome.

## Test plan
- [x] 5 new tests (3 for the view, 2 for the catch-all + dashboards-route 404s)
- [x] \`npm test\` — 1043/1043
- [x] \`npm run build\` clean
- [x] Live smoke: \`/this/does/not/exist\` → 404 + suggestions; \`/dashboards/nope\` → 404 with "No dashboard with id…" message

## Out of scope
The dozens of other \`res.status(404).redirect(303, '/agents')\` calls scattered across routes — those are silent recovery flows for internal navigation (delete an agent, click its bookmark) and are appropriate as redirects, not pages. Only routes that already chose to surface a user-visible 404 got upgraded here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)