### PR TITLE
feat(core): http-get/http-post accept custom headers; fix daily-joke

### DIFF
--- a/.changeset/http-headers-and-daily-joke.md
+++ b/.changeset/http-headers-and-daily-joke.md
@@ -1,0 +1,11 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Built-in `http-get` and `http-post` tools now accept an optional `headers` input. Many APIs (icanhazdadjoke, GitHub, anything content-negotiating) return HTML or text by default unless an explicit `Accept` header is sent — the tools used to ignore custom headers entirely, leaving agents to scrape HTML or fall back to a shell `curl` node. The new input is a `{name: value}` object passed through to `fetch`; for `http-post` the caller's headers are merged on top of the default `Content-Type: application/json` (and can override it).
+
+Also fixes the `daily-joke` example agent: it was rendering the icanhazdadjoke HTML page on pulse because the default content type isn't JSON. Now sends `Accept: application/json` and `User-Agent: some-useful-agents` and gets the documented `{joke}` shape, which the format node parses cleanly.

--- a/agents/examples/daily-joke.yaml
+++ b/agents/examples/daily-joke.yaml
@@ -27,6 +27,12 @@ nodes:
     tool: http-get
     toolInputs:
       url: "https://icanhazdadjoke.com/"
+      # Without an explicit Accept header icanhazdadjoke serves its HTML
+      # web page (their browser default). Asking for JSON gets us the
+      # documented {id, joke, status} shape that the format node parses.
+      headers:
+        Accept: "application/json"
+        User-Agent: "some-useful-agents (+https://github.com/gregmeyer/some-useful-agents)"
   - id: format
     type: shell
     command: |

--- a/packages/core/src/builtin-tools.test.ts
+++ b/packages/core/src/builtin-tools.test.ts
@@ -119,6 +119,83 @@ describe('Builtin tool registry', () => {
     expect(entry.definition.inputs.url.required).toBe(true);
     expect(entry.definition.outputs.status.type).toBe('number');
   });
+
+  describe('http-get / http-post headers passthrough', () => {
+    let originalFetch: typeof fetch;
+    let captured: { url: string; init?: RequestInit }[];
+
+    beforeEach(() => {
+      originalFetch = globalThis.fetch;
+      captured = [];
+      globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+        captured.push({ url: String(url), init });
+        return new Response('{"ok":true}', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }) as unknown as typeof fetch;
+    });
+    afterEach(() => { globalThis.fetch = originalFetch; });
+
+    it('http-get sends the supplied headers on the request', async () => {
+      const entry = getBuiltinTool('http-get')!;
+      // Use a public-DNS-shaped URL that passes assertSafeUrl. The fetch
+      // is mocked so no real network call goes out.
+      await entry.execute({
+        url: 'https://example.com/',
+        headers: { Accept: 'application/json', 'User-Agent': 'sua-test' },
+      }, {});
+      expect(captured).toHaveLength(1);
+      const sent = captured[0].init?.headers as Record<string, string>;
+      expect(sent.Accept).toBe('application/json');
+      expect(sent['User-Agent']).toBe('sua-test');
+    });
+
+    it('http-get tolerates JSON-string-shaped headers (templated upstream)', async () => {
+      const entry = getBuiltinTool('http-get')!;
+      await entry.execute({
+        url: 'https://example.com/',
+        headers: '{"Accept":"text/html"}',
+      }, {});
+      const sent = captured[0].init?.headers as Record<string, string>;
+      expect(sent.Accept).toBe('text/html');
+    });
+
+    it('http-get drops non-string header values defensively', async () => {
+      const entry = getBuiltinTool('http-get')!;
+      await entry.execute({
+        url: 'https://example.com/',
+        headers: { Accept: 'application/json', BadValue: 42 as unknown as string },
+      }, {});
+      const sent = captured[0].init?.headers as Record<string, string>;
+      expect(sent.Accept).toBe('application/json');
+      expect(sent.BadValue).toBeUndefined();
+    });
+
+    it('http-post merges custom headers on top of default Content-Type', async () => {
+      const entry = getBuiltinTool('http-post')!;
+      await entry.execute({
+        url: 'https://example.com/',
+        body: { hello: 'world' },
+        headers: { Authorization: 'Bearer x', Accept: 'application/vnd.api+json' },
+      }, {});
+      const sent = captured[0].init?.headers as Record<string, string>;
+      expect(sent['Content-Type']).toBe('application/json');
+      expect(sent.Authorization).toBe('Bearer x');
+      expect(sent.Accept).toBe('application/vnd.api+json');
+    });
+
+    it('http-post lets the caller override Content-Type', async () => {
+      const entry = getBuiltinTool('http-post')!;
+      await entry.execute({
+        url: 'https://example.com/',
+        body: { hello: 'world' },
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      }, {});
+      const sent = captured[0].init?.headers as Record<string, string>;
+      expect(sent['Content-Type']).toBe('application/x-www-form-urlencoded');
+    });
+  });
 });
 
 describe('assertSafeUrl (SSRF guard)', () => {

--- a/packages/core/src/builtin-tools.ts
+++ b/packages/core/src/builtin-tools.ts
@@ -74,6 +74,27 @@ function isPrivateIp(ip: string): boolean {
  * gate doesn't apply.
  */
 
+/**
+ * Normalize a free-form `headers` tool input into the `Record<string, string>`
+ * shape `fetch` expects. Accepts either an object literal from a templated
+ * input (`{Accept: 'application/json'}`), a JSON string (when the tool input
+ * arrives as serialized text from upstream nodes), or undefined. Drops
+ * non-string values defensively — fetch will throw on those.
+ */
+function normalizeHeaders(raw: unknown): Record<string, string> {
+  if (raw == null) return {};
+  let obj: unknown = raw;
+  if (typeof obj === 'string') {
+    try { obj = JSON.parse(obj); } catch { return {}; }
+  }
+  if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) return {};
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+    if (typeof k === 'string' && typeof v === 'string') out[k] = v;
+  }
+  return out;
+}
+
 function def(
   id: string,
   name: string,
@@ -181,6 +202,10 @@ const BUILTINS: BuiltinToolEntry[] = [
     {
       url: { type: 'string', description: 'Absolute URL to fetch.', required: true },
       timeout: { type: 'number', description: 'Timeout in seconds.', default: 30 },
+      headers: {
+        type: 'object',
+        description: 'Optional request headers ({"Accept":"application/json","User-Agent":"…"}). Many APIs return HTML instead of JSON without an explicit Accept header.',
+      },
     },
     {
       status: { type: 'number', description: 'HTTP status code.' },
@@ -196,7 +221,10 @@ const BUILTINS: BuiltinToolEntry[] = [
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), timeout);
       try {
-        const res = await fetch(url, { signal: controller.signal });
+        const res = await fetch(url, {
+          signal: controller.signal,
+          headers: normalizeHeaders(inputs.headers),
+        });
         const text = await res.text();
         let body: unknown;
         try { body = JSON.parse(text); } catch { body = text; }
@@ -221,6 +249,10 @@ const BUILTINS: BuiltinToolEntry[] = [
       url: { type: 'string', description: 'Absolute URL.', required: true },
       body: { type: 'json', description: 'Request body (JSON-encoded).' },
       timeout: { type: 'number', description: 'Timeout in seconds.', default: 30 },
+      headers: {
+        type: 'object',
+        description: 'Optional request headers. Merged on top of the default Content-Type: application/json (caller can override).',
+      },
     },
     {
       status: { type: 'number', description: 'HTTP status code.' },
@@ -237,9 +269,14 @@ const BUILTINS: BuiltinToolEntry[] = [
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), timeout);
       try {
+        const customHeaders = normalizeHeaders(inputs.headers);
+        const headers: Record<string, string> = {
+          ...(reqBody ? { 'Content-Type': 'application/json' } : {}),
+          ...customHeaders,
+        };
         const res = await fetch(url, {
           method: 'POST',
-          headers: reqBody ? { 'Content-Type': 'application/json' } : {},
+          headers,
           body: reqBody,
           signal: controller.signal,
         });


### PR DESCRIPTION
## Summary

\`http-get\` / \`http-post\` ignored custom headers entirely, so APIs that content-negotiate returned HTML/text by default. \`daily-joke\` was rendering the icanhazdadjoke web page on pulse for that reason.

**Tool change**: new optional \`headers\` input on both tools. Object form (\`{Accept: 'application/json'}\`) or JSON-string form (for templated upstream inputs that arrive serialized) both accepted; non-string values are dropped defensively. For \`http-post\`, caller headers merge on top of the default \`Content-Type: application/json\` and can override it.

**Agent fix**: \`agents/examples/daily-joke.yaml\` now sends \`Accept: application/json\` + \`User-Agent: some-useful-agents\`. Gets the documented \`{joke}\` shape; format node parses cleanly.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 1145/1145 (+5 new: headers passthrough, JSON-string parsing, defensive drop, http-post merging, http-post override)
- [x] Live-ran \`sua workflow run daily-joke\` after re-import: produced \`What is the hardest part about sky diving? The ground.\` (clean joke; no HTML)
- [ ] After merge: visit \`/agents/daily-joke\` pulse → tile shows just the joke text

🤖 Generated with [Claude Code](https://claude.com/claude-code)