### PR TITLE
feat(examples): default dogfood tiles render the full output widget

### DIFF
--- a/.changeset/dogfood-rich-tiles.md
+++ b/.changeset/dogfood-rich-tiles.md
@@ -1,0 +1,23 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Switch the two remaining dogfood agents to `signal.template: widget`
+so their dashboard tiles render the full output widget instead of a
+compact text-headline.
+
+`weather-forecast` and `vimeo-staff-picks` previously used
+`text-headline`, which surfaced just temperature/condition or
+`fetched_at` on tiles — none of the view-switch / field-toggle /
+replay / iframe machinery the agents were specifically built to
+showcase. `cat-video-finder` was already on `template: widget` and
+served as the proof. With this change all three demo tiles now
+render their full widgets, matching their behaviour on the agent
+detail page.
+
+Each YAML gained a comment explaining the trade-off: `text-headline`
+is the compact alternative for high-density Pulse layouts.

--- a/agents/examples/vimeo-staff-picks.yaml
+++ b/agents/examples/vimeo-staff-picks.yaml
@@ -68,10 +68,12 @@ nodes:
     timeout: 20
 signal:
   title: Vimeo Staff Picks
-  template: text-headline
-  mapping:
-    headline: fetched_at
-    body: fetched_at
+  # `widget` mirrors the full outputWidget on tiles so the iframe
+  # players + #each iteration + replay control all show inline.
+  # Switch to text-headline if you'd rather a tiny "last fetched at"
+  # tile instead of the full embed grid.
+  template: widget
+  mapping: {}
   size: 2x1
   accent: blue
 outputWidget:

--- a/agents/examples/weather-forecast.yaml
+++ b/agents/examples/weather-forecast.yaml
@@ -109,10 +109,12 @@ nodes:
     timeout: 25
 signal:
   title: Weather
-  template: text-headline
-  mapping:
-    headline: temperature
-    body: condition
+  # `widget` mirrors the full outputWidget on tiles — surfaces the
+  # view-switch / field-toggle / replay controls so the dashboard
+  # tile feels like the full result page. Use `text-headline` for
+  # a compact temperature-only summary instead.
+  template: widget
+  mapping: {}
   size: 2x1
   accent: blue
 outputWidget:


### PR DESCRIPTION
## Summary

Two of the three dogfood agents shipped with \`signal.template: text-headline\`, which produced a compact summary tile that never surfaced the view-switch / field-toggle / replay / iframe controls those agents were specifically built to demo.

Switched \`weather-forecast\` + \`vimeo-staff-picks\` to \`template: widget\` (the signal template that mirrors the full outputWidget on tiles). \`cat-video-finder\` already used this and proved the pattern.

| Agent | Was | Now |
|---|---|---|
| \`cat-video-finder\` | \`widget\` | unchanged |
| \`weather-forecast\` | \`text-headline\` | \`widget\` |
| \`vimeo-staff-picks\` | \`text-headline\` | \`widget\` |

Each YAML gained a comment explaining the trade-off (\`text-headline\` is still the right pick for compact Pulse layouts).

## Test plan
- [x] \`npm test\` — 1066/1066
- [x] \`npm run build\` clean
- [x] Live smoke: \`/dashboards/starter:weather\` shows the dashboard widget body inside the tile; \`/dashboards/starter:media\` shows the Vimeo iframe grid inside the tile
- [ ] Reviewer: open both dashboards and confirm the tile chrome (configure ⚙, palette ●, ×) coexists with the full widget body

🤖 Generated with [Claude Code](https://claude.com/claude-code)