### PR TITLE
feat(dashboard): "Save as pack" — export a dashboard as a pack manifest YAML

### DIFF
--- a/.changeset/dashboard-export-as-pack.md
+++ b/.changeset/dashboard-export-as-pack.md
@@ -1,0 +1,33 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+"Save as pack" — export a dashboard as a portable pack manifest YAML.
+
+Adds a download path so users can take a dashboard they've curated and
+turn it into a shareable pack file. Bundles the dashboard's layout
+plus the full YAML of every agent it references into one manifest.
+
+- **`dashboardToPackManifest()`** in core. Round-trips through
+  `packManifestSchema` — the file the browser downloads is parseable
+  by the existing pack loader and installable via `installPack`.
+- **`GET /dashboards/:id/export`** returns a YAML attachment with
+  `Content-Disposition: attachment; filename="<pack-id>.pack.yaml"`.
+  Missing agents (referenced in sections but not in the agent store)
+  are dropped from the export and surfaced via an
+  `X-Pack-Missing-Agents` response header.
+- **"Save as pack"** button on every dashboard view page, alongside
+  Edit layout / Edit sections.
+
+For now there's no user-pack directory — the downloaded file is
+ready to share or commit, but installing it locally still means
+dropping it in `packages/core/packs/` (a follow-up will add a
+user-pack directory under `~/.sua/packs/` so the loader picks them
+up automatically).
+
+6 new unit tests cover round-trip-through-schema, missing-agent
+handling, namespace stripping, and id/name/version overrides.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -82,6 +82,11 @@ export {
   type PackUninstallResult,
 } from './pack-installer.js';
 export {
+  dashboardToPackManifest,
+  type DashboardExportInput,
+  type DashboardExportResult,
+} from './pack-export.js';
+export {
   buildPlanSchema,
   extractPlanJson,
   type BuildPlan,

--- a/packages/core/src/pack-export.test.ts
+++ b/packages/core/src/pack-export.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { parse as parseYaml } from 'yaml';
+import { dashboardToPackManifest } from './pack-export.js';
+import { packManifestSchema } from './pack-schema.js';
+import type { Agent } from './agent-v2-types.js';
+import type { Dashboard } from './dashboards-store.js';
+
+function sampleAgent(id: string, overrides: Partial<Agent> = {}): Agent {
+  return {
+    id,
+    name: id,
+    status: 'active',
+    source: 'local',
+    mcp: false,
+    nodes: [{ id: 'n', type: 'shell', command: 'echo hi', dependsOn: [] }],
+    signal: { title: id, template: 'text-headline', mapping: { headline: 'h' } },
+    version: 1,
+    ...overrides,
+  } as Agent;
+}
+
+function sampleDashboard(overrides: Partial<Dashboard> = {}): Dashboard {
+  return {
+    id: 'user:morning-briefing',
+    packId: null,
+    name: 'Morning Briefing',
+    layout: { sections: [
+      { title: 'News', agentIds: ['hn-top-stories'] },
+      { title: 'Weather', agentIds: ['weather-forecast'] },
+    ]},
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+describe('dashboardToPackManifest', () => {
+  it('produces a manifest with both agents inlined', () => {
+    const dashboard = sampleDashboard();
+    const agents = [sampleAgent('hn-top-stories'), sampleAgent('weather-forecast')];
+    const result = dashboardToPackManifest({ dashboard, agents });
+    expect(result.manifest.id).toBe('morning-briefing');
+    expect(result.manifest.agents).toHaveLength(2);
+    expect(result.manifest.agents?.[0].yaml).toContain('id: hn-top-stories');
+    expect(result.manifest.dashboards?.[0].id).toBe('morning-briefing');
+    expect(result.manifest.dashboards?.[0].sections).toHaveLength(2);
+  });
+
+  it('strips the namespace prefix from the inner dashboard id', () => {
+    const result = dashboardToPackManifest({
+      dashboard: sampleDashboard({ id: 'starter:media' }),
+      agents: [],
+    });
+    expect(result.manifest.id).toBe('media');
+    expect(result.manifest.dashboards?.[0].id).toBe('media');
+  });
+
+  it('reports missingAgentIds when an agent is referenced but not supplied', () => {
+    const dashboard = sampleDashboard();
+    const agents = [sampleAgent('hn-top-stories')]; // missing weather-forecast
+    const result = dashboardToPackManifest({ dashboard, agents });
+    expect(result.missingAgentIds).toEqual(['weather-forecast']);
+    expect(result.manifest.agents).toHaveLength(1);
+  });
+
+  it('round-trips through packManifestSchema', () => {
+    const dashboard = sampleDashboard();
+    const agents = [sampleAgent('hn-top-stories'), sampleAgent('weather-forecast')];
+    const result = dashboardToPackManifest({ dashboard, agents });
+    // The YAML body should re-parse cleanly via the loader's schema.
+    const parsedAgain = parseYaml(result.yaml) as unknown;
+    const validation = packManifestSchema.safeParse(parsedAgain);
+    expect(validation.success).toBe(true);
+  });
+
+  it('honours packId / packName / version overrides', () => {
+    const result = dashboardToPackManifest({
+      dashboard: sampleDashboard(),
+      agents: [],
+      packId: 'morning-pack',
+      packName: 'My Morning Pack',
+      version: '0.5.0',
+      author: 'tester',
+    });
+    expect(result.manifest.id).toBe('morning-pack');
+    expect(result.manifest.name).toBe('My Morning Pack');
+    expect(result.manifest.version).toBe('0.5.0');
+    expect(result.manifest.author).toBe('tester');
+  });
+
+  it('deduplicates agent ids when one appears in multiple sections', () => {
+    const dashboard = sampleDashboard({
+      layout: { sections: [
+        { title: 'A', agentIds: ['shared'] },
+        { title: 'B', agentIds: ['shared'] },
+      ]},
+    });
+    const result = dashboardToPackManifest({ dashboard, agents: [sampleAgent('shared')] });
+    expect(result.manifest.agents).toHaveLength(1);
+  });
+});

--- a/packages/core/src/pack-export.ts
+++ b/packages/core/src/pack-export.ts
@@ -1,0 +1,116 @@
+/**
+ * Export a stored Dashboard as a Pack manifest YAML.
+ *
+ * Companion to pack-loader (which reads built-in pack manifests). The
+ * export path is the user-facing way to bundle "the dashboard I just
+ * curated, plus the agents it references" into a single, shareable
+ * artifact. Round-trips through the loader: the YAML this function
+ * emits is parseable by `packManifestSchema` + installable via
+ * `installPack`.
+ *
+ * Reference-only ownership stays consistent — exporting doesn't change
+ * the live agents/dashboard at all; it just snapshots them.
+ */
+
+import { stringify as stringifyYaml } from 'yaml';
+import { exportAgent } from './agent-yaml.js';
+import type { Agent } from './agent-v2-types.js';
+import type { Dashboard } from './dashboards-store.js';
+import type { PackManifest } from './packs-store.js';
+
+export interface DashboardExportInput {
+  dashboard: Dashboard;
+  /** Resolved agents referenced by the dashboard's sections. Missing agents are skipped. */
+  agents: Agent[];
+  /** Optional pack-id override. Default derives from dashboard.id by stripping the `user:` prefix. */
+  packId?: string;
+  /** Optional pack-name override. Default = dashboard.name. */
+  packName?: string;
+  /** Optional version. Default 0.1.0 — exporters should bump on edits. */
+  version?: string;
+  author?: string;
+  description?: string;
+}
+
+export interface DashboardExportResult {
+  manifest: PackManifest;
+  /** YAML rendering of the manifest, ready to write/download. */
+  yaml: string;
+  /** Agent ids the dashboard referenced but the caller didn't supply. */
+  missingAgentIds: string[];
+}
+
+/**
+ * Build a PackManifest from a dashboard and its referenced agents.
+ * Inlines each agent's full YAML under `agents[]`. The packed
+ * dashboard id strips the `user:` / `<pack>:` prefix so the resulting
+ * manifest is portable.
+ */
+export function dashboardToPackManifest(input: DashboardExportInput): DashboardExportResult {
+  const { dashboard, agents } = input;
+  const agentMap = new Map(agents.map((a) => [a.id, a]));
+
+  // Collect every agent id referenced anywhere in the dashboard sections.
+  const referencedIds = new Set<string>();
+  for (const section of dashboard.layout.sections) {
+    for (const id of section.agentIds) referencedIds.add(id);
+  }
+
+  const missingAgentIds: string[] = [];
+  const packedAgents = [];
+  for (const id of referencedIds) {
+    const agent = agentMap.get(id);
+    if (!agent) {
+      missingAgentIds.push(id);
+      continue;
+    }
+    packedAgents.push({
+      id: agent.id,
+      yaml: exportAgent(agent),
+    });
+  }
+
+  const packId = input.packId ?? slugifyDashboardId(dashboard.id);
+  const packName = input.packName ?? dashboard.name;
+  const innerDashboardId = bareDashboardId(dashboard.id);
+
+  const manifest: PackManifest = {
+    id: packId,
+    name: packName,
+    description: input.description ?? `Exported from dashboard "${dashboard.name}".`,
+    version: input.version ?? '0.1.0',
+    author: input.author,
+    agents: packedAgents,
+    dashboards: [{
+      id: innerDashboardId,
+      name: dashboard.name,
+      sections: dashboard.layout.sections,
+    }],
+  };
+
+  return {
+    manifest,
+    yaml: stringifyYaml(manifest, { lineWidth: 0 }),
+    missingAgentIds,
+  };
+}
+
+/**
+ * Drop the namespace prefix on a stored dashboard id when packing.
+ * Stored ids look like `user:morning-briefing` or `starter:media`;
+ * the manifest's inner dashboard id only needs the bare slug.
+ */
+function bareDashboardId(id: string): string {
+  const colon = id.indexOf(':');
+  return colon >= 0 ? id.slice(colon + 1) : id;
+}
+
+/**
+ * Build a pack-id from a dashboard id. Strips the namespace prefix
+ * and lowercases. Pack ids must match `^[a-z0-9][a-z0-9-]*$` per the
+ * pack manifest schema.
+ */
+function slugifyDashboardId(id: string): string {
+  const bare = bareDashboardId(id).toLowerCase();
+  return bare.replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '') || 'untitled';
+}

--- a/packages/dashboard/src/routes/dashboards.ts
+++ b/packages/dashboard/src/routes/dashboards.ts
@@ -9,7 +9,7 @@
  */
 
 import { Router, type Request, type Response } from 'express';
-import type { Agent, AgentSignal } from '@some-useful-agents/core';
+import { dashboardToPackManifest, type Agent, type AgentSignal } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 import {
   renderDashboardPage,
@@ -64,6 +64,50 @@ dashboardsRouter.get('/dashboards/:id', (req: Request, res: Response) => {
     installedDashboards,
     flash,
   }));
+});
+
+/**
+ * GET /dashboards/:id/export — download the dashboard as a Pack manifest YAML.
+ *
+ * Bundles the dashboard's layout + each agent it references (full YAML
+ * inlined). Round-trips through pack-loader: the file the browser
+ * downloads is parseable by `packManifestSchema` + installable via
+ * `installPack` once dropped in the right directory.
+ *
+ * Missing agents (referenced in sections but not in agentStore) are
+ * silently dropped from the export — surfaced as a header for the
+ * caller's awareness.
+ */
+dashboardsRouter.get('/dashboards/:id/export', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.dashboardsStore) {
+    res.status(404).type('html').send(renderNotFoundPage({ path: req.originalUrl, message: 'Dashboards store unavailable.' }));
+    return;
+  }
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const dashboard = ctx.dashboardsStore.getDashboard(id);
+  if (!dashboard) {
+    res.status(404).type('html').send(renderNotFoundPage({ path: req.originalUrl, message: `No dashboard with id "${id}".` }));
+    return;
+  }
+
+  // Resolve the agents the dashboard references.
+  const agentIds = new Set<string>();
+  for (const s of dashboard.layout.sections) for (const aid of s.agentIds) agentIds.add(aid);
+  const agents = Array.from(agentIds)
+    .map((aid) => ctx.agentStore.getAgent(aid))
+    .filter((a): a is NonNullable<typeof a> => a !== null);
+
+  const result = dashboardToPackManifest({ dashboard, agents });
+
+  // Suggest a sensible filename. Browsers honour `attachment;
+  // filename="..."` for download dialogs.
+  const filename = `${result.manifest.id}.pack.yaml`;
+  res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+  if (result.missingAgentIds.length) {
+    res.setHeader('X-Pack-Missing-Agents', result.missingAgentIds.join(','));
+  }
+  res.type('text/yaml').send(result.yaml);
 });
 
 function parseFlash(req: Request): { kind: 'ok' | 'error' | 'info'; message: string } | undefined {

--- a/packages/dashboard/src/views/dashboards.ts
+++ b/packages/dashboard/src/views/dashboards.ts
@@ -57,6 +57,7 @@ export function renderDashboardPage(input: RenderDashboardPageInput): string {
       <div style="margin-left: auto; display: flex; gap: var(--space-2);">
         <button type="button" class="btn btn--ghost btn--sm" id="dashboard-edit-toggle">✎ Edit layout</button>
         <a class="btn btn--ghost btn--sm" href="/dashboards/${encodeURIComponent(input.dashboard.id)}/edit">Edit sections</a>
+        <a class="btn btn--ghost btn--sm" href="/dashboards/${encodeURIComponent(input.dashboard.id)}/export" title="Download as a pack manifest YAML">Save as pack</a>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

Adds the "Save as pack" export path. Click a button on any dashboard, get a YAML file that's a valid pack manifest — round-trips through the existing pack loader, installable via \`installPack\`, shareable as a single artifact.

### What's in the box

- **\`dashboardToPackManifest()\`** in core. Inlines each referenced agent's full YAML.
- **\`GET /dashboards/:id/export\`** — \`Content-Disposition: attachment\` triggers a browser download. Missing agents (referenced but uninstalled) are dropped from the export and noted via an \`X-Pack-Missing-Agents\` response header.
- **"Save as pack"** link in the dashboard view header.

### Try it

Open \`/dashboards/starter:media\`, click **Save as pack**. Browser downloads \`media.pack.yaml\` containing both Vimeo + cat-video agents inlined plus the Media dashboard layout.

## What's next (deferred)

- **User-pack directory** at \`~/.sua/packs/\` so the loader picks up downloaded packs automatically. Today the file ships as something to share or commit; installing it locally still means dropping it in \`packages/core/packs/\` by hand. One small PR.

## Test plan
- [x] 6 new unit tests (round-trip-through-schema, missing-agent handling, namespace stripping, id/name/version overrides, dedup)
- [x] \`npm test\` — 1072/1072 passing
- [x] \`npm run build\` clean
- [x] Live smoke: download \`/dashboards/starter:media/export\` → 200 with \`Content-Disposition\` header, YAML body parses through the manifest schema
- [ ] Reviewer: open a user-created dashboard, click Save as pack, inspect the downloaded YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)