### PR TITLE
feat(core): wire loopConfig.inputMapping for loop+agent-invoke composition

### DIFF
--- a/.changeset/loop-input-mapping.md
+++ b/.changeset/loop-input-mapping.md
@@ -1,0 +1,24 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+`loopConfig.inputMapping` — pass per-iteration values to looped sub-agents.
+
+The build-planner v3 catalog teaches the `loop + agent-invoke` recipe with
+`inputMapping: { COMPANY_SLUG: "$item.slug", JOB_QUERY: "{{inputs.JOB_QUERY}}" }`,
+but the loop executor previously only set `ITEM` / `ITEM_INDEX` on each sub-run —
+so sub-agents fell through to their default inputs every iteration and the
+composition pattern never actually worked.
+
+This adds the schema field and resolves three source forms inside the loop:
+
+- `$item.<path>` — walk into the current iteration's item
+- `$upstream.<id>.<field>` — pull from any upstream node's structured output
+- `{{inputs.X}}` — forward the parent agent's input X down to each sub-run
+
+Anything else is treated as a literal. When `inputMapping` is unset, behaviour
+is unchanged (sub-agent still gets `{ITEM, ITEM_INDEX}`).

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -74,6 +74,7 @@ const loopConfigSchema = z.object({
   over: z.string(),
   agentId: z.string(),
   maxIterations: z.number().int().positive().optional(),
+  inputMapping: z.record(z.string()).optional(),
 });
 
 const agentInvokeConfigSchema = z.object({

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -142,6 +142,14 @@ export interface LoopConfig {
   /** Agent id to invoke per item. */
   agentId: string;
   maxIterations?: number;
+  /**
+   * Optional mapping of sub-agent input names to per-iteration source expressions.
+   * Supported sources: `$item.<path>` (current iteration's item),
+   * `$upstream.<id>.<field>` (any upstream node's structured output),
+   * `{{inputs.X}}` (the parent agent's input X). Anything else is a literal.
+   * When unset, the sub-agent receives `{ITEM, ITEM_INDEX}` as before.
+   */
+  inputMapping?: Record<string, string>;
 }
 
 export interface AgentInvokeConfig {

--- a/packages/core/src/dag-executor.test.ts
+++ b/packages/core/src/dag-executor.test.ts
@@ -1188,6 +1188,64 @@ describe('executeAgentDag — loop (Flow PR D)', () => {
     expect(execs.find((e) => e.nodeId === 'each')!.error).toContain('not an array');
   });
 
+  it('passes per-iteration values to the sub-agent via inputMapping', async () => {
+    agentStore.createAgent(
+      {
+        id: 'slug-echo',
+        name: 'Slug Echo',
+        status: 'active',
+        source: 'local',
+        mcp: false,
+        inputs: { COMPANY_SLUG: { type: 'string', default: 'unset' }, JOB_QUERY: { type: 'string', default: 'unset' } },
+        nodes: [{ id: 'echo', type: 'shell', command: 'echo "slug=$COMPANY_SLUG query=$JOB_QUERY"' }],
+      },
+      'cli',
+      'seed',
+    );
+
+    const parentAgent = makeAgent({
+      inputs: { JOB_QUERY: { type: 'string', default: 'pm' } },
+      nodes: [
+        { id: 'source', type: 'shell', command: 'echo source' },
+        {
+          id: 'each',
+          type: 'loop' as any,
+          dependsOn: ['source'],
+          loopConfig: {
+            over: 'companies',
+            agentId: 'slug-echo',
+            inputMapping: {
+              COMPANY_SLUG: '$item.slug',
+              JOB_QUERY: '{{inputs.JOB_QUERY}}',
+            },
+          },
+        },
+      ],
+    });
+
+    // Custom spawner: source emits the array; sub-agent's `echo` node echoes back the env vars
+    // it received, so we can verify the inputMapping resolved correctly per-iteration.
+    const spawner: DagExecutorDeps['spawnNode'] = async (node, env) => {
+      if (node.id === 'source') {
+        return { result: '{"companies": [{"slug": "rula"}, {"slug": "ramp"}]}', exitCode: 0 };
+      }
+      if (node.id === 'echo') {
+        return { result: `slug=${env.COMPANY_SLUG ?? ''} query=${env.JOB_QUERY ?? ''}`, exitCode: 0 };
+      }
+      return { result: 'ok', exitCode: 0 };
+    };
+    const deps: DagExecutorDeps = { runStore, agentStore, spawnNode: spawner };
+    const run = await executeAgentDag(parentAgent, { triggeredBy: 'cli', inputs: { JOB_QUERY: 'staff engineer' } }, deps);
+
+    expect(run.status).toBe('completed');
+    const allRuns = runStore.queryRuns({ limit: 20, offset: 0, statuses: [] });
+    const subRuns = allRuns.rows.filter((r) => r.parentRunId === run.id);
+    expect(subRuns).toHaveLength(2);
+    const subResults = subRuns.map((r) => r.result).sort();
+    expect(subResults[0]).toBe('slug=ramp query=staff engineer');
+    expect(subResults[1]).toBe('slug=rula query=staff engineer');
+  });
+
   it('respects maxIterations', async () => {
     agentStore.createAgent(
       {

--- a/packages/core/src/flow-control.ts
+++ b/packages/core/src/flow-control.ts
@@ -313,6 +313,12 @@ export async function executeLoopNode(
       ITEM_INDEX: String(i),
     };
 
+    if (config.inputMapping) {
+      for (const [subKey, sourceExpr] of Object.entries(config.inputMapping)) {
+        subInputs[subKey] = resolveLoopSource(sourceExpr, item, outputs, parentOptions.inputs ?? {});
+      }
+    }
+
     const subRun = await executeDag(
       subAgent,
       {
@@ -365,6 +371,40 @@ export function evaluateOnlyIf(condition: OnlyIfCondition, upOutput: NodeOutput 
     return value != condition.notEquals;
   }
   return value !== undefined && value !== null;
+}
+
+/**
+ * Resolve a loop inputMapping source expression. Supports:
+ *   `$item.<path>`            → walkPath into the current item
+ *   `$upstream.<id>.<field>`  → field of an upstream node's structured output
+ *   `{{inputs.X}}`            → parent agent's input X (substituted in-place)
+ * Anything else is treated as a literal string.
+ */
+function resolveLoopSource(
+  expr: string,
+  item: unknown,
+  outputs: Map<string, NodeOutput>,
+  parentInputs: Record<string, string>,
+): string {
+  if (expr.startsWith('$item')) {
+    const path = expr.slice('$item'.length).replace(/^\./, '');
+    const val = path ? walkPath(item, path) : item;
+    if (val === undefined || val === null) return '';
+    return typeof val === 'string' ? val : JSON.stringify(val);
+  }
+  if (expr.startsWith('$upstream.')) {
+    const parts = expr.slice('$upstream.'.length).split('.');
+    const upId = parts[0];
+    const field = parts.slice(1).join('.');
+    const upOutput = outputs.get(upId);
+    if (!upOutput) return '';
+    if (upOutput.outputs && field) {
+      const val = walkPath(upOutput.outputs, field);
+      return val !== undefined && val !== null ? String(val) : '';
+    }
+    return upOutput.result ?? '';
+  }
+  return expr.replace(/\{\{\s*inputs\.([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/g, (_m, name) => parentInputs[name] ?? '');
 }
 
 // ── Utility ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- The build-planner v3 catalog (shipped in #214) teaches the canonical *"loop over a discovered list, invoke an existing agent per item with inputMapping"* recipe — but the loop executor only set \`ITEM\` / \`ITEM_INDEX\` on each sub-run. Mapped inputs (e.g. \`COMPANY_SLUG: \$item.slug\`) silently fell through to the sub-agent's defaults, so every iteration ran with the same (default) inputs.
- This adds \`inputMapping\` to the \`loopConfig\` schema + type and wires the substitution in [\`executeLoopNode\`](packages/core/src/flow-control.ts), supporting three source forms:
  - \`\$item.<path>\` — walk into the current iteration's item
  - \`\$upstream.<id>.<field>\` — any upstream node's structured output
  - \`{{inputs.X}}\` — forward the parent agent's input X down per iteration
- Default behaviour (no mapping) is unchanged: sub-agent still receives \`{ITEM, ITEM_INDEX}\`.

## Verification
Built an \`ashby-discover\` → \`loop[ashby-job-finder]\` → \`claude-code summarise\` orchestrator locally. Discover returned 9 verified Ashby boards; the loop iterated 2 of them with \`inputMapping: { COMPANY_SLUG: \$item.slug, JOB_QUERY: {{inputs.JOB_QUERY}} }\`; each sub-run actually received the right slug + query and ashby-job-finder produced real Apply links. Full suite (1076 tests) green.

## Test plan
- [x] New unit test in [\`dag-executor.test.ts\`](packages/core/src/dag-executor.test.ts) — \`passes per-iteration values to the sub-agent via inputMapping\`
- [x] \`npm test\` — 1076/1076 pass
- [x] Live smoke against running daemon — discover → loop → summarise produced expected per-company results

## Out of scope (followup)
\`agent-invoke\`'s inputMapping doesn't substitute \`{{inputs.X}}\` either (only \`upstream.<id>.<field>\`). Surfaced when the orchestrator's \`agent-invoke\` step printed a literal \`{{inputs.TOPIC}}\` in its headline. Worth a small follow-up to make agent-invoke and loop substitution rules consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)