### PR TITLE
fix(scheduler): fire v2 (DAG) agents + distinguish idle from running

### DIFF
--- a/.changeset/scheduler-v2-agents.md
+++ b/.changeset/scheduler-v2-agents.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Scheduler now fires v2 (DAG) agents — fixes silently-dropped wizard-built schedules.
+
+Until now the scheduler daemon only loaded v1 YAML agents from disk: every v2 agent built via the dashboard wizard (or `sua workflow import`) was silently skipped at load time, even though the dashboard's Scheduled widget cheerfully listed them with "last: never" and a green "Scheduler running" dot. The split came from `loadAgents` skipping any file with `id:` + `nodes:` (the v2 marker), with no other code path picking them up.
+
+`LocalScheduler` now accepts a parallel set of v2 agents plus a small dependency bundle, registers cron tasks for both v1 and v2 entries, and fires v2 agents directly through `executeAgentWithRetry` (the same path the dashboard's run-now and `sua workflow run` already use). The scheduler CLI now opens AgentStore + VariablesStore + EncryptedFileStore alongside the v1 loader and merges everything before starting.
+
+Also: scheduler heartbeat now distinguishes `idle` (alive, zero agents registered) from `running` (alive, at least one agent registered). The dashboard widget surfaces this with an orange dot and the label "Scheduler idle (0 agents registered)" so future cases of "daemon happy, nothing firing" are visible at a glance instead of silently green.

--- a/packages/cli/src/commands/schedule.ts
+++ b/packages/cli/src/commands/schedule.ts
@@ -1,4 +1,6 @@
-import { resolve } from 'node:path';
+import { resolve, join, dirname } from 'node:path';
+import { existsSync, mkdirSync } from 'node:fs';
+import { DatabaseSync } from 'node:sqlite';
 import { Command } from 'commander';
 import chalk from 'chalk';
 import Table from 'cli-table3';
@@ -7,11 +9,14 @@ import {
   LocalScheduler,
   inspectSecretsFile,
   RunStore,
+  AgentStore,
+  VariablesStore,
+  EncryptedFileStore,
   cronToHuman,
   getSchedulerStatus,
   nextFireTime,
 } from '@some-useful-agents/core';
-import { loadConfig, getAgentDirs, getSecretsPath, getDbPath } from '../config.js';
+import { loadConfig, getAgentDirs, getSecretsPath, getDbPath, getDashboardBaseUrl } from '../config.js';
 import { createProvider } from '../provider-factory.js';
 import * as ui from '../ui.js';
 
@@ -183,12 +188,27 @@ scheduleCommand
       ui.warn(`${w.file}: ${w.message}`);
     }
 
+    // Open AgentStore + load v2 (DAG) agents that have a schedule. Until
+    // PR-4b lands LocalProvider.submitDagRun, these flow through the
+    // executor directly via LocalScheduler's v2 path. Without this, every
+    // wizard-built agent silently drops on the floor — see #228.
+    const dbPath = getDbPath(config);
+    const dbDir = dirname(dbPath);
+    if (!existsSync(dbDir)) mkdirSync(dbDir, { recursive: true });
+    const sharedDb = new DatabaseSync(dbPath);
+    const agentStore = AgentStore.fromHandle(sharedDb);
+    const v2Agents = agentStore.listAgents().filter(
+      (a) => a.schedule && a.status === 'active',
+    );
+
     // Preflight: if any scheduled agent needs secrets and the store is v2
     // passphrase-protected without SUA_SECRETS_PASSPHRASE set, fail fast.
     // Otherwise the daemon starts, fires on schedule, and every fire fails
     // silently at secret-resolution time — a nasty UX.
     const scheduledAgents = Array.from(agents.values()).filter((a) => a.schedule);
-    const needsSecrets = scheduledAgents.some((a) => (a.secrets ?? []).length > 0);
+    // v2 Agents declare secrets only at the node level.
+    const v2NeedsSecrets = v2Agents.some((a) => (a.nodes ?? []).some((n) => (n.secrets ?? []).length > 0));
+    const needsSecrets = scheduledAgents.some((a) => (a.secrets ?? []).length > 0) || v2NeedsSecrets;
     if (needsSecrets) {
       const status = inspectSecretsFile(getSecretsPath(config));
       const envPass = process.env.SUA_SECRETS_PASSPHRASE;
@@ -211,59 +231,96 @@ scheduleCommand
       allowUntrustedShell: new Set(options.allowUntrustedShell),
     });
 
-    // Create a read-only RunStore for catch-up queries.
-    const dbPath = getDbPath(config);
-    const runStore = new RunStore(dbPath);
+    // Share the AgentStore's DB handle with the RunStore so the scheduler
+    // and the v2 executor see a consistent view (matches workflow.ts's
+    // openStores pattern).
+    const runStore = RunStore.fromHandle(sharedDb);
+
+    // v2 wiring: optional stores. Variables are best-effort (absent stores
+    // just mean variables don't resolve at fire time). Secrets are loaded
+    // here (rather than only when needed) because v2 agents can declare
+    // secrets at the top level OR per-node, and we want predictable failure
+    // semantics across the daemon's lifetime.
+    const variablesStore = (() => {
+      try { return new VariablesStore(join(config.dataDir, '.sua', 'variables.json')); }
+      catch { return undefined; }
+    })();
+    const secretsStore = (() => {
+      try { return new EncryptedFileStore(getSecretsPath(config)); }
+      catch { return undefined; }
+    })();
 
     const scheduler = new LocalScheduler({
       provider,
       agents,
+      v2Agents,
+      v2Deps: {
+        runStore,
+        secretsStore,
+        variablesStore,
+        agentStore,
+        allowUntrustedShell: new Set(options.allowUntrustedShell),
+        dashboardBaseUrl: getDashboardBaseUrl(config),
+        dataRoot: agentStore.dataRoot,
+      },
       inputs: options.input,
       dataDir,
       runStore,
       onFire: (agent, runId) => {
         const ts = new Date().toISOString();
-        console.log(`${ui.dim(ts)} ${chalk.green('fired')} ${ui.agent(agent.name)} ${ui.dim(`run=${runId.slice(0, 8)}`)}`);
+        // v1 agents have `name`, v2 agents have `id` + `name`. Use whichever
+        // is present so the log line stays useful for both kinds.
+        const label = 'id' in agent && agent.id ? agent.id : agent.name;
+        console.log(`${ui.dim(ts)} ${chalk.green('fired')} ${ui.agent(label)} ${ui.dim(`run=${runId.slice(0, 8)}`)}`);
       },
       onError: (agent, err) => {
-        ui.fail(`Error firing ${agent.name}: ${err.message}`);
+        const label = 'id' in agent && agent.id ? agent.id : agent.name;
+        ui.fail(`Error firing ${label}: ${err.message}`);
       },
     });
 
     let entries;
+    let v2Entries: Array<{ agent: { id: string; name: string }; schedule: string }> = [];
     try {
       entries = await scheduler.start();
+      v2Entries = scheduler.getScheduledV2Agents();
     } catch (err) {
       ui.fail((err as Error).message);
       runStore.close();
+      sharedDb.close();
       await provider.shutdown();
       process.exit(1);
     }
 
-    if (entries.length === 0) {
+    const totalCount = entries.length + v2Entries.length;
+    if (totalCount === 0) {
       ui.warn(
         'No agents have a schedule. Idling — restart the scheduler after adding ' +
           '`schedule: "<cron>"` to an agent YAML.',
       );
     }
 
-    const bannerLines = entries.length > 0
-      ? entries.map(({ agent, schedule }) => `${agent.name.padEnd(24)} ${cronToHuman(schedule)}`)
+    const bannerLines = totalCount > 0
+      ? [
+          ...entries.map(({ agent, schedule }) => `${agent.name.padEnd(24)} ${cronToHuman(schedule)}`),
+          ...v2Entries.map(({ agent, schedule }) => `${agent.id.padEnd(24)} ${cronToHuman(schedule)} ${ui.dim('(v2)')}`),
+        ]
       : ['idle — no scheduled agents'];
-    ui.banner(`Scheduler running (${entries.length} agent${entries.length === 1 ? '' : 's'})`, bannerLines);
+    ui.banner(`Scheduler running (${totalCount} agent${totalCount === 1 ? '' : 's'})`, bannerLines);
     console.log(ui.dim('Press Ctrl+C to stop.\n'));
 
     // When there are no scheduled entries the scheduler holds no internal
     // timers, so the event loop would exit immediately. Keep a low-frequency
     // tick so the supervised process stays alive (and keeps writing the
     // heartbeat) until the user adds a schedule and restarts it.
-    const idleKeepAlive = entries.length === 0 ? setInterval(() => {}, 60_000) : null;
+    const idleKeepAlive = totalCount === 0 ? setInterval(() => {}, 60_000) : null;
 
     const shutdown = async () => {
       console.log('\nShutting down scheduler...');
       if (idleKeepAlive) clearInterval(idleKeepAlive);
       scheduler.stop();
       runStore.close();
+      sharedDb.close();
       await provider.shutdown();
       process.exit(0);
     };

--- a/packages/core/src/scheduler-heartbeat.test.ts
+++ b/packages/core/src/scheduler-heartbeat.test.ts
@@ -68,7 +68,7 @@ describe('getSchedulerStatus', () => {
     expect(heartbeat).toBeNull();
   });
 
-  it('returns running for a fresh heartbeat', () => {
+  it('returns running for a fresh heartbeat with at least one agent', () => {
     writeHeartbeat(dataDir, {
       pid: process.pid,
       startedAt: new Date().toISOString(),
@@ -77,6 +77,20 @@ describe('getSchedulerStatus', () => {
     });
     const { status } = getSchedulerStatus(dataDir);
     expect(status).toBe('running');
+  });
+
+  it('returns idle for a fresh heartbeat with zero agents registered', () => {
+    // Daemon alive but registered nothing. Used to be lumped in with
+    // 'running' (green dot), which let the v1/v2 loader split look healthy.
+    writeHeartbeat(dataDir, {
+      pid: process.pid,
+      startedAt: new Date().toISOString(),
+      agents: [],
+      nextFires: {},
+    });
+    const { status, heartbeat } = getSchedulerStatus(dataDir);
+    expect(status).toBe('idle');
+    expect(heartbeat).not.toBeNull();
   });
 
   it('returns stale for an old heartbeat', () => {

--- a/packages/core/src/scheduler-heartbeat.ts
+++ b/packages/core/src/scheduler-heartbeat.ts
@@ -55,12 +55,16 @@ export function clearHeartbeat(dataDir: string): void {
   }
 }
 
-export type SchedulerStatus = 'running' | 'stale' | 'stopped';
+export type SchedulerStatus = 'running' | 'idle' | 'stale' | 'stopped';
 
 /**
  * Determine scheduler status from the heartbeat file.
- * - 'running': heartbeat is fresh (within staleThresholdMs)
- * - 'stale': heartbeat exists but is older than threshold
+ * - 'running': heartbeat is fresh AND at least one agent is registered
+ * - 'idle':    heartbeat is fresh but zero agents are registered. The
+ *              daemon is alive but firing nothing — used to be lumped in
+ *              with 'running' (green dot), which made the dashboard lie
+ *              when v2 agents were silently dropped by the v1 loader.
+ * - 'stale':   heartbeat exists but is older than threshold
  * - 'stopped': no heartbeat file found
  */
 export function getSchedulerStatus(
@@ -71,7 +75,8 @@ export function getSchedulerStatus(
   if (!heartbeat) return { status: 'stopped', heartbeat: null };
 
   const age = Date.now() - new Date(heartbeat.lastHeartbeat).getTime();
-  const status: SchedulerStatus = age <= staleThresholdMs ? 'running' : 'stale';
+  if (age > staleThresholdMs) return { status: 'stale', heartbeat };
+  const status: SchedulerStatus = heartbeat.agents.length === 0 ? 'idle' : 'running';
   return { status, heartbeat };
 }
 

--- a/packages/core/src/scheduler.test.ts
+++ b/packages/core/src/scheduler.test.ts
@@ -1,9 +1,22 @@
 import { describe, it, expect, vi } from 'vitest';
 import { LocalScheduler } from './scheduler.js';
 import type { AgentDefinition, Provider, Run } from './types.js';
+import type { Agent } from './agent-v2-types.js';
 
 function makeAgent(name: string, schedule?: string, overrides: Partial<AgentDefinition> = {}): AgentDefinition {
   return { name, type: 'shell', command: `echo ${name}`, schedule, ...overrides };
+}
+
+function makeV2Agent(id: string, overrides: Partial<Agent> = {}): Agent {
+  return {
+    id,
+    name: id,
+    status: 'active',
+    source: 'local',
+    version: 1,
+    nodes: [{ id: 'n1', type: 'shell', command: `echo ${id}` }],
+    ...overrides,
+  } as Agent;
 }
 
 function makeFakeProvider(): Provider {
@@ -98,6 +111,51 @@ describe('LocalScheduler', () => {
     const scheduler = new LocalScheduler({ provider: makeFakeProvider(), agents });
     const entries = await scheduler.start();
     expect(entries.length).toBe(0);
+    scheduler.stop();
+  });
+
+  it('getScheduledV2Agents filters to active v2 agents with a schedule', () => {
+    const v2Agents: Agent[] = [
+      makeV2Agent('alpha', { schedule: '0 9 * * *', status: 'active' }),
+      makeV2Agent('beta', { schedule: '0 9 * * *', status: 'paused' }),     // wrong status
+      makeV2Agent('gamma', { schedule: undefined, status: 'active' }),       // no schedule
+      makeV2Agent('delta', { schedule: '0 10 * * *', status: 'active' }),
+    ];
+    const scheduler = new LocalScheduler({
+      provider: makeFakeProvider(),
+      agents: new Map(),
+      v2Agents,
+      v2Deps: { runStore: undefined as never },
+    });
+    const entries = scheduler.getScheduledV2Agents();
+    expect(entries.map((e) => e.agent.id).sort()).toEqual(['alpha', 'delta']);
+  });
+
+  it('throws when v2Agents is supplied without v2Deps', () => {
+    expect(() => new LocalScheduler({
+      provider: makeFakeProvider(),
+      agents: new Map(),
+      v2Agents: [makeV2Agent('alpha', { schedule: '0 9 * * *' })],
+    })).toThrow(/v2Deps/);
+  });
+
+  it('start() registers v2 cron tasks alongside v1 tasks', async () => {
+    const agents = new Map<string, AgentDefinition>([
+      ['v1a', makeAgent('v1a', '0 9 * * *')],
+    ]);
+    const v2Agents: Agent[] = [
+      makeV2Agent('v2a', { schedule: '0 10 * * *', status: 'active' }),
+      makeV2Agent('v2b', { schedule: '0 11 * * *', status: 'active' }),
+    ];
+    const scheduler = new LocalScheduler({
+      provider: makeFakeProvider(),
+      agents,
+      v2Agents,
+      v2Deps: { runStore: undefined as never },
+    });
+    const v1Entries = await scheduler.start();
+    expect(v1Entries).toHaveLength(1);
+    expect(scheduler.getScheduledV2Agents()).toHaveLength(2);
     scheduler.stop();
   });
 

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -1,5 +1,6 @@
 import cron from 'node-cron';
 import type { AgentDefinition, Provider, Run } from './types.js';
+import type { Agent } from './agent-v2-types.js';
 import { validateScheduleInterval } from './cron-validator.js';
 import {
   writeHeartbeat,
@@ -9,17 +10,58 @@ import {
 } from './scheduler-heartbeat.js';
 import { hasMissedFire, nextFireTime } from './scheduler-catchup.js';
 import type { RunStore } from './run-store.js';
+import type { SecretsStore } from './secrets-store.js';
+import type { VariablesStore } from './variables-store.js';
+import type { AgentStore } from './agent-store.js';
+import type { ToolStore } from './tool-store.js';
+import { executeAgentWithRetry } from './retry.js';
 
 export interface ScheduledAgentEntry {
   agent: AgentDefinition;
   schedule: string;
 }
 
+export interface ScheduledV2AgentEntry {
+  agent: Agent;
+  schedule: string;
+}
+
+/**
+ * Dependencies the scheduler needs to fire v2 (DAG) agents directly via
+ * `executeAgentWithRetry`. v1 agents continue to flow through the
+ * `Provider.submitRun` interface; v2 has no provider abstraction yet
+ * (see the dangling "PR 4b" comment in workflow.ts), so we wire the
+ * executor's deps in directly.
+ */
+export interface V2SchedulerDeps {
+  runStore: RunStore;
+  secretsStore?: SecretsStore;
+  variablesStore?: VariablesStore;
+  agentStore?: AgentStore;
+  toolStore?: ToolStore;
+  allowUntrustedShell?: ReadonlySet<string>;
+  dashboardBaseUrl?: string;
+  /** Same semantics as DagExecutorDeps.dataRoot. */
+  dataRoot?: string;
+}
+
 export interface LocalSchedulerOptions {
   provider: Provider;
   agents: Map<string, AgentDefinition>;
-  onFire?: (agent: AgentDefinition, runId: string) => void;
-  onError?: (agent: AgentDefinition, error: Error) => void;
+  /**
+   * v2 (DAG) agents to schedule alongside the v1 agents above. Wired
+   * separately because v2 has its own executor and dep bundle. Empty by
+   * default — callers that only deal in v1 don't need to think about it.
+   */
+  v2Agents?: Agent[];
+  /**
+   * Required iff `v2Agents` is non-empty. Provides the executor wiring
+   * (run store, secrets, variables, etc.) that `executeAgentWithRetry`
+   * needs to run a DAG agent.
+   */
+  v2Deps?: V2SchedulerDeps;
+  onFire?: (agent: AgentDefinition | Agent, runId: string) => void;
+  onError?: (agent: AgentDefinition | Agent, error: Error) => void;
   /**
    * Daemon-wide input overrides supplied via `sua schedule start --input K=V`.
    * Applied to every run the scheduler fires; individual agents that don't
@@ -36,29 +78,45 @@ const HEARTBEAT_INTERVAL_MS = 30_000;
 
 export class LocalScheduler {
   private tasks: Array<{ agent: AgentDefinition; task: cron.ScheduledTask }> = [];
+  private v2Tasks: Array<{ agent: Agent; task: cron.ScheduledTask }> = [];
   private readonly provider: Provider;
   private readonly agents: Map<string, AgentDefinition>;
-  private readonly onFire?: (agent: AgentDefinition, runId: string) => void;
-  private readonly onError?: (agent: AgentDefinition, error: Error) => void;
+  private readonly v2Agents: Agent[];
+  private readonly v2Deps?: V2SchedulerDeps;
+  private readonly onFire?: (agent: AgentDefinition | Agent, runId: string) => void;
+  private readonly onError?: (agent: AgentDefinition | Agent, error: Error) => void;
   private readonly inputs: Record<string, string>;
   private readonly dataDir?: string;
   private readonly runStore?: RunStore;
   private heartbeatTimer?: ReturnType<typeof setInterval>;
-  /** Track in-flight agents to prevent overlapping runs. */
+  /**
+   * Track in-flight agents to prevent overlapping runs. Keyed by a stable
+   * identity ("v1:<name>" or "v2:<id>") so v1 and v2 agents that happen to
+   * share a name don't shadow each other.
+   */
   private readonly inFlight = new Set<string>();
 
   constructor(options: LocalSchedulerOptions) {
     this.provider = options.provider;
     this.agents = options.agents;
+    this.v2Agents = options.v2Agents ?? [];
+    this.v2Deps = options.v2Deps;
     this.onFire = options.onFire;
     this.onError = options.onError;
     this.inputs = options.inputs ?? {};
     this.dataDir = options.dataDir;
     this.runStore = options.runStore;
+
+    if (this.v2Agents.length > 0 && !this.v2Deps) {
+      throw new Error(
+        'LocalScheduler: v2Agents supplied without v2Deps. ' +
+        'Pass { runStore, secretsStore, variablesStore, ... } via v2Deps.',
+      );
+    }
   }
 
   /**
-   * Return entries with a `schedule` field, validated.
+   * Return v1 entries with a `schedule` field, validated.
    * Throws on invalid cron strings or schedules that exceed the frequency cap.
    */
   getScheduledAgents(): ScheduledAgentEntry[] {
@@ -76,9 +134,30 @@ export class LocalScheduler {
     return entries;
   }
 
+  /**
+   * Return v2 entries with a `schedule` field, validated. Same cap-checking
+   * rules as v1 — `allowHighFrequency` opts out per-agent.
+   */
+  getScheduledV2Agents(): ScheduledV2AgentEntry[] {
+    const entries: ScheduledV2AgentEntry[] = [];
+    for (const agent of this.v2Agents) {
+      if (!agent.schedule) continue;
+      if (agent.status !== 'active') continue;
+      try {
+        validateScheduleInterval(agent.schedule, { allowHighFrequency: agent.allowHighFrequency });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(`Agent "${agent.id}": ${message}`);
+      }
+      entries.push({ agent, schedule: agent.schedule });
+    }
+    return entries;
+  }
+
   /** Register cron tasks for every agent with a schedule. */
   async start(): Promise<ScheduledAgentEntry[]> {
     const entries = this.getScheduledAgents();
+    const v2Entries = this.getScheduledV2Agents();
 
     // PID file guard.
     if (this.dataDir) {
@@ -91,14 +170,19 @@ export class LocalScheduler {
       }
     }
 
-    // Missed-fire catch-up.
+    // Missed-fire catch-up (v1).
     if (this.runStore) {
       for (const { agent, schedule } of entries) {
         await this.catchUpIfMissed(agent, schedule);
       }
+      // Missed-fire catch-up (v2). Looks up by agent.id since that's the
+      // run-store agentName field for DAG runs (see dag-executor.ts:198).
+      for (const { agent, schedule } of v2Entries) {
+        await this.catchUpV2IfMissed(agent, schedule);
+      }
     }
 
-    // Register cron tasks.
+    // Register cron tasks (v1).
     for (const { agent, schedule } of entries) {
       const task = cron.schedule(schedule, async () => {
         await this.fireAgent(agent, schedule);
@@ -106,11 +190,20 @@ export class LocalScheduler {
       this.tasks.push({ agent, task });
     }
 
-    // Start heartbeat.
+    // Register cron tasks (v2).
+    for (const { agent, schedule } of v2Entries) {
+      const task = cron.schedule(schedule, async () => {
+        await this.fireV2Agent(agent, schedule);
+      });
+      this.v2Tasks.push({ agent, task });
+    }
+
+    // Start heartbeat. Includes both v1 and v2 agents in the registered
+    // list so the dashboard's idle-detection sees the full picture.
     if (this.dataDir) {
-      this.writeHeartbeatNow(entries);
+      this.writeHeartbeatNow(entries, v2Entries);
       this.heartbeatTimer = setInterval(() => {
-        this.writeHeartbeatNow(entries);
+        this.writeHeartbeatNow(entries, v2Entries);
       }, HEARTBEAT_INTERVAL_MS);
       // Don't let the heartbeat timer prevent process exit.
       if (this.heartbeatTimer.unref) this.heartbeatTimer.unref();
@@ -121,10 +214,10 @@ export class LocalScheduler {
 
   /** Stop all tasks and release resources. */
   stop(): void {
-    for (const { task } of this.tasks) {
-      task.stop();
-    }
+    for (const { task } of this.tasks) task.stop();
+    for (const { task } of this.v2Tasks) task.stop();
     this.tasks = [];
+    this.v2Tasks = [];
 
     if (this.heartbeatTimer) {
       clearInterval(this.heartbeatTimer);
@@ -145,8 +238,8 @@ export class LocalScheduler {
   // ── Private ─────────────────────────────────────────────────────────
 
   private async fireAgent(agent: AgentDefinition, schedule: string): Promise<void> {
-    // Concurrency guard: skip if this agent is already running.
-    if (this.inFlight.has(agent.name)) {
+    const key = `v1:${agent.name}`;
+    if (this.inFlight.has(key)) {
       console.warn(
         `[overlap] "${agent.name}" still running from previous fire; skipping this tick`,
       );
@@ -160,7 +253,7 @@ export class LocalScheduler {
       );
     }
 
-    this.inFlight.add(agent.name);
+    this.inFlight.add(key);
     try {
       const run = await this.provider.submitRun({
         agent,
@@ -168,43 +261,91 @@ export class LocalScheduler {
         inputs: this.inputs,
       });
       this.onFire?.(agent, run.id);
-
-      // Wait for the run to complete before clearing in-flight.
-      // submitRun starts the agent but doesn't wait for completion.
-      // We'll clear in-flight after a reasonable timeout so the guard
-      // doesn't get stuck if the promise is never tracked.
-      this.waitForRunCompletion(run, agent);
+      this.waitForRunCompletion(run, key, agent.timeout);
     } catch (err) {
-      this.inFlight.delete(agent.name);
+      this.inFlight.delete(key);
       this.onError?.(agent, err instanceof Error ? err : new Error(String(err)));
     }
   }
 
   /**
-   * Poll the run store for completion status. Clear the in-flight guard
-   * when the run finishes or after a safety timeout.
+   * Fire a v2 (DAG) agent. Bypasses the v1 Provider.submitRun pathway
+   * because v2 has no provider abstraction yet — we call the executor
+   * directly (same path the dashboard's /run-now and the CLI's
+   * `sua workflow run` already use).
    */
-  private waitForRunCompletion(run: Run, agent: AgentDefinition): void {
+  private async fireV2Agent(agent: Agent, schedule: string): Promise<void> {
+    if (!this.v2Deps) return; // start() guarantees this, but type-narrows here.
+
+    const key = `v2:${agent.id}`;
+    if (this.inFlight.has(key)) {
+      console.warn(
+        `[overlap] v2 "${agent.id}" still running from previous fire; skipping this tick`,
+      );
+      return;
+    }
+
+    if (agent.allowHighFrequency) {
+      console.warn(
+        `[high-frequency] v2 agent "${agent.id}" firing on schedule "${schedule}". ` +
+          `allowHighFrequency=true bypasses the safety cap.`,
+      );
+    }
+
+    this.inFlight.add(key);
+    // executeAgentWithRetry resolves only after the agent finishes (or
+    // its retry budget is exhausted). Run it without awaiting here so a
+    // long agent doesn't block the cron tick — fire-and-track instead.
+    executeAgentWithRetry(
+      agent,
+      { triggeredBy: 'schedule', inputs: this.inputs },
+      {
+        runStore: this.v2Deps.runStore,
+        secretsStore: this.v2Deps.secretsStore,
+        variablesStore: this.v2Deps.variablesStore,
+        agentStore: this.v2Deps.agentStore,
+        toolStore: this.v2Deps.toolStore,
+        allowUntrustedShell: this.v2Deps.allowUntrustedShell,
+        dashboardBaseUrl: this.v2Deps.dashboardBaseUrl,
+        dataRoot: this.v2Deps.dataRoot,
+      },
+    ).then(
+      (run) => {
+        this.onFire?.(agent, run.id);
+        this.inFlight.delete(key);
+      },
+      (err) => {
+        this.inFlight.delete(key);
+        this.onError?.(agent, err instanceof Error ? err : new Error(String(err)));
+      },
+    );
+  }
+
+  /**
+   * Poll the run store for completion status. Clear the in-flight guard
+   * when the run finishes or after a safety timeout. The `inFlightKey`
+   * is the namespaced identity used in `this.inFlight` ("v1:<name>").
+   */
+  private waitForRunCompletion(run: Run, inFlightKey: string, agentTimeout?: number): void {
     if (!this.runStore) {
-      // No run store — clear after the agent's timeout + buffer.
-      const timeoutMs = ((agent.timeout ?? 300) + 30) * 1000;
-      setTimeout(() => this.inFlight.delete(agent.name), timeoutMs);
+      const timeoutMs = ((agentTimeout ?? 300) + 30) * 1000;
+      setTimeout(() => this.inFlight.delete(inFlightKey), timeoutMs);
       return;
     }
 
     const store = this.runStore;
-    const maxWaitMs = ((agent.timeout ?? 300) + 60) * 1000;
+    const maxWaitMs = ((agentTimeout ?? 300) + 60) * 1000;
     const startTime = Date.now();
     const pollMs = 5_000;
 
     const poll = () => {
       if (Date.now() - startTime > maxWaitMs) {
-        this.inFlight.delete(agent.name);
+        this.inFlight.delete(inFlightKey);
         return;
       }
       const current = store.getRun(run.id);
       if (current && (current.status === 'completed' || current.status === 'failed' || current.status === 'cancelled')) {
-        this.inFlight.delete(agent.name);
+        this.inFlight.delete(inFlightKey);
         return;
       }
       setTimeout(poll, pollMs);
@@ -244,7 +385,37 @@ export class LocalScheduler {
     }
   }
 
-  private writeHeartbeatNow(entries: ScheduledAgentEntry[]): void {
+  /**
+   * v2 catch-up. Same shape as the v1 path, but the run-store agentName
+   * for v2 runs is the agent.id (set by dag-executor.ts when creating the
+   * row), and the fire path goes through executeAgentWithRetry rather
+   * than the v1 provider.
+   */
+  private async catchUpV2IfMissed(agent: Agent, schedule: string): Promise<void> {
+    if (!this.runStore || !this.v2Deps) return;
+
+    const result = this.runStore.queryRuns({
+      agentName: agent.id,
+      triggeredBy: 'schedule',
+      limit: 1,
+    });
+    const lastRun = result.rows[0];
+    const lastFireTime = lastRun?.completedAt ?? lastRun?.startedAt;
+
+    if (hasMissedFire(schedule, lastFireTime)) {
+      console.log(
+        `[catch-up] v2 "${agent.id}" missed a scheduled fire ` +
+        `(last: ${lastFireTime ?? 'never'}). Firing now.`,
+      );
+      // fireV2Agent handles in-flight tracking + onFire/onError dispatch.
+      await this.fireV2Agent(agent, schedule);
+    }
+  }
+
+  private writeHeartbeatNow(
+    entries: ScheduledAgentEntry[],
+    v2Entries: ScheduledV2AgentEntry[] = [],
+  ): void {
     if (!this.dataDir) return;
 
     const nextFires: Record<string, string> = {};
@@ -252,11 +423,20 @@ export class LocalScheduler {
       const next = nextFireTime(schedule);
       if (next) nextFires[agent.name] = next;
     }
+    for (const { agent, schedule } of v2Entries) {
+      const next = nextFireTime(schedule);
+      // Keyed by id — matches the dashboard widget's lookup at
+      // `lastFires[a.id]` and `heartbeat.nextFires[a.id]`.
+      if (next) nextFires[agent.id] = next;
+    }
 
     writeHeartbeat(this.dataDir, {
       pid: process.pid,
       startedAt: this.startedAt,
-      agents: entries.map((e) => e.agent.name),
+      agents: [
+        ...entries.map((e) => e.agent.name),
+        ...v2Entries.map((e) => e.agent.id),
+      ],
       nextFires,
     });
   }

--- a/packages/dashboard/src/views/home-widgets.ts
+++ b/packages/dashboard/src/views/home-widgets.ts
@@ -245,13 +245,21 @@ function buildScheduled(data: HomeWidgetData): SystemWidget {
   }
 
   // Status indicator.
+  // 'idle' = daemon alive but registered zero agents. We surface this
+  // distinctly from 'running' so the dashboard doesn't falsely claim
+  // success when the v2/v1 loader split (or a stale agents/ dir) has
+  // left the daemon firing nothing.
   const statusDot = status === 'running'
     ? '\u{1F7E2}' // green circle
+    : status === 'idle'
+    ? '\u{1F7E0}' // orange circle — alive but firing nothing
     : status === 'stale'
     ? '\u{1F7E1}' // yellow circle
     : '\u{1F534}'; // red circle
   const statusLabel = status === 'running'
     ? 'Scheduler running'
+    : status === 'idle'
+    ? 'Scheduler idle (0 agents registered)'
     : status === 'stale'
     ? 'Scheduler stale'
     : 'Scheduler stopped';


### PR DESCRIPTION
## Summary

Fixes the silent-fail you spotted: the dashboard showed 4 scheduled agents with "last: never" under a green "Scheduler running" dot, but the daemon was actually firing zero of them.

**Root cause**: `loadAgents` in [agent-loader.ts:79-81](packages/core/src/agent-loader.ts#L79-L81) skips every file with `id:` + `nodes:` (v2 marker). The scheduler CLI was the only loader call, so every wizard-built agent silently dropped. There's a stale TODO in [workflow.ts:42](packages/cli/src/commands/workflow.ts#L42) referencing a "PR 4b" that was meant to wire `LocalProvider.submitDagRun` for the scheduler — never landed. This PR closes that gap directly through the executor (no provider abstraction yet).

## Changes

**A. v2 agents now fire (`packages/core/src/scheduler.ts` + `packages/cli/src/commands/schedule.ts`)**
- `LocalScheduler` accepts `v2Agents: Agent[]` + `v2Deps: V2SchedulerDeps` (runStore, secretsStore, variablesStore, agentStore, etc.)
- `start()` registers cron tasks for both v1 and v2 entries
- `fireV2Agent` calls `executeAgentWithRetry` directly — same path the dashboard's run-now and `sua workflow run` use
- Missed-fire catch-up extended to v2 (queries by `agent.id` since that's what dag-executor writes to `runs.agentName`)
- inFlight tracking namespaced (`v1:<name>` vs `v2:<id>`) so a v1/v2 name collision can't shadow either side
- CLI `schedule start` opens AgentStore + VariablesStore + EncryptedFileStore and merges them in; banner shows v2 entries with a `(v2)` tag
- Secrets preflight now includes per-node v2 secret declarations

**B. Honest heartbeat status (`packages/core/src/scheduler-heartbeat.ts` + `packages/dashboard/src/views/home-widgets.ts`)**
- New `'idle'` `SchedulerStatus` returned when heartbeat is fresh AND `agents.length === 0`
- Widget renders idle with an orange dot + label `"Scheduler idle (0 agents registered)"`
- Stops the dashboard from showing green-and-happy when the daemon is firing nothing

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 1121/1121 (4 new tests: idle status, v2 filter, v2Deps guard, mixed v1+v2 start)
- [ ] **Live test (manual)**: stop daemon, start it, confirm `daily-greeting`/`daily-joke`/`weather-forecast`/`hn-top-stories-rich` show up in the banner; wait for next scheduled fire and confirm a row lands in the run store with `triggeredBy='schedule'`
- [ ] Dashboard `/` shows agents list normally and never shows the orange-idle dot once the daemon registers them

🤖 Generated with [Claude Code](https://claude.com/claude-code)