### PR TITLE
fix(core): apply parent input defaults to {{inputs.X}} in inputMapping

### DIFF
--- a/.changeset/inputmapping-defaults.md
+++ b/.changeset/inputmapping-defaults.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+`{{inputs.X}}` in `loop` / `agent-invoke` `inputMapping` now resolves YAML-declared input defaults.
+
+The dashboard's run handler builds `options.inputs` from `input_*` form fields only — it does not merge in the agent's declared `inputs:` defaults. Per-node env construction applies defaults later, so single-node agents always saw their defaults. But composition node types (`loop`, `agent-invoke`) resolve `{{inputs.X}}` at the control-flow layer using `parentOptions.inputs` directly — which contained user-supplied values only.
+
+Effect: when a user ran a parent agent without supplying every declared input, any composition node referencing `{{inputs.X}}` for an unsupplied X passed empty string to the sub-run. The orchestrator's loop fanned out N times with empty `JOB_QUERY` even though the YAML declared a default.
+
+Both call sites now merge `parentAgent.inputs[*].default` into the resolved map before substitution, with user-supplied values still winning.

--- a/packages/core/src/dag-executor.test.ts
+++ b/packages/core/src/dag-executor.test.ts
@@ -1242,6 +1242,59 @@ describe('executeAgentDag — loop (Flow PR D)', () => {
     expect(loopOutput.items[1].headline).toBe('match for ramp');
   });
 
+  it('applies parent inputs defaults to {{inputs.X}} substitution when user did not supply', async () => {
+    agentStore.createAgent(
+      {
+        id: 'topic-echo',
+        name: 'Topic Echo',
+        status: 'active',
+        source: 'local',
+        mcp: false,
+        inputs: { TOPIC: { type: 'string', default: 'unset' } },
+        nodes: [{ id: 'echo', type: 'shell', command: 'echo "topic=$TOPIC"' }],
+      },
+      'cli',
+      'seed',
+    );
+
+    // Parent declares JOB_QUERY default, user does NOT supply it on this run.
+    // The loop's inputMapping references {{inputs.JOB_QUERY}} and must see
+    // the parent's spec.default ("default-query") rather than empty string.
+    const parentAgent = makeAgent({
+      inputs: { JOB_QUERY: { type: 'string', default: 'default-query' } },
+      nodes: [
+        { id: 'source', type: 'shell', command: 'echo source' },
+        {
+          id: 'each',
+          type: 'loop' as any,
+          dependsOn: ['source'],
+          loopConfig: {
+            over: 'companies',
+            agentId: 'topic-echo',
+            inputMapping: { TOPIC: '{{inputs.JOB_QUERY}}' },
+          },
+        },
+      ],
+    });
+
+    const spawner: DagExecutorDeps['spawnNode'] = async (node, env) => {
+      if (node.id === 'source') {
+        return { result: '{"companies": [{"slug": "rula"}]}', exitCode: 0 };
+      }
+      if (node.id === 'echo') {
+        return { result: `topic=${env.TOPIC ?? ''}`, exitCode: 0 };
+      }
+      return { result: 'ok', exitCode: 0 };
+    };
+    const deps: DagExecutorDeps = { runStore, agentStore, spawnNode: spawner };
+    // Note: no `inputs:` passed — exercises the defaults path.
+    const run = await executeAgentDag(parentAgent, { triggeredBy: 'cli' }, deps);
+
+    expect(run.status).toBe('completed');
+    const subRun = runStore.queryRuns({ limit: 20, offset: 0, statuses: [] }).rows.find((r) => r.parentRunId === run.id)!;
+    expect(subRun.result).toBe('topic=default-query');
+  });
+
   it('substitutes {{inputs.X}} in agent-invoke inputMapping', async () => {
     agentStore.createAgent(
       {

--- a/packages/core/src/flow-control.ts
+++ b/packages/core/src/flow-control.ts
@@ -33,6 +33,27 @@ export type ExecuteDagFn = (
   deps: DagExecutorDeps,
 ) => Promise<Run>;
 
+/**
+ * Merge YAML-declared input defaults into the user-supplied inputs map.
+ *
+ * The dashboard's run handler builds `options.inputs` from `input_*` form
+ * fields only — it does not apply spec defaults. Per-node env construction
+ * applies defaults later (`node-env.ts`), but `{{inputs.X}}` substitution
+ * in loop/agent-invoke `inputMapping` runs at the control-flow layer and
+ * needs the same merge to see declared defaults instead of an empty value.
+ *
+ * Precedence: user-supplied wins, then spec.default, otherwise omitted.
+ */
+function effectiveInputs(agent: Agent, supplied: Record<string, string>): Record<string, string> {
+  const merged: Record<string, string> = { ...supplied };
+  for (const [name, spec] of Object.entries(agent.inputs ?? {})) {
+    if (merged[name] === undefined && spec.default !== undefined) {
+      merged[name] = String(spec.default);
+    }
+  }
+  return merged;
+}
+
 // ── Conditional + Switch ───────────────────────────────────────────────
 
 export function executeControlFlowNode(
@@ -184,7 +205,7 @@ export async function executeAgentInvokeNode(
   parentRunId: string,
   parentOptions: DagExecuteOptions,
   deps: DagExecutorDeps,
-  _parentAgent: Agent,
+  parentAgent: Agent,
   executeDag: ExecuteDagFn,
 ): Promise<AgentInvokeResult> {
   const config = node.agentInvokeConfig;
@@ -200,10 +221,11 @@ export async function executeAgentInvokeNode(
     return { ok: false, error: `Sub-agent "${config.agentId}" not found in store` };
   }
 
+  const parentInputs = effectiveInputs(parentAgent, parentOptions.inputs ?? {});
   const subInputs: Record<string, string> = {};
   if (config.inputMapping) {
     for (const [subKey, sourceExpr] of Object.entries(config.inputMapping)) {
-      subInputs[subKey] = resolveSourceExpr(sourceExpr, undefined, outputs, parentOptions.inputs ?? {});
+      subInputs[subKey] = resolveSourceExpr(sourceExpr, undefined, outputs, parentInputs);
     }
   }
 
@@ -259,7 +281,7 @@ export async function executeLoopNode(
   parentRunId: string,
   parentOptions: DagExecuteOptions,
   deps: DagExecutorDeps,
-  _parentAgent: Agent,
+  parentAgent: Agent,
   executeDag: ExecuteDagFn,
   onProgress?: (event: SpawnProgress) => void,
 ): Promise<AgentInvokeResult> {
@@ -314,6 +336,7 @@ export async function executeLoopNode(
   const results: (unknown | null)[] = [];
 
   const total = limited.length;
+  const parentInputs = effectiveInputs(parentAgent, parentOptions.inputs ?? {});
   for (let i = 0; i < total; i++) {
     const item = limited[i];
     const label = itemLabel(item);
@@ -324,7 +347,7 @@ export async function executeLoopNode(
 
     if (config.inputMapping) {
       for (const [subKey, sourceExpr] of Object.entries(config.inputMapping)) {
-        subInputs[subKey] = resolveSourceExpr(sourceExpr, item, outputs, parentOptions.inputs ?? {});
+        subInputs[subKey] = resolveSourceExpr(sourceExpr, item, outputs, parentInputs);
       }
     }
 


### PR DESCRIPTION
## Summary
Surfaced by the end-to-end ashby smoke run after #217 landed.

\`{{inputs.X}}\` references inside \`loop\` / \`agent-invoke\` \`inputMapping\` were resolving against \`parentOptions.inputs\` directly — which the dashboard's run handler builds from \`input_*\` form fields *only* (no merge with the agent's declared \`inputs:\` defaults). Per-node env construction applies defaults later in the executor, so single-node agents always saw their defaults. But composition node types resolve at the control-flow layer and were missing them.

**Live symptom on \`ashby-search-discovered\`:** when the user clicked Run without filling the wizard form, every \`ashby-job-finder\` sub-run got \`JOB_QUERY=""\` — sub-agent claude-code reported "No specific role filter was provided (empty query)" instead of "senior product manager" (the orchestrator's declared default).

**Fix:** \`flow-control.ts\` now merges \`parentAgent.inputs[*].default\` into the resolved map before substitution at both \`executeLoopNode\` and \`executeAgentInvokeNode\` call sites. User-supplied still wins.

## Test plan
- [x] New unit test: \`applies parent inputs defaults to {{inputs.X}} substitution when user did not supply\`
- [x] \`npm test\` — 1080/1080 pass
- [x] Live smoke against \`ashby-search-discovered\` with no inputs supplied: sub-runs now see \`JOB_QUERY="senior product manager"\` (the parent's default), evidenced by sub-agent reporting matches against that query

## Why it surfaced now
Before #215 + #216 + #217 landed, \`loop\` / \`agent-invoke\` \`inputMapping\` either didn't exist or didn't propagate at all. With those PRs in, the substitution path runs — which is what exposed the missing-defaults gap. Classic dogfood-finds-bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)