### PR TITLE
feat(core): ARG_MAX defense-in-depth — tempfile fallback + spawn guardrail + codex stdin

### DIFF
--- a/.changeset/argmax-defense-in-depth.md
+++ b/.changeset/argmax-defense-in-depth.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+ARG_MAX defense-in-depth — three follow-ups to the claude-stdin fix (#220).
+
+1. **Fat upstream tempfile fallback** for shell nodes. When an `UPSTREAM_<ID>_RESULT` env value exceeds 32KB, it gets truncated inline (with a `...(truncated; full value at $UPSTREAM_<ID>_RESULT_FILE)` marker) and the full payload is written to `$STATE_DIR/_upstream/<runId>/<nodeId>.txt`. A new `UPSTREAM_<ID>_RESULT_FILE` env var holds the path. Shell agents that need the full payload do `cat $UPSTREAM_<ID>_RESULT_FILE`. Small upstreams behave exactly as today.
+
+2. **Argv+env soft-cap guardrail** at `spawnProcess`. Refuses spawn with a structured `setup`-category error when the rendered argv+env exceeds 200KB (well below kernel ARG_MAX ~256KB so we leave headroom for under-sandbox stricter limits). Error message names the heaviest env var and suggests `$<NAME>_FILE` as a fix. Catches any future regression that re-introduces fat-arg/env paths instead of surfacing as raw `spawn E2BIG`.
+
+3. **Codex spawner now pipes prompt via stdin** (mirrors #220's claude fix). The `codex exec` invocation reads its prompt from stdin natively. Was untouched in #220 because the CLI's stdin behaviour wasn't verified; codex-using agents now share the same E2BIG immunity as claude-code.
+
+Verified live on `ashby-search-discovered`: fat upstream payloads (1.6MB JSON, 180KB HTML) are now correctly written to `_upstream/<runId>/<nodeId>.txt` instead of being stuffed into env vars.

--- a/packages/core/src/agent-state.test.ts
+++ b/packages/core/src/agent-state.test.ts
@@ -133,6 +133,63 @@ describe('STATE_DIR env-var integration via buildNodeEnv', () => {
   });
 });
 
+describe('UPSTREAM_<ID>_RESULT_FILE fat-payload fallback', () => {
+  let dataRoot: string;
+  beforeEach(() => { dataRoot = mkdtempSync(join(tmpdir(), 'sua-upstream-')); });
+  afterEach(() => { rmSync(dataRoot, { recursive: true, force: true }); });
+
+  it('writes a tempfile + sets _FILE env when an upstream value exceeds the inline threshold', async () => {
+    const { buildNodeEnv, UPSTREAM_INLINE_THRESHOLD } = await import('./node-env.js');
+    const agent = {
+      id: 'upstream-test',
+      name: 'upstream-test',
+      status: 'active' as const,
+      source: 'local' as const,
+      mcp: false,
+      version: 1,
+      nodes: [{ id: 'main', type: 'shell' as const, command: 'echo hi' }],
+    };
+    const fatValue = 'x'.repeat(UPSTREAM_INLINE_THRESHOLD + 5_000);
+    const env = await buildNodeEnv(
+      agent,
+      agent.nodes[0],
+      {},
+      { 'fetch-jobs-html': fatValue },
+      { runStore: { } as never, dataRoot },
+      'run-abc',
+    );
+    expect(env.UPSTREAM_FETCH_JOBS_HTML_RESULT.length).toBeLessThan(fatValue.length);
+    expect(env.UPSTREAM_FETCH_JOBS_HTML_RESULT).toContain('truncated');
+    expect(env.UPSTREAM_FETCH_JOBS_HTML_RESULT_FILE).toBeTruthy();
+    expect(existsSync(env.UPSTREAM_FETCH_JOBS_HTML_RESULT_FILE)).toBe(true);
+    const onDisk = readFileSync(env.UPSTREAM_FETCH_JOBS_HTML_RESULT_FILE, 'utf8');
+    expect(onDisk).toBe(fatValue);
+  });
+
+  it('keeps small upstream values fully inline (no _FILE env, no tempfile)', async () => {
+    const { buildNodeEnv } = await import('./node-env.js');
+    const agent = {
+      id: 'small-upstream',
+      name: 'small-upstream',
+      status: 'active' as const,
+      source: 'local' as const,
+      mcp: false,
+      version: 1,
+      nodes: [{ id: 'main', type: 'shell' as const, command: 'echo hi' }],
+    };
+    const env = await buildNodeEnv(
+      agent,
+      agent.nodes[0],
+      {},
+      { 'tiny-node': 'small-payload' },
+      { runStore: { } as never, dataRoot },
+      'run-xyz',
+    );
+    expect(env.UPSTREAM_TINY_NODE_RESULT).toBe('small-payload');
+    expect(env.UPSTREAM_TINY_NODE_RESULT_FILE).toBeUndefined();
+  });
+});
+
 describe('stateDirSize (PR D.1)', () => {
   let dataRoot: string;
   beforeEach(() => { dataRoot = mkdtempSync(join(tmpdir(), 'sua-state-size-')); });

--- a/packages/core/src/dag-executor.test.ts
+++ b/packages/core/src/dag-executor.test.ts
@@ -1397,6 +1397,24 @@ describe('executeAgentDag — loop (Flow PR D)', () => {
     expect(subResults[1]).toBe('slug=rula query=staff engineer');
   });
 
+  it('refuses to spawn with a structured error when argv+env exceeds the soft cap', async () => {
+    // 250KB of garbage in a single env var pushes well past the 200KB cap.
+    const fatBlob = 'x'.repeat(250 * 1024);
+    const parentAgent = makeAgent({
+      nodes: [{ id: 'main', type: 'shell', command: 'echo hi', env: { FAT: fatBlob } }],
+    });
+    // Use the REAL spawnNode so the guardrail in spawnProcess fires; canned
+    // spawners would bypass it. We expect spawnProcess to refuse before exec.
+    const run = await executeAgentDag(parentAgent, { triggeredBy: 'cli' }, { runStore, agentStore });
+
+    expect(run.status).toBe('failed');
+    const exec = runStore.listNodeExecutions(run.id).find((e) => e.nodeId === 'main')!;
+    expect(exec.status).toBe('failed');
+    expect(exec.errorCategory).toBe('setup');
+    expect(exec.error).toMatch(/Refusing spawn.*soft cap/);
+    expect(exec.error).toMatch(/FAT/); // mentions the heaviest env var
+  });
+
   it('emits per-iteration progress events on the loop node execution row', async () => {
     agentStore.createAgent(
       {

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -586,7 +586,7 @@ export async function executeAgentDag(
     let upstreamSnapshot: Record<string, string>;
     try {
       upstreamSnapshot = buildUpstreamSnapshot(node, outputs);
-      env = await buildNodeEnv(agent, node, options.inputs ?? {}, upstreamSnapshot, deps);
+      env = await buildNodeEnv(agent, node, options.inputs ?? {}, upstreamSnapshot, deps, runId);
     } catch (err) {
       const message = (err as Error).message;
       deps.runStore.createNodeExecution({

--- a/packages/core/src/node-env.ts
+++ b/packages/core/src/node-env.ts
@@ -4,6 +4,8 @@
  * caller inputs, and upstream results. Extracted from dag-executor.ts.
  */
 
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import type { Agent, AgentNode, NodeOutput } from './agent-v2-types.js';
 import type { DagExecutorDeps } from './dag-executor.js';
 import { resolveUpstreamTemplate, resolveVarsTemplate } from './node-templates.js';
@@ -35,12 +37,24 @@ export const LOCAL_PATTERNS = [/^LC_/];
  * LD_PRELOAD, etc.) coming from user-supplied inputs are blocked — the
  * schema rejects these at load time but we defense-in-depth here too.
  */
+/**
+ * Soft cap above which an UPSTREAM_<ID>_RESULT env value gets truncated
+ * inline and the full payload is written to a per-run tempfile pointed
+ * at by UPSTREAM_<ID>_RESULT_FILE. Picked at 32KB so the common case
+ * (small upstream JSON / one-line shell echoes) stays fully inline; only
+ * fat HTML pages or large API dumps hit the file path. Chosen well below
+ * ARG_MAX (~256KB Linux) so even when several upstream-results stack
+ * the total exec env stays comfortably under the kernel cap.
+ */
+export const UPSTREAM_INLINE_THRESHOLD = 32 * 1024;
+
 export async function buildNodeEnv(
   agent: Agent,
   node: AgentNode,
   callerInputs: Record<string, string>,
   upstreamSnapshot: Record<string, string>,
   deps: DagExecutorDeps,
+  runId?: string,
 ): Promise<Record<string, string>> {
   const trustLevel = agent.source === 'community' ? 'community' : 'local';
   const baseAllowlist = trustLevel === 'community' ? MINIMAL_ALLOWLIST : LOCAL_ALLOWLIST;
@@ -103,10 +117,32 @@ export async function buildNodeEnv(
     env[k] = v;
   }
 
-  // 7: upstream results as UPSTREAM_<NODEID>_RESULT.
+  // 7: upstream results as UPSTREAM_<NODEID>_RESULT. Values above the
+  // soft cap get truncated inline and the full payload is written to
+  // a per-run tempfile pointed at by UPSTREAM_<NODEID>_RESULT_FILE.
+  // Falls back to inline-only when stateDir + runId aren't available
+  // (test paths, one-shot CLI runs without a dataRoot).
+  const stateDir = deps.dataRoot ? ensureStateDir(agent.id, deps.dataRoot) : undefined;
   for (const [upstreamId, value] of Object.entries(upstreamSnapshot)) {
     const key = `UPSTREAM_${upstreamId.toUpperCase().replace(/-/g, '_')}_RESULT`;
-    env[key] = value;
+    if (value.length <= UPSTREAM_INLINE_THRESHOLD || !stateDir || !runId) {
+      env[key] = value;
+      continue;
+    }
+    try {
+      const dir = join(stateDir, '_upstream', runId);
+      mkdirSync(dir, { recursive: true });
+      const path = join(dir, `${upstreamId}.txt`);
+      writeFileSync(path, value, 'utf8');
+      const marker = `\n...(truncated at ${UPSTREAM_INLINE_THRESHOLD} bytes; full value at $${key}_FILE)`;
+      env[key] = value.slice(0, UPSTREAM_INLINE_THRESHOLD) + marker;
+      env[`${key}_FILE`] = path;
+    } catch {
+      // Filesystem failure: fall back to inline (existing behaviour).
+      // The downstream node may still hit E2BIG; the guardrail in
+      // spawnProcess will surface a structured error in that case.
+      env[key] = value;
+    }
   }
 
   return env;

--- a/packages/core/src/node-spawner.ts
+++ b/packages/core/src/node-spawner.ts
@@ -178,7 +178,10 @@ export const codexSpawner: LlmSpawner = {
   binary: 'codex',
 
   buildArgs(opts: LlmSpawnOptions): string[] {
-    const args = ['exec', '-s', 'read-only', opts.prompt];
+    // Prompt rides on stdin (see claudeSpawner note). `codex exec` reads
+    // its prompt from stdin when no positional argument is given.
+    void opts.prompt;
+    const args = ['exec', '-s', 'read-only'];
     if (opts.model) args.push('-m', opts.model);
     return args;
   },
@@ -302,6 +305,30 @@ export interface SpawnProcessOptions {
 }
 
 /**
+ * Soft cap on the rendered argv + env total. Sits well below ARG_MAX
+ * (~256KB Linux, often stricter under sandboxes / containers) so the
+ * executor refuses with a structured error before the kernel rejects
+ * with `spawn E2BIG`. The fix-claude-stdin (#220) and tempfile-fallback
+ * (this PR) paths handle the common offenders; this guardrail is the
+ * safety net for any future regression or shell-node path that stacks
+ * multiple fat upstreams without using $UPSTREAM_<ID>_RESULT_FILE.
+ */
+const SPAWN_TOTAL_SOFT_CAP = 200 * 1024;
+
+function approximateExecSize(args: string[], env: Record<string, string>, stdinInput: string | undefined): number {
+  let total = 0;
+  // argv slot overhead: each arg pays its byte length + a NUL terminator.
+  for (const a of args) total += a.length + 1;
+  // env slot overhead: each "K=V" pays both lengths + NUL + the equals.
+  for (const [k, v] of Object.entries(env)) total += k.length + v.length + 2;
+  // Stdin doesn't go through execve, but a runaway prompt is still worth
+  // mentioning in the error so authors know which lever to pull. Counted
+  // separately from the argv+env cap.
+  void stdinInput;
+  return total;
+}
+
+/**
  * Low-level process spawn with timeout, exit-code categorization,
  * optional per-line progress callback, and result extraction.
  */
@@ -314,6 +341,26 @@ export async function spawnProcess(
     let child: ChildProcess;
     let killed = false;
     const stdinMode = opts.stdinInput !== undefined ? 'pipe' : 'ignore';
+
+    const execSize = approximateExecSize(args, opts.env, opts.stdinInput);
+    if (execSize > SPAWN_TOTAL_SOFT_CAP) {
+      // Find the heaviest contributor so the error tells the author
+      // which env var or arg to trim or move to a tempfile.
+      const heaviestEnv = Object.entries(opts.env)
+        .map(([k, v]) => ({ k, bytes: k.length + v.length + 2 }))
+        .sort((a, b) => b.bytes - a.bytes)[0];
+      const heaviestHint = heaviestEnv && heaviestEnv.bytes > 8 * 1024
+        ? ` Largest env var: ${heaviestEnv.k} (${heaviestEnv.bytes} bytes); consider $${heaviestEnv.k}_FILE if shell, or upstream trimming.`
+        : '';
+      resolve({
+        result: '',
+        exitCode: 127,
+        error: `Refusing spawn: argv+env total ${execSize} bytes exceeds soft cap ${SPAWN_TOTAL_SOFT_CAP} (kernel ARG_MAX ~256KB).${heaviestHint}`,
+        category: 'setup',
+      });
+      return;
+    }
+
     try {
       child = spawn(bin, args, {
         cwd: opts.cwd,


### PR DESCRIPTION
## Summary
Three follow-ups to #220 closing the remaining E2BIG risk surface. All three driven by the dogfood probe on \`ashby-search-discovered\`.

### 1. Fat upstream tempfile fallback (shell nodes)
\`UPSTREAM_<ID>_RESULT\` env values above 32KB are now:
- Truncated inline with a \`...(truncated; full value at \$UPSTREAM_<ID>_RESULT_FILE)\` marker
- Full payload written to \`\$STATE_DIR/_upstream/<runId>/<nodeId>.txt\`
- New \`UPSTREAM_<ID>_RESULT_FILE\` env var holds the absolute path

Shell agents that need the full payload \`cat \$UPSTREAM_<ID>_RESULT_FILE\`. Small upstreams behave exactly as today (no extra fs cost). Closes the symmetric path #220 left open for shell-node consumers chained off fat shell upstreams.

### 2. Argv+env soft-cap guardrail (\`spawnProcess\`)
Refuses spawn with a structured \`setup\`-category error when the rendered argv+env exceeds 200KB, well below kernel ARG_MAX (~256KB Linux, stricter under sandboxes). Error message names the heaviest env var and suggests \`\$<NAME>_FILE\` as the fix. Surfaces any future regression as a clean error instead of raw \`spawn E2BIG\`.

### 3. Codex stdin parity
\`codex exec\` invocation now reads prompt from stdin (mirrors #220's claude fix). Was deferred in #220 because the CLI's stdin behaviour wasn't verified; mirrors the same pattern for symmetry. Codex-using agents now share E2BIG immunity.

## Verified live
- \`ashby-search-discovered\` smoke run after this PR: fat upstream payloads (\`fetch-jobs-api\` 1.6MB JSON for the \`ashby\` slug, \`fetch-jobs-html\` 180KB) now land at \`data/agent-state/ashby-job-finder/_upstream/<runId>/<node>.txt\` instead of being stuffed into env vars
- All 4 sub-iterations spawn cleanly (\`zip\`, \`prelim\`, \`stable\` complete; \`ashby\` hits the user's Claude usage rate limit, unrelated category \`exit_nonzero\`)

## Test plan
- [x] New \`UPSTREAM_<ID>_RESULT_FILE\` test in [\`agent-state.test.ts\`](packages/core/src/agent-state.test.ts) — covers fat fallback + small-payload no-op
- [x] New guardrail test in [\`dag-executor.test.ts\`](packages/core/src/dag-executor.test.ts) — verifies refusal + error message contents
- [x] \`npm test\` — 1083/1083 pass
- [x] Live smoke against \`ashby-search-discovered\` — fat payloads correctly redirected to tempfiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)