### PR TITLE
feat(dashboard): synthesise default 'Run again' control on output widgets

### DIFF
--- a/.changeset/default-replay-control.md
+++ b/.changeset/default-replay-control.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Output widgets now synthesise a default "Run again" control when no replay is declared.
+
+Authoring an output widget previously required adding `controls: [{type: replay}]` in YAML to get a Re-run button on the agent / run detail pages. Most authors forgot, so most widgets shipped without one. The button now synthesises automatically when (a) the renderer is invoked with a `controlState` (i.e. a detail-page render, not Pulse / home / interactive tile), and (b) the schema has no `replay` control declared.
+
+The synthesised control is wired with the agent's declared `inputs[*]` names so the inline form lets users tweak inputs before re-running. Authors who declared a custom replay (with custom label or input subset) keep their config.

--- a/packages/dashboard/src/views/agent-detail/overview.ts
+++ b/packages/dashboard/src/views/agent-detail/overview.ts
@@ -44,7 +44,7 @@ export async function renderAgentOverview(args: AgentDetailArgs): Promise<string
           </div>
           ${latestCompletedRun?.result
             ? html`
-              ${renderOutputWidget(agent.outputWidget, latestCompletedRun.result, agent.id, widgetControls) ?? html`<p class="dim" style="font-size: var(--font-size-xs);">No output to preview.</p>`}
+              ${renderOutputWidget(agent.outputWidget, latestCompletedRun.result, agent.id, widgetControls, Object.keys(agent.inputs ?? {})) ?? html`<p class="dim" style="font-size: var(--font-size-xs);">No output to preview.</p>`}
               <p class="dim" style="font-size: var(--font-size-xs); margin: var(--space-3) 0 0;">From run <a href="/runs/${latestCompletedRun.id}" class="mono">${latestCompletedRun.id.slice(0, 8)}</a></p>
             `
             : html`<p class="dim" style="font-size: var(--font-size-xs); margin: 0;">Run the agent to see a preview.</p>`}

--- a/packages/dashboard/src/views/output-widgets.ts
+++ b/packages/dashboard/src/views/output-widgets.ts
@@ -179,6 +179,15 @@ export function renderOutputWidget(
   output: string,
   agentId: string,
   controlState?: WidgetControlState,
+  /**
+   * Names of the agent's declared inputs. When present and the schema has
+   * no `replay` control, the renderer synthesises a default Re-run button
+   * pre-wired with these inline input fields, so authors don't have to
+   * remember to declare `controls: [{type: replay}]` to get a re-run
+   * affordance on detail pages. Pulse / home tiles pass no `controlState`
+   * and so still render in static mode.
+   */
+  defaultReplayInputs?: string[],
 ): SafeHtml | undefined {
   // ai-template widgets render their own layout via the stored template;
   // field-toggle / view-switch don't apply (rejected at schema time). Only
@@ -207,9 +216,31 @@ export function renderOutputWidget(
       return undefined;
   }
 
-  if (!controlState || !schema.controls?.length) return body;
-  const controlsRow = renderControlsRow(schema, agentId, controlState);
+  if (!controlState) return body;
+  const effectiveSchema = ensureReplayControl(schema, defaultReplayInputs);
+  if (!effectiveSchema.controls?.length) return body;
+  const controlsRow = renderControlsRow(effectiveSchema, agentId, controlState);
   return html`${controlsRow}${body}`;
+}
+
+/**
+ * Return the schema unchanged when it already has a `replay` control or
+ * when the caller didn't supply default inputs to wire one with. Otherwise
+ * return a shallow copy with a synthesised replay control prepended so
+ * every detail-page widget gets a Re-run button for free.
+ */
+function ensureReplayControl(
+  schema: OutputWidgetSchema,
+  defaultReplayInputs: string[] | undefined,
+): OutputWidgetSchema {
+  const hasReplay = schema.controls?.some((c) => c.type === 'replay');
+  if (hasReplay) return schema;
+  const synthesized: WidgetControl = {
+    type: 'replay',
+    label: 'Run again',
+    inputs: defaultReplayInputs && defaultReplayInputs.length > 0 ? defaultReplayInputs : undefined,
+  };
+  return { ...schema, controls: [synthesized, ...(schema.controls ?? [])] };
 }
 
 /**

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -163,7 +163,7 @@ export function renderRunDetail(opts: RunDetailOptions): string {
             <h2 style="margin-top: 0;">Result</h2>
             ${!inProgress && run.result
               ? (agent?.outputWidget
-                  ? renderOutputWidget(agent.outputWidget, run.result, agent.id, widgetControls) ?? outputFrame(run.result)
+                  ? renderOutputWidget(agent.outputWidget, run.result, agent.id, widgetControls, Object.keys(agent.inputs ?? {})) ?? outputFrame(run.result)
                   : outputFrame(run.result))
               : inProgress
                 ? html`<p class="dim" style="font-size: var(--font-size-xs);">Run in progress...</p>`
@@ -191,7 +191,7 @@ export function renderRunDetail(opts: RunDetailOptions): string {
       ` : html`
         <h2>Output</h2>
         ${run.result
-          ? (agent?.outputWidget ? renderOutputWidget(agent.outputWidget, run.result, agent.id, widgetControls) ?? outputFrame(run.result) : outputFrame(run.result))
+          ? (agent?.outputWidget ? renderOutputWidget(agent.outputWidget, run.result, agent.id, widgetControls, Object.keys(agent.inputs ?? {})) ?? outputFrame(run.result) : outputFrame(run.result))
           : html`<p class="dim">No output yet.</p>`}
       `}
       ${cancelModal}


### PR DESCRIPTION
## Summary
Authoring an output widget previously required remembering to declare \`controls: [{type: replay}]\` in YAML to get a Re-run button on the agent / run detail pages. Most authors forgot, so most widgets shipped without one — meaning users had to bounce up to the agent page to trigger re-run via the wizard form.

\`renderOutputWidget\` now synthesises a replay control when:
1. The call site provides a \`controlState\` (agent overview / run detail — Pulse and home tiles still render in static mode by design)
2. The schema doesn't already declare a replay control

The synthesised control is wired with the agent's declared \`inputs[*]\` names so the inline form lets users tweak inputs before re-running. Authors who declared a custom replay (with custom label or input subset) keep their config.

## Verified live
- \`api-monitor\` (no \`controls:\` block in YAML) — synthesised "Run again" button now renders on the agent overview page
- \`ashby-search-discovered\` (declared its own \`controls: [{type: replay, label: Re-run, inputs: [...]}]\`) — keeps its custom "Re-run" label
- Pulse + dashboard tiles still render static (no controls row) — unchanged

## Test plan
- [x] \`npm test\` — 1080/1080 pass (no behavioural changes inside the widget bodies; only the control row gating was changed)
- [x] Live smoke against two agents (one without declared controls, one with)

## Why now
Surfaced when verifying \`ashby-search-discovered\` end-to-end after #218 — the user noticed Re-run was missing on Pulse, then asked why we don't auto-default it. Since most widgets ship without one, default-on is the right move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)