### PR TITLE
feat(core): unify inputMapping resolver + parse loop items as JSON

### DIFF
--- a/.changeset/compose-correctness.md
+++ b/.changeset/compose-correctness.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Composition correctness — `agent-invoke` and `loop` now share one input-mapping resolver, and loop items expose parsed structured outputs.
+
+Two correctness fixes that block clean composed agents (the "wizard → orchestrator → result widget" pattern the build-planner v3 catalog promotes):
+
+1. `agent-invoke` `inputMapping` now substitutes `{{inputs.X}}` (forwarding the parent agent's inputs to the sub-run) and accepts `$upstream.<id>.<field>` and `$item.<path>` for symmetry with `loop`. Previously only `upstream.<id>.<field>` worked, so a literal `{{inputs.TOPIC}}` would be passed verbatim to the sub-agent.
+
+2. `loop` results expose `items[]` as **parsed structured outputs** when the sub-agent's result was a JSON object — so a downstream summariser prompt can dot-walk via `{{upstream.<loop>.items.0.<field>}}` instead of having to parse JSON-encoded strings out of an array of strings. Plain-text sub-agent results still come through as raw strings; failed sub-runs are still `null`.
+
+Both change paths share one resolver (`resolveSourceExpr`), so future composition node types stay consistent.

--- a/packages/core/src/dag-executor.test.ts
+++ b/packages/core/src/dag-executor.test.ts
@@ -1188,6 +1188,104 @@ describe('executeAgentDag — loop (Flow PR D)', () => {
     expect(execs.find((e) => e.nodeId === 'each')!.error).toContain('not an array');
   });
 
+  it('exposes loop items as parsed JSON when sub-agent results are JSON objects', async () => {
+    agentStore.createAgent(
+      {
+        id: 'json-emitter',
+        name: 'JSON Emitter',
+        status: 'active',
+        source: 'local',
+        mcp: false,
+        inputs: { COMPANY_SLUG: { type: 'string', default: 'x' } },
+        nodes: [{ id: 'emit', type: 'shell', command: 'echo placeholder' }],
+      },
+      'cli',
+      'seed',
+    );
+
+    const parentAgent = makeAgent({
+      nodes: [
+        { id: 'source', type: 'shell', command: 'echo source' },
+        {
+          id: 'each',
+          type: 'loop' as any,
+          dependsOn: ['source'],
+          loopConfig: {
+            over: 'companies',
+            agentId: 'json-emitter',
+            inputMapping: { COMPANY_SLUG: '$item.slug' },
+          },
+        },
+      ],
+    });
+
+    const spawner: DagExecutorDeps['spawnNode'] = async (node, env) => {
+      if (node.id === 'source') {
+        return { result: '{"companies": [{"slug": "rula"}, {"slug": "ramp"}]}', exitCode: 0 };
+      }
+      if (node.id === 'emit') {
+        return { result: JSON.stringify({ headline: `match for ${env.COMPANY_SLUG}`, count: 3 }), exitCode: 0 };
+      }
+      return { result: 'ok', exitCode: 0 };
+    };
+    const deps: DagExecutorDeps = { runStore, agentStore, spawnNode: spawner };
+    const run = await executeAgentDag(parentAgent, { triggeredBy: 'cli' }, deps);
+
+    expect(run.status).toBe('completed');
+    const loopExec = runStore.listNodeExecutions(run.id).find((e) => e.nodeId === 'each')!;
+    const loopOutput = JSON.parse(loopExec.result!);
+    expect(loopOutput.count).toBe(2);
+    // Items must be objects (parsed), not JSON-encoded strings — so a downstream
+    // prompt can dot-walk into them via {{upstream.each.items.0.headline}}.
+    expect(typeof loopOutput.items[0]).toBe('object');
+    expect(loopOutput.items[0].headline).toBe('match for rula');
+    expect(loopOutput.items[1].headline).toBe('match for ramp');
+  });
+
+  it('substitutes {{inputs.X}} in agent-invoke inputMapping', async () => {
+    agentStore.createAgent(
+      {
+        id: 'echo-query',
+        name: 'Echo Query',
+        status: 'active',
+        source: 'local',
+        mcp: false,
+        inputs: { TOPIC: { type: 'string', default: 'unset' } },
+        nodes: [{ id: 'echo', type: 'shell', command: 'echo "topic=$TOPIC"' }],
+      },
+      'cli',
+      'seed',
+    );
+
+    const parentAgent = makeAgent({
+      inputs: { TOPIC: { type: 'string', default: 'fintech' } },
+      nodes: [
+        {
+          id: 'invoke-child',
+          type: 'agent-invoke' as any,
+          agentInvokeConfig: {
+            agentId: 'echo-query',
+            inputMapping: { TOPIC: '{{inputs.TOPIC}}' },
+          },
+        },
+      ],
+    });
+
+    const spawner: DagExecutorDeps['spawnNode'] = async (node, env) => {
+      if (node.id === 'echo') {
+        return { result: `topic=${env.TOPIC ?? ''}`, exitCode: 0 };
+      }
+      return { result: 'ok', exitCode: 0 };
+    };
+    const deps: DagExecutorDeps = { runStore, agentStore, spawnNode: spawner };
+    const run = await executeAgentDag(parentAgent, { triggeredBy: 'cli', inputs: { TOPIC: 'fintech' } }, deps);
+
+    expect(run.status).toBe('completed');
+    const subRuns = runStore.queryRuns({ limit: 20, offset: 0, statuses: [] }).rows.filter((r) => r.parentRunId === run.id);
+    expect(subRuns).toHaveLength(1);
+    expect(subRuns[0].result).toBe('topic=fintech');
+  });
+
   it('passes per-iteration values to the sub-agent via inputMapping', async () => {
     agentStore.createAgent(
       {

--- a/packages/core/src/flow-control.ts
+++ b/packages/core/src/flow-control.ts
@@ -202,20 +202,7 @@ export async function executeAgentInvokeNode(
   const subInputs: Record<string, string> = {};
   if (config.inputMapping) {
     for (const [subKey, sourceExpr] of Object.entries(config.inputMapping)) {
-      if (sourceExpr.startsWith('upstream.')) {
-        const parts = sourceExpr.split('.');
-        const upId = parts[1];
-        const field = parts.slice(2).join('.');
-        const upOutput = outputs.get(upId);
-        if (upOutput?.outputs) {
-          const val = walkPath(upOutput.outputs, field);
-          subInputs[subKey] = val !== undefined ? String(val) : '';
-        } else if (upOutput) {
-          subInputs[subKey] = upOutput.result;
-        }
-      } else {
-        subInputs[subKey] = sourceExpr;
-      }
+      subInputs[subKey] = resolveSourceExpr(sourceExpr, undefined, outputs, parentOptions.inputs ?? {});
     }
   }
 
@@ -304,7 +291,11 @@ export async function executeLoopNode(
 
   const maxIter = config.maxIterations ?? 1000;
   const limited = items.slice(0, maxIter);
-  const results: (string | null)[] = [];
+  // Per-iteration items: parsed JSON when the sub-agent's result was a JSON object,
+  // raw string when it wasn't, null when the sub-run failed. This lets downstream
+  // prompts read structured fields with `{{upstream.<id>.items.0.<field>}}` instead
+  // of having to parse JSON-encoded strings out of an array of strings.
+  const results: (unknown | null)[] = [];
 
   for (let i = 0; i < limited.length; i++) {
     const item = limited[i];
@@ -315,7 +306,7 @@ export async function executeLoopNode(
 
     if (config.inputMapping) {
       for (const [subKey, sourceExpr] of Object.entries(config.inputMapping)) {
-        subInputs[subKey] = resolveLoopSource(sourceExpr, item, outputs, parentOptions.inputs ?? {});
+        subInputs[subKey] = resolveSourceExpr(sourceExpr, item, outputs, parentOptions.inputs ?? {});
       }
     }
 
@@ -330,7 +321,16 @@ export async function executeLoopNode(
       deps,
     );
 
-    results.push(subRun.status === 'completed' ? (subRun.result ?? null) : null);
+    if (subRun.status !== 'completed' || subRun.result == null) {
+      results.push(null);
+    } else {
+      let parsed: unknown = subRun.result;
+      try {
+        const candidate = JSON.parse(subRun.result);
+        if (typeof candidate === 'object' && candidate !== null) parsed = candidate;
+      } catch { /* not JSON — keep raw string */ }
+      results.push(parsed);
+    }
   }
 
   return {
@@ -374,26 +374,37 @@ export function evaluateOnlyIf(condition: OnlyIfCondition, upOutput: NodeOutput 
 }
 
 /**
- * Resolve a loop inputMapping source expression. Supports:
- *   `$item.<path>`            → walkPath into the current item
- *   `$upstream.<id>.<field>`  → field of an upstream node's structured output
- *   `{{inputs.X}}`            → parent agent's input X (substituted in-place)
- * Anything else is treated as a literal string.
+ * Resolve an inputMapping source expression for both `loop` and `agent-invoke`.
+ * Supported source forms:
+ *   `$item.<path>`            → walkPath into the current item (loop only — agent-invoke
+ *                                passes `item: undefined`, in which case `$item` resolves
+ *                                to empty string)
+ *   `$upstream.<id>.<field>`  → field of an upstream node's structured output (or its
+ *                                raw `result` when no field is supplied)
+ *   `upstream.<id>.<field>`   → backward-compat alias for the above (no `$` prefix)
+ *   `{{inputs.X}}`            → parent agent's input X (in-place substitution; multiple
+ *                                {{inputs.X}} tokens may appear in a single expression)
+ * Anything else (including a plain literal with no recognized prefix) is treated as a
+ * literal string after `{{inputs.X}}` substitution.
  */
-function resolveLoopSource(
+function resolveSourceExpr(
   expr: string,
-  item: unknown,
+  item: unknown | undefined,
   outputs: Map<string, NodeOutput>,
   parentInputs: Record<string, string>,
 ): string {
   if (expr.startsWith('$item')) {
+    if (item === undefined) return '';
     const path = expr.slice('$item'.length).replace(/^\./, '');
     const val = path ? walkPath(item, path) : item;
     if (val === undefined || val === null) return '';
     return typeof val === 'string' ? val : JSON.stringify(val);
   }
-  if (expr.startsWith('$upstream.')) {
-    const parts = expr.slice('$upstream.'.length).split('.');
+  const upstreamPrefix = expr.startsWith('$upstream.') ? '$upstream.'
+    : expr.startsWith('upstream.') ? 'upstream.'
+    : null;
+  if (upstreamPrefix) {
+    const parts = expr.slice(upstreamPrefix.length).split('.');
     const upId = parts[0];
     const field = parts.slice(1).join('.');
     const upOutput = outputs.get(upId);


### PR DESCRIPTION
## Summary
Two correctness fixes that the ashby composition probe surfaced — both block clean "wizard → parent orchestrator → loop → summarise" agents:

1. **\`agent-invoke\` inputMapping** now substitutes \`{{inputs.X}}\`, \`\$upstream.<id>.<field>\`, and \`\$item.<path>\` (matches loop). Previously only the bare \`upstream.<id>.<field>\` form worked, so a literal \`{{inputs.TOPIC}}\` would be forwarded verbatim to the sub-run — visible in our orchestrator's discover-step headline.
2. **\`loop\` items[]** are now **parsed structured outputs** when the sub-agent returns a JSON object. Downstream prompts can dot-walk via \`{{upstream.<loop>.items.0.<field>}}\` instead of parsing JSON-encoded strings out of an array of strings. Plain-text results still come through as raw strings; failed sub-runs are still \`null\`.

Both call sites now share one resolver (\`resolveSourceExpr\`), so future composition node types stay consistent.

## Why this matters
The build-planner v3 catalog teaches "compose existing agents via loop+invoke." Without (1), parent inputs can't reach children. Without (2), the summariser prompt has to do nested JSON.parse — which LLMs do unreliably. Together with #215, this closes the gap between what the planner promises and what the executor delivers.

## Test plan
- [x] New test: \`exposes loop items as parsed JSON when sub-agent results are JSON objects\`
- [x] New test: \`substitutes {{inputs.X}} in agent-invoke inputMapping\`
- [x] \`npm test\` — 1078/1078 pass
- [x] Existing \`upstream.<id>.<field>\` agent-invoke callers still resolve via the backward-compat alias

## Stacked on
This builds on #215 (loopConfig.inputMapping); should be merged after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)