### PR TITLE
feat(dashboard): tool-usage visibility — PR A of tool policies

### DIFF
--- a/.changeset/tool-policies-pr-a-visibility.md
+++ b/.changeset/tool-policies-pr-a-visibility.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": minor
+---
+
+Tool-usage visibility on `/tools/:id` and the agent overview.
+
+The `/tools/:id` detail page now has a "Used by" section listing every agent in the catalog that statically references this tool — sourced from the parse-time `agent.capabilities.tools_used` (covers explicit `tool:`, type-based desugaring, and node-level `allowedTools`). Empty state renders an explicit "no agents reference this tool yet" line.
+
+Agent overview's tool badges now use the same canonical source, so badges include `allowedTools` entries that the previous inline derivation missed. Claude-code-native tools (`Bash`, `Edit`, `NotebookEdit`) render as plain badges instead of dead links to `/tools`.
+
+This is the first slice of the tool-policies feature (PR A: visibility surface). The policy file shape, enforcement engine, and CLI/dashboard rule editor land in PRs B–D.

--- a/packages/dashboard/src/routes/tools-used-by.test.ts
+++ b/packages/dashboard/src/routes/tools-used-by.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Smoke test for the "Used by" surface on `/tools/:id`. Doesn't poke the
+ * exact HTML — that's brittle — just asserts each agent's id appears in
+ * the rendered body when it references the tool, and is absent otherwise.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import request from 'supertest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AgentStore,
+  DashboardsStore,
+  LocalProvider,
+  MemorySecretsStore,
+  PacksStore,
+  RunStore,
+  ToolStore,
+  buildLoopbackAllowlist,
+  loadAgents,
+} from '@some-useful-agents/core';
+import { buildDashboardApp } from '../index.js';
+import type { DashboardContext } from '../context.js';
+import { SESSION_COOKIE } from '../auth-middleware.js';
+import { MemorySecretsSession } from '../secrets-session.js';
+
+const TOKEN = 'a'.repeat(64);
+const PORT = 3996;
+const COOKIE = `${SESSION_COOKIE}=${TOKEN}`;
+
+let dir: string;
+let provider: LocalProvider;
+let runStore: RunStore;
+let agentStore: AgentStore;
+let packsStore: PacksStore;
+let dashboardsStore: DashboardsStore;
+let toolStore: ToolStore;
+
+async function makeApp() {
+  dir = mkdtempSync(join(tmpdir(), 'sua-tools-usedby-'));
+  const dbPath = join(dir, 'runs.db');
+  const agentsDir = join(dir, 'agents', 'local');
+  mkdirSync(agentsDir, { recursive: true });
+
+  const secretsStore = new MemorySecretsStore();
+  runStore = new RunStore(dbPath);
+  agentStore = new AgentStore(dbPath);
+  packsStore = new PacksStore(dbPath);
+  dashboardsStore = new DashboardsStore(dbPath);
+  toolStore = new ToolStore(dbPath);
+  provider = new LocalProvider(dbPath, secretsStore);
+  await provider.initialize();
+
+  // Two agents that use http-get; one that doesn't.
+  agentStore.createAgent({
+    id: 'fetch-a', name: 'Fetch A', status: 'active', source: 'local', mcp: false,
+    nodes: [{ id: 'go', type: 'shell', tool: 'http-get', toolInputs: { url: 'https://example.com/a' }, dependsOn: [] }],
+  }, 'cli');
+  agentStore.createAgent({
+    id: 'fetch-b', name: 'Fetch B', status: 'active', source: 'local', mcp: false,
+    nodes: [{ id: 'go', type: 'shell', tool: 'http-get', toolInputs: { url: 'https://example.com/b' }, dependsOn: [] }],
+  }, 'cli');
+  agentStore.createAgent({
+    id: 'shell-only', name: 'Shell Only', status: 'active', source: 'local', mcp: false,
+    nodes: [{ id: 'echo', type: 'shell', command: 'echo hi', dependsOn: [] }],
+  }, 'cli');
+
+  const ctx: DashboardContext = {
+    token: TOKEN,
+    allowlist: buildLoopbackAllowlist(PORT),
+    port: PORT,
+    provider,
+    runStore,
+    agentStore,
+    toolStore,
+    loadAgents: () => loadAgents({ directories: [agentsDir] }),
+    secretsStore,
+    secretsSession: new MemorySecretsSession({ backing: secretsStore }),
+    tokenPath: join(dir, 'mcp-token'),
+    retentionDays: 30,
+    dbPath,
+    secretsPath: join(dir, 'secrets.enc'),
+    rotateToken: () => 'r'.repeat(64),
+    packsStore,
+    dashboardsStore,
+    allowUntrustedShell: new Set(),
+    activeRuns: new Map(),
+    dataDir: dir,
+    dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
+  };
+
+  return buildDashboardApp(ctx);
+}
+
+afterEach(async () => {
+  if (provider) {
+    const start = Date.now();
+    while ((provider as unknown as { running?: { size: number } }).running?.size && Date.now() - start < 2000) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    await provider.shutdown();
+  }
+  try { runStore?.close(); } catch { /* ignore */ }
+  try { agentStore?.close(); } catch { /* ignore */ }
+  try { packsStore?.close(); } catch { /* ignore */ }
+  try { dashboardsStore?.close(); } catch { /* ignore */ }
+  try { toolStore?.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('GET /tools/:id "Used by" section', () => {
+  it('lists agents that reference http-get and excludes those that do not', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/tools/http-get')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Used by');
+    expect(res.text).toMatch(/href="\/agents\/fetch-a"/);
+    expect(res.text).toMatch(/href="\/agents\/fetch-b"/);
+    expect(res.text).not.toMatch(/href="\/agents\/shell-only"/);
+  });
+
+  it('lists shell-only agent under the shell-exec tool', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/tools/shell-exec')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(200);
+    expect(res.text).toMatch(/href="\/agents\/shell-only"/);
+  });
+
+  it('renders an empty-state message when no agents reference the tool', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/tools/file-write')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(200);
+    expect(res.text).toMatch(/No agents reference this tool yet/);
+  });
+});

--- a/packages/dashboard/src/routes/tools.ts
+++ b/packages/dashboard/src/routes/tools.ts
@@ -204,9 +204,24 @@ toolsRouter.get('/tools/:id', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
   const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
 
+  // Find every agent that statically references this tool. Sourced from
+  // the parse-time `capabilities.tools_used` (covers explicit `tool:`,
+  // type-based desugaring, and node-level `allowedTools`). Cheap enough
+  // to walk all agents on each request — there's no high-cardinality
+  // workload that would warrant an index.
+  const usedByAgents = (() => {
+    try {
+      return ctx.agentStore.listAgents()
+        .filter((a) => a.capabilities?.tools_used.includes(id))
+        .map((a) => ({ id: a.id, name: a.name, status: a.status }));
+    } catch {
+      return [];
+    }
+  })();
+
   const builtin = getBuiltinTool(id);
   if (builtin) {
-    res.type('html').send(renderToolDetail({ tool: builtin.definition }));
+    res.type('html').send(renderToolDetail({ tool: builtin.definition, usedByAgents }));
     return;
   }
 
@@ -215,7 +230,7 @@ toolsRouter.get('/tools/:id', (req: Request, res: Response) => {
       const tool = ctx.toolStore.getTool(id);
       if (tool) {
         const serverId = ctx.toolStore.getToolServerId(id);
-        res.type('html').send(renderToolDetail({ tool, mcpServerId: serverId }));
+        res.type('html').send(renderToolDetail({ tool, mcpServerId: serverId, usedByAgents }));
         return;
       }
     }

--- a/packages/dashboard/src/views/agent-detail/overview.ts
+++ b/packages/dashboard/src/views/agent-detail/overview.ts
@@ -9,10 +9,27 @@ export async function renderAgentOverview(args: AgentDetailArgs): Promise<string
   const latestCompletedRun = recentRuns.find((r) => r.status === 'completed');
   const hasCommunityShellNode = agent.source === 'community' && agent.nodes.some((n) => n.type === 'shell');
 
-  // Quick stats row
-  const toolIds = new Set<string>();
-  for (const n of agent.nodes) toolIds.add(n.tool ?? (n.type === 'shell' ? 'shell-exec' : 'claude-code'));
-  const toolBadges = [...toolIds].sort().map((id) => html`<a href="/tools/${id}" class="badge badge--muted" style="text-decoration: none;">${id}</a>`);
+  // Quick stats row. Tools-used comes from `agent.capabilities` — the
+  // canonical static analysis (parse-time, includes explicit `tool:`,
+  // type-based desugaring, AND `allowedTools`). Falls back to a node-level
+  // walk only if capabilities wasn't computed (e.g., older row not yet
+  // re-read). claude-code-native tools (Bash, Edit, etc.) link to /tools
+  // and will 404 there; skipping the link keeps users out of dead ends.
+  const toolsUsed = agent.capabilities?.tools_used && agent.capabilities.tools_used.length > 0
+    ? agent.capabilities.tools_used
+    : (() => {
+        const ids = new Set<string>();
+        for (const n of agent.nodes) ids.add(n.tool ?? (n.type === 'shell' ? 'shell-exec' : 'claude-code'));
+        return [...ids].sort();
+      })();
+  // Linkable tool ids match sua's kebab-lowercase convention (built-ins,
+  // user tools, MCP-imported tools all use it). Claude-code-native tools
+  // like `Bash` / `Edit` / `NotebookEdit` ship in capitalised form and
+  // have no `/tools` entry — render those as plain badges.
+  const isLinkable = (id: string) => /^[a-z][a-z0-9_-]*$/.test(id);
+  const toolBadges = toolsUsed.map((id) => isLinkable(id)
+    ? html`<a href="/tools/${id}" class="badge badge--muted" style="text-decoration: none;">${id}</a>`
+    : html`<span class="badge badge--muted" title="Built into the LLM runtime; no /tools entry.">${id}</span>`);
 
   const runRows = recentRuns.slice(0, 5).map((r) => html`
     <tr>

--- a/packages/dashboard/src/views/tool-detail.ts
+++ b/packages/dashboard/src/views/tool-detail.ts
@@ -1,14 +1,28 @@
-import type { ToolDefinition } from '@some-useful-agents/core';
+import type { ToolDefinition, AgentStatus } from '@some-useful-agents/core';
 import { html, render, unsafeHtml, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
+import { statusBadge } from './components.js';
+
+export interface ToolUsage {
+  id: string;
+  name: string;
+  status: AgentStatus;
+}
 
 export function renderToolDetail(args: {
   tool: ToolDefinition;
   /** When set, link the tool to its source MCP server for navigation. */
   mcpServerId?: string;
+  /**
+   * Agents that statically reference this tool, derived from
+   * `agent.capabilities.tools_used`. Empty list renders an explicit
+   * "no agents use this tool yet" line so users can tell the difference
+   * between "loaded but empty" and "the section never rendered."
+   */
+  usedByAgents?: ToolUsage[];
 }): string {
-  const { tool, mcpServerId } = args;
+  const { tool, mcpServerId, usedByAgents = [] } = args;
 
   const sourceBadge = tool.source === 'builtin'
     ? html`<span class="badge badge--muted">builtin</span>`
@@ -102,6 +116,25 @@ export function renderToolDetail(args: {
           ` : unsafeHtml('')}
         </dl>
       </div>
+    </section>
+
+    <section class="mt-6">
+      <h2>Used by</h2>
+      ${usedByAgents.length === 0
+        ? html`<p class="dim">No agents reference this tool yet.</p>`
+        : html`
+          <table class="table">
+            <thead><tr><th>Agent</th><th>Status</th></tr></thead>
+            <tbody>
+              ${usedByAgents.map((a) => html`
+                <tr>
+                  <td><a href="/agents/${a.id}" class="mono">${a.id}</a> <span class="dim">${a.name}</span></td>
+                  <td>${statusBadge(a.status)}</td>
+                </tr>
+              `) as unknown as SafeHtml[]}
+            </tbody>
+          </table>
+        `}
     </section>
   `;
 


### PR DESCRIPTION
## Summary

First slice of the tool-policies feature (per the 4-PR plan). Read-only visibility surface — **no policy enforcement yet**, just the answer to "which agents use this tool?" and "which tools does this agent use?"

### Changes

- **\`/tools/:id\` "Used by" section** — lists every agent in the catalog that statically references this tool, sourced from \`agent.capabilities.tools_used\`. Empty-state line when no agents use it. Walks \`agentStore.listAgents()\` once per request — no new storage, no index, fine at dashboard scale.
- **Agent overview tool badges** — switched from an inline node walk (which missed \`allowedTools\` entries) to the canonical \`capabilities.tools_used\` source. Claude-code-native tools (\`Bash\`, \`Edit\`, \`NotebookEdit\`) render as plain badges instead of dead links to \`/tools\`.

### Why visibility before enforcement

You can't reason about a policy you can't see the surface area of. Shipping the visibility layer first means we get user feedback on the data shape before locking it in with rule files. Also tractable in one day, which fits the working cadence — PRs B–D each get their own focused review.

### What's coming next (PRs B–D, per the plan in \`~/.claude/plans/tool-policies.md\`)

- **B**: \`.sua/policies.json\` schema + \`policy_denied\` NodeErrorCategory + always-allow stub at the enforcement point
- **C**: real engine, glob matching (minimatch), agent-level \`policies:\` block, source-tier conditions; migrates \`--allow-untrusted-shell\` to a policy rule
- **D**: \`sua policy list/check/add/remove\` CLI + \`/settings/policies\` CRUD + \`sua doctor\` integration

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 1155/1155 (+3 new for the Used-by surface)
- [ ] After merge: visit \`/tools/http-get\` → see all agents listing it; visit \`/tools/file-write\` on a fresh DB → see "No agents reference this tool yet"

🤖 Generated with [Claude Code](https://claude.com/claude-code)