### PR TITLE
feat(dashboard,cli,docs): onboarding + packs discovery

### DIFF
--- a/.changeset/onboarding-and-packs-discovery.md
+++ b/.changeset/onboarding-and-packs-discovery.md
@@ -1,0 +1,26 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Onboarding + discovery for widget packs and Build-from-goal.
+
+- **Home page** (`/`) gains a "Build from goal" CTA + "Browse packs"
+  link in the header. The wizard modal markup is now a shared partial
+  (`build-from-goal-modal.ts`) used by both the home page and
+  `/agents`. New users start their session with the wizard one click
+  away instead of having to navigate into Agents first.
+- **Dashboard tutorial** gains an 8th step ("Install a widget pack")
+  that points users at `/packs`, marks itself done when any pack has
+  `installed_at` set, and explains the dashboards switcher dropdown.
+- **CLI tutorial outro** now closes with a "Want a richer experience?"
+  block: `sua dashboard start` plus the three surfaces worth visiting
+  first (Packs, Pulse, Build from goal).
+- **README** "What you get" gains Widget packs + Dashboards bullets;
+  the Output widgets bullet now mentions the `{{#if}}` / `{{#unless}}`
+  / `{{#each}}` grammar and inline widget controls; the Dashboard
+  section documents `/packs`, `/dashboards/:id`, the editor, and the
+  Pulse "Hide all" / "Show all" bulk-toggle.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ MIT-licensed. Published to [npm](https://www.npmjs.com/search?q=%40some-useful-a
 - **Multi-provider LLM support** — claude-code nodes can use Claude or Codex via the `provider` field. Stream-json progress tracking shows real-time turn status during execution.
 - **10 built-in tools** — `shell-exec`, `claude-code`, `http-get`, `http-post`, `file-read`, `file-write`, `json-parse`, `json-path`, `template`, `csv-to-chart-json`. Plus MCP-imported tools and user-authored tools. Full catalog: [docs/tools.md](docs/tools.md).
 - **MCP servers as first-class** — paste a Claude Desktop / Cursor `mcpServers` config, sua discovers the tools, you pick which to import, and runs can call them like any other tool. Enable/disable/delete whole servers from `/settings/mcp-servers`. Full guide: [docs/mcp.md](docs/mcp.md).
-- **Output widgets** — render run output as structured UI. Four built-in widget types (raw, key-value, diff-apply, dashboard) plus `ai-template`: describe the layout in plain English, Claude generates a sanitized HTML template. Full reference: [docs/output-widgets.md](docs/output-widgets.md).
-- **Dashboard** — web UI for managing agents, tools, runs, secrets, variables, MCP servers, and Pulse tiles. Visual DAG editor, click-to-replay, YAML editor, template palette autocomplete, per-node action dialogs, live preview for output widgets. Full tour: [docs/dashboard.md](docs/dashboard.md).
+- **Output widgets** — render run output as structured UI. Four built-in widget types (raw, key-value, diff-apply, dashboard) plus `ai-template` with an HTML grammar that supports `{{outputs.X}}`, `{{#each}}`, `{{#if}}` / `{{#unless}}` truthy conditionals, and sandboxed `<iframe>` from a small host allowlist (YouTube + Vimeo). Inline widget controls (`replay`, `field-toggle`, `view-switch`) drive interactivity from URL params with no client JS. Full reference: [docs/output-widgets.md](docs/output-widgets.md).
+- **Widget packs** — bundles of curated agents and dashboards that install as a unit. The bundled `Starter` pack ships three demo agents organised into Media + Weather dashboards. Browse + install at `/packs`; pack uninstall removes the dashboards but keeps the agents (reference-only ownership).
+- **Dashboards** — named, ordered, sectioned views over installed agents. Pack-owned (e.g. `starter:media`) or user-created. Inline editor at `/dashboards/:id/edit` — add/remove/reorder sections and tiles, all server-rendered. The default dashboard at `/pulse` is auto-derived from per-agent `pulseVisible` flags.
+- **Dashboard** — web UI for managing agents, tools, runs, secrets, variables, MCP servers, packs, and Pulse tiles. Visual DAG editor, click-to-replay, YAML editor, template palette autocomplete, per-node action dialogs, live preview for output widgets. Full tour: [docs/dashboard.md](docs/dashboard.md).
 - **AI suggest improvements** — one-click agent analysis via the built-in `agent-analyzer`. Reviews your agent's YAML, classifies changes, shows a colored diff, and auto-validates + fixes the suggested YAML before presenting it.
 - **Global variables** — plain-text, non-sensitive values available to every agent. CRUD via `/settings/variables` or `sua vars` CLI. Referenced as `$NAME` in shell, `{{vars.NAME}}` in prompts.
 - **MCP server (outbound)** — expose your agents to Claude Desktop and other MCP clients over HTTP/SSE.
@@ -128,8 +130,10 @@ Start with `sua dashboard start`. Dark mode by default, JetBrains Mono, warm sto
 
 ![Agent config](docs/images/agent-config.png)
 
-- **Pulse** — information radiator at `/pulse`. Signal tiles show agent output as live widgets. 10 display templates including `widget` (mirrors the agent's own outputWidget schema). Drag-and-drop reorder, widget palette with auto-theming, system metric tiles, markdown rendering, YouTube media player, tile collapse/expand.
-- **Build from goal** — describe what you want in plain language, the builder designs a complete agent YAML with nodes, tools, inputs, and a Pulse signal block.
+- **Pulse** — information radiator at `/pulse`, the default dashboard. Signal tiles show agent output as live widgets. 10 display templates including `widget` (mirrors the agent's own outputWidget schema). Drag-and-drop reorder, widget palette with auto-theming, system metric tiles, markdown rendering, YouTube media player, tile collapse/expand. A switcher dropdown at the top of the page lets you flip between Default and any installed pack/user dashboard. "Hide all" / "Show all" buttons bulk-toggle every signal — useful before installing a pack.
+- **Packs** — `/packs` lists all registered packs (bundled + user-created), shows install state, and routes Install/Uninstall through one click. Built-in packs ship in `packages/core/packs/*.yaml` and auto-register on daemon start.
+- **Dashboards** — render at `/dashboards/:id`, edit at `/dashboards/:id/edit`. Pack-owned dashboards are editable (rename, reorder, add/remove tiles) but not deletable; uninstall the pack instead. User-created dashboards are deletable. Create a new one from the dropdown's "+ New dashboard name" input.
+- **Build from goal** — Build button on the home page (`/`) and `/agents`. Describe what you want in plain language, the builder designs a complete agent YAML with nodes, tools, inputs, and a Pulse signal block. Review the generated YAML before saving.
 - **Agents** — card grid with **User / Examples / Community tabs**, per-tab counts, filtering (status, search), sorting, pagination. 5-tab detail page: Overview (DAG viz, stats), Nodes (edit/delete/add), Config (variables, output widget, signal, secrets), Runs (history), YAML (editor).
 - **Output widget editor** — at `/agents/:id/config`, pick from visual cards (raw / key-value / diff-apply / dashboard / ai-template), load one of 5 starter examples in one click, watch a live preview rerender as you edit. Full reference: [docs/output-widgets.md](docs/output-widgets.md).
 - **Tools** — browse **User / Built-in tabs** with per-tab counts, filtering, pagination. Paste a Claude-Desktop-style config at `/tools/mcp/import` to import MCP servers wholesale.
@@ -137,7 +141,7 @@ Start with `sua dashboard start`. Dark mode by default, JetBrains Mono, warm sto
 - **Suggest improvements** — AI-powered agent review with "Apply now" one-click save. Auto-fixes shell template mistakes. Available from failed run pages with the error pre-filled.
 - **Runs** — filter by agent/status, paginate, replay from any node, resolved variables panel, real-time turn progress for LLM nodes.
 - **Settings** — secrets CRUD with passphrase unlock, global variables, MCP servers, MCP token rotation.
-- **Tutorial** — 7-step guided walkthrough that scaffolds agents from the dashboard.
+- **Tutorial** — 8-step guided walkthrough that scaffolds agents and culminates in installing the bundled Starter pack.
 
 ## Flow control
 

--- a/packages/cli/src/commands/tutorial.ts
+++ b/packages/cli/src/commands/tutorial.ts
@@ -315,6 +315,13 @@ function printOutro(): void {
   ui.step('sua schedule start', 'start the scheduler');
   ui.step('sua agent new', 'scaffold your own agent');
   console.log('');
+  ui.section('Want a richer experience? Open the dashboard');
+  ui.step('sua dashboard start', 'launches the web UI on http://127.0.0.1:3000');
+  console.log('  Once it\'s up:');
+  console.log('   • visit ' + chalk.cyan('/packs') + ' to install the bundled Starter pack (3 demo agents + 2 dashboards)');
+  console.log('   • visit ' + chalk.cyan('/pulse') + ' to see live signal tiles for everything you\'ve scheduled');
+  console.log('   • use the ' + chalk.cyan('Build from goal') + ' button on / or /agents to design a new agent in plain English');
+  console.log('');
 }
 
 function indent(text: string, prefix: string): string {

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -458,7 +458,7 @@ describe('Dashboard help + tutorial', () => {
     expect(res.text).toMatch(/You have a project[\s\S]*?badge--ok[\s\S]*?done/);
     // Step 2: "Run your first agent" — not done yet, should show to-do badge
     // The progress card should reflect: 1 of 5 complete
-    expect(res.text).toContain('of 7 steps complete');
+    expect(res.text).toContain('of 8 steps complete');
   });
 
   it('GET /help/tutorial references the first agent by id for the Run CTA', async () => {

--- a/packages/dashboard/src/routes/help.ts
+++ b/packages/dashboard/src/routes/help.ts
@@ -200,6 +200,7 @@ function collectTutorialState(req: Request): TutorialState & { flash?: string } 
   const hasParameterisedGreet = !!ctx.agentStore.getAgent('parameterised-greet');
   const hasConditionalRouter = !!ctx.agentStore.getAgent('conditional-router');
   const hasResearchDigest = !!ctx.agentStore.getAgent('research-digest');
+  const hasInstalledPack = !!ctx.packsStore?.listInstalled().length;
 
   // Pick the friendliest starting agent: prefer single-node v2, then any v2, then v1.
   const firstAgentId = v2Agents.find((a) => a.nodes.length === 1)?.id
@@ -220,6 +221,7 @@ function collectTutorialState(req: Request): TutorialState & { flash?: string } 
     hasParameterisedGreet,
     hasConditionalRouter,
     hasResearchDigest,
+    hasInstalledPack,
     flash,
   };
 }

--- a/packages/dashboard/src/views/agents-list.ts
+++ b/packages/dashboard/src/views/agents-list.ts
@@ -3,6 +3,7 @@ import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
 import { typeBadge, sourceBadge, formatAge, cronToHuman } from './components.js';
+import { buildFromGoalButton, buildFromGoalModal } from './build-from-goal-modal.js';
 
 export interface HomeStats {
   agents: number;
@@ -62,7 +63,7 @@ export function renderAgentsList(input: AgentsListInput): string {
       cta: html`
         <span style="display: inline-flex; gap: var(--space-2);">
           <a class="btn btn--ghost btn--sm" href="/help/tutorial">Tutorial</a>
-          <button type="button" class="btn btn--sm" id="build-from-goal-btn">Build from goal</button>
+          ${buildFromGoalButton()}
           <a class="btn btn--primary btn--sm" href="/agents/new">New agent</a>
         </span>
       `,
@@ -93,30 +94,7 @@ export function renderAgentsList(input: AgentsListInput): string {
       </footer>
     `}
 
-    <div id="build-modal" class="modal-backdrop">
-      <div class="modal" style="max-width: 600px; max-height: 85vh; overflow-y: auto;">
-        <div id="build-modal-content">
-          <h3 style="margin: 0 0 var(--space-3);">Build from goal</h3>
-          <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-3);">
-            Describe what you want your agent to do. Claude will design a complete agent with the right nodes, tools, and wiring.
-          </p>
-          <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-3);">
-            <strong style="font-size: var(--font-size-sm);">Goal</strong>
-            <textarea id="build-goal" rows="3" placeholder="e.g. Scrape job listings from ashbyhq, extract key details, and save to a local JSON file"
-              style="padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm); resize: vertical;"></textarea>
-          </label>
-          <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-4);">
-            <strong style="font-size: var(--font-size-sm);">Constraints <span class="dim" style="font-weight: var(--weight-regular);">(optional)</span></strong>
-            <input id="build-focus" type="text" placeholder="e.g. use shell nodes only, schedule daily at 9am"
-              style="padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm);">
-          </label>
-          <div style="display: flex; gap: var(--space-2); justify-content: flex-end;">
-            <button type="button" class="btn btn--ghost btn--sm" data-close-build="1">Cancel</button>
-            <button type="button" class="btn btn--primary btn--sm" id="build-submit-btn">Build agent</button>
-          </div>
-        </div>
-      </div>
-    </div>
+    ${buildFromGoalModal()}
   `;
 
   return render(layout({ title: 'Agents', activeNav: 'agents', flash: input.flash }, body));

--- a/packages/dashboard/src/views/build-from-goal-modal.ts
+++ b/packages/dashboard/src/views/build-from-goal-modal.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared markup for the "Build from goal" wizard modal.
+ *
+ * The wizard JS is in build-from-goal.js.ts and is wired in via
+ * layout.ts (so it's globally available). It binds to:
+ *   - #build-from-goal-btn — opens the modal
+ *   - #build-modal         — the modal backdrop
+ *   - #build-modal-content — replaceable inner panel for stage swaps
+ *
+ * Pages that want the wizard render `buildFromGoalButton()` somewhere
+ * in their CTA strip and `buildFromGoalModal()` once at the bottom of
+ * the page body. Both the home page and the agents list page use this.
+ */
+
+import { html, type SafeHtml } from './html.js';
+
+export function buildFromGoalButton(opts: { variant?: 'primary' | 'ghost' } = {}): SafeHtml {
+  const cls = opts.variant === 'primary' ? 'btn btn--primary btn--sm' : 'btn btn--sm';
+  return html`<button type="button" class="${cls}" id="build-from-goal-btn">Build from goal</button>`;
+}
+
+export function buildFromGoalModal(): SafeHtml {
+  return html`
+    <div id="build-modal" class="modal-backdrop">
+      <div class="modal" style="max-width: 600px; max-height: 85vh; overflow-y: auto;">
+        <div id="build-modal-content">
+          <h3 style="margin: 0 0 var(--space-3);">Build from goal</h3>
+          <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-3);">
+            Describe what you want your agent to do. Claude will design a complete agent with the right nodes, tools, and wiring.
+          </p>
+          <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-3);">
+            <strong style="font-size: var(--font-size-sm);">Goal</strong>
+            <textarea id="build-goal" rows="3" placeholder="e.g. Scrape job listings from ashbyhq, extract key details, and save to a local JSON file"
+              style="padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm); resize: vertical;"></textarea>
+          </label>
+          <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-4);">
+            <strong style="font-size: var(--font-size-sm);">Constraints <span class="dim" style="font-weight: var(--weight-regular);">(optional)</span></strong>
+            <input id="build-focus" type="text" placeholder="e.g. use shell nodes only, schedule daily at 9am"
+              style="padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm);">
+          </label>
+          <div style="display: flex; gap: var(--space-2); justify-content: flex-end;">
+            <button type="button" class="btn btn--ghost btn--sm" data-close-build="1">Cancel</button>
+            <button type="button" class="btn btn--primary btn--sm" id="build-submit-btn">Build agent</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+}

--- a/packages/dashboard/src/views/home.ts
+++ b/packages/dashboard/src/views/home.ts
@@ -9,6 +9,7 @@ import { html, render, unsafeHtml, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { buildHomeWidgets, renderHomeWidget } from './home-widgets.js';
 import type { HomeWidgetData } from './home-widgets.js';
+import { buildFromGoalButton, buildFromGoalModal } from './build-from-goal-modal.js';
 
 export { type HomeWidgetData as HomePageInput } from './home-widgets.js';
 
@@ -25,6 +26,8 @@ export function renderHomePage(input: HomeWidgetData): string {
         ${String(input.agents.length)} agents registered
       </span>
       <div style="margin-left: auto; display: flex; gap: var(--space-2);">
+        ${buildFromGoalButton({ variant: 'primary' })}
+        <a class="btn btn--ghost btn--sm" href="/packs">Browse packs</a>
         <button type="button" class="btn btn--ghost btn--sm" id="home-edit-toggle">\u270E Edit layout</button>
         <button type="button" class="btn btn--ghost btn--sm" id="home-add-container" style="display: none;">+ Add group</button>
       </div>
@@ -39,6 +42,8 @@ export function renderHomePage(input: HomeWidgetData): string {
     </div>
 
     ${unsafeHtml(`<script type="application/json" id="home-widget-data">${JSON.stringify({ allTileIds, systemTileIds })}</script>`)}
+
+    ${buildFromGoalModal()}
   `;
 
   return render(layout({ title: 'Dashboard', activeNav: 'agents' }, body));

--- a/packages/dashboard/src/views/tutorial.ts
+++ b/packages/dashboard/src/views/tutorial.ts
@@ -33,6 +33,8 @@ export interface TutorialState {
   hasConditionalRouter: boolean;
   /** Whether the research-digest example is in the DB. */
   hasResearchDigest: boolean;
+  /** Whether at least one widget pack is installed. */
+  hasInstalledPack: boolean;
   /** Optional flash message from a scaffold action (success or error). */
   flash?: string;
 }
@@ -99,6 +101,7 @@ function buildSteps(s: TutorialState): Step[] {
     step5ConfigurableInputs(s),
     step6FlowControl(s),
     step7WireUpSecret(s),
+    step8InstallAPack(s),
   ];
 }
 
@@ -348,6 +351,41 @@ function scaffoldPreview(p: ScaffoldPreviewArgs): SafeHtml {
       </ol>
     </div>
   `;
+}
+
+// ─── Step 8 ──────────────────────────────────────────────────────────
+// "Install a pack" — packs bundle agents and curated dashboards. Done
+// when any pack has installed_at set. Points users at /packs and at
+// /pulse + the dashboards dropdown so they discover the broader
+// dashboards architecture from a concrete starting point.
+function step8InstallAPack(s: TutorialState): Step {
+  const summary = s.hasInstalledPack
+    ? html`
+        You've installed at least one pack — its dashboards are now in the
+        switcher dropdown above the <a href="/pulse">Pulse</a> header. You can
+        also create your own dashboards (open the dropdown →
+        "New dashboard name" → Create) or browse more at <a href="/packs">/packs</a>.
+      `
+    : html`
+        Packs bundle agents and curated dashboards as installable units —
+        like extensions for the dashboard. The bundled
+        <code>Starter</code> pack contains the three ai-template demo agents
+        organised into Media + Weather dashboards. Install it from
+        <a href="/packs">/packs</a> to see the dashboards dropdown light up
+        on Pulse.
+      `;
+
+  const action = s.hasInstalledPack
+    ? html`<a class="btn btn--ghost btn--sm" href="/packs">Browse packs</a>`
+    : html`<a class="btn btn--primary btn--sm" href="/packs">Open /packs</a>`;
+
+  return {
+    n: 8,
+    title: 'Install a widget pack',
+    done: s.hasInstalledPack,
+    summary,
+    action,
+  };
 }
 
 // ─── Renderer ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Three coordinated edits to surface the widget-packs work and the Build-from-goal wizard to new users.

### Home page CTA
"Build from goal" used to live only on \`/agents\`. Promoted to \`/\` alongside a "Browse packs" link. Modal markup extracted to a shared partial so both pages stay in sync.

### Dashboard tutorial step 8
New "Install a widget pack" step that points users at \`/packs\`, marks itself done when any pack has \`installed_at\` set, and explains the dashboards switcher dropdown on Pulse. Threads a \`hasInstalledPack\` flag through \`TutorialState\`.

### CLI tutorial outro
Adds a final block about \`sua dashboard start\` + the three surfaces worth visiting first (Packs, Pulse, Build from goal).

### README
- "What you get" gains **Widget packs** + **Dashboards** bullets.
- Output widgets bullet now mentions the \`{{#if}}\` / \`{{#unless}}\` / \`{{#each}}\` grammar, iframe allowlist, and inline widget controls.
- Dashboard section documents \`/packs\`, \`/dashboards/:id\`, the editor, and the Pulse bulk-toggle.

## Test plan
- [x] \`npm test\` — 1043/1043 (updated one assertion: tutorial step count 7 → 8)
- [x] \`npm run build\` clean
- [x] Live smoke: home page renders Build + Browse packs; tutorial shows step 8 + "of 8 steps complete"
- [ ] Reviewer: open \`/\` and click Build to confirm modal still works; open \`/help/tutorial\` to read step 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)