### PR TITLE
feat(core): tool-policies PR B — file shape + executor seam (always-allow stub)

### DIFF
--- a/.changeset/tool-policies-pr-b-shape.md
+++ b/.changeset/tool-policies-pr-b-shape.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Tool-policies PR B: file shape, loader, executor seam (always-allow stub).
+
+Defines the on-disk schema for `.sua/policies.json` (`version: 1`, `defaultAction`, `rules[]`) plus `loadPolicyDocument(dataDir)` which reads the file when present and returns the default allow-all document otherwise. Malformed JSON or schema-invalid files throw `PolicyLoadError` rather than falling back silently — operators want a loud failure on configuration bugs.
+
+The dag-executor now runs every tool dispatch through `evaluatePolicy()` before calling `tool.execute()`. **No behaviour change today**: the function is a stub that always returns `{effect: 'allow'}`. PR C drops in real glob matching + condition evaluation here without touching downstream dispatch.
+
+New `'policy_denied'` value on `NodeErrorCategory` and a corresponding `PolicyDeniedError` class. The executor's tool-dispatch catch is special-cased so a thrown `PolicyDeniedError` lands in `node_executions.errorCategory` as `policy_denied` instead of the generic `setup`. Policy denials are intentionally NOT in the default retryable-categories list — denying is a stable signal.
+
+`extractPrimaryResource(node, toolId)` extracts the URL/path/command the tool would touch, ready for PR C's matcher to glob against. Templated values are returned as-is (the seam runs before substitution, by design — authors can write deny rules against literal template strings).

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -66,7 +66,15 @@ export type NodeErrorCategory =
   | 'cancelled'
   | 'upstream_failed'
   | 'condition_not_met'
-  | 'flow_ended';
+  | 'flow_ended'
+  /**
+   * Tool-policy denied this node. Set when a future enforcement engine
+   * (PR C of the tool-policies feature) refuses a tool call against a
+   * resource the project policy blocks. Lives in the enum from PR B
+   * onward so calling code, retry-policy filters, and dashboard
+   * categorisation can reason about it before the engine ships.
+   */
+  | 'policy_denied';
 
 // Re-export so consumers of v2 types can import from one place without
 // reaching back into the v1 loader module.

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -29,6 +29,7 @@ import type { ToolStore } from './tool-store.js';
 import type { VariablesStore } from './variables-store.js';
 import type { ToolOutput, BuiltinToolContext } from './tool-types.js';
 import { getBuiltinTool } from './builtin-tools.js';
+import { evaluatePolicy, DEFAULT_POLICY_DOCUMENT, PolicyDeniedError, type PolicyDocument, type PolicyEvaluationRequest } from './policy-store.js';
 import { buildToolOutput } from './output-framing.js';
 import { callMcpTool } from './mcp-client.js';
 import { resolveUpstreamTemplate, resolveVarsTemplate, resolveStateTemplate } from './node-templates.js';
@@ -110,6 +111,14 @@ export interface DagExecutorDeps {
    * and one-shot CLI runs typically omit it.
    */
   dataRoot?: string;
+  /**
+   * Tool-policy document loaded from `.sua/policies.json` (or built
+   * inline by tests). When absent, the executor evaluates against the
+   * default allow-all document — same effective behaviour as projects
+   * that haven't authored a policy. PR B ships this as a no-op seam
+   * so PR C can drop in real allow/deny logic without changing dispatch.
+   */
+  policyDocument?: PolicyDocument;
 }
 
 export interface DagExecuteOptions {
@@ -681,6 +690,29 @@ export async function executeAgentDag(
     const toolId = resolveToolId(node);
     const builtinEntry = toolId ? getBuiltinTool(toolId) : undefined;
 
+    // PR B (tool policies): single seam that every tool-execute path
+    // crosses. The stub always allows; PR C wires real allow/deny logic
+    // here without touching downstream dispatch. The throw is caught by
+    // the existing tool-dispatch catch (~30 lines below) and re-mapped
+    // to errorCategory='policy_denied' via the instanceof check.
+    if (toolId) {
+      const policyRequest: PolicyEvaluationRequest = {
+        toolId,
+        resource: extractPrimaryResource(node, toolId),
+        agentSource: agent.source,
+        agentId: agent.id,
+      };
+      const decision = evaluatePolicy(deps.policyDocument ?? DEFAULT_POLICY_DOCUMENT, policyRequest);
+      if (decision.effect === 'deny') {
+        throw new PolicyDeniedError(
+          decision.reason ?? `Policy denied tool "${toolId}" on resource "${policyRequest.resource}".`,
+          toolId,
+          policyRequest.resource,
+          decision.matchedRuleIndex,
+        );
+      }
+    }
+
     let result: SpawnResult;
     let structuredOutput: ToolOutput | undefined;
 
@@ -822,14 +854,20 @@ export async function executeAgentDag(
     } catch (err) {
       const message = (err as Error).message;
       const stateBytesAfter = deps.dataRoot ? stateDirSize(agent.id, deps.dataRoot) : undefined;
+      // PolicyDeniedError comes from the policy-eval seam above. Map it
+      // to its own category so dashboards + retry-policy filters can
+      // distinguish "policy refused this" from generic setup failures.
+      // Policy denials are deliberately NOT in the default retry-categories
+      // list — denying is a stable signal, not a transient one.
+      const errorCategory: NodeErrorCategory = err instanceof PolicyDeniedError ? 'policy_denied' : 'setup';
       deps.runStore.updateNodeExecution(runId, node.id, {
         status: 'failed',
-        errorCategory: 'setup',
+        errorCategory,
         completedAt: new Date().toISOString(),
         error: message,
         stateBytesAfter,
       });
-      firstFailure = { nodeId: node.id, category: 'setup' };
+      firstFailure = { nodeId: node.id, category: errorCategory };
       continue;
     }
 
@@ -929,6 +967,43 @@ export async function executeAgentDag(
  * passes an Agent constructed outside the schema, throw rather than
  * silently dropping nodes from the output.
  */
+/**
+ * Extract the "primary resource" from a node for policy evaluation —
+ * the URL for http tools, the path for file tools, the command for
+ * shell-exec, etc. Returns empty string when no obvious resource is
+ * present (templated values that haven't been resolved yet, MCP tools
+ * with no canonical primary input). PR C's matcher treats `''` as
+ * "unknown resource" and uses `'*'` resource patterns to match it.
+ *
+ * Templated values (`{{inputs.X}}`, `{{upstream.Y.z}}`) are returned
+ * as-is — the eval seam runs *before* substitution so authors can write
+ * deny rules against the literal template strings if they want.
+ */
+function extractPrimaryResource(node: AgentNode, toolId: string): string {
+  // Tools whose primary resource is a URL.
+  if (toolId === 'http-get' || toolId === 'http-post') {
+    const ti = node.toolInputs ?? {};
+    const url = ti.url ?? ti.endpoint;
+    if (typeof url === 'string') return url;
+    return '';
+  }
+  // Tools whose primary resource is a filesystem path.
+  if (toolId === 'file-read' || toolId === 'file-write') {
+    const ti = node.toolInputs ?? {};
+    const path = (typeof ti.path === 'string' ? ti.path : undefined) ?? node.path;
+    if (typeof path === 'string') return path;
+    return '';
+  }
+  // shell-exec: the command itself is the resource. Same for un-tooled
+  // shell nodes that desugar to shell-exec.
+  if (toolId === 'shell-exec') {
+    return node.command ?? '';
+  }
+  // claude-code: prompt isn't really a resource; PR C may grow this to
+  // inspect node.allowedTools instead. For now, return empty.
+  return '';
+}
+
 export function topologicalSort(nodes: AgentNode[]): AgentNode[] {
   const byId = new Map<string, AgentNode>();
   const remainingDeps = new Map<string, Set<string>>();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -105,6 +105,20 @@ export {
   type PlanCriticContext,
 } from './build-plan-critic.js';
 export {
+  policyDocumentSchema,
+  policyRuleSchema,
+  loadPolicyDocument,
+  policyFilePath,
+  evaluatePolicy,
+  PolicyLoadError,
+  PolicyDeniedError,
+  DEFAULT_POLICY_DOCUMENT,
+  type PolicyDocument,
+  type PolicyRule,
+  type PolicyEvaluationRequest,
+  type PolicyDecision,
+} from './policy-store.js';
+export {
   getBuiltinTool,
   listBuiltinTools,
   isBuiltinTool,

--- a/packages/core/src/policy-store.test.ts
+++ b/packages/core/src/policy-store.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  loadPolicyDocument,
+  evaluatePolicy,
+  policyDocumentSchema,
+  policyFilePath,
+  PolicyLoadError,
+  PolicyDeniedError,
+  DEFAULT_POLICY_DOCUMENT,
+} from './policy-store.js';
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'sua-policy-')); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+function writeDoc(content: string): void {
+  mkdirSync(join(dir, '.sua'), { recursive: true });
+  writeFileSync(join(dir, '.sua', 'policies.json'), content);
+}
+
+describe('loadPolicyDocument', () => {
+  it('returns the default allow-all document when no file exists', () => {
+    const doc = loadPolicyDocument(dir);
+    expect(doc).toEqual(DEFAULT_POLICY_DOCUMENT);
+    expect(doc.defaultAction).toBe('allow');
+    expect(doc.rules).toEqual([]);
+  });
+
+  it('parses a minimal valid document', () => {
+    writeDoc(JSON.stringify({ version: 1, rules: [] }));
+    const doc = loadPolicyDocument(dir);
+    expect(doc.version).toBe(1);
+    expect(doc.defaultAction).toBe('allow');
+  });
+
+  it('parses a document with rules', () => {
+    writeDoc(JSON.stringify({
+      version: 1,
+      defaultAction: 'allow',
+      rules: [
+        { tool: 'http-post', effect: 'deny', resources: ['*'], reason: 'no egress' },
+        { tool: 'file-write', effect: 'allow', resources: ['./data/*'] },
+      ],
+    }));
+    const doc = loadPolicyDocument(dir);
+    expect(doc.rules).toHaveLength(2);
+    expect(doc.rules[0].effect).toBe('deny');
+    expect(doc.rules[0].action).toBe('execute'); // schema default
+    expect(doc.rules[1].resources).toEqual(['./data/*']);
+  });
+
+  it('throws PolicyLoadError on malformed JSON', () => {
+    writeDoc('{ this is not json');
+    let err: unknown;
+    try { loadPolicyDocument(dir); } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(PolicyLoadError);
+    expect((err as PolicyLoadError).path).toBe(policyFilePath(dir));
+    expect((err as PolicyLoadError).message).toMatch(/Invalid JSON/);
+  });
+
+  it('throws PolicyLoadError on schema validation failure', () => {
+    writeDoc(JSON.stringify({ version: 1, rules: [{ tool: 'http-get' /* missing effect */ }] }));
+    expect(() => loadPolicyDocument(dir)).toThrow(/schema validation failed/);
+  });
+
+  it('rejects non-1 version numbers (locks the format for future migrations)', () => {
+    writeDoc(JSON.stringify({ version: 2, rules: [] }));
+    expect(() => loadPolicyDocument(dir)).toThrow();
+  });
+
+  it('rejects unknown effect values', () => {
+    writeDoc(JSON.stringify({ version: 1, rules: [{ tool: 'http-get', effect: 'maybe' }] }));
+    expect(() => loadPolicyDocument(dir)).toThrow();
+  });
+});
+
+describe('policyDocumentSchema', () => {
+  it('parses an empty rules array', () => {
+    expect(() => policyDocumentSchema.parse({ version: 1, rules: [] })).not.toThrow();
+  });
+
+  it('fills defaults: defaultAction=allow, rules=[]', () => {
+    const parsed = policyDocumentSchema.parse({ version: 1 });
+    expect(parsed.defaultAction).toBe('allow');
+    expect(parsed.rules).toEqual([]);
+  });
+
+  it('rejects rules with unknown action types', () => {
+    expect(() => policyDocumentSchema.parse({
+      version: 1,
+      rules: [{ tool: 'http-get', effect: 'allow', action: 'mutate' }],
+    })).toThrow();
+  });
+
+  it('accepts conditions.source array of valid sources', () => {
+    const parsed = policyDocumentSchema.parse({
+      version: 1,
+      rules: [{ tool: 'shell-exec', effect: 'deny', conditions: { source: ['community'] } }],
+    });
+    expect(parsed.rules[0].conditions?.source).toEqual(['community']);
+  });
+});
+
+describe('evaluatePolicy (PR B stub)', () => {
+  it('always returns allow against the default document', () => {
+    const decision = evaluatePolicy(DEFAULT_POLICY_DOCUMENT, {
+      toolId: 'http-get',
+      resource: 'https://example.com/',
+      agentSource: 'local',
+      agentId: 'a1',
+    });
+    expect(decision.effect).toBe('allow');
+    expect(decision.matchedRuleIndex).toBe(-1);
+  });
+
+  it('always returns allow even against a doc with deny rules (stub)', () => {
+    // Sanity: the stub ignores rules. PR C flips this and adds tests
+    // that exercise the real eval logic; for now we just lock in that
+    // PR B does not accidentally start denying anything.
+    const decision = evaluatePolicy({
+      version: 1,
+      defaultAction: 'allow',
+      rules: [{ tool: '*', action: 'execute', resources: ['*'], effect: 'deny' }],
+    }, {
+      toolId: 'http-post',
+      resource: '*',
+      agentSource: 'community',
+      agentId: 'a1',
+    });
+    expect(decision.effect).toBe('allow');
+  });
+});
+
+describe('PolicyDeniedError', () => {
+  it('carries the tool, resource, and rule index for downstream surfaces', () => {
+    const err = new PolicyDeniedError('Custom reason', 'http-post', 'https://evil/', 3);
+    expect(err.name).toBe('PolicyDeniedError');
+    expect(err.toolId).toBe('http-post');
+    expect(err.resource).toBe('https://evil/');
+    expect(err.matchedRuleIndex).toBe(3);
+  });
+});

--- a/packages/core/src/policy-store.ts
+++ b/packages/core/src/policy-store.ts
@@ -1,0 +1,203 @@
+/**
+ * Tool policies — schema, loader, and a stub enforcement function.
+ *
+ * PR B of the tool-policies feature ships the file shape + the call seam
+ * the executor uses to ask "is this tool call allowed?". The actual
+ * allow/deny logic (glob matching, conditions, agent-level overrides)
+ * lands in PR C. Today the stub always returns `{effect: 'allow'}` so
+ * existing projects keep running without a `.sua/policies.json` file.
+ *
+ * Why a Zod-validated file rather than a TypeScript module? The policy
+ * is operator config, not code. Operators edit it directly or via the
+ * forthcoming `sua policy` CLI. A schema gives us coherent error
+ * messages when someone hand-edits the file and gets a key wrong, and
+ * it's the same validation surface the dashboard's `/settings/policies`
+ * editor will reuse.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { z } from 'zod';
+
+/**
+ * Authoritative on-disk schema for `.sua/policies.json`.
+ *
+ * `version` exists so future format breaks (e.g., conditions DSL changes
+ * in PR D+) can be migrated by `sua policy migrate` rather than rejecting
+ * old files.
+ *
+ * `defaultAction` is `allow` by default to match the v0.16 posture
+ * (everything runs unless explicitly denied) — switching to deny-by-default
+ * would force every project to enumerate an allowlist before anything
+ * works, which we'd want behind a `sua doctor --strict` flag, not as the
+ * default. See `~/.claude/plans/tool-policies.md` § Open questions.
+ */
+export const policyRuleSchema = z.object({
+  /** Tool id this rule applies to. `*` matches every tool. */
+  tool: z.string().min(1),
+  /**
+   * What operation to gate. Today the only meaningful value is `execute`;
+   * future writable-resource APIs (file-write open/close, http-post body
+   * inspection) may add more.
+   */
+  action: z.enum(['execute']).default('execute'),
+  /**
+   * Glob patterns matched against the tool's primary input — `url` for
+   * http tools, `path` for file tools, `command` for shell-exec, etc.
+   * `*` matches anything. Empty array == applies to every resource.
+   */
+  resources: z.array(z.string()).default([]),
+  /** `allow` overrides any earlier `deny`; `deny` overrides any earlier `allow`. */
+  effect: z.enum(['allow', 'deny']),
+  /**
+   * Optional gating conditions evaluated against the *agent* invoking the
+   * tool. Today only `source` is wired; PR C/D may add `node-id`, `tag`,
+   * and `created-by` filters as the need surfaces.
+   */
+  conditions: z.object({
+    source: z.array(z.enum(['examples', 'local', 'community'])).optional(),
+  }).optional(),
+  /**
+   * Operator-authored explanation. Surfaced in the dashboard run-detail
+   * page when the policy denies a node, and in `sua policy check`
+   * output, so debugging is a lookup instead of a code-trace.
+   */
+  reason: z.string().optional(),
+});
+
+export const policyDocumentSchema = z.object({
+  version: z.literal(1),
+  defaultAction: z.enum(['allow', 'deny']).default('allow'),
+  rules: z.array(policyRuleSchema).default([]),
+});
+
+export type PolicyRule = z.infer<typeof policyRuleSchema>;
+export type PolicyDocument = z.infer<typeof policyDocumentSchema>;
+
+/**
+ * The default in-memory policy document used when no `.sua/policies.json`
+ * exists. Allow-by-default with no rules — same posture every existing
+ * project has today.
+ */
+export const DEFAULT_POLICY_DOCUMENT: PolicyDocument = {
+  version: 1,
+  defaultAction: 'allow',
+  rules: [],
+};
+
+/**
+ * Resolve the on-disk path for a project's policy file. Centralised so
+ * both the loader and the future `sua policy add/remove` writers agree.
+ */
+export function policyFilePath(dataDir: string): string {
+  return join(dataDir, '.sua', 'policies.json');
+}
+
+/**
+ * Load the project policy document. Returns the default (allow-all)
+ * document when no file exists, so callers don't need to handle a null.
+ *
+ * On parse / schema failure we throw `PolicyLoadError` instead of falling
+ * back silently — a malformed policy file is a configuration bug the
+ * operator needs to fix, not a permissive surprise. The error includes
+ * the path so the CLI can surface it cleanly.
+ */
+export function loadPolicyDocument(dataDir: string): PolicyDocument {
+  const path = policyFilePath(dataDir);
+  if (!existsSync(path)) return DEFAULT_POLICY_DOCUMENT;
+
+  let raw: string;
+  try { raw = readFileSync(path, 'utf-8'); }
+  catch (e) { throw new PolicyLoadError(`Cannot read ${path}: ${(e as Error).message}`, path); }
+
+  let parsed: unknown;
+  try { parsed = JSON.parse(raw); }
+  catch (e) { throw new PolicyLoadError(`Invalid JSON in ${path}: ${(e as Error).message}`, path); }
+
+  const result = policyDocumentSchema.safeParse(parsed);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`)
+      .join('; ');
+    throw new PolicyLoadError(`Policy schema validation failed at ${path}: ${issues}`, path);
+  }
+  return result.data;
+}
+
+export class PolicyLoadError extends Error {
+  constructor(message: string, public readonly path: string) {
+    super(message);
+    this.name = 'PolicyLoadError';
+  }
+}
+
+/**
+ * Thrown by the executor's tool-dispatch path when the policy engine
+ * denies a tool call. The dag-executor catches this specifically and
+ * categorises the failed node as `policy_denied` so dashboards can
+ * distinguish "policy refused this" from "the tool itself errored."
+ *
+ * Carries the rule index that decided so `sua policy check` and the
+ * dashboard error surface can link to the rule.
+ */
+export class PolicyDeniedError extends Error {
+  constructor(
+    message: string,
+    public readonly toolId: string,
+    public readonly resource: string,
+    public readonly matchedRuleIndex?: number,
+  ) {
+    super(message);
+    this.name = 'PolicyDeniedError';
+  }
+}
+
+/**
+ * Request shape evaluated against the policy. Built by the executor at
+ * tool-dispatch time. PR C grows the actual matching logic; PR B's stub
+ * doesn't read most of these fields, but they're the contract callers
+ * commit to so PR C can drop in without changing dispatch.
+ */
+export interface PolicyEvaluationRequest {
+  /** Tool id (`http-get`, `shell-exec`, an MCP tool id, etc.). */
+  toolId: string;
+  /**
+   * Primary resource the tool would touch — extracted from the resolved
+   * tool inputs (e.g. the `url` field for http tools, `path` for
+   * file tools, `command` for shell-exec). Empty string when the tool
+   * has no obvious primary resource.
+   */
+  resource: string;
+  /** Source tier of the agent invoking the tool. */
+  agentSource: 'examples' | 'local' | 'community';
+  /** Agent id, for telemetry / per-agent overrides. */
+  agentId: string;
+}
+
+export interface PolicyDecision {
+  effect: 'allow' | 'deny';
+  /** Populated on `deny` so the executor can surface a useful error. */
+  reason?: string;
+  /** Index into `doc.rules` of the rule that decided, or -1 for default. */
+  matchedRuleIndex?: number;
+}
+
+/**
+ * Evaluate a tool-execute request against the project policy.
+ *
+ * **PR B stub**: always returns `{effect: 'allow', matchedRuleIndex: -1}`.
+ * Wired into the executor seam so PR C can implement real glob matching
+ * + condition eval here without touching every dispatch point.
+ *
+ * **Why a stub instead of skipping the call entirely**: every PR-B-shipped
+ * deployment runs through `evaluatePolicy` exactly the way PR C will, so
+ * we get telemetry on the call rate, ensure the seam compiles cleanly
+ * across providers, and lock in the request/decision shape against
+ * existing tests before the engine's behaviour changes.
+ */
+export function evaluatePolicy(
+  _doc: PolicyDocument,
+  _request: PolicyEvaluationRequest,
+): PolicyDecision {
+  return { effect: 'allow', matchedRuleIndex: -1 };
+}


### PR DESCRIPTION
## Summary

Second slice of the tool-policies feature. **Zero behaviour change** — this PR lays the file shape, the loader, and the single executor seam that every tool-execute path crosses, with an always-allow stub plugged in. PR C drops the engine into the seam without touching dispatch.

### Changes

**File shape + loader** ([packages/core/src/policy-store.ts](packages/core/src/policy-store.ts))
- Zod schema for \`.sua/policies.json\`: \`version: 1\`, \`defaultAction\`, \`rules[]\` with \`tool / action / resources[] / effect / conditions / reason\`.
- \`loadPolicyDocument(dataDir)\` returns the default allow-all doc when the file is missing; throws \`PolicyLoadError\` on parse / schema-invalid (loud failure on operator config bugs, not silent allow).
- \`DEFAULT_POLICY_DOCUMENT\` constant exported for tests + tooling.

**Executor seam** ([packages/core/src/dag-executor.ts](packages/core/src/dag-executor.ts))
- New optional \`policyDocument\` on \`DagExecutorDeps\` (defaults to allow-all when absent).
- \`evaluatePolicy()\` stub call inserted between tool resolution and \`tool.execute()\`. Throws \`PolicyDeniedError\` on deny — caught by the existing tool-dispatch catch, special-cased to set \`errorCategory: 'policy_denied'\` instead of the generic \`setup\`.
- \`extractPrimaryResource(node, toolId)\` helper pulls the URL/path/command the tool would touch (returns templated values as-is — by design, so authors can write deny rules against literal template strings).

**Error category** ([packages/core/src/agent-v2-types.ts](packages/core/src/agent-v2-types.ts))
- New \`'policy_denied'\` value on \`NodeErrorCategory\`. Intentionally NOT added to the default retryable-categories list in the retry schema — denying is a stable signal, not a transient failure.

### What ships in PRs C–D

- **C**: real glob matching (\`minimatch\`), condition eval (source-tier filters), agent-level \`policies:\` block, migration of \`--allow-untrusted-shell\` to a policy rule.
- **D**: \`sua policy list/check/add/remove\` CLI, \`/settings/policies\` CRUD page, \`sua doctor\` integration.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 1169/1169 (+14 new for schema validation, loader error paths, stub allow-all behaviour, error class shape)
- [x] Confirmed: existing executor tests still pass, no regression — the stub is a true no-op.
- [ ] After merge: \`echo '{"version":1,"defaultAction":"allow","rules":[]}' > .sua/policies.json\`, run any agent, verify it still works (sanity check that the loader reads + the seam compiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)