### PR TITLE
feat: ship ashby orchestration examples + Composed Starters pack

### DIFF
--- a/agents/examples/ashby-discover.yaml
+++ b/agents/examples/ashby-discover.yaml
@@ -1,0 +1,120 @@
+# Ashby Discover — find companies that use Ashby HQ for hiring.
+#
+# Searches DuckDuckGo for jobs.ashbyhq.com URLs (optionally filtered by
+# topic), extracts the company slugs, then verifies each candidate via
+# the public posting API to drop dead boards. Emits a structured array
+# of {slug, job_count} suitable for a downstream loop+invoke.
+#
+# Run:
+#   sua workflow run ashby-discover
+#   sua workflow run ashby-discover --input TOPIC=fintech --input MAX_RESULTS=15
+id: ashby-discover
+name: Ashby Discover
+description: |
+  Finds companies hiring on Ashby HQ via web search, extracts the company
+  slugs, and verifies each one against the public Ashby posting API.
+  Emits a `companies[]` array of {slug, job_count} ready to be looped over.
+status: draft
+source: local
+mcp: false
+pulseVisible: true
+inputs:
+  TOPIC:
+    type: string
+    default: ""
+    description: Optional topic filter (e.g. "fintech", "remote", "ai"). Empty = broad search.
+  MAX_RESULTS:
+    type: number
+    default: 15
+    description: Cap on candidate slugs to verify (the API check is one HTTP call each).
+outputs:
+  headline:
+    type: string
+  count:
+    type: number
+  companies:
+    type: array
+    description: Array of {slug, job_count} for verified Ashby boards
+nodes:
+  - id: search-and-verify
+    type: shell
+    command: |
+      set -e
+      python3 << 'PYEOF'
+      import json, os, re, urllib.request, urllib.error, urllib.parse
+
+      topic = os.environ.get("TOPIC", "").strip()
+      try:
+          cap = int(os.environ.get("MAX_RESULTS", "15"))
+      except ValueError:
+          cap = 15
+
+      query = f"site:jobs.ashbyhq.com {topic}".strip()
+      ddg_url = "https://html.duckduckgo.com/html/?q=" + urllib.parse.quote(query)
+      ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
+
+      req = urllib.request.Request(ddg_url, headers={"User-Agent": ua, "Accept": "text/html"})
+      try:
+          with urllib.request.urlopen(req, timeout=20) as resp:
+              html = resp.read().decode("utf-8", errors="replace")
+      except Exception as e:
+          print(json.dumps({"headline": "Search failed", "count": 0, "companies": [], "error": str(e)[:120]}))
+          raise SystemExit(0)
+
+      # Pull the first path segment after jobs.ashbyhq.com/
+      slugs = []
+      seen = set()
+      for m in re.finditer(r"jobs\.ashbyhq\.com/([A-Za-z0-9_-]+)", html):
+          s = m.group(1).lower()
+          # Skip Ashby's own marketing paths.
+          if s in {"www", "blog", "about", "careers", "jobs"}:
+              continue
+          if s not in seen:
+              seen.add(s)
+              slugs.append(s)
+          if len(slugs) >= cap:
+              break
+
+      verified = []
+      for slug in slugs:
+          api = f"https://api.ashbyhq.com/posting-api/job-board/{slug}"
+          r = urllib.request.Request(api, headers={"User-Agent": ua, "Accept": "application/json"})
+          try:
+              with urllib.request.urlopen(r, timeout=8) as resp:
+                  data = json.loads(resp.read().decode("utf-8", errors="replace"))
+              jobs = data.get("jobs") or data.get("jobPostings") or []
+              verified.append({"slug": slug, "job_count": len(jobs)})
+          except Exception:
+              continue
+
+      topic_label = topic if topic else "all"
+      print(json.dumps({
+          "headline": f"{len(verified)} Ashby boards ({topic_label})",
+          "count": len(verified),
+          "companies": verified,
+      }))
+      PYEOF
+    timeout: 180
+signal:
+  title: Ashby Discover
+  icon: 🔎
+  template: text-headline
+  mapping:
+    headline: headline
+  refresh: 24h
+  size: 2x1
+outputWidget:
+  type: raw
+  fields:
+    - name: headline
+      label: Summary
+      type: text
+    - name: companies
+      label: Verified Ashby boards
+      type: code
+  controls:
+    - type: replay
+      label: Search Again
+      inputs:
+        - TOPIC
+        - MAX_RESULTS

--- a/agents/examples/ashby-search-discovered.yaml
+++ b/agents/examples/ashby-search-discovered.yaml
@@ -1,0 +1,166 @@
+# Ashby Search Discovered — multi-agent composition demo.
+#
+# Demonstrates the canonical "producer → loop → aggregate" pattern:
+#
+#   1. agent-invoke ashby-discover  → produces companies[] {slug, job_count}
+#   2. loop over companies, calling ashby-job-finder per slug (inputMapping
+#      translates $item.slug → COMPANY_SLUG and forwards this agent's
+#      JOB_QUERY input down via {{inputs.JOB_QUERY}})
+#   3. claude-code rolls per-company JSON results into a single structured
+#      summary
+#
+# After #216, loopConfig output exposes items[] as parsed objects, so
+# summarise can read {{upstream.search-each.items.0.roles}} directly
+# instead of parsing JSON-encoded strings.
+#
+# Run:
+#   sua workflow run ashby-search-discovered
+#   sua workflow run ashby-search-discovered --input JOB_QUERY="staff engineer" --input TOPIC=fintech
+id: ashby-search-discovered
+name: Ashby Search Discovered
+description: |
+  Discovers companies hiring on Ashby (via ashby-discover), loops over
+  the discovered slugs running ashby-job-finder per company, then rolls
+  them into one structured summary widget.
+status: draft
+source: local
+mcp: false
+inputs:
+  JOB_QUERY:
+    type: string
+    default: senior product manager
+    description: Role to filter for across all discovered companies.
+  TOPIC:
+    type: string
+    default: ""
+    description: Optional topic to narrow the discovery search (e.g. "fintech", "ai").
+  MAX_COMPANIES:
+    type: number
+    default: 4
+    description: Cap how many discovered companies to actually search (each is one sub-run).
+outputs:
+  headline:
+    type: string
+  total_matches:
+    type: number
+  companies_searched:
+    type: number
+  matches:
+    type: array
+    description: Flat array of {company, title, team, location, type, url} for every matching role
+nodes:
+  - id: discover
+    type: agent-invoke
+    agentInvokeConfig:
+      agentId: ashby-discover
+      inputMapping:
+        TOPIC: "{{inputs.TOPIC}}"
+        MAX_RESULTS: "15"
+  - id: search-each
+    type: loop
+    dependsOn: [discover]
+    loopConfig:
+      over: companies
+      agentId: ashby-job-finder
+      maxIterations: 4
+      inputMapping:
+        COMPANY_SLUG: $item.slug
+        JOB_QUERY: "{{inputs.JOB_QUERY}}"
+        MAX_RESULTS: "5"
+  - id: summarise
+    type: claude-code
+    dependsOn: [search-each]
+    prompt: |
+      Roll up Ashby job-search results from multiple companies into one structured summary.
+
+      USER QUERY: {{inputs.JOB_QUERY}}
+      TOPIC FILTER: {{inputs.TOPIC}}
+
+      RAW DATA — `items[]` is one entry per searched company. Each entry is
+      already-parsed JSON from ashby-job-finder with shape:
+        {
+          "headline": "<n> matching roles at <Co>",
+          "match_count": <number>,
+          "total_count": <number>,
+          "summary": "<one-line>",
+          "roles": [{"title", "team", "location", "type", "url"}, ...]
+        }
+
+      {{upstream.search-each.result}}
+
+      Output ONLY a single JSON object (no markdown, no fences, no commentary)
+      with this exact shape:
+
+      {
+        "headline": "<short summary, e.g. '3 matches across 4 companies'>",
+        "total_matches": <number>,
+        "companies_searched": <number>,
+        "matches": [
+          {
+            "company": "<company headline / slug>",
+            "title": "<role title>",
+            "team": "<team or empty string>",
+            "location": "<location or empty string>",
+            "type": "<employment type or empty string>",
+            "url": "<apply url>"
+          }
+        ]
+      }
+
+      Flatten roles[] from every company that had match_count > 0 into the
+      top-level matches[] array. Skip companies with match_count == 0.
+      If NO companies had matches, set matches to [] and headline to
+      "No matching roles across <N> companies".
+    maxTurns: 1
+    timeout: 240
+signal:
+  title: Ashby (discovered)
+  icon: 🧭
+  template: text-headline
+  mapping:
+    headline: headline
+  refresh: 24h
+  size: 2x1
+outputWidget:
+  type: ai-template
+  template: |
+    <div style="font-family: system-ui, sans-serif; padding: 1rem;">
+      <h2 style="margin: 0 0 0.25rem 0; font-size: 1.25rem;">{{outputs.headline}}</h2>
+      <p style="margin: 0 0 1rem 0; color: #666; font-size: 0.9rem;">
+        Searched {{outputs.companies_searched}} discovered companies, found {{outputs.total_matches}} matching roles.
+      </p>
+      {{#if outputs.matches}}
+      <table style="width: 100%; border-collapse: collapse; font-size: 0.85rem;">
+        <thead>
+          <tr style="border-bottom: 2px solid #e2e8f0; text-align: left;">
+            <th style="padding: 0.5rem;">Company</th>
+            <th style="padding: 0.5rem;">Title</th>
+            <th style="padding: 0.5rem;">Team</th>
+            <th style="padding: 0.5rem;">Location</th>
+            <th style="padding: 0.5rem;">Apply</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{#each outputs.matches as item}}
+          <tr style="border-bottom: 1px solid #e2e8f0;">
+            <td style="padding: 0.5rem; font-weight: 500;">{{item.company}}</td>
+            <td style="padding: 0.5rem;">{{item.title}}</td>
+            <td style="padding: 0.5rem;">{{item.team}}</td>
+            <td style="padding: 0.5rem;">{{item.location}}</td>
+            <td style="padding: 0.5rem;"><a href="{{item.url}}" target="_blank" style="color: #2563eb;">Apply →</a></td>
+          </tr>
+          {{/each}}
+        </tbody>
+      </table>
+      {{/if}}
+      {{#unless outputs.matches}}
+      <p style="color: #888; font-style: italic;">No matching roles found.</p>
+      {{/unless}}
+    </div>
+  controls:
+    - type: replay
+      label: Re-run
+      inputs:
+        - JOB_QUERY
+        - TOPIC
+        - MAX_COMPANIES

--- a/packages/core/packs/composed-starters.yaml
+++ b/packages/core/packs/composed-starters.yaml
@@ -1,0 +1,45 @@
+# Composed Starters pack — the canonical "wizard → orchestrator → widget"
+# example as an installable skeleton.
+#
+# Bundles the three agents that make up one worked example of the
+# loop + agent-invoke composition pattern that build-planner v3 (#214)
+# teaches and PRs #215–#221 made correct end-to-end:
+#
+#   ashby-discover           producer    — emits companies[] {slug, ...}
+#   ashby-job-finder         per-item    — looped over each discovered slug
+#   ashby-search-discovered  orchestrator — wraps the two with a wizard
+#                                           form (declared inputs:) and a
+#                                           structured ai-template widget
+#
+# Install this pack to get a runnable skeleton you can copy and adapt
+# for your own wizard → orchestrator → widget flow. Uninstall removes
+# the dashboard but keeps the agents installed.
+
+id: composed-starters
+name: Composed Agents
+description: |
+  Worked example of the wizard → orchestrator → output-widget composition
+  pattern. Install, run the orchestrator, then read the YAML to see how
+  loop + agent-invoke + inputMapping fit together.
+version: 0.1.0
+author: some-useful-agents
+
+agents:
+  - id: ashby-discover
+    yamlPath: ../../../agents/examples/ashby-discover.yaml
+  - id: ashby-job-finder
+    yamlPath: ../../../agents/examples/ashby-job-finder.yaml
+  - id: ashby-search-discovered
+    yamlPath: ../../../agents/examples/ashby-search-discovered.yaml
+
+dashboards:
+  - id: composed-starters
+    name: Composed Agents
+    sections:
+      - title: Orchestrator (start here)
+        agentIds:
+          - ashby-search-discovered
+      - title: Sub-agents it composes
+        agentIds:
+          - ashby-discover
+          - ashby-job-finder


### PR DESCRIPTION
## Summary
Two coordinated changes that make the dogfood from PRs #215–#221 stick:

### (1) Promote orchestration probes to committed examples
\`agents/examples/ashby-discover.yaml\` + \`agents/examples/ashby-search-discovered.yaml\` — the two agents that drove the entire \`loopConfig.inputMapping\` / parsed-loop-items / progress-propagation / E2BIG defense work now ship as default-imported examples. New installs get them automatically; future executor refactors get free regression coverage.

### (2) Composed Starters installable pack
\`packages/core/packs/composed-starters.yaml\` — bundles the orchestrator + its two sub-agents (\`ashby-discover\`, \`ashby-job-finder\`) into a one-click installable pack at \`/packs\`. Dashboard groups them by role:

- **Orchestrator (start here):** \`ashby-search-discovered\` — wizard form + \`ai-template\` widget
- **Sub-agents it composes:** \`ashby-discover\`, \`ashby-job-finder\`

Users install it, run the orchestrator, then read the YAML to see how \`agent-invoke\` + \`loop\` + \`inputMapping\` + structured-output widget bind together. Reframed (2) from "yaml-template scaffold" to "installable working skeleton" because rotting scaffolds was the original concern; pack form leverages infra you already shipped (#199, #200, #204–#207).

## Verified live
- Both YAMLs validate via \`parseAgent\`
- Pack registers at \`/packs\`, installs to \`/dashboards/composed-starters:composed-starters\` rendering both sections + the orchestrator's last result
- Uninstall round-trip: dashboard removed, agents kept (per pack-installer convention), reinstall clean
- \`npm test\` — 1083/1083 pass

## Skip rationale
No changeset — \`agents/\` and \`packages/core/packs/*.yaml\` are non-published asset paths per CLAUDE.md.

## Why this closes the loop
Dogfood started with "does the build-planner v3 catalog actually work" → 7 PRs of executor fixes → now: copyable working example committed + installable. Anyone who wants to write their own composed agent has a runnable reference and can install it + adapt rather than authoring from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)