### PR TITLE
feat(dashboard): tile-control parity between /dashboards/:id and Pulse

### DIFF
--- a/.changeset/dashboard-tile-parity.md
+++ b/.changeset/dashboard-tile-parity.md
@@ -1,0 +1,46 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Bring `/dashboards/:id` to parity with Pulse for tile-level controls.
+
+Tiles on a stored dashboard now get the same chrome as Pulse tiles:
+- **Configure tile** (already worked — listener is global).
+- **Palette cycle** with persistence (was renderless on dashboards).
+- **Resize handle** with persistence (didn't work at all on dashboards).
+- **Collapse / expand** with persistence (didn't work at all).
+- **"Edit layout" toggle** in the dashboard header reveals resize handles
+  and delete buttons, mirroring Pulse's edit mode.
+- **× remove button**: when rendered on a dashboard, the × now removes
+  the tile from THAT DASHBOARD's section (POSTs to the existing
+  `/sections/:idx/tiles/:tileIdx/delete` endpoint) instead of toggling
+  the agent's global Pulse visibility. Pulse's × keeps its old semantic.
+
+Cosmetic state (palette / size / collapsed) is persisted to localStorage
+keyed per-dashboard (`sua-dashboard-<kind>-<id>`), matching Pulse's
+client-state model. Server still owns section structure (which is
+edited via `/dashboards/:id/edit`'s up/down + add/remove flow).
+
+Implementation:
+- `widgetLayoutJS` gained an optional `runtimeKeySuffixAttr` that
+  appends a host-element attribute value to all storage keys at
+  runtime — so a single global JS bundle can serve every dashboard
+  page with isolated state.
+- New `DASHBOARDS_LAYOUT_JS` module composes `widgetLayoutJS` with
+  dashboard-specific element ids + a per-dashboard collapse handler.
+- `tileWrap` now accepts an optional `TileWrapContext` that controls
+  the × button's form action.
+- The dashboards view renders a `#dashboard-containers` host with
+  `data-dashboard-id`, embeds tile data in
+  `<script id="dashboard-tile-data">`, and adds an "Edit layout"
+  button next to the existing "Edit sections" link.
+
+Out of scope (deferred): drag-drop tile reorder + add-container —
+the existing `/dashboards/:id/edit` page covers section structure
+with up/down arrows.
+
+Tests bumped; full suite 1066/1066.

--- a/packages/dashboard/src/routes/dashboards.test.ts
+++ b/packages/dashboard/src/routes/dashboards.test.ts
@@ -112,6 +112,17 @@ describe('dashboards routes', () => {
     expect(res.text).toContain('Greetings');
     expect(res.text).toContain('data-agent-id="hello"');
     expect(res.text).toContain('from pack: starter');
+    // Pulse-parity tile chrome.
+    expect(res.text).toContain('id="dashboard-containers"');
+    expect(res.text).toContain('data-dashboard-id="starter:main"');
+    expect(res.text).toContain('id="dashboard-edit-toggle"');
+    expect(res.text).toContain('id="dashboard-tile-data"');
+    expect(res.text).toContain('class="pulse-tile__resize-handle"');
+    expect(res.text).toContain('class="pulse-tile__configure-btn"');
+    expect(res.text).toContain('class="pulse-tile__palette-btn"');
+    // × button removes from this dashboard, not from Pulse.
+    expect(res.text).toContain('action="/dashboards/starter%3Amain/sections/0/tiles/0/delete"');
+    expect(res.text).not.toContain('action="/agents/hello/signal/toggle"');
   });
 
   it('renders missing-agent placeholders for ids the agent store doesn\'t know', async () => {

--- a/packages/dashboard/src/views/dashboards-layout.js.ts
+++ b/packages/dashboard/src/views/dashboards-layout.js.ts
@@ -1,0 +1,75 @@
+/**
+ * Dashboards layout JS — gives /dashboards/:id parity with Pulse for
+ * tile-level controls (configure, palette, resize, collapse, edit
+ * toggle). Reuses the shared widgetLayoutJS factory; storage keys are
+ * suffixed at runtime with the dashboard id so each dashboard owns
+ * its own client-side state without compiling per-page JS.
+ *
+ * Server still owns section structure (sections + agentIds) — that's
+ * edited via /dashboards/:id/edit. This module only handles the
+ * cosmetic state Pulse already manages: palette, size, collapse.
+ */
+
+import { widgetLayoutJS } from './widget-layout.js.js';
+
+export const DASHBOARDS_LAYOUT_JS = widgetLayoutJS({
+  prefix: 'dashboard',
+  storageKey: 'sua-dashboard-layout',
+  hostId: 'dashboard-containers',
+  dataId: 'dashboard-tile-data',
+  editToggleId: 'dashboard-edit-toggle',
+  addContainerId: 'dashboard-add-container', // intentionally absent in DOM; widget-layout no-ops
+  paletteKey: 'sua-dashboard-palettes',
+  sizesKey: 'sua-dashboard-sizes',
+  collapsedKey: 'sua-dashboard-collapsed',
+  runtimeKeySuffixAttr: 'data-dashboard-id',
+}) + `
+  // ── Dashboard tile collapse/expand ──────────────────────────────────
+  // Mirrors the Pulse collapse handler. Lives here (not in pulse-layout)
+  // because the storage key needs the runtime dashboard-id suffix.
+  (function () {
+    var host = document.getElementById('dashboard-containers');
+    if (!host) return;
+    var dashId = host.getAttribute('data-dashboard-id') || '';
+    var STORAGE_KEY = 'sua-dashboard-collapsed' + (dashId ? '-' + dashId : '');
+
+    function getCollapsed() {
+      try { return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}'); } catch { return {}; }
+    }
+    function setCollapsed(map) {
+      try { localStorage.setItem(STORAGE_KEY, JSON.stringify(map)); } catch {}
+    }
+
+    var collapsed = getCollapsed();
+    var tiles = host.querySelectorAll('.pulse-tile');
+    for (var i = 0; i < tiles.length; i++) {
+      var btn = tiles[i].querySelector('.pulse-tile__collapse');
+      if (btn) {
+        var id = btn.getAttribute('data-tile-id');
+        if (id && collapsed[id]) tiles[i].classList.add('pulse-tile--collapsed');
+      }
+    }
+
+    document.addEventListener('click', function (e) {
+      var target = e.target;
+      var tileId = null;
+      if (target.classList && target.classList.contains('pulse-tile__collapse')) {
+        tileId = target.getAttribute('data-tile-id');
+      } else if (target.closest && target.closest('[data-collapse-trigger]')) {
+        tileId = target.closest('[data-collapse-trigger]').getAttribute('data-tile-id');
+      }
+      if (!tileId) return;
+      var tile = target.closest('.pulse-tile');
+      if (!tile || !host.contains(tile)) return; // only act on dashboards-page tiles
+
+      tile.classList.toggle('pulse-tile--collapsed');
+      var map = getCollapsed();
+      if (tile.classList.contains('pulse-tile--collapsed')) {
+        map[tileId] = true;
+      } else {
+        delete map[tileId];
+      }
+      setCollapsed(map);
+    });
+  })();
+`;

--- a/packages/dashboard/src/views/dashboards.ts
+++ b/packages/dashboard/src/views/dashboards.ts
@@ -9,7 +9,7 @@
  */
 
 import type { Dashboard } from '@some-useful-agents/core';
-import { html, render, type SafeHtml } from './html.js';
+import { html, render, unsafeHtml, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
 import { renderTile } from './pulse-renderers.js';
@@ -54,7 +54,10 @@ export function renderDashboardPage(input: RenderDashboardPageInput): string {
         ${totalMissing > 0 ? html`, ${String(totalMissing)} missing` : html``}
         · ${sourceLabel}
       </span>
-      <a class="btn btn--ghost btn--sm" href="/dashboards/${encodeURIComponent(input.dashboard.id)}/edit" style="margin-left: auto;">Edit</a>
+      <div style="margin-left: auto; display: flex; gap: var(--space-2);">
+        <button type="button" class="btn btn--ghost btn--sm" id="dashboard-edit-toggle">✎ Edit layout</button>
+        <a class="btn btn--ghost btn--sm" href="/dashboards/${encodeURIComponent(input.dashboard.id)}/edit">Edit sections</a>
+      </div>
     </div>
 
     ${pageHeader({
@@ -64,7 +67,15 @@ export function renderDashboardPage(input: RenderDashboardPageInput): string {
 
     ${input.sections.length === 0
       ? html`<p class="dim" style="padding: var(--space-4); text-align: center;">No sections in this dashboard.</p>`
-      : input.sections.map((s) => renderSection(s)) as unknown as SafeHtml[]}
+      : html`
+        <div id="dashboard-containers" data-dashboard-id="${input.dashboard.id}">
+          ${input.sections.map((s, idx) => renderSection(input.dashboard.id, s, idx)) as unknown as SafeHtml[]}
+        </div>
+        ${unsafeHtml(`<script type="application/json" id="dashboard-tile-data">${JSON.stringify({
+          allTileIds: input.sections.flatMap((s) => s.tiles.map((t) => t.agent.id)),
+          systemTileIds: [],
+        })}</script>`)}
+      `}
   `;
 
   return render(layout({
@@ -74,14 +85,25 @@ export function renderDashboardPage(input: RenderDashboardPageInput): string {
   }, body));
 }
 
-function renderSection(s: DashboardSectionRender): SafeHtml {
+function renderSection(
+  dashboardId: string,
+  s: DashboardSectionRender,
+  sectionIdx: number,
+): SafeHtml {
   const isEmpty = s.tiles.length === 0 && s.missingAgentIds.length === 0;
   if (isEmpty) return html``;
   return html`
-    <section style="margin-bottom: var(--space-5);">
+    <section class="pulse-container" data-container-id="section-${String(sectionIdx)}" style="margin-bottom: var(--space-5);">
       <h2 style="margin: 0 0 var(--space-3) 0; font-size: var(--font-size-md); font-weight: var(--weight-semibold);">${s.title}</h2>
-      <div class="pulse-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: var(--space-3);">
-        ${s.tiles.map((t) => renderTile(t, tileWrap)) as unknown as SafeHtml[]}
+      <div class="pulse-grid" data-container-id="section-${String(sectionIdx)}" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: var(--space-3);">
+        ${s.tiles.map((t, tileIdx) =>
+          renderTile(t, (tile, content) => tileWrap(tile, content, {
+            kind: 'dashboard',
+            dashboardId,
+            sectionIdx,
+            tileIdx,
+          }))
+        ) as unknown as SafeHtml[]}
         ${s.missingAgentIds.map((id) => html`
           <div class="card dim" style="padding: var(--space-3); border: 1px dashed var(--color-border-strong);">
             <div style="font-family: var(--font-mono); font-size: var(--font-size-sm);">${id}</div>

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -4,6 +4,7 @@ import { TEMPLATE_PALETTE_JS } from './template-palette.js.js';
 import { SUGGEST_IMPROVEMENTS_JS } from './suggest-improvements.js.js';
 import { PULSE_LAYOUT_JS } from './pulse-layout.js.js';
 import { HOME_LAYOUT_JS } from './home-layout.js.js';
+import { DASHBOARDS_LAYOUT_JS } from './dashboards-layout.js.js';
 import { BUILD_FROM_GOAL_JS } from './build-from-goal.js.js';
 import { OUTPUT_WIDGET_ACTIONS_JS } from './output-widget-actions.js.js';
 import { RUN_DETAIL_FILTER_JS } from './run-detail-filter.js.js';
@@ -69,7 +70,7 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
   ${body}
 </main>
 ${footer()}
-<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + HOME_LAYOUT_JS + BUILD_FROM_GOAL_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS)}</script>
+<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + HOME_LAYOUT_JS + DASHBOARDS_LAYOUT_JS + BUILD_FROM_GOAL_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS)}</script>
 </body>
 </html>`;
 }

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -20,8 +20,22 @@ import type { PulseTile, PulsePageInput, TileWrapFn } from './pulse-types.js';
 
 // ── Tile chrome ──────────────────────────────────────────────────────────
 
+/**
+ * Surface where a tile is being rendered. Determines what the tile's
+ * × button does — on Pulse it toggles the agent's pulseVisible flag;
+ * on a dashboard it removes the tile from that specific dashboard's
+ * section without touching pulseVisible.
+ */
+export type TileWrapContext =
+  | { kind: 'pulse' }
+  | { kind: 'dashboard'; dashboardId: string; sectionIdx: number; tileIdx: number };
+
 /** Wraps tile content with header, footer, resize handle, and data attributes. */
-export function tileWrap(tile: PulseTile, content: SafeHtml): SafeHtml {
+export function tileWrap(
+  tile: PulseTile,
+  content: SafeHtml,
+  ctx: TileWrapContext = { kind: 'pulse' },
+): SafeHtml {
   const isSystem = tile.agent.id.startsWith('_system-');
   const sizeAttr = tile.signal.size ?? '1x1';
   const autoPalette = resolveAutoPalette(tile);
@@ -33,7 +47,7 @@ export function tileWrap(tile: PulseTile, content: SafeHtml): SafeHtml {
     : '';
   return unsafeHtml(
     `<div class="pulse-tile ${sizeClass(sizeAttr)}" data-agent-id="${esc(tile.agent.id)}" data-tile-size="${esc(sizeAttr)}"${paletteAttr}${accentAttr}>` +
-    tileHeader(tile, isSystem).toString() +
+    tileHeader(tile, isSystem, ctx).toString() +
     content.toString() +
     (isSystem ? '' : tileFooter(tile).toString()) +
     '<div class="pulse-tile__resize-handle" data-agent-id="' + esc(tile.agent.id) + '"></div>' +
@@ -72,7 +86,7 @@ function sizeClass(size: string): string {
   return '';
 }
 
-function tileHeader(tile: PulseTile, isSystem: boolean): SafeHtml {
+function tileHeader(tile: PulseTile, isSystem: boolean, ctx: TileWrapContext): SafeHtml {
   const icon = tile.signal.icon ?? '';
   const { template, mapping } = normalizeSignal(tile.signal);
   // Embed signal config as data attributes for the configure modal JS.
@@ -101,11 +115,17 @@ function tileHeader(tile: PulseTile, isSystem: boolean): SafeHtml {
           <button type="button" class="pulse-tile__configure-btn" data-tile-id="${tile.agent.id}" title="Configure tile">\u2699</button>
         `}
         <button type="button" class="pulse-tile__palette-btn" data-tile-id="${tile.agent.id}" title="Change palette">\u25CF</button>
-        ${isSystem ? html`` : html`
-          <form method="POST" action="/agents/${tile.agent.id}/signal/toggle" style="margin: 0;">
-            <button type="submit" class="pulse-tile__toggle" title="Hide from Pulse">\u00D7</button>
-          </form>
-        `}
+        ${isSystem ? html`` : (ctx.kind === 'dashboard'
+          ? html`
+              <form method="POST" action="/dashboards/${encodeURIComponent(ctx.dashboardId)}/sections/${String(ctx.sectionIdx)}/tiles/${String(ctx.tileIdx)}/delete" style="margin: 0;">
+                <button type="submit" class="pulse-tile__toggle" title="Remove from this dashboard">\u00D7</button>
+              </form>
+            `
+          : html`
+              <form method="POST" action="/agents/${tile.agent.id}/signal/toggle" style="margin: 0;">
+                <button type="submit" class="pulse-tile__toggle" title="Hide from Pulse">\u00D7</button>
+              </form>
+            `)}
       </div>
     </div>
   `;

--- a/packages/dashboard/src/views/widget-layout.js.ts
+++ b/packages/dashboard/src/views/widget-layout.js.ts
@@ -29,6 +29,14 @@ export interface WidgetLayoutConfig {
   sizesKey?: string;
   /** Override localStorage key for collapsed state. Defaults to `${storageKey}-collapsed`. */
   collapsedKey?: string;
+  /**
+   * Optional. When set, the generated JS reads this attribute from the
+   * host element at runtime and appends its value to all four storage
+   * keys (layout/palette/sizes/collapsed). Used by the dashboards
+   * surface so each `/dashboards/<id>` page gets its own isolated
+   * client state without compiling per-page JS.
+   */
+  runtimeKeySuffixAttr?: string;
 }
 
 export function widgetLayoutJS(config: WidgetLayoutConfig): string {
@@ -50,10 +58,11 @@ export function widgetLayoutJS(config: WidgetLayoutConfig): string {
     var systemIds = tileData.systemTileIds || [];
     var protectedPrefixes = ${protectedPrefixes};
 
-    var LAYOUT_KEY = '${config.storageKey}';
-    var PALETTE_KEY = '${paletteKey}';
-    var SIZES_KEY = '${sizesKey}';
-    var COLLAPSED_KEY = '${collapsedKey}';
+    var KEY_SUFFIX = ${config.runtimeKeySuffixAttr ? `host.getAttribute('${config.runtimeKeySuffixAttr}') || ''` : `''`};
+    var LAYOUT_KEY = '${config.storageKey}' + (KEY_SUFFIX ? '-' + KEY_SUFFIX : '');
+    var PALETTE_KEY = '${paletteKey}' + (KEY_SUFFIX ? '-' + KEY_SUFFIX : '');
+    var SIZES_KEY = '${sizesKey}' + (KEY_SUFFIX ? '-' + KEY_SUFFIX : '');
+    var COLLAPSED_KEY = '${collapsedKey}' + (KEY_SUFFIX ? '-' + KEY_SUFFIX : '');
     var PALETTES = ['default', 'dark', 'light', 'accent-teal', 'accent-red', 'accent-green'];
 
     function isProtected(id) {


### PR DESCRIPTION
## Summary

Stored dashboards now have the same per-tile controls as Pulse — configure, palette cycle, resize handle, collapse/expand, "Edit layout" toggle. The × button on a dashboard tile correctly **removes the tile from that dashboard** instead of toggling the agent's global Pulse visibility.

### What changed

| Feature | Before | After |
|---|---|---|
| Configure (⚙) | ✅ already worked (global JS) | ✅ |
| Palette (●) | Click did something but state didn't persist | ✅ persists to per-dashboard localStorage |
| Resize (↘) | Render-only, no JS handler bound | ✅ works in edit mode |
| Collapse (▼) | No persistence | ✅ persists per-dashboard |
| Edit layout toggle | Absent | ✅ new button next to "Edit sections" |
| × button | POSTed to \`/agents/:id/signal/toggle\` (wrong!) | POSTs to \`/dashboards/:id/sections/:idx/tiles/:tileIdx/delete\` |

### Implementation

- \`widgetLayoutJS\` gained \`runtimeKeySuffixAttr\` so a single global JS bundle can scope state per-page by reading a host attribute at runtime.
- New \`DASHBOARDS_LAYOUT_JS\` module composes the shared widget-layout + a per-dashboard collapse handler.
- \`tileWrap\` accepts an optional \`TileWrapContext\` that controls the × button form action — \`{ kind: 'pulse' }\` or \`{ kind: 'dashboard', dashboardId, sectionIdx, tileIdx }\`. Pulse default unchanged.
- Dashboards view renders \`#dashboard-containers[data-dashboard-id]\` with \`<script id="dashboard-tile-data">\`, and an "Edit layout" toggle button.

Cosmetic state (palette/size/collapsed) persists in localStorage with keys like \`sua-dashboard-palettes-starter:media\`, isolated per-dashboard. Section structure stays server-side, edited via the existing \`/dashboards/:id/edit\` page.

### Out of scope (deliberate)

- **Drag-drop tile reorder + add-container.** The existing editor at \`/dashboards/:id/edit\` already handles section structure with up/down arrows, which is testable, deterministic, and works without JS. Drag-drop on the view page would duplicate that.

## Test plan
- [x] \`npm test\` — 1066/1066 (one existing dashboards test extended with chrome assertions)
- [x] \`npm run build\` clean
- [x] Live smoke: \`/dashboards/starter:media\` shows resize handles, configure ⚙, palette ●, edit-layout toggle; × forms POST to \`/dashboards/.../sections/0/tiles/N/delete\`
- [ ] Reviewer: open a dashboard, click "✎ Edit layout", drag the resize handle on a tile, refresh — size persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)