### PR TITLE
fix(build-from-goal): include drafts in catalog + dashboard integrity at commit

### DIFF
--- a/.changeset/planner-drafts-and-dashboard-integrity.md
+++ b/.changeset/planner-drafts-and-dashboard-integrity.md
@@ -1,0 +1,33 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Two related Build-from-goal fixes that surfaced from a real-user dashboard
+where the planner hallucinated an agent id and the wizard still created
+the dashboard pointing at it.
+
+**A. Discovery catalog includes draft agents.** `buildAgentsSection`
+previously filtered to `status: 'active'` only, so any agent the user
+had scaffolded but not yet activated was invisible to the planner.
+Result: when the goal mentioned "the ashby job search," the planner
+couldn't see the user's draft `ashby-job-finder` and invented
+`ashby-job-hunter` instead. Drafts are now included, marked
+`(draft)` in the catalog so the LLM treats them as work-in-progress
+candidates rather than hidden. Cap raised from 20 → 30 agents.
+
+**B. Commit refuses to create a dashboard whose tiles reference
+agents that didn't land.** Previously each agent in `newAgents` had
+its YAML parsed/upserted independently; failures went into
+`agentsSkipped[]` but the dashboard was still upserted, leaving the
+user with empty "not installed" placeholder cards and no clear cause.
+The commit now checks every `dashboard.sections[].agentIds[]` against
+both the just-created agents AND the existing AgentStore. If any are
+unmet, the dashboard is NOT created and `dashboardError` includes the
+ids and the per-agent skip reasons.
+
+3 new tests (catalog draft inclusion, archived exclusion, commit
+integrity check); full suite 1075/1075 green.

--- a/packages/core/src/discovery-catalog.test.ts
+++ b/packages/core/src/discovery-catalog.test.ts
@@ -248,6 +248,40 @@ describe('buildDiscoveryCatalog', () => {
     expect(catalog).toContain('3 agents, 1 dashboard');
   });
 
+  it('includes draft agents marked as (draft)', () => {
+    const draftAgent = {
+      id: 'wip-explorer',
+      name: 'WIP Explorer',
+      description: 'Work in progress.',
+      status: 'draft',
+      version: 1,
+      nodes: [],
+    } as unknown as Agent;
+    const catalog = buildDiscoveryCatalog({
+      agents: [...MOCK_AGENTS, draftAgent],
+      tools: [],
+      templateRegistry: MOCK_REGISTRY,
+    });
+    expect(catalog).toContain('wip-explorer (draft)');
+  });
+
+  it('does not include archived/paused agents', () => {
+    const archived = {
+      id: 'old-agent',
+      name: 'Old',
+      description: 'archived',
+      status: 'archived',
+      version: 1,
+      nodes: [],
+    } as unknown as Agent;
+    const catalog = buildDiscoveryCatalog({
+      agents: [...MOCK_AGENTS, archived],
+      tools: [],
+      templateRegistry: MOCK_REGISTRY,
+    });
+    expect(catalog).not.toContain('old-agent');
+  });
+
   it('renders empty-state lines when dashboards/packs are empty arrays', () => {
     const catalog = buildDiscoveryCatalog({
       agents: MOCK_AGENTS,

--- a/packages/core/src/discovery-catalog.ts
+++ b/packages/core/src/discovery-catalog.ts
@@ -172,9 +172,14 @@ function buildPacksSection(packs: Pack[]): string {
 }
 
 function buildAgentsSection(agents: Agent[]): string {
+  // Include drafts AND active agents. Drafts are work-in-progress
+  // agents the user has scaffolded but not yet promoted; they're
+  // still installed and the planner should reuse them rather than
+  // hallucinate a new id with overlapping purpose. Marked `(draft)`
+  // so the LLM can decide whether to surface them in matchedAgents.
   const eligible = agents
-    .filter((a) => a.status === 'active' && !EXCLUDED_AGENT_IDS.has(a.id))
-    .slice(0, 20); // cap to keep catalog lean
+    .filter((a) => (a.status === 'active' || a.status === 'draft') && !EXCLUDED_AGENT_IDS.has(a.id))
+    .slice(0, 30); // cap to keep catalog lean
 
   if (eligible.length === 0) {
     return '## AVAILABLE AGENTS (for agent-invoke / loop nodes)\nNo agents available yet.';
@@ -186,7 +191,8 @@ function buildAgentsSection(agents: Agent[]): string {
     const outputNames = a.outputs ? Object.keys(a.outputs).join(', ') : '';
     const tools = a.capabilities?.tools_used?.join(', ') ?? '';
     const sideEffects = a.capabilities?.side_effects?.join(', ') ?? '';
-    const parts: string[] = [`- ${a.id}: ${desc}`];
+    const statusTag = a.status === 'draft' ? ' (draft)' : '';
+    const parts: string[] = [`- ${a.id}${statusTag}: ${desc}`];
     if (inputNames) parts.push(`    inputs: ${inputNames}`);
     if (outputNames) parts.push(`    outputs: ${outputNames}`);
     if (tools) parts.push(`    tools: ${tools}`);
@@ -195,7 +201,7 @@ function buildAgentsSection(agents: Agent[]): string {
   });
 
   return `## AVAILABLE AGENTS (for agent-invoke / loop nodes)
-Each agent's outputs are what its final-node JSON produces — use these field names when referencing the result via {{upstream.<id>.<field>}} or "$upstream.<id>.<field>" in inputMapping.
+Each agent's outputs are what its final-node JSON produces — use these field names when referencing the result via {{upstream.<id>.<field>}} or "$upstream.<id>.<field>" in inputMapping. Agents tagged "(draft)" are user work-in-progress — prefer reusing one over creating a near-duplicate with a fresh id.
 ${lines.join('\n')}`;
 }
 

--- a/packages/dashboard/src/routes/build-commit.test.ts
+++ b/packages/dashboard/src/routes/build-commit.test.ts
@@ -195,6 +195,34 @@ describe('POST /agents/build/commit', () => {
     expect(res.body.dashboardCreated).toBe('user:morning');
   });
 
+  it('refuses to create the dashboard when a referenced agent failed to land', async () => {
+    const app = await makeApp();
+    // YAML with a v1 inputs-as-array shape — autoFixYaml + schema reject.
+    const broken = `id: broken-agent\nname: Broken\nstatus: active\nsource: local\nmcp: false\ninputs:\n  - name: foo\n    description: bad shape\nnodes:\n  - id: n\n    type: shell\n    command: echo x\n    dependsOn: []\n`;
+    const plan: BuildPlan = {
+      intent: 'dashboard-mixed',
+      summary: 'Mixed with failing new agent',
+      survey: { matchedAgents: [{ id: 'hn-top-stories', matchedFor: 'HN' }], missingFor: ['notes'], existingDashboards: [] },
+      newAgents: [{ id: 'broken-agent', purpose: 'will fail to parse', yaml: broken }],
+      dashboard: {
+        id: 'user:will-not-land',
+        name: 'Will Not Land',
+        sections: [{ title: 'Mixed', agentIds: ['hn-top-stories', 'broken-agent'] }],
+      },
+      questions: [],
+    };
+    const res = await request(app).post('/agents/build/commit')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .send({ plan });
+    expect(res.body.ok).toBe(true);
+    expect(res.body.agentsCreated).toEqual([]);
+    expect(res.body.agentsSkipped).toHaveLength(1);
+    // Dashboard was NOT created (would have referenced a non-existent agent).
+    expect(res.body.dashboardCreated).toBeNull();
+    expect(res.body.dashboardError).toMatch(/broken-agent/);
+    expect(dashboardsStore.getDashboard('user:will-not-land')).toBeNull();
+  });
+
   it('rejects plans that fail schema validation', async () => {
     const app = await makeApp();
     const res = await request(app).post('/agents/build/commit')

--- a/packages/dashboard/src/routes/run-now-build.ts
+++ b/packages/dashboard/src/routes/run-now-build.ts
@@ -892,16 +892,37 @@ buildRouter.post('/agents/build/commit', (req: Request, res: Response) => {
   let dashboardCreated: string | null = null;
   let dashboardError: string | undefined;
   if (plan.dashboard && ctx.dashboardsStore) {
-    try {
-      ctx.dashboardsStore.upsertDashboard({
-        id: plan.dashboard.id,
-        packId: null,
-        name: plan.dashboard.name,
-        layout: { sections: plan.dashboard.sections },
-      });
-      dashboardCreated = plan.dashboard.id;
-    } catch (e) {
-      dashboardError = (e as Error).message;
+    // Integrity check: every agentId the dashboard references must
+    // either already exist in AgentStore or have just been created.
+    // Otherwise we'd persist a dashboard pointing at agents that
+    // never landed (e.g. their YAML failed to parse) — the user
+    // sees broken "not installed" tiles with no clear cause.
+    const createdSet = new Set(agentsCreated);
+    const referencedIds = new Set<string>();
+    for (const s of plan.dashboard.sections) for (const id of s.agentIds) referencedIds.add(id);
+    const unmet: string[] = [];
+    for (const id of referencedIds) {
+      if (createdSet.has(id)) continue;
+      if (ctx.agentStore.getAgent(id)) continue;
+      unmet.push(id);
+    }
+    if (unmet.length > 0) {
+      const skippedDetail = agentsSkipped.length
+        ? ` ${agentsSkipped.map((s) => `${s.id}: ${s.reason}`).join('; ')}`
+        : '';
+      dashboardError = `Dashboard references ${unmet.length} agent${unmet.length === 1 ? '' : 's'} that did not land: ${unmet.join(', ')}.${skippedDetail}`;
+    } else {
+      try {
+        ctx.dashboardsStore.upsertDashboard({
+          id: plan.dashboard.id,
+          packId: null,
+          name: plan.dashboard.name,
+          layout: { sections: plan.dashboard.sections },
+        });
+        dashboardCreated = plan.dashboard.id;
+      } catch (e) {
+        dashboardError = (e as Error).message;
+      }
     }
   } else if (plan.dashboard && !ctx.dashboardsStore) {
     dashboardError = 'Dashboards store unavailable.';


### PR DESCRIPTION
## Summary

Two related Build-from-goal fixes from a user-reported broken dashboard. The planner had invented an agent id (\`ashby-job-hunter\`) instead of matching the user's existing draft (\`ashby-job-finder\`), then the commit endpoint created the dashboard anyway pointing at the phantom.

### A. Catalog includes draft agents

\`buildAgentsSection\` previously filtered to \`status: 'active'\`. Any agent the user had scaffolded but not activated was invisible to the planner — so the planner duplicated work with a fresh id. Drafts are now included, marked \`(draft)\` so the LLM treats them as candidates and the catalog text explains what the tag means. Cap raised 20 → 30.

### B. Commit fail-fast on unmet dashboard references

Each \`newAgents[i]\` had its YAML parsed/upserted independently; failures went into \`agentsSkipped[]\` but the dashboard upsert ran unconditionally. Result: dashboard pointing at agents that never landed → empty "not installed" placeholder tiles with no clear cause.

Now the commit:
1. Walks \`dashboard.sections[].agentIds[]\` after agent creation.
2. If any agentId is in neither \`agentsCreated\` NOR \`agentStore.getAgent()\` → dashboard is **not** created.
3. \`dashboardError\` reports the unmet ids plus the per-agent skip reasons.

The user sees a clear failure summary in the wizard rather than a silently-broken dashboard.

## Test plan
- [x] 3 new tests (catalog draft inclusion, catalog archived exclusion, commit integrity check rejects + reports cause)
- [x] \`npm test\` — 1075/1075
- [x] \`npm run build\` clean
- [x] Live: user's broken \`/dashboards/user:job-search\` manually patched (\`ashby-job-finder\` + \`job-search-explainer\`); dashboard now renders both real agents.
- [ ] Reviewer: re-run a Build-from-goal prompt that previously caused the issue and confirm either the planner now matches the draft, or the commit refuses cleanly with an explanatory error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)