### PR TITLE
feat: default outputWidget.interactive=true for parameterized agents

### DIFF
--- a/.changeset/interactive-widgets-default.md
+++ b/.changeset/interactive-widgets-default.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Pulse tiles for parameterized agents now ship with the inputs form + re-run button by default.
+
+The flag (`outputWidget.interactive: true`) was always available, but neither the agent-builder nor the build-planner prompted the LLM to set it — so every wizard-built search/lookup agent rendered as a static tile on pulse, with the re-run UI only available on the `/agents/<id>` detail page. The agent-builder + build-planner prompts now both instruct the model to set `interactive: true` whenever the agent declares runtime `inputs:`.
+
+Also flips the flag on `agents/examples/ashby-job-finder.yaml` so it benefits immediately.

--- a/agents/examples/agent-builder.yaml
+++ b/agents/examples/agent-builder.yaml
@@ -104,6 +104,7 @@ nodes:
           type: metric
 
       WIDGET INTERACTION (outputWidget.controls — make widgets feel alive):
+      For ANY agent with declared `inputs:` — set `outputWidget.interactive: true`. This makes the pulse tile render an inline inputs form + run button so users can re-run with tweaked values without leaving the dashboard. Without this flag, pulse tiles render in static mode and only the /agents/<id> detail page exposes a re-run UI. Skip the flag for purely scheduled agents that take no inputs (daily digests, status checks).
       Add a controls: array on outputWidget when the user might interact with the result. Three control types — replay, field-toggle, view-switch — render as a row above the widget body. State is URL-driven (no client JS). field-toggle and view-switch are NOT supported on ai-template widgets.
       Per archetype:
       - Weather / forecast: include all three. replay with inputs:[CITY] for tweaking. view-switch metric ↔ imperial. field-toggle (default: hidden) for optional metrics like uv / sunrise / precip.

--- a/agents/examples/ashby-job-finder.yaml
+++ b/agents/examples/ashby-job-finder.yaml
@@ -165,6 +165,12 @@ signal:
   size: 2x1
 outputWidget:
   type: ai-template
+  # Renders an inline inputs form + "Search Again" button on pulse tiles
+  # so users can tweak COMPANY_SLUG / JOB_QUERY / MAX_RESULTS without
+  # leaving the dashboard. Without this, pulse renders the widget body
+  # in static mode (run-detail page synthesises its own controls, but
+  # pulse stays glanceable by default and only opts in via this flag).
+  interactive: true
   template: |
     <div style="font-family: system-ui, sans-serif; padding: 1rem;">
       <h2 style="margin: 0 0 0.25rem 0; font-size: 1.25rem;">{{outputs.headline}}</h2>

--- a/agents/examples/build-planner.yaml
+++ b/agents/examples/build-planner.yaml
@@ -95,6 +95,10 @@ nodes:
       - DO NOT propose modifying any existing agent. (The user does that via /agents/<id>/yaml.)
       - Each new agent's YAML should include both signal: and outputWidget: blocks so dashboard
         tiles render correctly.
+      - When the agent declares any `inputs:`, set `outputWidget.interactive: true`. This wires
+        the pulse tile to render an inline inputs form + run button so users can re-run with
+        tweaked values without leaving the dashboard. Skip this flag for purely scheduled agents
+        that take no runtime inputs.
 
       STEP 3b — COMPOSE OVER EXISTING AGENTS (the `loop + agent-invoke` pattern).
       Before drafting a brand-new agent, ask: "is this goal a list × primitive?"


### PR DESCRIPTION
## Summary

Closes the gap from the screenshot: pulse tile for \`ashby-job-finder\` was missing the "Search Again" inputs form even though the same agent's run-detail page rendered it cleanly. Two coupled fixes:

1. **\`agents/examples/ashby-job-finder.yaml\`** — adds \`outputWidget.interactive: true\`. One-line flip; pulse now renders the form + button immediately.
2. **\`agents/examples/agent-builder.yaml\` + \`agents/examples/build-planner.yaml\`** — both prompts now instruct the LLM to set \`interactive: true\` whenever the agent declares runtime \`inputs:\`. Prevents this gap on every future wizard-built parameterized agent.

## Why this isn't a platform-level default

The flag's been intentional opt-in since [output-widgets.ts:188-189](packages/dashboard/src/views/output-widgets.ts#L188-L189) — pulse is designed to be glanceable, and most signal templates (metric, status, time-series, daily-digest) shouldn't grow a form. The fix is making the planner smart enough to set the flag for the cases that benefit (search, lookup, parameter-driven tools) without inflicting it on scheduled or output-only agents.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 1135/1135
- [x] \`parseAgent\` round-trips ashby-job-finder.yaml with \`interactive: true\` set
- [ ] After merge: visit \`/agents/ashby-job-finder\` pulse → see the inputs form + Search Again button on the tile

🤖 Generated with [Claude Code](https://claude.com/claude-code)