### PR TITLE
feat(build-from-goal): plan agents, dashboards, or both with survey + review (v2)

### DIFF
--- a/.changeset/build-from-goal-v2.md
+++ b/.changeset/build-from-goal-v2.md
@@ -1,0 +1,48 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Build from goal v2 — agents, dashboards, or both, with a survey-and-plan
+review screen.
+
+The wizard previously only built single agents. It now auto-classifies
+intent across four flavors: `agent`, `dashboard-existing`,
+`dashboard-new`, `dashboard-mixed`. The user's goal hits the new
+`build-planner` agent, which surveys what's already installed
+(matched agents, missing fragments, overlapping dashboards) and emits
+a structured `BuildPlan` JSON with:
+- the proposed dashboard (when applicable)
+- new agents to create (each with full YAML — editable in the review)
+- clarifying questions for ambiguous parts of the goal
+
+The review screen surfaces all four blocks; the user edits YAMLs
+inline, then commits via `POST /agents/build/commit` which walks the
+plan creating agents + the dashboard atomically (with partial-success
+reporting). Redirect lands on the new dashboard for dashboard intents,
+or the new agent's page for agent intents.
+
+**New plumbing:**
+
+- `packages/core/src/build-plan-schema.ts` — Zod schema for `BuildPlan`
+  with cross-field validation (intent="agent" can't have a dashboard;
+  dashboard agentIds must reference matched or new agents; etc.) plus
+  `extractPlanJson()` for unwrapping `<plan>…</plan>` / fenced JSON.
+- `packages/core/src/discovery-catalog.ts` — accepts optional
+  `dashboards` + `packs` args and renders them as new catalog sections
+  so the planner LLM can see installed-state.
+- `agents/examples/build-planner.yaml` — the multi-flavor planner.
+  Single claude-code node, structured output to `<plan>…</plan>`.
+- `POST /agents/build/commit` (new) + `GET /agents/build/:runId`
+  (extended to return `BuildPlan` instead of raw YAML) +
+  `POST /agents/build` (now invokes the planner instead of agent-builder).
+- `POST /agents/build/create` kept as a thin compat shim.
+- Wizard JS + modal copy updated to surface the plan-review stage and
+  hint at the dashboard flavors.
+
+19 new unit + supertest cases; full suite 1066/1066 green. Live smoke
+on three goals (agent / dashboard-existing / dashboard-mixed)
+produces sensible plans.

--- a/agents/examples/build-planner.yaml
+++ b/agents/examples/build-planner.yaml
@@ -1,0 +1,159 @@
+# Build Planner — multi-flavor goal → plan agent.
+#
+# The Build-from-goal wizard sends a user's goal here. The planner
+# reads the discovery catalog (existing agents, dashboards, packs,
+# node types, signal templates) and returns a structured BuildPlan
+# JSON with:
+#   - intent classification (agent / dashboard-existing / dashboard-new / dashboard-mixed)
+#   - survey of what's already installed that matches the goal
+#   - new agents to create (each with full YAML)
+#   - dashboard layout (when applicable)
+#   - clarifying questions
+#
+# The wizard renders the plan, lets the user review/edit, then commits
+# via POST /agents/build/commit which creates the agents and dashboard.
+
+id: build-planner
+name: Build Planner
+description: >
+  Multi-flavor agent + dashboard planner. Reads a goal + the live
+  catalog of installed agents/dashboards/packs and emits a structured
+  BuildPlan JSON. Replaces direct invocation of agent-builder when the
+  goal might involve a dashboard. Run via "Build from goal" on the
+  home page or /agents.
+status: active
+source: examples
+
+inputs:
+  GOAL:
+    type: string
+    required: true
+    description: Natural language description of what the user wants built.
+  FOCUS:
+    type: string
+    required: false
+    default: ""
+    description: Optional constraints or preferences (e.g. "schedule daily", "shell only").
+  AVAILABLE_TOOLS:
+    type: string
+    required: false
+    default: ""
+    description: Dynamically injected tool catalog. Populated at build time.
+  DISCOVERY_CATALOG:
+    type: string
+    required: false
+    default: ""
+    description: >
+      Node types, signal templates, output widgets, INSTALLED AGENTS,
+      INSTALLED DASHBOARDS, INSTALLED + AVAILABLE PACKS, and architecture
+      patterns. Injected at build time.
+
+nodes:
+  - id: plan
+    type: claude-code
+    prompt: |
+      You are the multi-flavor build planner for the sua agent platform.
+
+      Read the user's goal + the live catalog of what's already installed,
+      then emit a structured BuildPlan JSON describing what to do.
+
+      ════════════════════════════════════════════════════════════════
+      USER'S GOAL:
+      {{inputs.GOAL}}
+
+      OPTIONAL FOCUS / CONSTRAINTS:
+      {{inputs.FOCUS}}
+
+      AVAILABLE TOOLS:
+      {{inputs.AVAILABLE_TOOLS}}
+
+      DISCOVERY CATALOG:
+      {{inputs.DISCOVERY_CATALOG}}
+      ════════════════════════════════════════════════════════════════
+
+      STEP 1 — CLASSIFY INTENT.
+      One of:
+        - "agent"               : the goal is one agent, no dashboard.
+        - "dashboard-existing"  : the goal is a dashboard composed entirely of agents that already exist.
+        - "dashboard-new"       : the goal is a dashboard composed entirely of new agents you must create.
+        - "dashboard-mixed"     : the goal is a dashboard mixing some existing agents with some new ones.
+
+      STEP 2 — SURVEY THE GOAL FRAGMENTS.
+      Decompose the goal into logical fragments (e.g. "HN top stories", "today's weather", "my notes list").
+      For each fragment, look in INSTALLED AGENTS for a fuzzy id+description match.
+      - Match found → add to `survey.matchedAgents` with the fragment text in `matchedFor`.
+      - No match → add the fragment text to `survey.missingFor`.
+      Also scan INSTALLED DASHBOARDS — if any look like overlap, mention them in `survey.existingDashboards`.
+
+      STEP 3 — DRAFT NEW AGENTS for everything in survey.missingFor.
+      Each new agent is { id, purpose, yaml }. The YAML must be a complete, parseable sua agent
+      (same rules as agent-builder.yaml — signal block, output widget, source: local, snake_case
+      outputs, UPPERCASE inputs, no double-brace templates in shell nodes, etc.).
+      Crucial constraints:
+      - id MUST be lowercase-with-hyphens AND must NOT collide with any id already in INSTALLED AGENTS.
+      - Add `schedule:` to NEW agents if the goal asks for "daily" / "every morning" / etc.
+      - DO NOT propose modifying any existing agent. (The user does that via /agents/<id>/yaml.)
+      - Each new agent's YAML should include both signal: and outputWidget: blocks so dashboard
+        tiles render correctly.
+
+      STEP 4 — DESIGN THE DASHBOARD (when intent ≠ "agent").
+      Dashboard id MUST start with `user:` followed by lowercase-with-hyphens (e.g. `user:morning-briefing`).
+      Pick a `name` (Title Case, human-readable). Group tiles into 1-3 sections by topic.
+      Every agentId in dashboard.sections MUST appear in either survey.matchedAgents (existing)
+      or newAgents (proposed) — never an id you didn't include in one of those two lists.
+
+      STEP 5 — CLARIFYING QUESTIONS.
+      For anything ambiguous (file paths, frequency, region, units, source URL), add a question
+      to `questions[]`. Provide `suggestedAnswer` when reasonable. The user re-runs the wizard
+      with answers appended to the goal — no multi-turn chat in v1.
+
+      STEP 6 — RECOMMEND PACK INSTALL (optional).
+      If a pack in INSTALLED + AVAILABLE PACKS labelled "available" already covers the goal,
+      surface it as a question (suggestedAnswer: "yes") rather than proposing redundant agents.
+
+      OUTPUT FORMAT — wrap the plan in <plan>…</plan> tags. The body MUST be valid JSON
+      matching this exact shape (extra fields will be rejected by the schema validator):
+
+      <plan>
+      {
+        "intent": "agent" | "dashboard-existing" | "dashboard-new" | "dashboard-mixed",
+        "summary": "one-line human description of what you're going to do",
+        "survey": {
+          "matchedAgents": [{ "id": "weather-forecast", "matchedFor": "today's weather" }],
+          "missingFor": ["my notes list"],
+          "existingDashboards": []
+        },
+        "newAgents": [
+          {
+            "id": "notes-list-daily",
+            "purpose": "Reads markdown files from a notes folder and returns the latest 10 titles.",
+            "yaml": "id: notes-list-daily\nname: ...\n... (full YAML)"
+          }
+        ],
+        "dashboard": {
+          "id": "user:morning-briefing",
+          "name": "Morning Briefing",
+          "sections": [
+            { "title": "News", "agentIds": ["hn-top-stories"] },
+            { "title": "Weather", "agentIds": ["weather-forecast"] },
+            { "title": "Notes", "agentIds": ["notes-list-daily"] }
+          ]
+        },
+        "questions": [
+          { "text": "Which folder should the notes agent read from?", "suggestedAnswer": "~/Documents/Notes" }
+        ]
+      }
+      </plan>
+
+      RULES THE VALIDATOR ENFORCES (failing these means the plan gets rejected and the user
+      sees an error):
+      - intent="agent" must have exactly one newAgents entry AND dashboard=null.
+      - intent="dashboard-existing" must have newAgents=[] AND a non-null dashboard.
+      - intent="dashboard-new" / "dashboard-mixed" must have a non-null dashboard.
+      - Every dashboard.sections[].agentIds[] must appear in survey.matchedAgents or newAgents.
+      - dashboard.id must start with "user:".
+      - newAgents[].id and matchedAgents[].id must be lowercase-with-hyphens.
+
+      Output ONLY the <plan>…</plan> block. No explanation before or after.
+    maxTurns: 3
+    timeout: 180

--- a/packages/core/src/build-plan-schema.test.ts
+++ b/packages/core/src/build-plan-schema.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { buildPlanSchema, extractPlanJson, type BuildPlanInput } from './build-plan-schema.js';
+
+function basePlan(overrides: Partial<BuildPlanInput> = {}): BuildPlanInput {
+  return {
+    intent: 'agent',
+    summary: 'A single XKCD-fetcher agent',
+    survey: { matchedAgents: [], missingFor: [], existingDashboards: [] },
+    newAgents: [{ id: 'xkcd', purpose: 'fetch latest', yaml: 'id: xkcd\nname: x\n' }],
+    dashboard: null,
+    questions: [],
+    ...overrides,
+  };
+}
+
+describe('buildPlanSchema', () => {
+  it('accepts a minimal agent-only plan', () => {
+    const plan = buildPlanSchema.parse(basePlan());
+    expect(plan.intent).toBe('agent');
+    expect(plan.newAgents).toHaveLength(1);
+    expect(plan.dashboard).toBeNull();
+  });
+
+  it('fills in defaults for omitted survey + arrays', () => {
+    const plan = buildPlanSchema.parse({
+      intent: 'agent',
+      summary: 'X',
+      newAgents: [{ id: 'x', purpose: 'p', yaml: 'id: x\n' }],
+    });
+    expect(plan.survey.matchedAgents).toEqual([]);
+    expect(plan.questions).toEqual([]);
+    expect(plan.dashboard).toBeNull();
+  });
+
+  it('rejects intent="agent" with a dashboard', () => {
+    expect(() => buildPlanSchema.parse(basePlan({
+      dashboard: { id: 'user:x', name: 'X', sections: [{ title: 'T', agentIds: ['xkcd'] }] },
+    }))).toThrow(/dashboard=null/);
+  });
+
+  it('rejects intent="agent" with multiple new agents', () => {
+    expect(() => buildPlanSchema.parse(basePlan({
+      newAgents: [
+        { id: 'a', purpose: 'p', yaml: 'id: a\n' },
+        { id: 'b', purpose: 'p', yaml: 'id: b\n' },
+      ],
+    }))).toThrow(/exactly one/);
+  });
+
+  it('rejects dashboard intents without a dashboard', () => {
+    expect(() => buildPlanSchema.parse(basePlan({
+      intent: 'dashboard-mixed',
+      newAgents: [{ id: 'a', purpose: 'p', yaml: 'id: a\n' }],
+      dashboard: null,
+    }))).toThrow(/requires a dashboard/);
+  });
+
+  it('rejects dashboard-existing with new agents', () => {
+    expect(() => buildPlanSchema.parse(basePlan({
+      intent: 'dashboard-existing',
+      newAgents: [{ id: 'a', purpose: 'p', yaml: 'id: a\n' }],
+      dashboard: { id: 'user:x', name: 'X', sections: [{ title: 'T', agentIds: ['weather-forecast'] }] },
+      survey: { matchedAgents: [{ id: 'weather-forecast', matchedFor: 'weather' }], missingFor: [], existingDashboards: [] },
+    }))).toThrow(/must not include new agents/);
+  });
+
+  it('rejects dashboards referencing unknown agent ids', () => {
+    expect(() => buildPlanSchema.parse(basePlan({
+      intent: 'dashboard-mixed',
+      newAgents: [{ id: 'notes', purpose: 'p', yaml: 'id: notes\n' }],
+      dashboard: { id: 'user:x', name: 'X', sections: [{ title: 'T', agentIds: ['ghost'] }] },
+    }))).toThrow(/hallucinated/);
+  });
+
+  it('accepts dashboard-mixed with existing + new agent ids', () => {
+    const plan = buildPlanSchema.parse(basePlan({
+      intent: 'dashboard-mixed',
+      newAgents: [{ id: 'notes-list', purpose: 'p', yaml: 'id: notes-list\n' }],
+      dashboard: {
+        id: 'user:morning',
+        name: 'Morning',
+        sections: [
+          { title: 'News', agentIds: ['hn-top-stories'] },
+          { title: 'Notes', agentIds: ['notes-list'] },
+        ],
+      },
+      survey: {
+        matchedAgents: [{ id: 'hn-top-stories', matchedFor: 'top stories on HN' }],
+        missingFor: ['notes list'],
+        existingDashboards: [],
+      },
+    }));
+    expect(plan.dashboard?.sections).toHaveLength(2);
+  });
+
+  it('rejects user dashboard ids without the user: prefix', () => {
+    expect(() => buildPlanSchema.parse(basePlan({
+      intent: 'dashboard-new',
+      newAgents: [{ id: 'a', purpose: 'p', yaml: 'id: a\n' }],
+      dashboard: { id: 'morning', name: 'M', sections: [{ title: 'T', agentIds: ['a'] }] },
+    }))).toThrow(/user:/);
+  });
+});
+
+describe('extractPlanJson', () => {
+  it('extracts from <plan>…</plan> wrapper', () => {
+    const out = extractPlanJson('Here is the plan:\n<plan>{"intent":"agent"}</plan>\nDone.');
+    expect(out).toBe('{"intent":"agent"}');
+  });
+
+  it('extracts from ```json fence', () => {
+    const out = extractPlanJson('```json\n{"intent":"agent"}\n```');
+    expect(out).toBe('{"intent":"agent"}');
+  });
+
+  it('extracts from bare ``` fence', () => {
+    const out = extractPlanJson('```\n{"intent":"agent"}\n```');
+    expect(out).toBe('{"intent":"agent"}');
+  });
+
+  it('returns the input as-is when it looks like bare JSON', () => {
+    const out = extractPlanJson('  {"intent":"agent"}  ');
+    expect(out).toBe('{"intent":"agent"}');
+  });
+
+  it('returns null when no plan block is found', () => {
+    expect(extractPlanJson('Sorry, I can\'t do that.')).toBeNull();
+  });
+});

--- a/packages/core/src/build-plan-schema.ts
+++ b/packages/core/src/build-plan-schema.ts
@@ -1,0 +1,141 @@
+/**
+ * Schema for the structured plan emitted by the build-planner agent.
+ *
+ * The build wizard sends a goal → planner returns a BuildPlan → wizard
+ * renders survey + proposal + questions → user confirms → commit endpoint
+ * walks the plan to create agents and the dashboard.
+ *
+ * Validation runs server-side after extracting the plan JSON from the
+ * planner's `<plan>…</plan>` wrapper. Loose enough to absorb LLM noise
+ * (optional fields default to []), strict enough to catch obvious
+ * structural lies (intent='agent' with a non-null dashboard, etc.).
+ */
+
+import { z } from 'zod';
+
+const AGENT_ID_RE = /^[a-z0-9][a-z0-9_-]*$/;
+const DASHBOARD_ID_RE = /^user:[a-z0-9][a-z0-9_-]*$/;
+
+export const buildPlanSchema = z.object({
+  intent: z.enum(['agent', 'dashboard-existing', 'dashboard-new', 'dashboard-mixed']),
+  summary: z.string().min(1, 'summary is required'),
+
+  survey: z.object({
+    matchedAgents: z.array(z.object({
+      id: z.string().regex(AGENT_ID_RE, 'matchedAgents.id must be lowercase_with_dashes'),
+      matchedFor: z.string().min(1),
+    })).default([]),
+    missingFor: z.array(z.string().min(1)).default([]),
+    existingDashboards: z.array(z.object({
+      id: z.string().min(1),
+      // The display name + reason are LLM-best-effort labels. Required
+      // would fail-the-plan needlessly; default to empty so the rest
+      // of the plan still validates and the user sees a usable card.
+      name: z.string().optional().default(''),
+      reason: z.string().optional().default(''),
+    })).default([]),
+  }).default({ matchedAgents: [], missingFor: [], existingDashboards: [] }),
+
+  newAgents: z.array(z.object({
+    id: z.string().regex(AGENT_ID_RE, 'newAgents.id must be lowercase_with_dashes'),
+    purpose: z.string().min(1),
+    yaml: z.string().min(1, 'newAgents.yaml is required'),
+  })).default([]),
+
+  dashboard: z.union([
+    z.null(),
+    z.object({
+      id: z.string().regex(DASHBOARD_ID_RE, 'dashboard.id must start with "user:"'),
+      name: z.string().min(1),
+      sections: z.array(z.object({
+        title: z.string().min(1),
+        agentIds: z.array(z.string().min(1)).min(1, 'each section needs at least one agent'),
+      })).min(1, 'dashboard needs at least one section'),
+    }),
+  ]).default(null),
+
+  questions: z.array(z.object({
+    text: z.string().min(1),
+    suggestedAnswer: z.string().optional(),
+  })).default([]),
+}).superRefine((plan, ctx) => {
+  // intent='agent' must have exactly one new agent and no dashboard.
+  if (plan.intent === 'agent') {
+    if (plan.dashboard !== null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['dashboard'],
+        message: 'intent="agent" must have dashboard=null',
+      });
+    }
+    if (plan.newAgents.length !== 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['newAgents'],
+        message: 'intent="agent" must have exactly one newAgents entry',
+      });
+    }
+  }
+
+  // dashboard-bearing intents must have a dashboard.
+  if (plan.intent !== 'agent' && plan.dashboard === null) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['dashboard'],
+      message: `intent="${plan.intent}" requires a dashboard`,
+    });
+  }
+
+  // intent='dashboard-existing' must not propose new agents.
+  if (plan.intent === 'dashboard-existing' && plan.newAgents.length > 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['newAgents'],
+      message: 'intent="dashboard-existing" must not include new agents',
+    });
+  }
+
+  // dashboard.sections.agentIds must reference EITHER a matched existing
+  // agent OR a newAgents entry. Catches "I made up an id" hallucinations.
+  if (plan.dashboard) {
+    const knownIds = new Set<string>([
+      ...plan.survey.matchedAgents.map((m) => m.id),
+      ...plan.newAgents.map((a) => a.id),
+    ]);
+    plan.dashboard.sections.forEach((s, sIdx) => {
+      s.agentIds.forEach((id, aIdx) => {
+        if (!knownIds.has(id)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['dashboard', 'sections', sIdx, 'agentIds', aIdx],
+            message: `agent id "${id}" is not in survey.matchedAgents or newAgents — planner hallucinated it`,
+          });
+        }
+      });
+    });
+  }
+});
+
+export type BuildPlanInput = z.input<typeof buildPlanSchema>;
+export type BuildPlan = z.output<typeof buildPlanSchema>;
+
+/**
+ * Extract a plan JSON string from a raw LLM response. Strips common
+ * wrappers: `<plan>…</plan>`, ```json fences, ``` fences. Returns the
+ * trimmed JSON text ready for `JSON.parse`. Returns null when no plan
+ * block can be located.
+ */
+export function extractPlanJson(raw: string): string | null {
+  const planTag = /<plan>([\s\S]*?)<\/plan>/i.exec(raw);
+  if (planTag) return planTag[1].trim();
+
+  // Code fence with json hint.
+  const fenced = /```(?:json)?\s*([\s\S]*?)```/i.exec(raw);
+  if (fenced) return fenced[1].trim();
+
+  // Bare JSON-looking blob.
+  const bare = raw.trim();
+  if (bare.startsWith('{') && bare.endsWith('}')) return bare;
+
+  return null;
+}

--- a/packages/core/src/discovery-catalog.test.ts
+++ b/packages/core/src/discovery-catalog.test.ts
@@ -191,4 +191,72 @@ describe('buildDiscoveryCatalog', () => {
 
     expect(catalog).toContain('No agents available yet.');
   });
+
+  it('omits dashboards + packs sections when those args are absent', () => {
+    const catalog = buildDiscoveryCatalog({
+      agents: MOCK_AGENTS,
+      tools: [],
+      templateRegistry: MOCK_REGISTRY,
+    });
+    expect(catalog).not.toContain('INSTALLED DASHBOARDS');
+    expect(catalog).not.toContain('INSTALLED + AVAILABLE PACKS');
+  });
+
+  it('renders dashboards section with section + agent details', () => {
+    const catalog = buildDiscoveryCatalog({
+      agents: MOCK_AGENTS,
+      tools: [],
+      templateRegistry: MOCK_REGISTRY,
+      dashboards: [{
+        id: 'starter:media',
+        packId: 'starter',
+        name: 'Media',
+        layout: { sections: [
+          { title: 'Video', agentIds: ['vimeo-staff-picks', 'cat-video-finder'] },
+        ]},
+        createdAt: 0,
+        updatedAt: 0,
+      }],
+    });
+    expect(catalog).toContain('INSTALLED DASHBOARDS');
+    expect(catalog).toContain('starter:media (pack:starter)');
+    expect(catalog).toContain('Video [vimeo-staff-picks, cat-video-finder]');
+  });
+
+  it('renders packs section with installed/available state', () => {
+    const catalog = buildDiscoveryCatalog({
+      agents: MOCK_AGENTS,
+      tools: [],
+      templateRegistry: MOCK_REGISTRY,
+      packs: [{
+        id: 'starter',
+        name: 'Starter',
+        description: 'demo',
+        version: '0.1.0',
+        author: 'sua',
+        source: 'builtin',
+        manifest: {
+          id: 'starter', name: 'Starter', version: '0.1.0',
+          agents: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+          dashboards: [{ id: 'd', name: 'D', sections: [{ title: 'T', agentIds: ['a'] }] }],
+        },
+        installedAt: null,
+      }],
+    });
+    expect(catalog).toContain('INSTALLED + AVAILABLE PACKS');
+    expect(catalog).toContain('starter (available)');
+    expect(catalog).toContain('3 agents, 1 dashboard');
+  });
+
+  it('renders empty-state lines when dashboards/packs are empty arrays', () => {
+    const catalog = buildDiscoveryCatalog({
+      agents: MOCK_AGENTS,
+      tools: [],
+      templateRegistry: MOCK_REGISTRY,
+      dashboards: [],
+      packs: [],
+    });
+    expect(catalog).toContain('No dashboards installed yet');
+    expect(catalog).toContain('No packs registered.');
+  });
 });

--- a/packages/core/src/discovery-catalog.ts
+++ b/packages/core/src/discovery-catalog.ts
@@ -9,6 +9,8 @@
 
 import type { Agent } from './agent-v2-types.js';
 import type { ToolDefinition } from './tool-types.js';
+import type { Dashboard } from './dashboards-store.js';
+import type { Pack } from './packs-store.js';
 import { NODE_CATALOG } from './node-catalog.js';
 
 export interface TemplateDef {
@@ -22,6 +24,19 @@ export interface DiscoveryCatalogOptions {
   agents: Agent[];
   tools: ToolDefinition[];
   templateRegistry: Record<string, TemplateDef>;
+  /**
+   * Optional. When supplied, the catalog appends an INSTALLED DASHBOARDS
+   * section so the build-planner LLM can spot overlap with existing
+   * curated layouts (e.g. "extend Morning Briefing instead of creating
+   * a new dashboard").
+   */
+  dashboards?: Dashboard[];
+  /**
+   * Optional. When supplied, the catalog appends an INSTALLED PACKS
+   * section so the planner can suggest pack installation as an
+   * alternative to from-scratch agent generation.
+   */
+  packs?: Pack[];
 }
 
 const EXCLUDED_AGENT_IDS = new Set(['agent-builder', 'agent-analyzer']);
@@ -129,6 +144,33 @@ function buildTemplateSection(registry: Record<string, TemplateDef>): string {
   return `## SIGNAL TEMPLATES (signal.template in agent YAML)\n${lines.join('\n')}`;
 }
 
+function buildDashboardsSection(dashboards: Dashboard[]): string {
+  if (dashboards.length === 0) {
+    return '## INSTALLED DASHBOARDS\nNo dashboards installed yet. (Default Pulse layout at /pulse is auto-derived from pulseVisible, not stored here.)';
+  }
+  const lines = dashboards.map((d) => {
+    const owner = d.packId ? `pack:${d.packId}` : 'user';
+    const sectionLine = d.layout.sections
+      .map((s) => `${s.title} [${s.agentIds.join(', ') || '(empty)'}]`)
+      .join(' · ');
+    return `- ${d.id} (${owner}): "${d.name}" — sections: ${sectionLine || '(none)'}`;
+  });
+  return `## INSTALLED DASHBOARDS\nNamed dashboards stored in DashboardsStore. When a goal asks for a dashboard, prefer extending an existing one over creating a duplicate.\n${lines.join('\n')}`;
+}
+
+function buildPacksSection(packs: Pack[]): string {
+  if (packs.length === 0) {
+    return '## INSTALLED + AVAILABLE PACKS\nNo packs registered.';
+  }
+  const lines = packs.map((p) => {
+    const state = p.installedAt ? 'installed' : 'available';
+    const dashCount = p.manifest.dashboards?.length ?? 0;
+    const agentCount = p.manifest.agents?.length ?? 0;
+    return `- ${p.id} (${state}): "${p.name}" v${p.version} — ${agentCount} agent${agentCount === 1 ? '' : 's'}, ${dashCount} dashboard${dashCount === 1 ? '' : 's'}`;
+  });
+  return `## INSTALLED + AVAILABLE PACKS\nIf an available pack already covers the goal, suggest installing it as a question rather than building from scratch.\n${lines.join('\n')}`;
+}
+
 function buildAgentsSection(agents: Agent[]): string {
   const eligible = agents
     .filter((a) => a.status === 'active' && !EXCLUDED_AGENT_IDS.has(a.id))
@@ -179,15 +221,15 @@ WRONG: \`url: YouTube watch URL\` (description in the type slot — schema rejec
 6. FAIL FAST. When a step's primary purpose returns no data (HTTP non-200, empty array, null lookup, missing required field), exit with a non-zero status so downstream nodes skip cleanly via the executor's upstream_failed cascade. Don't return {x: null, y: null} and trust downstream to notice — they won't, and you'll get cryptic jq parse errors three nodes later. Pattern for shell: \`if [ "$LAT" = "null" ] || [ -z "$LAT" ]; then echo '{"error":"city not found"}' >&2; exit 1; fi\`. Pattern for tool calls: check the exit code and bail.`.trim();
 
 export function buildDiscoveryCatalog(opts: DiscoveryCatalogOptions): string {
-  const sections = [
+  const sections: string[] = [
     buildNodeTypesSection(),
     buildTemplateSection(opts.templateRegistry),
     OUTPUT_WIDGETS,
     buildAgentsSection(opts.agents),
-    PATTERNS,
-    WIDGET_GUIDANCE,
-    DESIGN_DISCIPLINE,
   ];
+  if (opts.dashboards) sections.push(buildDashboardsSection(opts.dashboards));
+  if (opts.packs) sections.push(buildPacksSection(opts.packs));
+  sections.push(PATTERNS, WIDGET_GUIDANCE, DESIGN_DISCIPLINE);
 
   return sections.join('\n\n');
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -82,6 +82,12 @@ export {
   type PackUninstallResult,
 } from './pack-installer.js';
 export {
+  buildPlanSchema,
+  extractPlanJson,
+  type BuildPlan,
+  type BuildPlanInput,
+} from './build-plan-schema.js';
+export {
   getBuiltinTool,
   listBuiltinTools,
   isBuiltinTool,

--- a/packages/dashboard/src/routes/build-commit.test.ts
+++ b/packages/dashboard/src/routes/build-commit.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import request from 'supertest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AgentStore,
+  DashboardsStore,
+  LocalProvider,
+  MemorySecretsStore,
+  PacksStore,
+  RunStore,
+  buildLoopbackAllowlist,
+  loadAgents,
+  type BuildPlan,
+} from '@some-useful-agents/core';
+import { buildDashboardApp } from '../index.js';
+import type { DashboardContext } from '../context.js';
+import { SESSION_COOKIE } from '../auth-middleware.js';
+import { MemorySecretsSession } from '../secrets-session.js';
+
+const TOKEN = 'a'.repeat(64);
+const PORT = 3994;
+const COOKIE = `${SESSION_COOKIE}=${TOKEN}`;
+
+let dir: string;
+let provider: LocalProvider;
+let runStore: RunStore;
+let agentStore: AgentStore;
+let packsStore: PacksStore;
+let dashboardsStore: DashboardsStore;
+
+async function makeApp() {
+  dir = mkdtempSync(join(tmpdir(), 'sua-build-commit-'));
+  const dbPath = join(dir, 'runs.db');
+  const agentsDir = join(dir, 'agents', 'local');
+  mkdirSync(agentsDir, { recursive: true });
+
+  const secretsStore = new MemorySecretsStore();
+  runStore = new RunStore(dbPath);
+  agentStore = new AgentStore(dbPath);
+  packsStore = new PacksStore(dbPath);
+  dashboardsStore = new DashboardsStore(dbPath);
+  provider = new LocalProvider(dbPath, secretsStore);
+  await provider.initialize();
+
+  // Pre-install one signal-bearing agent ("hn-top-stories") so the
+  // dashboard-existing flavor has something to point at.
+  agentStore.createAgent({
+    id: 'hn-top-stories',
+    name: 'HN Top Stories',
+    status: 'active',
+    source: 'local',
+    mcp: false,
+    nodes: [{ id: 'fetch', type: 'shell', command: 'echo hi', dependsOn: [] }],
+    signal: { title: 'HN', template: 'text-headline', mapping: { headline: 'h' } },
+  }, 'cli');
+
+  const ctx: DashboardContext = {
+    token: TOKEN,
+    allowlist: buildLoopbackAllowlist(PORT),
+    port: PORT,
+    provider,
+    runStore,
+    agentStore,
+    loadAgents: () => loadAgents({ directories: [agentsDir] }),
+    secretsStore,
+    secretsSession: new MemorySecretsSession({ backing: secretsStore }),
+    tokenPath: join(dir, 'mcp-token'),
+    retentionDays: 30,
+    dbPath,
+    secretsPath: join(dir, 'secrets.enc'),
+    rotateToken: () => 'r'.repeat(64),
+    packsStore,
+    dashboardsStore,
+    allowUntrustedShell: new Set(),
+    activeRuns: new Map(),
+    dataDir: dir,
+    dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
+  };
+
+  return buildDashboardApp(ctx);
+}
+
+afterEach(async () => {
+  if (provider) {
+    const start = Date.now();
+    while ((provider as unknown as { running?: { size: number } }).running?.size && Date.now() - start < 2000) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    await provider.shutdown();
+  }
+  try { runStore?.close(); } catch { /* ignore */ }
+  try { agentStore?.close(); } catch { /* ignore */ }
+  try { packsStore?.close(); } catch { /* ignore */ }
+  try { dashboardsStore?.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+const NOTES_AGENT_YAML = `id: notes-list-daily
+name: Notes List Daily
+status: active
+source: local
+mcp: false
+nodes:
+  - id: read
+    type: shell
+    command: ls ~/Documents
+    dependsOn: []
+signal:
+  title: Notes
+  template: text-headline
+  mapping:
+    headline: result
+`;
+
+describe('POST /agents/build/commit', () => {
+  it('agent-only intent: creates one agent, redirects to /agents/:id', async () => {
+    const app = await makeApp();
+    const plan: BuildPlan = {
+      intent: 'agent',
+      summary: 'Build a notes-list agent',
+      survey: { matchedAgents: [], missingFor: ['notes list'], existingDashboards: [] },
+      newAgents: [{ id: 'notes-list-daily', purpose: 'list latest notes', yaml: NOTES_AGENT_YAML }],
+      dashboard: null,
+      questions: [],
+    };
+    const res = await request(app).post('/agents/build/commit')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .send({ plan });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.agentsCreated).toEqual(['notes-list-daily']);
+    expect(res.body.dashboardCreated).toBeNull();
+    expect(res.body.redirectUrl).toBe('/agents/notes-list-daily');
+    expect(agentStore.getAgent('notes-list-daily')).not.toBeNull();
+  });
+
+  it('dashboard-mixed intent: creates new agent + dashboard wiring it with an existing one', async () => {
+    const app = await makeApp();
+    const plan: BuildPlan = {
+      intent: 'dashboard-mixed',
+      summary: 'Morning briefing',
+      survey: {
+        matchedAgents: [{ id: 'hn-top-stories', matchedFor: 'top stories on HN' }],
+        missingFor: ['notes list'],
+        existingDashboards: [],
+      },
+      newAgents: [{ id: 'notes-list-daily', purpose: 'list latest notes', yaml: NOTES_AGENT_YAML }],
+      dashboard: {
+        id: 'user:morning-briefing',
+        name: 'Morning Briefing',
+        sections: [
+          { title: 'News', agentIds: ['hn-top-stories'] },
+          { title: 'Notes', agentIds: ['notes-list-daily'] },
+        ],
+      },
+      questions: [],
+    };
+    const res = await request(app).post('/agents/build/commit')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .send({ plan });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.agentsCreated).toEqual(['notes-list-daily']);
+    expect(res.body.dashboardCreated).toBe('user:morning-briefing');
+    expect(res.body.redirectUrl).toBe('/dashboards/user%3Amorning-briefing');
+
+    const dash = dashboardsStore.getDashboard('user:morning-briefing');
+    expect(dash).not.toBeNull();
+    expect(dash?.layout.sections).toHaveLength(2);
+  });
+
+  it('skips an agent whose id already exists; still creates the dashboard', async () => {
+    const app = await makeApp();
+    const plan: BuildPlan = {
+      intent: 'dashboard-mixed',
+      summary: 'Morning briefing',
+      survey: { matchedAgents: [{ id: 'hn-top-stories', matchedFor: 'HN' }], missingFor: [], existingDashboards: [] },
+      newAgents: [{ id: 'hn-top-stories', purpose: 'duplicate', yaml: NOTES_AGENT_YAML.replace('notes-list-daily', 'hn-top-stories') }],
+      dashboard: {
+        id: 'user:morning',
+        name: 'Morning',
+        sections: [{ title: 'News', agentIds: ['hn-top-stories'] }],
+      },
+      questions: [],
+    };
+    const res = await request(app).post('/agents/build/commit')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .send({ plan });
+    expect(res.body.ok).toBe(true);
+    expect(res.body.agentsCreated).toEqual([]);
+    expect(res.body.agentsSkipped).toHaveLength(1);
+    expect(res.body.agentsSkipped[0].reason).toMatch(/already exists/);
+    expect(res.body.dashboardCreated).toBe('user:morning');
+  });
+
+  it('rejects plans that fail schema validation', async () => {
+    const app = await makeApp();
+    const res = await request(app).post('/agents/build/commit')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .send({ plan: { intent: 'agent', summary: 'X', newAgents: [], dashboard: null, questions: [] } });
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toMatch(/exactly one|requires|failed/);
+  });
+
+  it('rejects a plan with mismatched YAML id', async () => {
+    const app = await makeApp();
+    const plan: BuildPlan = {
+      intent: 'agent',
+      summary: 'X',
+      survey: { matchedAgents: [], missingFor: [], existingDashboards: [] },
+      newAgents: [{ id: 'wrong-id', purpose: 'p', yaml: NOTES_AGENT_YAML }],
+      dashboard: null,
+      questions: [],
+    };
+    const res = await request(app).post('/agents/build/commit')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .send({ plan });
+    expect(res.body.ok).toBe(true); // commit returned a partial result
+    expect(res.body.agentsCreated).toEqual([]);
+    expect(res.body.agentsSkipped[0].reason).toMatch(/does not match/);
+  });
+});

--- a/packages/dashboard/src/routes/run-now-build.ts
+++ b/packages/dashboard/src/routes/run-now-build.ts
@@ -6,7 +6,18 @@
  */
 
 import { Router, type Request, type Response } from 'express';
-import { executeAgentDag, exportAgent, listBuiltinTools, parseAgent, buildDiscoveryCatalog, type RunStatus, type ToolDefinition } from '@some-useful-agents/core';
+import {
+  executeAgentDag,
+  exportAgent,
+  listBuiltinTools,
+  parseAgent,
+  buildDiscoveryCatalog,
+  buildPlanSchema,
+  extractPlanJson,
+  type BuildPlan,
+  type RunStatus,
+  type ToolDefinition,
+} from '@some-useful-agents/core';
 import { TEMPLATE_REGISTRY } from '../views/pulse-templates.js';
 import { parse as parseRawYaml, stringify as stringifyRawYaml } from 'yaml';
 import { readFileSync } from 'node:fs';
@@ -17,6 +28,7 @@ export const buildRouter: Router = Router();
 
 const ANALYZER_AGENT_ID = 'agent-analyzer';
 const BUILDER_AGENT_ID = 'agent-builder';
+const PLANNER_AGENT_ID = 'build-planner';
 
 // ── Auto-fix common LLM YAML mistakes ──────────────────────────────────
 
@@ -638,22 +650,22 @@ buildRouter.post('/agents/build', async (req: Request, res: Response) => {
     return;
   }
 
-  // Auto-import or update builder agent from examples YAML.
+  // Auto-import or update planner agent from examples YAML.
   // Uses upsertAgent so prompt improvements take effect without manual deletion.
-  let builder: ReturnType<typeof ctx.agentStore.getAgent> = null;
+  let planner: ReturnType<typeof ctx.agentStore.getAgent> = null;
   try {
-    const yamlPath = join(resolve('agents/examples'), `${BUILDER_AGENT_ID}.yaml`);
+    const yamlPath = join(resolve('agents/examples'), `${PLANNER_AGENT_ID}.yaml`);
     const yamlText = readFileSync(yamlPath, 'utf-8');
     const parsed = parseAgent(yamlText);
-    ctx.agentStore.upsertAgent(parsed, 'import', 'Auto-imported for agent builder');
-    builder = ctx.agentStore.getAgent(BUILDER_AGENT_ID);
+    ctx.agentStore.upsertAgent(parsed, 'import', 'Auto-imported for build planner');
+    planner = ctx.agentStore.getAgent(PLANNER_AGENT_ID);
   } catch { /* fall through */ }
-  if (!builder) {
-    res.json({ ok: false, error: 'Builder agent not found. Ensure agent-builder.yaml exists in agents/examples/.' });
+  if (!planner) {
+    res.json({ ok: false, error: 'Build planner agent not found. Ensure build-planner.yaml exists in agents/examples/.' });
     return;
   }
 
-  // Build a dynamic tool catalog so the builder LLM knows about all
+  // Build a dynamic tool catalog so the planner LLM knows about all
   // registered tools, not just the 9 hardcoded built-ins.
   const builtins = listBuiltinTools();
   let userTools: ToolDefinition[] = [];
@@ -665,10 +677,14 @@ buildRouter.post('/agents/build', async (req: Request, res: Response) => {
     agents: ctx.agentStore.listAgents(),
     tools: [...builtins, ...userTools],
     templateRegistry: TEMPLATE_REGISTRY,
+    // Optional — when present, the planner sees them and can suggest
+    // reuse / pack install / dashboard extension instead of duplicating.
+    dashboards: ctx.dashboardsStore?.listDashboards(),
+    packs: ctx.packsStore?.listPacks(),
   });
 
   const runPromise = executeAgentDag(
-    builder,
+    planner,
     {
       triggeredBy: 'dashboard',
       inputs: {
@@ -692,7 +708,7 @@ buildRouter.post('/agents/build', async (req: Request, res: Response) => {
   ]);
 
   const { rows } = ctx.runStore.queryRuns({
-    agentName: BUILDER_AGENT_ID,
+    agentName: PLANNER_AGENT_ID,
     statuses: ['running', 'completed', 'failed'] as RunStatus[],
     limit: 1,
     offset: 0,
@@ -727,7 +743,8 @@ buildRouter.get('/agents/build/:runId', (req: Request, res: Response) => {
   if (run.status === 'running' || run.status === 'pending') {
     const execs = ctx.runStore.listNodeExecutions(runId);
     const runningNode = execs.find((e) => e.status === 'running');
-    const phaseMessage = runningNode?.nodeId === 'design' ? 'Designing agent...'
+    const phaseMessage = runningNode?.nodeId === 'plan' ? 'Planning agents and dashboard...'
+      : runningNode?.nodeId === 'design' ? 'Designing agent...'
       : runningNode?.nodeId === 'validate' ? 'Validating YAML...'
       : runningNode?.nodeId === 'fix' ? 'Fixing validation errors...'
       : 'Starting...';
@@ -744,7 +761,51 @@ buildRouter.get('/agents/build/:runId', (req: Request, res: Response) => {
     return;
   }
 
-  // Extract YAML from the result (may come from design or fix node).
+  // Detect which agent produced this run (planner emits a plan; the
+  // legacy agent-builder still emits raw YAML).
+  const ranPlanner = run.agentName === PLANNER_AGENT_ID;
+
+  if (ranPlanner) {
+    // Extract + validate the plan JSON.
+    let resultText = run.result;
+    if (!resultText.includes('<plan>')) {
+      const execs = ctx.runStore.listNodeExecutions(runId);
+      const planExec = execs.find((e) => e.nodeId === 'plan' && e.status === 'completed');
+      if (planExec?.result) resultText = planExec.result;
+    }
+    const planText = extractPlanJson(resultText);
+    if (!planText) {
+      res.json({ ok: true, status: 'failed', error: 'Planner did not produce a <plan>…</plan> block.' });
+      return;
+    }
+    let parsed: unknown;
+    try { parsed = JSON.parse(planText); }
+    catch (e) {
+      res.json({ ok: true, status: 'failed', error: `Plan JSON parse failed: ${(e as Error).message}` });
+      return;
+    }
+    const result = buildPlanSchema.safeParse(parsed);
+    if (!result.success) {
+      const issues = result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+      res.json({ ok: true, status: 'failed', error: `Plan validation failed: ${issues}`, rawPlan: parsed });
+      return;
+    }
+
+    // Apply autoFixYaml to each newAgent's YAML so we surface a clean
+    // form to the user (mirrors what /create did before).
+    const cleanedNewAgents = result.data.newAgents.map((a) => ({
+      ...a,
+      yaml: autoFixYaml(a.yaml),
+    }));
+    const plan: BuildPlan = { ...result.data, newAgents: cleanedNewAgents };
+
+    res.json({ ok: true, status: 'done', plan });
+    return;
+  }
+
+  // Legacy agent-builder path — kept for any external script still
+  // hitting POST /agents/build (the wizard's own route now uses the
+  // planner).
   let resultText = run.result;
   if (!resultText.includes('<yaml>')) {
     const execs = ctx.runStore.listNodeExecutions(runId);
@@ -762,7 +823,6 @@ buildRouter.get('/agents/build/:runId', (req: Request, res: Response) => {
     return;
   }
 
-  // Validate the YAML.
   let agentId: string | undefined;
   let agentName: string | undefined;
   let yamlError: string | undefined;
@@ -774,18 +834,103 @@ buildRouter.get('/agents/build/:runId', (req: Request, res: Response) => {
     yamlError = e instanceof Error ? e.message : String(e);
   }
 
+  res.json({ ok: true, status: 'done', yaml, agentId, agentName, yamlError });
+});
+
+/**
+ * POST /agents/build/commit — execute an approved BuildPlan.
+ *
+ * Walks `plan.newAgents` creating each via agentStore (skipping any whose
+ * id already exists). Then if `plan.dashboard` is non-null, upserts the
+ * dashboard via dashboardsStore. Returns a partial-success report so
+ * the wizard can show what landed and what didn't.
+ */
+buildRouter.post('/agents/build/commit', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const body = (req.body ?? {}) as Record<string, unknown>;
+
+  const result = buildPlanSchema.safeParse(body.plan);
+  if (!result.success) {
+    const issues = result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+    res.json({ ok: false, error: `Plan failed validation: ${issues}` });
+    return;
+  }
+  const plan = result.data;
+
+  const agentsCreated: string[] = [];
+  const agentsSkipped: Array<{ id: string; reason: string }> = [];
+
+  for (const ref of plan.newAgents) {
+    if (ctx.agentStore.getAgent(ref.id)) {
+      agentsSkipped.push({ id: ref.id, reason: 'agent id already exists' });
+      continue;
+    }
+    let parsed;
+    try {
+      const fixedYaml = autoFixYaml(ref.yaml);
+      parsed = parseAgent(fixedYaml);
+    } catch (e) {
+      agentsSkipped.push({ id: ref.id, reason: `YAML parse failed: ${(e as Error).message}` });
+      continue;
+    }
+    if (parsed.id !== ref.id) {
+      agentsSkipped.push({ id: ref.id, reason: `YAML id "${parsed.id}" does not match plan ref id "${ref.id}"` });
+      continue;
+    }
+    try {
+      ctx.agentStore.createAgent(
+        { ...parsed, source: 'local' },
+        'dashboard',
+        `Created via Build from goal wizard (intent: ${plan.intent})`,
+      );
+      agentsCreated.push(ref.id);
+    } catch (e) {
+      agentsSkipped.push({ id: ref.id, reason: (e as Error).message });
+    }
+  }
+
+  let dashboardCreated: string | null = null;
+  let dashboardError: string | undefined;
+  if (plan.dashboard && ctx.dashboardsStore) {
+    try {
+      ctx.dashboardsStore.upsertDashboard({
+        id: plan.dashboard.id,
+        packId: null,
+        name: plan.dashboard.name,
+        layout: { sections: plan.dashboard.sections },
+      });
+      dashboardCreated = plan.dashboard.id;
+    } catch (e) {
+      dashboardError = (e as Error).message;
+    }
+  } else if (plan.dashboard && !ctx.dashboardsStore) {
+    dashboardError = 'Dashboards store unavailable.';
+  }
+
+  // Choose a redirect target: prefer the new dashboard, fall back to
+  // the first new agent, fall back to /agents.
+  const redirectUrl = dashboardCreated
+    ? `/dashboards/${encodeURIComponent(dashboardCreated)}`
+    : agentsCreated[0]
+      ? `/agents/${encodeURIComponent(agentsCreated[0])}`
+      : '/agents';
+
   res.json({
     ok: true,
-    status: 'done',
-    yaml,
-    agentId,
-    agentName,
-    yamlError,
+    agentsCreated,
+    agentsSkipped,
+    dashboardCreated,
+    dashboardError,
+    redirectUrl,
   });
 });
 
 /**
- * POST /agents/build/create — create an agent from builder-suggested YAML.
+ * POST /agents/build/create — legacy single-agent create endpoint.
+ *
+ * Kept as a thin compat shim for any external script that still POSTs
+ * raw YAML here. Wraps the YAML in a one-agent BuildPlan and forwards
+ * to /commit so we have one execution path.
  */
 buildRouter.post('/agents/build/create', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
@@ -799,13 +944,12 @@ buildRouter.post('/agents/build/create', (req: Request, res: Response) => {
 
   let parsed;
   try {
-    parsed = parseAgent(yaml);
+    parsed = parseAgent(autoFixYaml(yaml));
   } catch (e) {
     res.json({ ok: false, error: e instanceof Error ? e.message : String(e) });
     return;
   }
 
-  // Check if agent already exists.
   if (ctx.agentStore.getAgent(parsed.id)) {
     res.json({ ok: false, error: `Agent "${parsed.id}" already exists. Edit the YAML to use a different id.` });
     return;
@@ -815,7 +959,7 @@ buildRouter.post('/agents/build/create', (req: Request, res: Response) => {
     ctx.agentStore.createAgent(
       { ...parsed, source: 'local' },
       'dashboard',
-      'Created via Build from goal wizard',
+      'Created via Build from goal wizard (legacy /create)',
     );
     res.json({ ok: true, agentId: parsed.id });
   } catch (e) {

--- a/packages/dashboard/src/views/build-from-goal-modal.ts
+++ b/packages/dashboard/src/views/build-from-goal-modal.ts
@@ -26,11 +26,11 @@ export function buildFromGoalModal(): SafeHtml {
         <div id="build-modal-content">
           <h3 style="margin: 0 0 var(--space-3);">Build from goal</h3>
           <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-3);">
-            Describe what you want your agent to do. Claude will design a complete agent with the right nodes, tools, and wiring.
+            Describe an agent <em>or</em> a dashboard. Claude surveys what's already installed, drafts any missing agents, and assembles the dashboard. Review the plan before anything is created.
           </p>
           <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-3);">
             <strong style="font-size: var(--font-size-sm);">Goal</strong>
-            <textarea id="build-goal" rows="3" placeholder="e.g. Scrape job listings from ashbyhq, extract key details, and save to a local JSON file"
+            <textarea id="build-goal" rows="3" placeholder="e.g. a daily morning dashboard with HN top stories, today's weather, and my notes folder"
               style="padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm); resize: vertical;"></textarea>
           </label>
           <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-4);">

--- a/packages/dashboard/src/views/build-from-goal.js.ts
+++ b/packages/dashboard/src/views/build-from-goal.js.ts
@@ -1,18 +1,25 @@
 /**
- * Build from goal wizard JS: multi-stage modal for designing agents from a prompt.
+ * Build from goal wizard JS: multi-stage modal for designing agents
+ * AND dashboards from a prompt.
  *
- * Extracted from js.ts. Inlined via layout.ts.
+ * Stage flow:
+ *   1. Goal input (rendered server-side; this script only wires events)
+ *   2. Polling (spinner + timer + phase messages)
+ *   3. Plan review (NEW) — survey + new agents + dashboard + questions,
+ *      with editable YAML per new agent
+ *   4. Commit progress (handled by the Commit button)
+ *   5. Redirect to the new dashboard or agent
+ *
+ * Inlined into pages via layout.ts.
  */
 export const BUILD_FROM_GOAL_JS = `
-  // ── Build from goal wizard ─────────────────────────────────────────
-  // Modal wizard that designs a new agent from a prompt.
   (function () {
     var btn = document.getElementById('build-from-goal-btn');
     var modal = document.getElementById('build-modal');
     var content = document.getElementById('build-modal-content');
     if (!btn || !modal || !content) return;
 
-    function esc(s) { var d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+    function esc(s) { var d = document.createElement('div'); d.textContent = s == null ? '' : String(s); return d.innerHTML; }
     function closeModal() { modal.classList.remove('is-open'); }
 
     btn.addEventListener('click', function () { modal.classList.add('is-open'); });
@@ -35,14 +42,14 @@ export const BUILD_FROM_GOAL_JS = `
       var t0 = Date.now();
       var cancelled = false;
       var pollTimer = null;
-      var PHASES = [[0,'Designing agent...'],[5,'Selecting tools...'],[15,'Building node pipeline...'],[30,'Generating YAML...'],[60,'Still working...'],[90,'Almost there...']];
+      var PHASES = [[0,'Planning...'],[10,'Surveying installed agents...'],[25,'Drafting new agents...'],[55,'Designing dashboard...'],[90,'Almost there...']];
 
       content.innerHTML =
         '<div style="padding:var(--space-4);">' +
         '<div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-4);">' +
           '<div class="spinner"></div>' +
-          '<div style="flex:1;"><div style="font-weight:var(--weight-medium);">Building agent</div>' +
-          '<div class="dim" style="font-size:var(--font-size-xs);" id="build-phase">Designing agent...</div></div>' +
+          '<div style="flex:1;"><div style="font-weight:var(--weight-medium);">Planning</div>' +
+          '<div class="dim" style="font-size:var(--font-size-xs);" id="build-phase">Planning...</div></div>' +
           '<div style="font-family:var(--font-mono);font-size:var(--font-size-lg);color:var(--color-text-muted);min-width:3rem;text-align:right;" id="build-timer">0s</div>' +
         '</div>' +
         '<div style="height:4px;background:var(--color-border);border-radius:2px;overflow:hidden;margin-bottom:var(--space-3);">' +
@@ -55,7 +62,6 @@ export const BUILD_FROM_GOAL_JS = `
         var s = Math.round((Date.now() - t0) / 1000);
         var te = document.getElementById('build-timer'); if (te) te.textContent = s + 's';
         var be = document.getElementById('build-bar'); if (be) be.style.width = Math.min(s/120*100, 98) + '%';
-        // Only use timer-based fallback phases when no server phase has arrived.
         if (!serverPhase) {
           var pe = document.getElementById('build-phase'); if (pe) {
             var m = PHASES[0][1]; for (var i = 0; i < PHASES.length; i++) { if (s >= PHASES[i][0]) m = PHASES[i][1]; }
@@ -76,8 +82,7 @@ export const BUILD_FROM_GOAL_JS = `
       .then(function (startData) {
         if (!startData.ok || !startData.runId) {
           clearInterval(tickTimer);
-          content.innerHTML = '<div class="flash flash--error">' + esc(startData.error || 'Failed') + '</div>' +
-            '<div style="margin-top:var(--space-3);text-align:right;"><button type="button" class="btn btn--ghost btn--sm" data-close-build="1">Close</button></div>';
+          renderError(startData.error || 'Failed to start planner');
           return;
         }
         var runId = startData.runId;
@@ -95,70 +100,24 @@ export const BUILD_FROM_GOAL_JS = `
                   if (pe) pe.textContent = data.phase;
                 }
                 pollTimer = setTimeout(poll, 2000);
-              } else if (data.status === 'done') {
+              } else if (data.status === 'done' && data.plan) {
                 clearInterval(tickTimer);
-                var h = '<h3 style="margin:0 0 var(--space-3);">Agent designed</h3>';
-                if (data.agentName) h += '<p style="font-weight:var(--weight-medium);margin:0 0 var(--space-2);">' + esc(data.agentName) + ' <span class="dim">(' + esc(data.agentId) + ')</span></p>';
-                if (data.yamlError) {
-                  h += '<div class="flash flash--error" style="margin-bottom:var(--space-3);font-size:var(--font-size-xs);">' +
-                    '<strong>Validation error:</strong> ' + esc(data.yamlError) +
-                    '<br>Edit the YAML below to fix, then create.</div>';
-                }
-                if (data.yaml) {
-                  h += '<label style="display:flex;flex-direction:column;gap:var(--space-1);margin-bottom:var(--space-3);">' +
-                    '<span class="dim" style="font-size:var(--font-size-xs);font-weight:var(--weight-semibold);">Review and edit YAML before creating</span>' +
-                    '<textarea id="build-yaml-editor" rows="15" ' +
-                    'style="padding:var(--space-3);border:1px solid var(--color-border-strong);border-radius:var(--radius-sm);' +
-                    'font-family:var(--font-mono);font-size:var(--font-size-xs);resize:vertical;line-height:1.5;tab-size:2;">' +
-                    esc(data.yaml) + '</textarea></label>';
-                }
-                h += '<div id="build-result-flash"></div>';
-                h += '<div style="display:flex;gap:var(--space-2);justify-content:flex-end;flex-wrap:wrap;">';
-                if (data.yaml) {
-                  h += '<button type="button" class="btn btn--primary btn--sm" id="build-create-btn">Create agent</button>';
-                }
-                h += '<button type="button" class="btn btn--ghost btn--sm" data-close-build="1">Dismiss</button></div>';
-                content.innerHTML = h;
-
-                var createBtn = document.getElementById('build-create-btn');
-                if (createBtn) {
-                  createBtn.addEventListener('click', function () {
-                    var yamlEditor = document.getElementById('build-yaml-editor');
-                    var yamlText = yamlEditor ? yamlEditor.value : '';
-                    if (!yamlText.trim()) return;
-                    createBtn.disabled = true;
-                    createBtn.textContent = 'Creating...';
-                    var flashEl = document.getElementById('build-result-flash');
-                    if (flashEl) flashEl.innerHTML = '';
-                    fetch('/agents/build/create', {
-                      method: 'POST', credentials: 'same-origin',
-                      headers: { 'Content-Type': 'application/json' },
-                      body: JSON.stringify({ yaml: yamlText }),
-                    })
-                    .then(function (r) { return r.json(); })
-                    .then(function (result) {
-                      if (result.ok) {
-                        window.location.href = '/agents/' + encodeURIComponent(result.agentId);
-                      } else {
-                        createBtn.disabled = false;
-                        createBtn.textContent = 'Create agent';
-                        // If agent already exists, show a link to it.
-                        var msg = result.error || 'Creation failed';
-                        var existsMatch = msg.match(/["']([a-z0-9][a-z0-9-]*)["'] already exists/i);
-                        if (existsMatch && flashEl) {
-                          flashEl.innerHTML = '<div class="flash flash--error" style="margin-bottom:var(--space-3);font-size:var(--font-size-xs);">' +
-                            esc(msg) + ' <a href="/agents/' + encodeURIComponent(existsMatch[1]) + '" style="font-weight:var(--weight-semibold);">Open existing agent \\u2192</a></div>';
-                        } else if (flashEl) {
-                          flashEl.innerHTML = '<div class="flash flash--error" style="margin-bottom:var(--space-3);font-size:var(--font-size-xs);">' + esc(msg) + '</div>';
-                        }
-                      }
-                    });
-                  });
-                }
+                renderPlanReview(data.plan);
+              } else if (data.status === 'done' && data.yaml) {
+                // Legacy single-YAML response (agent-builder fallback). Wrap it
+                // in a one-agent plan and reuse the review UI.
+                clearInterval(tickTimer);
+                renderPlanReview({
+                  intent: 'agent',
+                  summary: data.agentName ? 'Build agent: ' + data.agentName : 'Build a new agent',
+                  survey: { matchedAgents: [], missingFor: [], existingDashboards: [] },
+                  newAgents: [{ id: data.agentId || 'new-agent', purpose: '', yaml: data.yaml }],
+                  dashboard: null,
+                  questions: [],
+                });
               } else {
                 clearInterval(tickTimer);
-                content.innerHTML = '<div class="flash flash--error">' + esc(data.error || 'Build failed') + '</div>' +
-                  '<div style="margin-top:var(--space-3);text-align:right;"><button type="button" class="btn btn--ghost btn--sm" data-close-build="1">Close</button></div>';
+                renderError(data.error || 'Build failed');
               }
             })
             .catch(function () { if (!cancelled) pollTimer = setTimeout(poll, 3000); });
@@ -167,9 +126,168 @@ export const BUILD_FROM_GOAL_JS = `
       })
       .catch(function (err) {
         clearInterval(tickTimer);
-        content.innerHTML = '<div class="flash flash--error">' + esc(String(err)) + '</div>' +
-          '<div style="margin-top:var(--space-3);text-align:right;"><button type="button" class="btn btn--ghost btn--sm" data-close-build="1">Close</button></div>';
+        renderError(String(err));
       });
+
+      function renderError(msg) {
+        content.innerHTML = '<div class="flash flash--error">' + esc(msg) + '</div>' +
+          '<div style="margin-top:var(--space-3);text-align:right;"><button type="button" class="btn btn--ghost btn--sm" data-close-build="1">Close</button></div>';
+      }
+
+      function renderPlanReview(plan) {
+        var h = '';
+        var intentLabel = {
+          'agent': 'Agent',
+          'dashboard-existing': 'Dashboard (existing agents)',
+          'dashboard-new': 'Dashboard (new agents)',
+          'dashboard-mixed': 'Dashboard (mixed)',
+        }[plan.intent] || plan.intent;
+
+        h += '<div style="display:flex;align-items:baseline;gap:var(--space-2);margin-bottom:var(--space-2);">' +
+             '<h3 style="margin:0;">Plan ready</h3>' +
+             '<span class="badge dim" style="font-size:var(--font-size-xs);">' + esc(intentLabel) + '</span>' +
+             '</div>';
+        h += '<p style="margin:0 0 var(--space-3);font-size:var(--font-size-sm);">' + esc(plan.summary) + '</p>';
+
+        // Survey block
+        var s = plan.survey || {};
+        var surveyBits = [];
+        if (s.matchedAgents && s.matchedAgents.length) {
+          surveyBits.push('<div><span class="dim">Already have:</span> ' +
+            s.matchedAgents.map(function (m) {
+              return '<code>' + esc(m.id) + '</code> <span class="dim" style="font-size:var(--font-size-xs);">(' + esc(m.matchedFor) + ')</span>';
+            }).join(', ') + '</div>');
+        }
+        if (s.missingFor && s.missingFor.length) {
+          surveyBits.push('<div><span class="dim">Missing:</span> ' +
+            s.missingFor.map(function (m) { return esc(m); }).join(', ') + '</div>');
+        }
+        if (s.existingDashboards && s.existingDashboards.length) {
+          surveyBits.push('<div><span class="dim">Existing dashboards:</span> ' +
+            s.existingDashboards.map(function (d) {
+              return '<code>' + esc(d.id) + '</code> <span class="dim" style="font-size:var(--font-size-xs);">(' + esc(d.reason) + ')</span>';
+            }).join(', ') + '</div>');
+        }
+        if (surveyBits.length) {
+          h += '<div class="card" style="padding:var(--space-2) var(--space-3);margin-bottom:var(--space-3);font-size:var(--font-size-xs);display:flex;flex-direction:column;gap:var(--space-1);">' +
+               surveyBits.join('') + '</div>';
+        }
+
+        // New agents — each as a collapsible card with editable YAML textarea
+        if (plan.newAgents && plan.newAgents.length) {
+          h += '<div style="margin-bottom:var(--space-3);">' +
+               '<div class="dim" style="font-size:var(--font-size-xs);font-weight:var(--weight-semibold);margin-bottom:var(--space-2);">New agents to create (' + plan.newAgents.length + ')</div>';
+          for (var i = 0; i < plan.newAgents.length; i++) {
+            var a = plan.newAgents[i];
+            h += '<details ' + (i === 0 ? 'open' : '') + ' style="margin-bottom:var(--space-2);">' +
+                 '<summary style="cursor:pointer;padding:var(--space-1) 0;font-size:var(--font-size-sm);">' +
+                 '<code>' + esc(a.id) + '</code> <span class="dim" style="font-size:var(--font-size-xs);">' + esc(a.purpose) + '</span></summary>' +
+                 '<textarea data-new-agent-idx="' + i + '" rows="12" ' +
+                 'style="width:100%;padding:var(--space-2);border:1px solid var(--color-border);border-radius:var(--radius-sm);' +
+                 'font-family:var(--font-mono);font-size:var(--font-size-xs);resize:vertical;line-height:1.5;tab-size:2;">' +
+                 esc(a.yaml) + '</textarea></details>';
+          }
+          h += '</div>';
+        }
+
+        // Dashboard preview
+        if (plan.dashboard) {
+          h += '<div class="card" style="padding:var(--space-3);margin-bottom:var(--space-3);">' +
+               '<div style="font-weight:var(--weight-semibold);margin-bottom:var(--space-2);">Dashboard: ' + esc(plan.dashboard.name) + ' <span class="dim" style="font-size:var(--font-size-xs);font-weight:normal;">(' + esc(plan.dashboard.id) + ')</span></div>';
+          for (var j = 0; j < plan.dashboard.sections.length; j++) {
+            var sec = plan.dashboard.sections[j];
+            h += '<div style="font-size:var(--font-size-xs);margin-top:var(--space-1);"><strong>' + esc(sec.title) + ':</strong> ' +
+                 sec.agentIds.map(function (id) { return '<code>' + esc(id) + '</code>'; }).join(', ') + '</div>';
+          }
+          h += '</div>';
+        }
+
+        // Questions block
+        if (plan.questions && plan.questions.length) {
+          h += '<div class="card card--muted" style="padding:var(--space-2) var(--space-3);margin-bottom:var(--space-3);font-size:var(--font-size-xs);">' +
+               '<div class="dim" style="font-weight:var(--weight-semibold);margin-bottom:var(--space-1);">Questions</div>';
+          for (var k = 0; k < plan.questions.length; k++) {
+            var q = plan.questions[k];
+            h += '<div style="margin-top:var(--space-1);">• ' + esc(q.text);
+            if (q.suggestedAnswer) h += ' <span class="dim">(suggested: ' + esc(q.suggestedAnswer) + ')</span>';
+            h += '</div>';
+          }
+          h += '<div class="dim" style="margin-top:var(--space-2);font-size:var(--font-size-xs);">To answer, append your reply to the goal and re-run.</div>' +
+               '</div>';
+        }
+
+        h += '<div id="build-result-flash"></div>';
+        h += '<div style="display:flex;gap:var(--space-2);justify-content:flex-end;flex-wrap:wrap;">' +
+             '<button type="button" class="btn btn--ghost btn--sm" data-close-build="1">Dismiss</button>' +
+             '<button type="button" class="btn btn--primary btn--sm" id="build-commit-btn">' +
+             (plan.dashboard ? 'Create dashboard + ' + (plan.newAgents.length || 0) + ' agent(s)' :
+              plan.newAgents.length === 1 ? 'Create agent' :
+              'Create ' + plan.newAgents.length + ' agents') +
+             '</button></div>';
+        content.innerHTML = h;
+
+        // Stash the plan so commit can rebuild it with edited YAMLs.
+        wireCommit(plan);
+      }
+
+      function wireCommit(plan) {
+        var commitBtn = document.getElementById('build-commit-btn');
+        if (!commitBtn) return;
+        commitBtn.addEventListener('click', function () {
+          // Pull the latest YAML edits out of each new-agent textarea.
+          var editedNewAgents = (plan.newAgents || []).map(function (a, i) {
+            var ta = document.querySelector('[data-new-agent-idx="' + i + '"]');
+            return { id: a.id, purpose: a.purpose, yaml: ta ? ta.value : a.yaml };
+          });
+          var payload = { plan: Object.assign({}, plan, { newAgents: editedNewAgents }) };
+
+          commitBtn.disabled = true;
+          commitBtn.textContent = 'Creating...';
+          var flashEl = document.getElementById('build-result-flash');
+          if (flashEl) flashEl.innerHTML = '';
+
+          fetch('/agents/build/commit', {
+            method: 'POST', credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          })
+          .then(function (r) { return r.json(); })
+          .then(function (result) {
+            if (!result.ok) {
+              commitBtn.disabled = false;
+              commitBtn.textContent = 'Commit';
+              if (flashEl) flashEl.innerHTML = '<div class="flash flash--error" style="margin-bottom:var(--space-3);font-size:var(--font-size-xs);">' + esc(result.error || 'Commit failed') + '</div>';
+              return;
+            }
+            // Render a brief summary then redirect.
+            var summary = '';
+            if (result.agentsCreated && result.agentsCreated.length) {
+              summary += '<div>Created ' + result.agentsCreated.length + ' agent(s): <code>' + result.agentsCreated.map(esc).join('</code>, <code>') + '</code></div>';
+            }
+            if (result.agentsSkipped && result.agentsSkipped.length) {
+              summary += '<div class="dim" style="margin-top:var(--space-1);">Skipped ' + result.agentsSkipped.length + ': ' +
+                result.agentsSkipped.map(function (s) { return esc(s.id) + ' (' + esc(s.reason) + ')'; }).join('; ') + '</div>';
+            }
+            if (result.dashboardCreated) {
+              summary += '<div>Created dashboard: <code>' + esc(result.dashboardCreated) + '</code></div>';
+            }
+            if (result.dashboardError) {
+              summary += '<div class="dim" style="color:var(--color-danger,#a00);">Dashboard error: ' + esc(result.dashboardError) + '</div>';
+            }
+            content.innerHTML = '<div style="padding:var(--space-3);">' +
+              '<h3 style="margin:0 0 var(--space-2);">Done</h3>' +
+              '<div style="font-size:var(--font-size-sm);">' + summary + '</div>' +
+              '<div class="dim" style="margin-top:var(--space-3);font-size:var(--font-size-xs);">Redirecting in 1.5s...</div>' +
+              '</div>';
+            setTimeout(function () { window.location.href = result.redirectUrl || '/agents'; }, 1500);
+          })
+          .catch(function (err) {
+            commitBtn.disabled = false;
+            commitBtn.textContent = 'Commit';
+            if (flashEl) flashEl.innerHTML = '<div class="flash flash--error">' + esc(String(err)) + '</div>';
+          });
+        });
+      }
     });
   })();
 `;


### PR DESCRIPTION
## Summary

Build from goal used to only build single agents. It now handles three flavors:

1. **Build an agent** — original behavior.
2. **Build a dashboard from existing agents** — the planner matches goal fragments against your installed agents.
3. **Build a dashboard plus the new agents to fill it** — drafts what's missing, wires existing + new tiles into a section layout.

Auto-detected from the goal text. One review screen surveys what's already installed, shows the new agents (editable YAML inline), shows the dashboard layout, and lists clarifying questions before commit.

## Live smoke (the user's exact example)

> *"Build me a dashboard with daily scheduled reminders: a) the top stories on hacker news, b) today's weather, c) my notes list from my computer, refresh daily"*

Produces:

- **intent**: \`dashboard-mixed\`
- **matched**: \`hn-top-stories-rich\` (top stories on HN), \`weather-forecast\` (today's weather)
- **missing**: my notes list from my computer
- **newAgents**: \`local-notes-list\` (Scans a local notes folder for markdown/text files, returns the 15 most recent)
- **dashboard**: \`user:morning-briefing\` "Morning Briefing" — News / Weather / Notes
- **questions**: which notes folder · what refresh time · overlap with existing Morning Briefing dashboard

## What's new

- \`agents/examples/build-planner.yaml\` — single-node claude-code planner.
- \`packages/core/src/build-plan-schema.ts\` — Zod schema for the structured plan.
- \`packages/core/src/discovery-catalog.ts\` — accepts \`dashboards\` + \`packs\` args, renders as new sections.
- \`POST /agents/build\` — switched to invoke the planner.
- \`GET /agents/build/:runId\` — returns \`BuildPlan\` JSON instead of raw YAML.
- \`POST /agents/build/commit\` (new) — walks the plan, creates agents + dashboard.
- \`POST /agents/build/create\` — kept as compat shim.
- \`packages/dashboard/src/views/build-from-goal.js.ts\` — rewritten with plan-review stage.
- Modal copy + textarea placeholder hint at the new flavors.

## Test plan

- [x] 19 new tests (schema cross-validation, catalog dashboards/packs sections, commit endpoint flavors)
- [x] \`npm test\` — 1066/1066 passing
- [x] \`npm run build\` clean
- [x] Live smoke: 3 goals exercising all three flavors; commit creates agents + dashboard; redirect works
- [ ] Reviewer: open the wizard from \`/\` and try a dashboard goal — confirm the review screen reads well

🤖 Generated with [Claude Code](https://claude.com/claude-code)