### PR TITLE
fix(dashboard): align CSP frame-src/img-src with iframe sanitizer allowlist

### DIFF
--- a/.changeset/csp-vimeo.md
+++ b/.changeset/csp-vimeo.md
@@ -1,0 +1,19 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+CSP `frame-src` and `img-src` were missing the Vimeo + youtube-nocookie
+hosts that the iframe sanitizer's allowlist permits. The browser
+silently blocked Vimeo iframes (and their poster images) even though
+the sanitizer rendered them. Added `https://player.vimeo.com` and
+`https://www.youtube-nocookie.com` to `frame-src`, plus
+`https://i.vimeocdn.com` to `img-src` for the Vimeo CDN's posters.
+
+CSP block now mirrors the host allowlist in
+`packages/core/src/html-sanitizer.ts:IFRAME_ALLOWED_HOSTS`. Comment
+above the directive flags this — any future host added to the
+sanitizer must also be added here or it'll silently 4xx in browsers.

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -107,7 +107,13 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   app.use((_req, res, next) => {
     res.setHeader(
       'Content-Security-Policy',
-      "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://img.youtube.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-src 'self' https://www.youtube.com; frame-ancestors 'none'",
+      // frame-src + img-src must include every host on the iframe
+      // sanitizer's IFRAME_ALLOWED_HOSTS allowlist (packages/core/src/
+      // html-sanitizer.ts). Otherwise the sanitizer renders the
+      // <iframe> but the browser silently blocks the load — and the
+      // poster image (loaded inside the iframe) never appears either.
+      // Mirror any allowlist additions in core here too.
+      "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://img.youtube.com https://i.vimeocdn.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com; frame-ancestors 'none'",
     );
     res.setHeader('X-Content-Type-Options', 'nosniff');
     res.setHeader('X-Frame-Options', 'DENY');


### PR DESCRIPTION
## Summary

Vimeo iframes were silently blocked by the browser. The HTML sanitizer rendered the \`<iframe src="https://player.vimeo.com/video/...">\` correctly, but the page-level CSP \`frame-src\` only listed YouTube — so the browser refused to load the iframe (no player, no poster preview).

Added \`https://player.vimeo.com\` + \`https://www.youtube-nocookie.com\` to \`frame-src\`, and \`https://i.vimeocdn.com\` to \`img-src\` for the Vimeo CDN's posters. CSP now mirrors \`IFRAME_ALLOWED_HOSTS\` in [html-sanitizer.ts](packages/core/src/html-sanitizer.ts).

Comment above the directive flags the invariant for future contributors.

## Test plan
- [x] \`npm test\` — 1066/1066
- [x] \`npm run build\` clean
- [x] Live smoke: \`/dashboards/starter:media\` now shows Vimeo posters + click-to-play
- [ ] Reviewer: open \`/dashboards/starter:media\` and confirm poster + play button render before clicking

🤖 Generated with [Claude Code](https://claude.com/claude-code)