### PR TITLE
feat(core): emit per-iteration progress events for loop nodes

### DIFF
--- a/.changeset/loop-progress.md
+++ b/.changeset/loop-progress.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Loop nodes now emit per-iteration progress events.
+
+When a parent agent uses `loop` to fan out across N items, the dashboard previously rendered the loop as a single black box that read "running" for the entire fan-out — users had to dig into nested sub-run pages by URL to see whether iteration 3 of 8 was alive, dead, or just slow.
+
+Loop nodes now create a `running` node-execution row up front and emit two `SpawnProgress` events per iteration (`loop_iteration_start` / `loop_iteration_complete`) into the existing `progressJson` channel. The dashboard's run-detail progress indicator already reads that channel, so messages like `iteration 3/4: rula done` and `iteration 1/4: ashby failed — <error>` show up inline at the parent run without further dashboard work.
+
+Failed iterations also surface their sub-run error in the message, so partial-failure debugging no longer requires URL-walking into nested runs.

--- a/packages/core/src/dag-executor.test.ts
+++ b/packages/core/src/dag-executor.test.ts
@@ -1344,6 +1344,71 @@ describe('executeAgentDag — loop (Flow PR D)', () => {
     expect(subResults[1]).toBe('slug=rula query=staff engineer');
   });
 
+  it('emits per-iteration progress events on the loop node execution row', async () => {
+    agentStore.createAgent(
+      {
+        id: 'progress-child',
+        name: 'Progress Child',
+        status: 'active',
+        source: 'local',
+        mcp: false,
+        inputs: { COMPANY_SLUG: { type: 'string', default: 'x' } },
+        nodes: [{ id: 'echo', type: 'shell', command: 'echo ok' }],
+      },
+      'cli',
+      'seed',
+    );
+
+    const parentAgent = makeAgent({
+      nodes: [
+        { id: 'source', type: 'shell', command: 'echo source' },
+        {
+          id: 'each',
+          type: 'loop' as any,
+          dependsOn: ['source'],
+          loopConfig: {
+            over: 'companies',
+            agentId: 'progress-child',
+            inputMapping: { COMPANY_SLUG: '$item.slug' },
+          },
+        },
+      ],
+    });
+
+    // Sub-run for slug "ramp" deliberately fails so we can verify the
+    // failed-iteration progress event surfaces the error.
+    const spawner: DagExecutorDeps['spawnNode'] = async (node, env) => {
+      if (node.id === 'source') {
+        return { result: '{"companies": [{"slug": "rula"}, {"slug": "ramp"}, {"slug": "linear"}]}', exitCode: 0 };
+      }
+      if (node.id === 'echo') {
+        if (env.COMPANY_SLUG === 'ramp') {
+          return { result: '', exitCode: 1, error: 'simulated ramp failure' };
+        }
+        return { result: 'ok', exitCode: 0 };
+      }
+      return { result: 'ok', exitCode: 0 };
+    };
+    const deps: DagExecutorDeps = { runStore, agentStore, spawnNode: spawner };
+    const run = await executeAgentDag(parentAgent, { triggeredBy: 'cli' }, deps);
+
+    expect(run.status).toBe('completed');
+    const loopExec = runStore.listNodeExecutions(run.id).find((e) => e.nodeId === 'each')!;
+    expect(loopExec.progressJson).toBeTruthy();
+    const events = JSON.parse(loopExec.progressJson!) as Array<{ type: string; turn?: number; maxTurns?: number; message?: string }>;
+    // 3 starts + 3 completes = 6 events.
+    expect(events).toHaveLength(6);
+    expect(events[0].type).toBe('loop_iteration_start');
+    expect(events[0].message).toContain('iteration 1/3: rula');
+    expect(events[1].type).toBe('loop_iteration_complete');
+    expect(events[1].message).toContain('done');
+    // Iteration 2 (ramp) should be marked failed.
+    expect(events[3].type).toBe('loop_iteration_complete');
+    expect(events[3].message).toContain('failed');
+    // Iteration 3 (linear) succeeds.
+    expect(events[5].message).toContain('done');
+  });
+
   it('respects maxIterations', async () => {
     agentStore.createAgent(
       {

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -457,7 +457,24 @@ export async function executeAgentDag(
     }
 
     if (node.type === 'loop') {
-      const loopResult = await executeLoopNode(node, outputs, runId, options, deps, agent, executeAgentDag);
+      // Create the running row up-front so the dashboard can render
+      // per-iteration progress while sub-runs are in flight, instead of
+      // showing a black hole until the loop finishes.
+      deps.runStore.createNodeExecution({
+        runId,
+        nodeId: node.id,
+        workflowVersion: agent.version,
+        status: 'running',
+        startedAt: nodeStartedAt,
+      });
+      const loopProgress: SpawnProgress[] = [];
+      const onLoopProgress = (event: SpawnProgress) => {
+        loopProgress.push(event);
+        deps.runStore.updateNodeExecution(runId, node.id, {
+          progressJson: JSON.stringify(loopProgress),
+        });
+      };
+      const loopResult = await executeLoopNode(node, outputs, runId, options, deps, agent, executeAgentDag, onLoopProgress);
       const completedAt = new Date().toISOString();
       if (loopResult.ok) {
         const outputsJson = JSON.stringify(loopResult.output);
@@ -467,25 +484,17 @@ export async function executeAgentDag(
           source: agent.source,
           outputs: loopResult.output,
         });
-        deps.runStore.createNodeExecution({
-          runId,
-          nodeId: node.id,
-          workflowVersion: agent.version,
+        deps.runStore.updateNodeExecution(runId, node.id, {
           status: 'completed',
-          startedAt: nodeStartedAt,
           completedAt,
           result: JSON.stringify(loopResult.output),
           exitCode: 0,
           outputsJson,
         });
       } else {
-        deps.runStore.createNodeExecution({
-          runId,
-          nodeId: node.id,
-          workflowVersion: agent.version,
+        deps.runStore.updateNodeExecution(runId, node.id, {
           status: 'failed',
           errorCategory: 'setup',
-          startedAt: nodeStartedAt,
           completedAt,
           error: loopResult.error,
         });

--- a/packages/core/src/flow-control.ts
+++ b/packages/core/src/flow-control.ts
@@ -9,6 +9,7 @@
 import type { Agent, AgentNode, NodeOutput, OnlyIfCondition } from './agent-v2-types.js';
 import type { Run } from './types.js';
 import type { DagExecutorDeps, DagExecuteOptions } from './dag-executor.js';
+import type { SpawnProgress } from './node-spawner.js';
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -238,6 +239,20 @@ export async function executeAgentInvokeNode(
 
 // ── Loop ───────────────────────────────────────────────────────────────
 
+/** Short label for an iteration's item — used in progress messages. */
+function itemLabel(item: unknown): string {
+  if (typeof item === 'string') return item.length > 40 ? item.slice(0, 37) + '...' : item;
+  if (item && typeof item === 'object') {
+    const rec = item as Record<string, unknown>;
+    for (const key of ['slug', 'id', 'name', 'title']) {
+      const v = rec[key];
+      if (typeof v === 'string' && v) return v.length > 40 ? v.slice(0, 37) + '...' : v;
+    }
+  }
+  const s = JSON.stringify(item);
+  return s.length > 40 ? s.slice(0, 37) + '...' : s;
+}
+
 export async function executeLoopNode(
   node: AgentNode,
   outputs: Map<string, NodeOutput>,
@@ -246,6 +261,7 @@ export async function executeLoopNode(
   deps: DagExecutorDeps,
   _parentAgent: Agent,
   executeDag: ExecuteDagFn,
+  onProgress?: (event: SpawnProgress) => void,
 ): Promise<AgentInvokeResult> {
   const config = node.loopConfig;
   if (!config) {
@@ -297,8 +313,10 @@ export async function executeLoopNode(
   // of having to parse JSON-encoded strings out of an array of strings.
   const results: (unknown | null)[] = [];
 
-  for (let i = 0; i < limited.length; i++) {
+  const total = limited.length;
+  for (let i = 0; i < total; i++) {
     const item = limited[i];
+    const label = itemLabel(item);
     const subInputs: Record<string, string> = {
       ITEM: typeof item === 'string' ? item : JSON.stringify(item),
       ITEM_INDEX: String(i),
@@ -309,6 +327,14 @@ export async function executeLoopNode(
         subInputs[subKey] = resolveSourceExpr(sourceExpr, item, outputs, parentOptions.inputs ?? {});
       }
     }
+
+    onProgress?.({
+      timestamp: new Date().toISOString(),
+      type: 'loop_iteration_start',
+      turn: i + 1,
+      maxTurns: total,
+      message: `iteration ${i + 1}/${total}: ${label}`,
+    });
 
     const subRun = await executeDag(
       subAgent,
@@ -321,7 +347,8 @@ export async function executeLoopNode(
       deps,
     );
 
-    if (subRun.status !== 'completed' || subRun.result == null) {
+    const ok = subRun.status === 'completed' && subRun.result != null;
+    if (!ok || subRun.result == null) {
       results.push(null);
     } else {
       let parsed: unknown = subRun.result;
@@ -331,6 +358,16 @@ export async function executeLoopNode(
       } catch { /* not JSON — keep raw string */ }
       results.push(parsed);
     }
+
+    onProgress?.({
+      timestamp: new Date().toISOString(),
+      type: 'loop_iteration_complete',
+      turn: i + 1,
+      maxTurns: total,
+      message: ok
+        ? `iteration ${i + 1}/${total}: ${label} done`
+        : `iteration ${i + 1}/${total}: ${label} failed${subRun.error ? ` — ${subRun.error.slice(0, 80)}` : ''}`,
+    });
   }
 
   return {

--- a/packages/core/src/node-spawner.ts
+++ b/packages/core/src/node-spawner.ts
@@ -24,10 +24,18 @@ export type SpawnNodeFn = (
   opts: { agentId: string; agentSource: Agent['source']; allowUntrustedShell?: ReadonlySet<string> },
 ) => Promise<SpawnResult>;
 
-/** Progress event emitted during LLM execution. */
+/**
+ * Progress event emitted during a node's execution. Originally LLM-only
+ * (turn_*, tool_use, thinking, output_chunk), now also surfaces per-iteration
+ * progress for `loop` nodes so the dashboard can render "iteration 3/4: rula"
+ * and per-iteration failures inline at the parent run instead of forcing the
+ * user to dig into nested sub-run pages.
+ */
 export interface SpawnProgress {
   timestamp: string;
-  type: 'turn_start' | 'turn_complete' | 'tool_use' | 'thinking' | 'output_chunk';
+  type:
+    | 'turn_start' | 'turn_complete' | 'tool_use' | 'thinking' | 'output_chunk'
+    | 'loop_iteration_start' | 'loop_iteration_complete';
   turn?: number;
   maxTurns?: number;
   message?: string;


### PR DESCRIPTION
## Summary
When a parent agent runs a \`loop\` fanning out across N items, the dashboard previously rendered the loop as a single black box reading "running" for the entire fan-out. Two consequences:

1. The agent looks frozen for 60–180s during multi-iteration loops with claude-code sub-runs — users refresh, cancel, re-run.
2. When a sub-run fails, it shows up as a silent \`null\` in the loop's \`items[]\`. To find which iteration failed and why, you have to URL-walk into nested sub-run pages.

This PR emits per-iteration progress on the existing \`progressJson\` channel, so both stories work without any new UI:

- Loop nodes create a \`running\` node-execution row up front.
- Each iteration emits a \`loop_iteration_start\` (\"iteration 3/4: rula\") and \`loop_iteration_complete\` (\"iteration 3/4: rula done\" or \"... failed — <error>\") into \`progressJson\`.
- Dashboard's existing run-detail \`renderProgressIndicator\` reads the channel and shows the latest event inline at the parent run.

## Why now
Direct dogfood payoff. While verifying #216 against \`ashby-search-discovered\`, two of four sub-runs returned \`null\` and we couldn't see why without digging into nested pages. After this PR, the same parent run shows \`iteration 1/4: ashby failed — Failed at node \"filter-and-summarize\" (spawn_failure)\` directly in the run feed.

## What's next
Next up (separate PR): a curated \`composed-starters\` pack with this orchestrator and 1–2 siblings so users have a copyable working skeleton for the wizard → orchestrator → widget pattern.

## Test plan
- [x] New unit test in [\`dag-executor.test.ts\`](packages/core/src/dag-executor.test.ts) — \`emits per-iteration progress events on the loop node execution row\` (covers both done + failed iterations)
- [x] \`npm test\` — 1079/1079 pass
- [x] Live smoke against \`ashby-search-discovered\` — surfaced an existing iteration failure inline that we previously had to URL-walk to find

🤖 Generated with [Claude Code](https://claude.com/claude-code)