### PR TITLE
fix(mcp-server): conservative shutdown — use closeAllConnections, drop per-session McpServer.close

### DIFF
--- a/.changeset/mcp-shutdown-conservative.md
+++ b/.changeset/mcp-shutdown-conservative.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Make `startMcpServer().shutdown()` use `httpServer.closeAllConnections()` instead of per-session `McpServer.close()`.
+
+#225 added a `shutdown()` handle so tests could stop the listening http server, which fixed the EADDRINUSE flake. But the `for entry of sessions: await entry.server.close?.()` loop raced SDK transport teardown against the next test's first request, surfacing as a different flake: `TypeError: fetch failed — SocketError: other side closed`. The Release workflow tripped this on the post-#225 main push.
+
+Conservative fix: drop the per-session McpServer close, just `httpServer.closeAllConnections()` + drain provider + await `httpServer.close()`. Releases the port without poking at SDK internals. 10/10 stress runs of the file pass locally.

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -220,11 +220,13 @@ export async function startMcpServer(options: McpServerOptions): Promise<McpServ
   const shutdown = async (): Promise<void> => {
     if (shuttingDown) return;
     shuttingDown = true;
-    // Close all live MCP transports first so their underlying HTTP responses
-    // don't race the server.close() callback.
-    for (const entry of sessions.values()) {
-      try { await entry.server.close?.(); } catch { /* ignore */ }
-    }
+    // Stop accepting new connections + actively close existing ones via
+    // closeAllConnections so the close-callback fires promptly even when
+    // streamable-HTTP sessions left long-lived responses open. This is
+    // intentionally simpler than calling McpServer.close() per session —
+    // doing that races SDK transport teardown against the next test's
+    // first request and surfaces as "other side closed" client errors.
+    try { (httpServer as unknown as { closeAllConnections?: () => void }).closeAllConnections?.(); } catch { /* ignore */ }
     sessions.clear();
     try { await provider.shutdown(); } catch { /* ignore */ }
     await new Promise<void>((resolve) => httpServer.close(() => resolve()));


### PR DESCRIPTION
## Summary
Follow-up to #225. The Release workflow on the post-#225 main push hit a different MCP test flake:

\`\`\`
TypeError: fetch failed
Caused by: SocketError: other side closed
\`\`\`

#225's \`shutdown()\` added a \`for entry of sessions: await entry.server.close?.()\` loop. That races SDK transport teardown against the *next* test's first request — the SDK's \`McpServer.close()\` tears down internal streamable-HTTP transport state, and a subsequent client \`fetch\` to the new (different) server happens to hit a socket the SDK had marked dead. The EADDRINUSE flake (#225) is fixed; the per-session close logic is what introduced this new edge.

## Fix
Drop the per-session \`McpServer.close()\` call. Use \`httpServer.closeAllConnections()\` instead — actively kills any long-lived streamable-HTTP responses without reaching into SDK internals. Then drain provider + await \`httpServer.close()\`.

## Verified
- **10/10 stress runs** of \`packages/mcp-server/src/server.test.ts\` pass locally
- \`npm test\` — 1101/1101 across the repo

## Why this won't regress to the EADDRINUSE flake
\`closeAllConnections()\` actively terminates open sockets so the close-callback fires promptly even when streamable-HTTP sessions have long-lived responses open. \`httpServer.close()\` then resolves and the port is released before the next test's startMcpServer tries to bind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)