### PR TITLE
feat(dashboard): edit cron schedule from the Config tab + 2 latent bugs

### DIFF
--- a/.changeset/schedule-editor.md
+++ b/.changeset/schedule-editor.md
@@ -1,0 +1,14 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Schedule is now editable from the agent's Config tab — previously you had to hand-edit YAML to set or clear a cron expression. New card shows the current cron expression, a human-readable summary (`Every day at 8:00 AM`), and a Save button that validates server-side via the same `validateScheduleInterval` the scheduler uses. Empty input clears the schedule. Sub-minute (6-field) cron is still rejected unless `allowHighFrequency` is set on the agent.
+
+Two latent bugs fixed along the way:
+
+1. **`allowHighFrequency` was being silently dropped on every save**: `extractDag` didn't include it, so even agents that declared `allowHighFrequency: true` lost it on every `upsertAgent`/`createNewVersion`, breaking the scheduler's frequency-cap exception. Now persisted via `AgentVersionDag`.
+2. **`updateAgentMeta` couldn't clear nullable fields**: it skipped any field whose value was `undefined`, conflating "key absent" with "key present, clear me." Switched the nullable fields (description, schedule, stateMaxBytes) to use `'key' in patch` so explicit-clear works.

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ Thumbs.db
 
 # Runtime agent output
 /output/
+hn-digests/

--- a/packages/core/src/agent-store.ts
+++ b/packages/core/src/agent-store.ts
@@ -218,16 +218,21 @@ export class AgentStore {
   ): void {
     const fields: string[] = [];
     const values: SqlValue[] = [];
+    // For nullable fields (description, schedule, stateMaxBytes), distinguish
+    // "key absent from patch" (skip the column) from "key present with
+    // undefined value" (clear the column to NULL). Using `in` operator so
+    // callers can explicitly pass {schedule: undefined} to clear without
+    // also having to special-case-null.
     if (patch.name !== undefined) { fields.push('name = ?'); values.push(patch.name); }
-    if (patch.description !== undefined) { fields.push('description = ?'); values.push(patch.description ?? null); }
+    if ('description' in patch) { fields.push('description = ?'); values.push(patch.description ?? null); }
     if (patch.status !== undefined) { fields.push('status = ?'); values.push(patch.status); }
-    if (patch.schedule !== undefined) { fields.push('schedule = ?'); values.push(patch.schedule ?? null); }
+    if ('schedule' in patch) { fields.push('schedule = ?'); values.push(patch.schedule ?? null); }
     if (patch.mcp !== undefined) { fields.push('mcp = ?'); values.push(patch.mcp ? 1 : 0); }
     if (patch.starred !== undefined) { fields.push('starred = ?'); values.push(patch.starred ? 1 : 0); }
     if (patch.source !== undefined) { fields.push('source = ?'); values.push(patch.source); }
     if (patch.pulseVisible !== undefined) { fields.push('pulse_visible = ?'); values.push(patch.pulseVisible ? 1 : 0); }
     if (patch.dashboardVisible !== undefined) { fields.push('dashboard_visible = ?'); values.push(patch.dashboardVisible ? 1 : 0); }
-    if (patch.stateMaxBytes !== undefined) { fields.push('state_max_bytes = ?'); values.push(patch.stateMaxBytes); }
+    if ('stateMaxBytes' in patch) { fields.push('state_max_bytes = ?'); values.push(patch.stateMaxBytes ?? null); }
     if (fields.length === 0) return;
     fields.push('updated_at = ?');
     values.push(new Date().toISOString());
@@ -370,6 +375,7 @@ export class AgentStore {
     };
     if (agent.provider) dag.provider = agent.provider;
     if (agent.model) dag.model = agent.model;
+    if (agent.allowHighFrequency) dag.allowHighFrequency = agent.allowHighFrequency;
     if (agent.inputs) dag.inputs = agent.inputs;
     if (agent.outputs) dag.outputs = agent.outputs;
     if (agent.signal) dag.signal = agent.signal;
@@ -412,6 +418,7 @@ export class AgentStore {
       version: row.current_version as number,
       provider: dag.provider,
       model: dag.model,
+      allowHighFrequency: dag.allowHighFrequency,
       inputs: dag.inputs,
       outputs: dag.outputs,
       nodes: dag.nodes,

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -439,6 +439,14 @@ export interface AgentVersionDag {
   id: string;
   provider?: 'claude' | 'codex';
   model?: string;
+  /**
+   * Per-agent opt-out of the scheduler's frequency cap. When true, sub-minute
+   * (6-field) cron expressions are accepted. Lives in the versioned DAG —
+   * not row metadata — because relaxing the safety cap is a design-time
+   * decision authors make alongside the cron expression itself, not
+   * something operators flip casually.
+   */
+  allowHighFrequency?: boolean;
   inputs?: Record<string, AgentInputSpec>;
   outputs?: Record<string, AgentOutputSpec>;
   nodes: AgentNode[];

--- a/packages/dashboard/src/routes/schedule-edit.test.ts
+++ b/packages/dashboard/src/routes/schedule-edit.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import request from 'supertest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AgentStore,
+  DashboardsStore,
+  LocalProvider,
+  MemorySecretsStore,
+  PacksStore,
+  RunStore,
+  buildLoopbackAllowlist,
+  loadAgents,
+} from '@some-useful-agents/core';
+import { buildDashboardApp } from '../index.js';
+import type { DashboardContext } from '../context.js';
+import { SESSION_COOKIE } from '../auth-middleware.js';
+import { MemorySecretsSession } from '../secrets-session.js';
+
+const TOKEN = 'a'.repeat(64);
+const PORT = 3995;
+const COOKIE = `${SESSION_COOKIE}=${TOKEN}`;
+
+let dir: string;
+let provider: LocalProvider;
+let runStore: RunStore;
+let agentStore: AgentStore;
+let packsStore: PacksStore;
+let dashboardsStore: DashboardsStore;
+
+async function makeApp(opts: { schedule?: string; allowHighFrequency?: boolean } = {}) {
+  dir = mkdtempSync(join(tmpdir(), 'sua-schedule-edit-'));
+  const dbPath = join(dir, 'runs.db');
+  const agentsDir = join(dir, 'agents', 'local');
+  mkdirSync(agentsDir, { recursive: true });
+
+  const secretsStore = new MemorySecretsStore();
+  runStore = new RunStore(dbPath);
+  agentStore = new AgentStore(dbPath);
+  packsStore = new PacksStore(dbPath);
+  dashboardsStore = new DashboardsStore(dbPath);
+  provider = new LocalProvider(dbPath, secretsStore);
+  await provider.initialize();
+
+  agentStore.createAgent({
+    id: 'sched-agent',
+    name: 'Sched Agent',
+    status: 'active',
+    source: 'local',
+    mcp: false,
+    schedule: opts.schedule,
+    allowHighFrequency: opts.allowHighFrequency,
+    nodes: [{ id: 'n', type: 'shell', command: 'echo hi', dependsOn: [] }],
+  }, 'cli');
+
+  const ctx: DashboardContext = {
+    token: TOKEN,
+    allowlist: buildLoopbackAllowlist(PORT),
+    port: PORT,
+    provider,
+    runStore,
+    agentStore,
+    loadAgents: () => loadAgents({ directories: [agentsDir] }),
+    secretsStore,
+    secretsSession: new MemorySecretsSession({ backing: secretsStore }),
+    tokenPath: join(dir, 'mcp-token'),
+    retentionDays: 30,
+    dbPath,
+    secretsPath: join(dir, 'secrets.enc'),
+    rotateToken: () => 'r'.repeat(64),
+    packsStore,
+    dashboardsStore,
+    allowUntrustedShell: new Set(),
+    activeRuns: new Map(),
+    dataDir: dir,
+    dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
+  };
+
+  return buildDashboardApp(ctx);
+}
+
+afterEach(async () => {
+  if (provider) {
+    const start = Date.now();
+    while ((provider as unknown as { running?: { size: number } }).running?.size && Date.now() - start < 2000) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    await provider.shutdown();
+  }
+  try { runStore?.close(); } catch { /* ignore */ }
+  try { agentStore?.close(); } catch { /* ignore */ }
+  try { packsStore?.close(); } catch { /* ignore */ }
+  try { dashboardsStore?.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('POST /agents/:id/schedule', () => {
+  it('sets a valid 5-field cron expression', async () => {
+    const app = await makeApp();
+    const res = await request(app).post('/agents/sched-agent/schedule')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .type('form').send({ schedule: '0 8 * * *' });
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toContain('Schedule%20set');
+    expect(agentStore.getAgent('sched-agent')!.schedule).toBe('0 8 * * *');
+  });
+
+  it('clears the schedule when given an empty string', async () => {
+    const app = await makeApp({ schedule: '0 8 * * *' });
+    const res = await request(app).post('/agents/sched-agent/schedule')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .type('form').send({ schedule: '' });
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toContain('Schedule%20cleared');
+    expect(agentStore.getAgent('sched-agent')!.schedule).toBeUndefined();
+  });
+
+  it('reports unchanged when the same schedule is submitted', async () => {
+    const app = await makeApp({ schedule: '0 8 * * *' });
+    const res = await request(app).post('/agents/sched-agent/schedule')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .type('form').send({ schedule: '0 8 * * *' });
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toContain('Schedule%20unchanged');
+  });
+
+  it('rejects invalid cron with a helpful message', async () => {
+    const app = await makeApp();
+    const res = await request(app).post('/agents/sched-agent/schedule')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .type('form').send({ schedule: 'totally bogus' });
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/not%20a%20valid%20cron/i);
+    expect(agentStore.getAgent('sched-agent')!.schedule).toBeUndefined();
+  });
+
+  it('rejects sub-minute (6-field) schedules unless allowHighFrequency is set', async () => {
+    const app = await makeApp();
+    const res = await request(app).post('/agents/sched-agent/schedule')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .type('form').send({ schedule: '*/30 * * * * *' });
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/sub-minute|allowHighFrequency/i);
+    expect(agentStore.getAgent('sched-agent')!.schedule).toBeUndefined();
+  });
+
+  it('accepts sub-minute schedules when allowHighFrequency is true', async () => {
+    const app = await makeApp({ allowHighFrequency: true });
+    const res = await request(app).post('/agents/sched-agent/schedule')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .type('form').send({ schedule: '*/30 * * * * *' });
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toContain('Schedule%20set');
+    expect(agentStore.getAgent('sched-agent')!.schedule).toBe('*/30 * * * * *');
+  });
+
+  it('returns 404 for unknown agent ids', async () => {
+    const app = await makeApp();
+    const res = await request(app).post('/agents/nope/schedule')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .type('form').send({ schedule: '0 8 * * *' });
+    // 404 → redirect to /agents per the existing pattern.
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toBe('/agents');
+  });
+});

--- a/packages/dashboard/src/routes/versions.ts
+++ b/packages/dashboard/src/routes/versions.ts
@@ -1,6 +1,7 @@
 import { Router, type Request, type Response } from 'express';
 import { getContext } from '../context.js';
 import { renderVersionsList, renderVersionDetail } from '../views/versions.js';
+import { validateScheduleInterval, CronInvalidError, CronTooFrequentError } from '@some-useful-agents/core';
 
 /**
  * Version history + rollback routes for v2 DAG agents.
@@ -210,6 +211,73 @@ versionsRouter.post('/agents/:id/visibility', (req: Request, res: Response) => {
   } catch (err) {
     const m = err instanceof Error ? err.message : String(err);
     res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent(`Visibility toggle failed: ${m}`)}`);
+  }
+});
+
+/**
+ * POST /agents/:id/schedule — set or clear the agent's cron schedule.
+ *
+ * Body: { schedule: string } — empty string clears the schedule.
+ * Validation: parses + applies the frequency cap via core's
+ * validateScheduleInterval, honouring the agent's allowHighFrequency flag.
+ * Schedule lives on the agents row metadata (no version bump) — the
+ * scheduler reads it from there at start time and re-reads on each
+ * heartbeat tick.
+ */
+versionsRouter.post('/agents/:id/schedule', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const raw = typeof body.schedule === 'string' ? body.schedule.trim() : '';
+
+  const agent = ctx.agentStore.getAgent(id);
+  if (!agent) {
+    res.status(404).redirect(303, '/agents');
+    return;
+  }
+
+  // Empty input clears the schedule.
+  if (raw === '') {
+    if (!agent.schedule) {
+      res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent('Schedule unchanged.')}`);
+      return;
+    }
+    try {
+      ctx.agentStore.updateAgentMeta(id, { schedule: undefined });
+      res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent('Schedule cleared.')}`);
+    } catch (err) {
+      const m = err instanceof Error ? err.message : String(err);
+      res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent(`Schedule clear failed: ${m}`)}`);
+    }
+    return;
+  }
+
+  try {
+    validateScheduleInterval(raw, { allowHighFrequency: agent.allowHighFrequency });
+  } catch (err) {
+    let msg: string;
+    if (err instanceof CronInvalidError) {
+      msg = `"${raw}" is not a valid cron expression. Use 5 fields (minute hour day month weekday), e.g. "0 8 * * *".`;
+    } else if (err instanceof CronTooFrequentError) {
+      msg = `"${raw}" fires sub-minute. Set allowHighFrequency: true on the agent YAML to bypass the safety cap.`;
+    } else {
+      msg = err instanceof Error ? err.message : String(err);
+    }
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent(msg)}`);
+    return;
+  }
+
+  if (agent.schedule === raw) {
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent('Schedule unchanged.')}`);
+    return;
+  }
+
+  try {
+    ctx.agentStore.updateAgentMeta(id, { schedule: raw });
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent(`Schedule set to "${raw}". Restart the scheduler daemon to pick it up.`)}`);
+  } catch (err) {
+    const m = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent(`Schedule update failed: ${m}`)}`);
   }
 });
 

--- a/packages/dashboard/src/views/agent-detail/config.ts
+++ b/packages/dashboard/src/views/agent-detail/config.ts
@@ -5,6 +5,7 @@ import {
   providerOption,
   renderModelOptions,
 } from '../agent-detail-helpers.js';
+import { cronToHuman } from '../components.js';
 import { agentPageShell, type AgentDetailArgs } from './shell.js';
 
 /**
@@ -102,6 +103,35 @@ export async function renderAgentConfig(args: AgentDetailArgs): Promise<string> 
       ? html`<p class="dim" style="font-size: var(--font-size-xs); margin: var(--space-2) 0 0;">Hidden agents are still reachable by direct URL, MCP, scheduler, and the runs page.</p>`
       : html``}
   `);
+
+  const scheduleCard = (() => {
+    // The scheduler watches the `schedule` column on the agents row;
+    // editing it here is metadata-only (no version bump). Empty input
+    // disables the schedule. Validation lives server-side — we don't
+    // try to gate keystrokes here because the cron-validator messages
+    // are more useful than what we'd hand-roll in JS.
+    const current = agent.schedule ?? '';
+    const human = current ? cronToHuman(current) : null;
+    return configCard('Schedule', html`
+      <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-3);">
+        Five-field cron expression. Empty disables. Examples: <code>0 8 * * *</code> (daily 8am), <code>*/15 * * * *</code> (every 15m), <code>0 9 * * 1-5</code> (weekdays 9am).
+      </p>
+      <form method="POST" action="/agents/${agent.id}/schedule" style="display: flex; flex-direction: column; gap: var(--space-2);">
+        <div style="display: flex; gap: var(--space-2); align-items: center;">
+          <input type="text" name="schedule" value="${current}" placeholder="0 8 * * *"
+                 class="form-field mono"
+                 style="flex: 1; padding: var(--space-1) var(--space-2); font-size: var(--font-size-sm);" />
+          <button type="submit" class="btn btn--sm">Save</button>
+        </div>
+        ${current
+          ? html`<div class="dim" style="font-size: var(--font-size-xs);">${human ? html`Currently: <strong>${human}</strong>` : html`<span style="color: var(--color-danger);">Currently set, but not parseable as cron.</span>`}</div>`
+          : html`<div class="dim" style="font-size: var(--font-size-xs);">No schedule. The agent only fires on demand (run-now / MCP).</div>`}
+        ${current && agent.allowHighFrequency
+          ? html`<div class="dim" style="font-size: var(--font-size-xs); color: var(--color-warn);">allowHighFrequency: true — sub-minute schedules permitted.</div>`
+          : html``}
+      </form>
+    `);
+  })();
 
   const mcpCard = configCard('MCP exposure', html`
     <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-3);">
@@ -201,6 +231,7 @@ export async function renderAgentConfig(args: AgentDetailArgs): Promise<string> 
     <div class="config-grid" style="margin-top: var(--space-4);">
       <div class="config-grid__col">
         ${llmCard}
+        ${scheduleCard}
         ${visibilityCard}
         ${mcpCard}
         ${secretsCard}


### PR DESCRIPTION
## Summary

User flagged that \`/agents/<id>/config\` had no schedule UI — the only way to set or clear a cron expression was to hand-edit YAML. New Schedule card on the Config tab with a cron input, human-readable summary (\`Every day at 8:00 AM\`), and validation server-side via core's \`validateScheduleInterval\` (same path the scheduler uses).

Two latent bugs surfaced while wiring the tests:

1. **\`extractDag\` was dropping \`allowHighFrequency\`** ([agent-store.ts:363-382](packages/core/src/agent-store.ts#L363-L382)). Every \`upsertAgent\` / \`createNewVersion\` silently stripped the field, so any agent that declared \`allowHighFrequency: true\` lost it on its first save. Persisted now via \`AgentVersionDag\`.
2. **\`updateAgentMeta\` couldn't clear nullable fields** ([agent-store.ts:215-236](packages/core/src/agent-store.ts#L215-L236)). The skip-if-undefined check conflated "key absent" with "explicit clear." Changed the nullable fields (\`description\`, \`schedule\`, \`stateMaxBytes\`) to use \`'key' in patch\` so callers can pass \`{schedule: undefined}\` to clear.

## On visibility toggles

User also asked why pulse/dashboard visibility toggles weren't visible — they ARE on the Config tab (verified via curl) but not on Overview. That's a UX issue, not a missing feature; out of scope here. If we want them on Overview too, easy follow-up.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 1152/1152 (+7 new schedule POST tests; existing agent-store tests still pass)
- [ ] After merge: visit \`/agents/hn-top-stories-rich/config\` → see Schedule card with current value or "no schedule"; set a cron, hit Save, daemon restart picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)