### PR TITLE
feat(core): build-planner critic loop + auto-retry + commit gating

### DIFF
--- a/.changeset/build-plan-critic-loop.md
+++ b/.changeset/build-plan-critic-loop.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Build planner: critic loop with auto-retry + tighter commit telemetry.
+
+The build wizard now structurally validates each plan before showing it to you. New `critiquePlan()` walks every newAgent YAML through `parseAgent`, checks dashboard refs against your actual catalog, and verifies that `loopConfig.agentId` / `agentInvokeConfig.agentId` cross-references inside generated agents resolve to either an installed agent or another newAgent in the same plan.
+
+When the critic flags issues, the planner is re-fired up to two more times with a structured "Critic feedback:" block appended to the goal — so it sees exactly which fields to fix. After all retries exhaust, the wizard surfaces the remaining issues with a "Commit anyway" override so you stay in control.
+
+Telemetry: `recordCommit` now only fires when an agent or dashboard actually landed, so `/metrics/planner` no longer counts dismissed/failed commits toward commit-rate. Retry attempts are routed back to the original telemetry row via the new alias map, so per-pipeline metrics stay accurate.

--- a/packages/core/src/build-plan-critic.test.ts
+++ b/packages/core/src/build-plan-critic.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { critiquePlan, formatCriticFeedback } from './build-plan-critic.js';
+import { buildPlanSchema, type BuildPlanInput } from './build-plan-schema.js';
+
+const validYaml = (id: string) => `id: ${id}\nname: ${id} agent\nnodes:\n  - id: n1\n    type: shell\n    command: echo hi\n`;
+
+function planFor(overrides: Partial<BuildPlanInput> = {}): ReturnType<typeof buildPlanSchema.parse> {
+  return buildPlanSchema.parse({
+    intent: 'agent',
+    summary: 'A test plan',
+    survey: { matchedAgents: [], missingFor: [], existingDashboards: [] },
+    newAgents: [{ id: 'one', purpose: 'p', yaml: validYaml('one') }],
+    dashboard: null,
+    questions: [],
+    ...overrides,
+  });
+}
+
+describe('critiquePlan', () => {
+  it('passes a clean single-agent plan', () => {
+    const result = critiquePlan(planFor(), { existingAgentIds: new Set() });
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('flags YAML that fails parseAgent', () => {
+    const result = critiquePlan(
+      planFor({ newAgents: [{ id: 'broken', purpose: 'p', yaml: 'id: broken\n' /* missing name */ }] }),
+      { existingAgentIds: new Set() },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors[0].path).toBe('newAgents[0].yaml');
+    expect(result.errors[0].message).toMatch(/failed to parse/i);
+  });
+
+  it('flags YAML id mismatch with plan ref id', () => {
+    const result = critiquePlan(
+      planFor({ newAgents: [{ id: 'planref', purpose: 'p', yaml: validYaml('different') }] }),
+      { existingAgentIds: new Set() },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => /id field is "different"/.test(e.message))).toBe(true);
+  });
+
+  it('flags duplicate newAgents.id', () => {
+    const result = critiquePlan(
+      buildPlanSchema.parse({
+        intent: 'dashboard-new',
+        summary: 'dup',
+        newAgents: [
+          { id: 'dup', purpose: 'p', yaml: validYaml('dup') },
+          { id: 'dup', purpose: 'p', yaml: validYaml('dup') },
+        ],
+        dashboard: { id: 'user:d', name: 'D', sections: [{ title: 'T', agentIds: ['dup'] }] },
+      }),
+      { existingAgentIds: new Set() },
+    );
+    expect(result.errors.some((e) => /Duplicate newAgents.id/.test(e.message))).toBe(true);
+  });
+
+  it('flags survey.matchedAgents that are not actually installed', () => {
+    const result = critiquePlan(
+      buildPlanSchema.parse({
+        intent: 'dashboard-mixed',
+        summary: 's',
+        survey: { matchedAgents: [{ id: 'phantom', matchedFor: 'x' }], missingFor: [], existingDashboards: [] },
+        newAgents: [{ id: 'real', purpose: 'p', yaml: validYaml('real') }],
+        dashboard: { id: 'user:d', name: 'D', sections: [{ title: 'T', agentIds: ['phantom', 'real'] }] },
+      }),
+      { existingAgentIds: new Set(['something-else']) },
+    );
+    expect(result.errors.some((e) => /not installed/.test(e.message))).toBe(true);
+  });
+
+  it('flags dashboard agentIds that resolve to neither newAgents nor catalog', () => {
+    // Schema would normally reject this, but here we force it via a matched
+    // agent that the schema thinks is real (matched can be hallucinated).
+    const result = critiquePlan(
+      buildPlanSchema.parse({
+        intent: 'dashboard-existing',
+        summary: 's',
+        survey: { matchedAgents: [{ id: 'ghost', matchedFor: 'x' }], missingFor: [], existingDashboards: [] },
+        newAgents: [],
+        dashboard: { id: 'user:d', name: 'D', sections: [{ title: 'T', agentIds: ['ghost'] }] },
+      }),
+      { existingAgentIds: new Set() },
+    );
+    expect(result.errors.some((e) => /no installed agent or newAgent/.test(e.message))).toBe(true);
+  });
+
+  it('flags loopConfig.agentId that does not resolve', () => {
+    const yaml = `id: orchestrator\nname: orch\nnodes:\n  - id: loop1\n    type: loop\n    loopConfig:\n      over: \"items\"\n      agentId: missing-target\n`;
+    const result = critiquePlan(
+      planFor({ newAgents: [{ id: 'orchestrator', purpose: 'p', yaml }] }),
+      { existingAgentIds: new Set() },
+    );
+    expect(result.errors.some((e) => /loopConfig.agentId/.test(e.path) && /missing-target/.test(e.message))).toBe(true);
+  });
+
+  it('accepts loopConfig.agentId that points at another newAgent in the same plan', () => {
+    const orchestratorYaml = `id: orchestrator\nname: orch\nnodes:\n  - id: loop1\n    type: loop\n    loopConfig:\n      over: \"items\"\n      agentId: worker\n`;
+    const result = critiquePlan(
+      buildPlanSchema.parse({
+        intent: 'dashboard-new',
+        summary: 's',
+        newAgents: [
+          { id: 'orchestrator', purpose: 'p', yaml: orchestratorYaml },
+          { id: 'worker', purpose: 'p', yaml: validYaml('worker') },
+        ],
+        dashboard: { id: 'user:d', name: 'D', sections: [{ title: 'T', agentIds: ['orchestrator'] }] },
+      }),
+      { existingAgentIds: new Set() },
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts agentInvokeConfig.agentId that points at an installed catalog agent', () => {
+    const yaml = `id: caller\nname: caller\nnodes:\n  - id: invoke1\n    type: agent-invoke\n    agentInvokeConfig:\n      agentId: catalog-agent\n`;
+    const result = critiquePlan(
+      planFor({ newAgents: [{ id: 'caller', purpose: 'p', yaml }] }),
+      { existingAgentIds: new Set(['catalog-agent']) },
+    );
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe('formatCriticFeedback', () => {
+  it('returns empty string when no errors', () => {
+    expect(formatCriticFeedback([])).toBe('');
+  });
+
+  it('renders each error as a bullet line under a header', () => {
+    const out = formatCriticFeedback([
+      { path: 'a.b', message: 'thing one' },
+      { path: 'c[0]', message: 'thing two' },
+    ]);
+    expect(out).toMatch(/Critic feedback/);
+    expect(out).toMatch(/- a\.b: thing one/);
+    expect(out).toMatch(/- c\[0\]: thing two/);
+  });
+});

--- a/packages/core/src/build-plan-critic.ts
+++ b/packages/core/src/build-plan-critic.ts
@@ -1,0 +1,155 @@
+/**
+ * Plan critic — second-pass structural validation for build-planner output.
+ *
+ * `buildPlanSchema` (Zod) catches obvious shape violations: wrong intent,
+ * missing dashboard sections, agent IDs that aren't in survey.matchedAgents
+ * or newAgents. The critic catches the next layer: things that *look*
+ * structurally valid to the schema but don't survive contact with reality.
+ *
+ * Concretely:
+ *  - newAgent YAMLs must round-trip through `parseAgent` (after autoFix).
+ *    Real failure observed in the wild: planner emitted a `signal` node
+ *    missing the required `title` field — schema-valid, parse-broken.
+ *  - loopConfig.agentId / agentInvokeConfig.agentId inside newAgent YAMLs
+ *    must reference either another newAgent or an existing catalog agent.
+ *    Schema doesn't peek inside YAML strings.
+ *  - newAgent.id collisions (the schema permits duplicates).
+ *  - survey.matchedAgents.id must exist in the actual catalog. The schema's
+ *    `knownIds` set trusts whatever the planner wrote; we need ground truth.
+ *
+ * Output shape is deliberately structured: each error has a path + message
+ * so the caller can build a tight "Critic feedback:" block to feed back
+ * into the planner for retry.
+ */
+
+import { parseAgent } from './agent-yaml.js';
+import type { BuildPlan } from './build-plan-schema.js';
+
+export interface PlanCriticError {
+  /** Dotted path into the plan (e.g. `newAgents[0].yaml`, `dashboard.sections[1].agentIds[0]`). */
+  path: string;
+  /** Human-readable problem statement, written to be useful when fed back to the LLM. */
+  message: string;
+}
+
+export interface PlanCriticResult {
+  ok: boolean;
+  errors: PlanCriticError[];
+}
+
+export interface PlanCriticContext {
+  /** Set of agent IDs that exist in the local catalog. */
+  existingAgentIds: Set<string>;
+}
+
+/**
+ * Run the critic against a parsed BuildPlan. The plan is assumed to have
+ * already passed `buildPlanSchema.safeParse` (so basic shape is sound).
+ *
+ * Caller is expected to have applied autoFixYaml to each newAgent.yaml
+ * before invoking the critic — autoFix lives in the dashboard package
+ * and is part of the extract step that runs upstream of this.
+ */
+export function critiquePlan(plan: BuildPlan, ctx: PlanCriticContext): PlanCriticResult {
+  const errors: PlanCriticError[] = [];
+
+  // Build the set of IDs known after this plan would land. Used both for
+  // dashboard section validation and for cross-references inside newAgent
+  // YAMLs (a newAgent may invoke another newAgent in the same plan).
+  const newAgentIds = new Set<string>();
+  const seenNew = new Set<string>();
+  plan.newAgents.forEach((a, i) => {
+    if (seenNew.has(a.id)) {
+      errors.push({
+        path: `newAgents[${i}].id`,
+        message: `Duplicate newAgents.id "${a.id}" — each new agent needs a unique id.`,
+      });
+    }
+    seenNew.add(a.id);
+    newAgentIds.add(a.id);
+  });
+
+  // matchedAgents must reference catalog reality. Schema can't know what's
+  // installed; we do.
+  plan.survey.matchedAgents.forEach((m, i) => {
+    if (!ctx.existingAgentIds.has(m.id)) {
+      errors.push({
+        path: `survey.matchedAgents[${i}].id`,
+        message: `survey.matchedAgents references agent id "${m.id}" which is not installed. Drop it from matchedAgents (and add it to newAgents if you intended to create it).`,
+      });
+    }
+  });
+
+  // After-this-plan-lands universe of agent IDs.
+  const allIds = new Set<string>([...ctx.existingAgentIds, ...newAgentIds]);
+
+  // Dashboard section agentIds must resolve against the post-plan universe.
+  // (Schema only checks against survey.matchedAgents + newAgents, which can
+  // both lie. This is the ground-truth check.)
+  if (plan.dashboard) {
+    plan.dashboard.sections.forEach((s, sIdx) => {
+      s.agentIds.forEach((id, aIdx) => {
+        if (!allIds.has(id)) {
+          errors.push({
+            path: `dashboard.sections[${sIdx}].agentIds[${aIdx}]`,
+            message: `Dashboard references agent id "${id}" but no installed agent or newAgent has that id. Either add a newAgent with id="${id}" or pick an installed agent.`,
+          });
+        }
+      });
+    });
+  }
+
+  // Walk each newAgent YAML: parse + check internal cross-refs.
+  plan.newAgents.forEach((a, i) => {
+    let agent;
+    try {
+      agent = parseAgent(a.yaml);
+    } catch (e) {
+      errors.push({
+        path: `newAgents[${i}].yaml`,
+        message: `newAgents[${i}] (id="${a.id}") YAML failed to parse: ${(e as Error).message}`,
+      });
+      return;
+    }
+    // YAML id must match the plan ref id — otherwise commit will skip.
+    if (agent.id !== a.id) {
+      errors.push({
+        path: `newAgents[${i}].yaml`,
+        message: `newAgents[${i}] declares id="${a.id}" but the YAML's id field is "${agent.id}". They must match.`,
+      });
+    }
+    // loopConfig.agentId / agentInvokeConfig.agentId references.
+    (agent.nodes ?? []).forEach((n, nIdx) => {
+      const refs: Array<{ field: string; id: string | undefined }> = [
+        { field: 'loopConfig.agentId', id: n.loopConfig?.agentId },
+        { field: 'agentInvokeConfig.agentId', id: n.agentInvokeConfig?.agentId },
+      ];
+      for (const { field, id } of refs) {
+        if (!id) continue;
+        if (!allIds.has(id)) {
+          errors.push({
+            path: `newAgents[${i}].yaml.nodes[${nIdx}].${field}`,
+            message: `Node "${n.id}" in newAgent "${a.id}" references agent id "${id}" via ${field}, but no installed agent or newAgent has that id.`,
+          });
+        }
+      }
+    });
+  });
+
+  return { ok: errors.length === 0, errors };
+}
+
+/**
+ * Format critic errors as a block suitable for appending to the planner
+ * goal on retry. The planner prompt already knows about <plan>...</plan>;
+ * this section gives it the specific structural problems to fix.
+ */
+export function formatCriticFeedback(errors: PlanCriticError[]): string {
+  if (errors.length === 0) return '';
+  const lines = errors.map((e) => `- ${e.path}: ${e.message}`);
+  return [
+    '',
+    'Critic feedback on your previous plan (fix every item below; emit a complete revised <plan>...</plan>):',
+    ...lines,
+  ].join('\n');
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -98,6 +98,13 @@ export {
   type BuildPlanInput,
 } from './build-plan-schema.js';
 export {
+  critiquePlan,
+  formatCriticFeedback,
+  type PlanCriticError,
+  type PlanCriticResult,
+  type PlanCriticContext,
+} from './build-plan-critic.js';
+export {
   getBuiltinTool,
   listBuiltinTools,
   isBuiltinTool,

--- a/packages/core/src/planner-telemetry-store.test.ts
+++ b/packages/core/src/planner-telemetry-store.test.ts
@@ -95,6 +95,48 @@ describe('PlannerTelemetryStore', () => {
     expect(store.get('run-retry')!.planAttempts).toBe(3);
   });
 
+  describe('retry alias map', () => {
+    it('routes incrementAttempts on a retry runId back to the original row', () => {
+      store.recordStart('orig', 'goal');
+      store.recordRetrySpawn('orig', 'retry-1');
+      store.incrementAttempts('retry-1');
+      expect(store.get('orig')!.planAttempts).toBe(2);
+      // No row was created for the retry id.
+      expect(store.get('retry-1')).toBeNull();
+    });
+
+    it('routes recordExtract on a retry runId back to the original row', () => {
+      store.recordStart('orig2', 'goal');
+      store.recordRetrySpawn('orig2', 'retry-2');
+      store.recordExtract({ runId: 'retry-2', status: 'ok', autofixCount: 1, validationErrors: 2, timeToPlanMs: 9000, intent: 'agent' });
+      const row = store.get('orig2')!;
+      expect(row.planExtractStatus).toBe('ok');
+      expect(row.planAutofixCount).toBe(1);
+      expect(row.planValidationErrors).toBe(2);
+      expect(row.intent).toBe('agent');
+    });
+
+    it('routes recordCommit on a retry runId back to the original row', () => {
+      store.recordStart('orig3', 'goal');
+      store.recordRetrySpawn('orig3', 'retry-3');
+      store.recordCommit('retry-3', 4242);
+      expect(store.get('orig3')!.timeToCommitMs).toBe(4242);
+    });
+
+    it('resolveOriginalRunId returns input unchanged when no alias is registered', () => {
+      expect(store.resolveOriginalRunId('unknown')).toBe('unknown');
+    });
+
+    it('resolves alias-of-alias chains down to the root', () => {
+      store.recordStart('root', 'goal');
+      store.recordRetrySpawn('root', 'retry-a');
+      store.recordRetrySpawn('retry-a', 'retry-b');
+      expect(store.resolveOriginalRunId('retry-b')).toBe('root');
+      store.incrementAttempts('retry-b');
+      expect(store.get('root')!.planAttempts).toBe(2);
+    });
+  });
+
   describe('computeStats', () => {
     it('returns zeroed stats when no rows exist', () => {
       const s = store.computeStats(7);

--- a/packages/core/src/planner-telemetry-store.ts
+++ b/packages/core/src/planner-telemetry-store.ts
@@ -66,6 +66,15 @@ export interface PlannerTelemetryStats {
 export class PlannerTelemetryStore {
   private db: DatabaseSync;
   private readonly ownsConnection: boolean;
+  /**
+   * Maps retry run-ids back to the original (root) run-id whose telemetry
+   * row owns the pipeline. PR2's critic-loop spawns a new planner run on
+   * critic failure; the new run's run_id is aliased here so subsequent
+   * recordExtract / incrementAttempts / recordCommit calls update the
+   * original row. In-memory only — daemon restart abandons in-flight
+   * retries, which is fine because the wizard modal is short-lived.
+   */
+  private readonly retryAliases = new Map<string, string>();
 
   constructor(dbPath: string) {
     const dir = dirname(dbPath);
@@ -111,6 +120,26 @@ export class PlannerTelemetryStore {
     `);
   }
 
+  /**
+   * Register a retry planner run as an alias of an original (root) run.
+   * Subsequent telemetry updates targeting `retryRunId` will be applied to
+   * `originalRunId` instead. Safe to call multiple times — last call wins.
+   */
+  recordRetrySpawn(originalRunId: string, retryRunId: string): void {
+    // Resolve transitively in case the caller passes an already-aliased id
+    // (avoids alias-of-alias chains that drift if the original gets renamed).
+    const root = this.resolveOriginalRunId(originalRunId);
+    this.retryAliases.set(retryRunId, root);
+  }
+
+  /**
+   * Resolve a potentially-aliased run-id to the root telemetry-row run-id.
+   * Returns the input unchanged when no alias is registered.
+   */
+  resolveOriginalRunId(runId: string): string {
+    return this.retryAliases.get(runId) ?? runId;
+  }
+
   /** Insert a row for a freshly-started planner run. Idempotent — re-runs no-op via INSERT OR IGNORE. */
   recordStart(runId: string, goal: string): void {
     const truncated = goal.length > 1024 ? goal.slice(0, 1024) : goal;
@@ -147,7 +176,7 @@ export class PlannerTelemetryStore {
       args.validationErrors ?? null,
       args.timeToPlanMs,
       args.intent ?? null,
-      args.runId,
+      this.resolveOriginalRunId(args.runId),
     );
   }
 
@@ -158,7 +187,7 @@ export class PlannerTelemetryStore {
   incrementAttempts(runId: string): void {
     this.db.prepare(`
       UPDATE planner_telemetry SET plan_attempts = plan_attempts + 1 WHERE run_id = ?
-    `).run(runId);
+    `).run(this.resolveOriginalRunId(runId));
   }
 
   /** Record that the user clicked Commit on this plan. */
@@ -168,7 +197,7 @@ export class PlannerTelemetryStore {
       SET committed_at = datetime('now'),
           time_to_commit_ms = ?
       WHERE run_id = ?
-    `).run(timeToCommitMs, runId);
+    `).run(timeToCommitMs, this.resolveOriginalRunId(runId));
   }
 
   /** Read a single row (mainly for tests + debugging). */

--- a/packages/dashboard/src/routes/run-now-build.ts
+++ b/packages/dashboard/src/routes/run-now-build.ts
@@ -14,7 +14,10 @@ import {
   buildDiscoveryCatalog,
   buildPlanSchema,
   extractPlanJson,
+  critiquePlan,
+  formatCriticFeedback,
   type BuildPlan,
+  type PlanCriticError,
   type RunStatus,
   type ToolDefinition,
 } from '@some-useful-agents/core';
@@ -273,6 +276,111 @@ function formatToolCatalog(tools: ToolDefinition[]): string {
       return `- ${t.id} (type: ${implType}): ${desc}${inputNames ? ` Inputs: ${inputNames}.` : ''}`;
     })
     .join('\n');
+}
+
+/**
+ * Maximum number of *additional* planner attempts after the first one. So
+ * total tries = 1 initial + MAX_CRITIC_RETRIES retries = up to 3 calls into
+ * the planner per pipeline. After that, surface critic errors to the user
+ * with a "Continue anyway" override.
+ */
+const MAX_CRITIC_RETRIES = 2;
+
+interface PlannerKickoffArgs {
+  ctx: ReturnType<typeof getContext>;
+  goal: string;
+  focus?: string;
+  /**
+   * When set, this is a retry: append the formatted critic feedback to the
+   * goal so the planner sees *exactly* which structural mistakes to fix.
+   */
+  criticFeedback?: string;
+}
+
+/**
+ * Spawn a single planner agent run and return its run-id. Shared by the
+ * initial POST /agents/build call and by the GET-handler's critic-retry
+ * loop. Returns null when the planner agent itself can't be loaded
+ * (caller surfaces an error to the user).
+ */
+async function kickoffPlannerRun(args: PlannerKickoffArgs): Promise<string | null> {
+  const { ctx, goal, focus, criticFeedback } = args;
+
+  let planner: ReturnType<typeof ctx.agentStore.getAgent> = null;
+  try {
+    const yamlPath = join(resolve('agents/examples'), `${PLANNER_AGENT_ID}.yaml`);
+    const yamlText = readFileSync(yamlPath, 'utf-8');
+    const parsed = parseAgent(yamlText);
+    ctx.agentStore.upsertAgent(parsed, 'import', 'Auto-imported for build planner');
+    planner = ctx.agentStore.getAgent(PLANNER_AGENT_ID);
+  } catch { /* fall through */ }
+  if (!planner) return null;
+
+  const builtins = listBuiltinTools();
+  let userTools: ToolDefinition[] = [];
+  try {
+    if (ctx.toolStore) userTools = ctx.toolStore.listTools();
+  } catch { /* store not available */ }
+  const catalog = formatToolCatalog([...builtins, ...userTools]);
+  const discoveryCatalog = buildDiscoveryCatalog({
+    agents: ctx.agentStore.listAgents(),
+    tools: [...builtins, ...userTools],
+    templateRegistry: TEMPLATE_REGISTRY,
+    dashboards: ctx.dashboardsStore?.listDashboards(),
+    packs: ctx.packsStore?.listPacks(),
+  });
+
+  // Append critic feedback to the goal on retry. Keeps the rest of the
+  // input pipeline unchanged — the planner prompt already speaks <plan>.
+  const effectiveGoal = criticFeedback ? `${goal}\n${criticFeedback}` : goal;
+
+  const runPromise = executeAgentDag(
+    planner,
+    {
+      triggeredBy: 'dashboard',
+      inputs: {
+        GOAL: effectiveGoal,
+        ...(focus ? { FOCUS: `Constraints: ${focus}` } : {}),
+        AVAILABLE_TOOLS: catalog,
+        DISCOVERY_CATALOG: discoveryCatalog,
+      },
+    },
+    {
+      runStore: ctx.runStore,
+      secretsStore: ctx.secretsStore,
+      variablesStore: ctx.variablesStore,
+      dataRoot: ctx.agentStore.dataRoot,
+    },
+  );
+
+  // Race the run-record creation; we only need its id, not its result.
+  await Promise.race([runPromise, new Promise((r) => setTimeout(r, 200))]);
+  const { rows } = ctx.runStore.queryRuns({
+    agentName: PLANNER_AGENT_ID,
+    statuses: ['running', 'completed', 'failed'] as RunStatus[],
+    limit: 1,
+    offset: 0,
+  });
+  if (rows.length > 0) return rows[0].id;
+  try {
+    const run = await runPromise;
+    return run.id;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a stable `existingAgentIds` Set from the current AgentStore.
+ * Used by the critic to check survey.matchedAgents and dashboard refs
+ * against catalog reality.
+ */
+function loadExistingAgentIds(ctx: ReturnType<typeof getContext>): Set<string> {
+  try {
+    return new Set(ctx.agentStore.listAgents().map((a) => a.id));
+  } catch {
+    return new Set();
+  }
 }
 
 // ── Analyze (suggest improvements) ──────────────────────────────────────
@@ -655,87 +763,17 @@ buildRouter.post('/agents/build', async (req: Request, res: Response) => {
     return;
   }
 
-  // Auto-import or update planner agent from examples YAML.
-  // Uses upsertAgent so prompt improvements take effect without manual deletion.
-  let planner: ReturnType<typeof ctx.agentStore.getAgent> = null;
-  try {
-    const yamlPath = join(resolve('agents/examples'), `${PLANNER_AGENT_ID}.yaml`);
-    const yamlText = readFileSync(yamlPath, 'utf-8');
-    const parsed = parseAgent(yamlText);
-    ctx.agentStore.upsertAgent(parsed, 'import', 'Auto-imported for build planner');
-    planner = ctx.agentStore.getAgent(PLANNER_AGENT_ID);
-  } catch { /* fall through */ }
-  if (!planner) {
+  const runId = await kickoffPlannerRun({ ctx, goal, focus });
+  if (!runId) {
     res.json({ ok: false, error: 'Build planner agent not found. Ensure build-planner.yaml exists in agents/examples/.' });
     return;
   }
 
-  // Build a dynamic tool catalog so the planner LLM knows about all
-  // registered tools, not just the 9 hardcoded built-ins.
-  const builtins = listBuiltinTools();
-  let userTools: ToolDefinition[] = [];
-  try {
-    if (ctx.toolStore) userTools = ctx.toolStore.listTools();
-  } catch { /* store not available */ }
-  const catalog = formatToolCatalog([...builtins, ...userTools]);
-  const discoveryCatalog = buildDiscoveryCatalog({
-    agents: ctx.agentStore.listAgents(),
-    tools: [...builtins, ...userTools],
-    templateRegistry: TEMPLATE_REGISTRY,
-    // Optional — when present, the planner sees them and can suggest
-    // reuse / pack install / dashboard extension instead of duplicating.
-    dashboards: ctx.dashboardsStore?.listDashboards(),
-    packs: ctx.packsStore?.listPacks(),
-  });
+  res.json({ ok: true, status: 'started', runId });
 
-  const runPromise = executeAgentDag(
-    planner,
-    {
-      triggeredBy: 'dashboard',
-      inputs: {
-        GOAL: goal,
-        ...(focus ? { FOCUS: `Constraints: ${focus}` } : {}),
-        AVAILABLE_TOOLS: catalog,
-        DISCOVERY_CATALOG: discoveryCatalog,
-      },
-    },
-    {
-      runStore: ctx.runStore,
-      secretsStore: ctx.secretsStore,
-      variablesStore: ctx.variablesStore,
-      dataRoot: ctx.agentStore.dataRoot,
-    },
-  );
-
-  await Promise.race([
-    runPromise,
-    new Promise((resolve) => setTimeout(resolve, 200)),
-  ]);
-
-  const { rows } = ctx.runStore.queryRuns({
-    agentName: PLANNER_AGENT_ID,
-    statuses: ['running', 'completed', 'failed'] as RunStatus[],
-    limit: 1,
-    offset: 0,
-  });
-
-  let runId: string | undefined;
-  if (rows.length > 0) {
-    runId = rows[0].id;
-    res.json({ ok: true, status: 'started', runId });
-  } else {
-    try {
-      const run = await runPromise;
-      runId = run.id;
-      res.json({ ok: true, status: 'started', runId });
-    } catch (err) {
-      res.json({ ok: false, error: (err as Error).message });
-      return;
-    }
-  }
   // Telemetry: record this planner run with its goal so /metrics/planner
   // can correlate timing + outcome later. Best-effort — failure is silent.
-  if (runId && ctx.plannerTelemetryStore) {
+  if (ctx.plannerTelemetryStore) {
     try { ctx.plannerTelemetryStore.recordStart(runId, goal); } catch { /* swallow */ }
   }
 });
@@ -744,7 +782,7 @@ buildRouter.post('/agents/build', async (req: Request, res: Response) => {
  * GET /agents/build/:runId — poll builder run status.
  * Returns YAML when done so the client can preview + create.
  */
-buildRouter.get('/agents/build/:runId', (req: Request, res: Response) => {
+buildRouter.get('/agents/build/:runId', async (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
   const runId = Array.isArray(req.params.runId) ? req.params.runId[0] : req.params.runId;
 
@@ -824,17 +862,90 @@ buildRouter.get('/agents/build/:runId', (req: Request, res: Response) => {
     });
     const plan: BuildPlan = { ...result.data, newAgents: cleanedNewAgents };
 
+    // Critic loop: structurally validate the plan against catalog reality
+    // (newAgent YAMLs parse, cross-refs resolve, dashboard refs land, etc.).
+    // On failure, retry up to MAX_CRITIC_RETRIES times by spawning a fresh
+    // planner run with the critic feedback appended to the goal.
+    const critic = critiquePlan(plan, { existingAgentIds: loadExistingAgentIds(ctx) });
+
+    // The runId we got polled with may be a retry alias; resolve to root
+    // for telemetry + attempt-counting, and look the goal up there.
+    const rootRunId = ctx.plannerTelemetryStore?.resolveOriginalRunId(runId) ?? runId;
+    const rootRow = ctx.plannerTelemetryStore?.get(rootRunId) ?? null;
+    const attemptsSoFar = rootRow?.planAttempts ?? 1;
+
+    if (!critic.ok && attemptsSoFar <= MAX_CRITIC_RETRIES) {
+      // Spawn a retry with the critic feedback. Increment attempts on the
+      // root telemetry row so the next pass can stop after MAX retries.
+      try { ctx.plannerTelemetryStore?.incrementAttempts(runId); } catch { /* swallow */ }
+      const goal = rootRow?.goal ?? '';
+      const feedback = formatCriticFeedback(critic.errors);
+      const retryRunId = await kickoffPlannerRun({ ctx, goal, criticFeedback: feedback });
+      if (retryRunId && ctx.plannerTelemetryStore) {
+        try { ctx.plannerTelemetryStore.recordRetrySpawn(rootRunId, retryRunId); } catch { /* swallow */ }
+      }
+      // Telemetry: stamp this attempt's extract status as schema-valid (the
+      // schema accepted it; only the critic rejected). Record validation
+      // errors as the critic-error count so the metrics page reflects them.
+      try {
+        ctx.plannerTelemetryStore?.recordExtract({
+          runId,
+          status: 'ok',
+          autofixCount,
+          validationErrors: critic.errors.length,
+          timeToPlanMs: planMs,
+          intent: plan.intent,
+        });
+      } catch { /* swallow */ }
+
+      if (!retryRunId) {
+        // Couldn't spawn a retry — surface what we have with the critic errors.
+        res.json({
+          ok: true,
+          status: 'done',
+          plan,
+          criticErrors: critic.errors,
+          criticWarning: 'Plan has unresolved structural issues; retry could not be started. You can commit anyway or dismiss.',
+        });
+        return;
+      }
+
+      res.json({
+        ok: true,
+        status: 'retrying',
+        runId: retryRunId,
+        attempt: attemptsSoFar + 1,
+        criticErrors: critic.errors,
+        phase: `Refining plan (attempt ${attemptsSoFar + 1})...`,
+      });
+      return;
+    }
+
+    // Either critic passed, or we've exhausted retries — return the plan.
+    // When the critic is still failing, surface its errors so the wizard
+    // can show "Continue anyway" with eyes-open consent.
     try {
       ctx.plannerTelemetryStore?.recordExtract({
         runId,
         status: 'ok',
         autofixCount,
+        validationErrors: critic.ok ? 0 : critic.errors.length,
         timeToPlanMs: planMs,
         intent: plan.intent,
       });
     } catch { /* swallow */ }
 
-    res.json({ ok: true, status: 'done', plan });
+    if (critic.ok) {
+      res.json({ ok: true, status: 'done', plan });
+    } else {
+      res.json({
+        ok: true,
+        status: 'done',
+        plan,
+        criticErrors: critic.errors,
+        criticWarning: `Planner could not produce a clean plan after ${attemptsSoFar} attempts. Review the issues below and either fix the YAML inline or commit anyway.`,
+      });
+    }
     return;
   }
 
@@ -969,10 +1080,12 @@ buildRouter.post('/agents/build/commit', (req: Request, res: Response) => {
 
   // Telemetry: stamp the commit time + total time-to-commit. Only fires
   // when the wizard supplied plannerRunId (correlates this commit back
-  // to its planner-run row); otherwise the row stays uncommitted in the
-  // telemetry view, which is the correct semantic for direct /commit
-  // POSTs from non-wizard callers.
-  if (plannerRunId && ctx.plannerTelemetryStore) {
+  // to its planner-run row) AND something actually landed (an agent was
+  // created or a dashboard was upserted). A "Commit" click that ends with
+  // zero creates is not a successful commit — counting it would inflate
+  // /metrics/planner's commit-rate for failures the user just dismissed.
+  const somethingLanded = agentsCreated.length > 0 || dashboardCreated !== null;
+  if (plannerRunId && somethingLanded && ctx.plannerTelemetryStore) {
     try {
       const plannerRun = ctx.runStore.getRun(plannerRunId);
       if (plannerRun?.startedAt) {

--- a/packages/dashboard/src/views/build-from-goal.js.ts
+++ b/packages/dashboard/src/views/build-from-goal.js.ts
@@ -100,9 +100,21 @@ export const BUILD_FROM_GOAL_JS = `
                   if (pe) pe.textContent = data.phase;
                 }
                 pollTimer = setTimeout(poll, 2000);
+              } else if (data.status === 'retrying' && data.runId) {
+                // Critic rejected the plan; server spawned a fresh planner
+                // run with the structural feedback. Switch our polling
+                // target to the new runId and update the phase label so
+                // the user sees that we're refining, not stuck.
+                runId = data.runId;
+                if (data.phase) {
+                  serverPhase = data.phase;
+                  var per = document.getElementById('build-phase');
+                  if (per) per.textContent = data.phase;
+                }
+                pollTimer = setTimeout(poll, 2000);
               } else if (data.status === 'done' && data.plan) {
                 clearInterval(tickTimer);
-                renderPlanReview(data.plan);
+                renderPlanReview(data.plan, data.criticErrors, data.criticWarning);
               } else if (data.status === 'done' && data.yaml) {
                 // Legacy single-YAML response (agent-builder fallback). Wrap it
                 // in a one-agent plan and reuse the review UI.
@@ -134,8 +146,24 @@ export const BUILD_FROM_GOAL_JS = `
           '<div style="margin-top:var(--space-3);text-align:right;"><button type="button" class="btn btn--ghost btn--sm" data-close-build="1">Close</button></div>';
       }
 
-      function renderPlanReview(plan) {
+      function renderPlanReview(plan, criticErrors, criticWarning) {
         var h = '';
+        // Critic warnings appear up top so the user sees them before
+        // scanning the plan body. Each error is path + message; the user
+        // can fix the YAML inline (textareas below) or commit anyway.
+        if (criticErrors && criticErrors.length) {
+          h += '<div class="flash flash--warning" style="margin-bottom:var(--space-3);font-size:var(--font-size-xs);">' +
+               '<div style="font-weight:var(--weight-semibold);margin-bottom:var(--space-1);">Plan has structural issues:</div>';
+          if (criticWarning) {
+            h += '<div style="margin-bottom:var(--space-1);">' + esc(criticWarning) + '</div>';
+          }
+          h += '<ul style="margin:0;padding-left:var(--space-4);">';
+          for (var ce = 0; ce < criticErrors.length; ce++) {
+            var er = criticErrors[ce];
+            h += '<li><code>' + esc(er.path) + '</code>: ' + esc(er.message) + '</li>';
+          }
+          h += '</ul></div>';
+        }
         var intentLabel = {
           'agent': 'Agent',
           'dashboard-existing': 'Dashboard (existing agents)',
@@ -217,12 +245,16 @@ export const BUILD_FROM_GOAL_JS = `
         }
 
         h += '<div id="build-result-flash"></div>';
+        var hasCritic = criticErrors && criticErrors.length > 0;
+        var commitLabel = hasCritic
+          ? 'Commit anyway'
+          : (plan.dashboard ? 'Create dashboard + ' + (plan.newAgents.length || 0) + ' agent(s)' :
+             plan.newAgents.length === 1 ? 'Create agent' :
+             'Create ' + plan.newAgents.length + ' agents');
         h += '<div style="display:flex;gap:var(--space-2);justify-content:flex-end;flex-wrap:wrap;">' +
              '<button type="button" class="btn btn--ghost btn--sm" data-close-build="1">Dismiss</button>' +
              '<button type="button" class="btn btn--primary btn--sm" id="build-commit-btn">' +
-             (plan.dashboard ? 'Create dashboard + ' + (plan.newAgents.length || 0) + ' agent(s)' :
-              plan.newAgents.length === 1 ? 'Create agent' :
-              'Create ' + plan.newAgents.length + ' agents') +
+             esc(commitLabel) +
              '</button></div>';
         content.innerHTML = h;
 


### PR DESCRIPTION
## Summary

PR2 of the build-planner 10x program (PR1 = telemetry, #224). Adds a structural critic that runs after Zod validation and an auto-retry loop that re-fires the planner with feedback when the critic flags issues.

- **`critiquePlan()`** in core walks every newAgent YAML through `parseAgent`, validates `loopConfig.agentId` / `agentInvokeConfig.agentId` cross-references against the post-plan agent universe, checks `survey.matchedAgents` against catalog reality, and verifies dashboard sections resolve.
- **Auto-retry loop** in the wizard's GET poll handler: on critic failure, spawns a new planner run with `formatCriticFeedback()` appended to the goal. Up to 2 retries (3 attempts total), then surfaces remaining errors with a "Commit anyway" button.
- **Telemetry alias map**: retries route back to the original `planner_telemetry` row so `plan_attempts`, extract status, and commit timing stay accurate per pipeline. New `recordRetrySpawn` / `resolveOriginalRunId` API; `recordExtract` / `incrementAttempts` / `recordCommit` resolve aliases internally.
- **`recordCommit` gating**: only fires when an agent or dashboard actually landed. Dismissed/empty commits no longer inflate `/metrics/planner` commit-rate.

### Motivating failure (from yesterday's live run)

Real planner HN-digest output had a `signal:` block missing the required `title` field. Schema-valid (signal is optional), parse-broken (when present, title is required). Critic catches exactly this class — the new test `flags YAML that fails parseAgent` covers it.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 1117/1117 passing
- [x] 11 new critic unit tests (`build-plan-critic.test.ts`)
- [x] 5 new alias-map unit tests on `PlannerTelemetryStore`
- [ ] Live wizard test: run a goal that triggers a critic failure, watch the retry kick off, then commit
- [ ] Verify `/metrics/planner` reflects accurate commit-rate after the gating fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)