### PR TITLE
fix(mcp-server): expose shutdown handle so tests can stop the http server

### DIFF
--- a/.changeset/mcp-server-shutdown.md
+++ b/.changeset/mcp-server-shutdown.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+`startMcpServer` now returns a `{ shutdown }` handle so callers (tests, CLI, embedders) can stop the listening http server cleanly.
+
+Pre-fix it returned `void`, leaving callers no way to drain the server. Two MCP test describe blocks ran random-port servers per test and never shut them down — across CI runs the random-port pool occasionally collided and a fresh test ended up talking to a prior test's still-running server (whose agentDir had been rm'd), surfacing as flaky `Agent "..." not found`. The planner-telemetry PR (#224) added enough test load to shift ordering and trip the latent flake reliably.
+
+`shutdown()` closes all live MCP transports, drains the provider, and awaits `httpServer.close()`. Also tightened the initial `listen()` to await the bind and surface listen errors instead of fire-and-forget.

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -65,7 +65,13 @@ function rejectIfNotOk(res: ServerResponse, check: AuthCheckResult): boolean {
   return true;
 }
 
-export async function startMcpServer(options: McpServerOptions): Promise<void> {
+/** Handle returned by `startMcpServer` so callers (tests, CLI) can shut down cleanly. */
+export interface McpServerHandle {
+  /** Stop accepting new connections, drain the provider, and close the http server. */
+  shutdown(): Promise<void>;
+}
+
+export async function startMcpServer(options: McpServerOptions): Promise<McpServerHandle> {
   const host = options.host ?? '127.0.0.1';
   const tokenPath = options.tokenPath ?? getMcpTokenPath();
 
@@ -198,17 +204,37 @@ export async function startMcpServer(options: McpServerOptions): Promise<void> {
     res.end();
   });
 
-  httpServer.listen(options.port, host, () => {
-    const displayHost = host === '0.0.0.0' || host === '::' ? '<all interfaces>' : host;
-    console.log(`MCP server listening on http://${displayHost}:${options.port}/mcp`);
-    console.log(`Health check: http://${displayHost}:${options.port}/health`);
-    console.log(`Bearer token: ${tokenPath}`);
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once('error', reject);
+    httpServer.listen(options.port, host, () => {
+      httpServer.removeListener('error', reject);
+      const displayHost = host === '0.0.0.0' || host === '::' ? '<all interfaces>' : host;
+      console.log(`MCP server listening on http://${displayHost}:${options.port}/mcp`);
+      console.log(`Health check: http://${displayHost}:${options.port}/health`);
+      console.log(`Bearer token: ${tokenPath}`);
+      resolve();
+    });
   });
+
+  let shuttingDown = false;
+  const shutdown = async (): Promise<void> => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    // Close all live MCP transports first so their underlying HTTP responses
+    // don't race the server.close() callback.
+    for (const entry of sessions.values()) {
+      try { await entry.server.close?.(); } catch { /* ignore */ }
+    }
+    sessions.clear();
+    try { await provider.shutdown(); } catch { /* ignore */ }
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  };
 
   process.on('SIGINT', async () => {
     console.log('\nShutting down...');
-    await provider.shutdown();
-    httpServer.close();
+    await shutdown();
     process.exit(0);
   });
+
+  return { shutdown };
 }

--- a/packages/mcp-server/src/server.test.ts
+++ b/packages/mcp-server/src/server.test.ts
@@ -20,7 +20,12 @@ describe('MCP server multi-session', () => {
   let tokenPath: string;
   let secretsPath: string;
   let port: number;
-  let httpServer: { close: () => void } | undefined;
+  // Handle from startMcpServer; afterEach uses it to drain the http server
+  // before deleting the tmpdir + ending the test. Without this the http
+  // server keeps listening on the random port and a future test that hits
+  // the same port talks to a server pointing at a deleted agentDir,
+  // surfacing as flaky "Agent ... not found" in CI.
+  let serverHandle: { shutdown: () => Promise<void> } | undefined;
 
   beforeEach(() => {
     dataDir = mkdtempSync(join(tmpdir(), 'sua-mcp-multi-'));
@@ -32,13 +37,16 @@ describe('MCP server multi-session', () => {
     port = 18000 + Math.floor(Math.random() * 1000);
   });
 
-  afterEach(() => {
-    httpServer?.close();
+  afterEach(async () => {
+    if (serverHandle) {
+      await serverHandle.shutdown();
+      serverHandle = undefined;
+    }
     rmSync(dataDir, { recursive: true, force: true });
   });
 
   it('serves two independent initialize requests without crashing', async () => {
-    await startMcpServer({
+    serverHandle = await startMcpServer({
       port,
       host: '127.0.0.1',
       agentDirs: [dataDir], // empty dir — agent loader returns no agents
@@ -106,6 +114,10 @@ describe('MCP run-agent with inputs', () => {
   let tokenPath: string;
   let secretsPath: string;
   let port: number;
+  // See note in the first describe block — without this the random-port
+  // pool collides across tests and a fresh test ends up talking to a
+  // prior test's still-running server (whose agentDir was rm'd).
+  let serverHandle: { shutdown: () => Promise<void> } | undefined;
 
   beforeEach(() => {
     dataDir = mkdtempSync(join(tmpdir(), 'sua-mcp-run-'));
@@ -136,7 +148,11 @@ describe('MCP run-agent with inputs', () => {
     );
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    if (serverHandle) {
+      await serverHandle.shutdown();
+      serverHandle = undefined;
+    }
     rmSync(dataDir, { recursive: true, force: true });
   });
 
@@ -155,7 +171,7 @@ describe('MCP run-agent with inputs', () => {
   }
 
   it('list-agents returns the declared input schema', async () => {
-    await startMcpServer({
+    serverHandle = await startMcpServer({
       port,
       host: '127.0.0.1',
       agentDirs: [agentDir],
@@ -179,7 +195,7 @@ describe('MCP run-agent with inputs', () => {
   });
 
   it('run-agent threads inputs through to the run', async () => {
-    await startMcpServer({
+    serverHandle = await startMcpServer({
       port,
       host: '127.0.0.1',
       agentDirs: [agentDir],
@@ -204,7 +220,7 @@ describe('MCP run-agent with inputs', () => {
   });
 
   it('run-agent returns an MCP error when a required input is missing', async () => {
-    await startMcpServer({
+    serverHandle = await startMcpServer({
       port,
       host: '127.0.0.1',
       agentDirs: [agentDir],
@@ -228,7 +244,7 @@ describe('MCP run-agent with inputs', () => {
   });
 
   it('run-agent rejects oversize input values before submitting', async () => {
-    await startMcpServer({
+    serverHandle = await startMcpServer({
       port,
       host: '127.0.0.1',
       agentDirs: [agentDir],


### PR DESCRIPTION
## Summary
**Unblocks the changeset publish workflow that failed on #224.**

\`startMcpServer()\` returned \`void\` and gave callers no way to stop the listening http server. Two test describe blocks declared an \`httpServer\` local but never assigned it (the \`close()\` call in afterEach was a no-op). The "with inputs" describe didn't even try — it just rm'd the tmpdir between tests.

Tests pick \`port = 19000 + Math.floor(Math.random() * 500)\`. With 5 tests and only 500 ports, occasional collisions are guaranteed across CI runs. When test N's port matches a prior still-running server's port, the client connects to the **old** server (whose agentDir was rm'd in afterEach) → \`loadMcpExposedAgents\` returns empty → \`Agent "echoer" not found\` reaches the assertion expecting \`/per-value cap/\`. **Pre-existing latent flake**, just got tripped reliably when #224 added test load that shifted ordering.

## Fix
- \`startMcpServer\` now returns \`Promise<McpServerHandle>\` with a \`shutdown()\` that closes all live MCP transports, drains the provider, and awaits \`httpServer.close()\`.
- Both test describe blocks capture the handle and call \`shutdown()\` in \`afterEach\` before deleting the tmpdir.
- Tightened the initial \`listen()\` to **await the bind and surface listen errors** instead of fire-and-forget — previously \`EADDRINUSE\` would resolve the awaiter before the error fired.

## Verified
- 5 consecutive full-suite runs of \`packages/mcp-server/src/server.test.ts\` — all pass clean
- \`npm test\` — 1101/1101 across the repo
- The \`shutdown()\` API also makes the SIGINT handler in the CLI cleaner — it now reuses the same code path

## Backwards compatibility
\`startMcpServer\`'s return type changed from \`Promise<void>\` to \`Promise<McpServerHandle>\`. Existing callers (CLI \`sua mcp serve\`) ignore the return value, so no breakage. New callers (tests + future embedders) get clean teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)