### PR TITLE
fix(prompts): planner emits signal.template=widget for outputWidget agents

### DIFF
--- a/.changeset/widget-signal-template.md
+++ b/.changeset/widget-signal-template.md
@@ -1,0 +1,19 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Planner prompts: teach the LLM to use `signal.template: widget` when the agent has an `outputWidget`.
+
+Pulse tile rendering is dispatched by `signal.template`, NOT by `outputWidget.type`. An agent with `outputWidget: { type: ai-template, template: <rich HTML> }` and `signal.template: text-headline` will silently render the bare headline on Pulse — the ai-template work is wasted.
+
+Both planner prompts (`agents/examples/agent-builder.yaml` and `agents/examples/build-planner.yaml`) previously omitted `widget` from the allowed `signal.template` list, so wizard-built rich-output agents could never reach Pulse with their template. Both now:
+
+- Include `widget` in the allowed list
+- Explicitly recommend `signal.template: widget` whenever the agent declares an `outputWidget`
+- Note that `signal.mapping` should be omitted in that case (the widget drives layout)
+
+The schema, autoFix, and Pulse Configure dialog have always accepted `widget` correctly — this PR closes the prompt gap that was preventing wizard-built agents from emitting it.

--- a/agents/examples/agent-builder.yaml
+++ b/agents/examples/agent-builder.yaml
@@ -115,7 +115,10 @@ nodes:
       Avoid controls on agents that are purely scheduled and never user-driven. Always reference declared field names — every name in field-toggle.fields[] and view-switch.views[].fields[] must match an outputWidget.fields[].name.
 
       SIGNAL TEMPLATE RULES:
-      - signal.template MUST be one of the names listed above (metric, time-series, text-headline, text-image, image, table, status, media, comparison, key-value, story, funnel).
+      - signal.template MUST be one of: metric, time-series, text-headline, text-image, image, table, status, media, comparison, key-value, story, funnel, widget.
+      - **`widget` is the right choice when the agent declares an `outputWidget`.** Pulse tile rendering is dispatched by `signal.template`, NOT by `outputWidget.type` — so an agent with `outputWidget: { type: ai-template, template: <rich HTML> }` and `signal.template: text-headline` will silently render the bare headline on Pulse and waste the ai-template entirely. Set `signal.template: widget` to make Pulse mirror the agent's outputWidget.
+      - When using `signal.template: widget`, omit `signal.mapping` — the outputWidget schema drives the layout, no slot mapping is needed. Keep `signal.title` as a static string (the chrome label).
+      - `text-headline`, `metric`, etc. are the right choice when the agent has NO outputWidget OR its outputWidget is a simple structured renderer (raw / key-value / dashboard) and you want the Pulse tile to be a glanceable summary instead of mirroring the full widget.
       - signal.title is a literal string. Do NOT use expression syntax like "'Weather: ' + output.city".
       - signal.mapping values are field names or "result" — not expressions.
 

--- a/agents/examples/build-planner.yaml
+++ b/agents/examples/build-planner.yaml
@@ -95,6 +95,12 @@ nodes:
       - DO NOT propose modifying any existing agent. (The user does that via /agents/<id>/yaml.)
       - Each new agent's YAML should include both signal: and outputWidget: blocks so dashboard
         tiles render correctly.
+      - **When the agent declares an `outputWidget`, set `signal.template: widget`.** Pulse tile
+        rendering is dispatched by `signal.template`, NOT `outputWidget.type` — so an agent with
+        `outputWidget: { type: ai-template, template: <rich HTML> }` and `signal.template:
+        text-headline` will render the bare headline on Pulse and the rich widget never appears.
+        With `signal.template: widget`, Pulse mirrors the agent's outputWidget. Omit `signal.mapping`
+        in that case; the widget drives layout, no slot mapping needed.
       - When the agent declares any `inputs:`, set `outputWidget.interactive: true`. This wires
         the pulse tile to render an inline inputs form + run button so users can re-run with
         tweaked values without leaving the dashboard. Skip this flag for purely scheduled agents


### PR DESCRIPTION
## Summary

You flagged that \`hn-top-stories-rich\`'s pulse tile renders a plain text-headline instead of the rich ai-template the agent declares. Root cause is in the planner prompts:

\`signal.template\` is what dispatches pulse tile rendering — NOT \`outputWidget.type\`. The two existed in separate worlds: an agent with \`outputWidget: { type: ai-template, template: <rich HTML> }\` and \`signal.template: text-headline\` would render the bare headline on pulse, wasting the ai-template.

The configure-tile panel + pulse-renderers + schema + autoFixYaml all already accept \`widget\` as a valid \`signal.template\` value. The bug was that **both planner prompts explicitly forbade it**:

- [agent-builder.yaml:118](agents/examples/agent-builder.yaml#L118): \`signal.template MUST be one of the names listed above (metric, time-series, text-headline, ..., funnel)\` — \`widget\` was missing from the list.
- [build-planner.yaml](agents/examples/build-planner.yaml) had no guidance at all.

So no wizard-built agent could ever land \`signal.template: widget\`, even when the agent had a rich ai-template outputWidget.

### Changes

- **\`agent-builder.yaml\`** — adds \`widget\` to the allowed list; explicitly recommends it for any agent with an outputWidget; notes that \`signal.mapping\` should be omitted with widget (the widget drives layout).
- **\`build-planner.yaml\`** — same guidance with a concrete example showing the failure mode.

### Live fix for the user's existing agent

\`hn-top-stories-rich\` was already in the user's DB with the broken combo. Upserted it to v4 with \`signal.template: widget\` + cleared \`signal.mapping\`. Pulse should render the rich ai-template now without any further action.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 1169/1169 (no test changes; this is a prompt-only fix)
- [x] Verified \`widget\` is in \`VALID_SIGNAL_TEMPLATES\` ([run-now-build.ts:215](packages/dashboard/src/routes/run-now-build.ts#L215)) so autoFix wouldn't strip it
- [x] Live-upserted hn-top-stories-rich to v4 with the fix
- [ ] After merge: hit "Build" with a goal that produces a rich ai-template (e.g. "daily HN digest with cards"), verify the planner now emits \`signal.template: widget\` and pulse renders the rich template

🤖 Generated with [Claude Code](https://claude.com/claude-code)