### PR TITLE
fix(dashboard): sticky pulse-tile footer so agent link stays reachable

### DIFF
--- a/.changeset/sticky-tile-footer.md
+++ b/.changeset/sticky-tile-footer.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Fix pulse tile footer being overlapped by tall interactive widgets.
+
+When a tile renders an interactive widget whose inputs form is taller than the tile's `max-height: 400px`, the footer (agent link + run age) used to scroll with the content and end up visually overlapped by the form fields — making the agent link unreachable and the timestamp invisible.
+
+`.pulse-tile__footer` now uses `position: sticky; bottom: 0; background: var(--color-surface)` so it pins to the bottom of the visible tile area regardless of how tall the body is. `margin-top: auto` is preserved so it still sits at the bottom of the flex column when content is short.

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -1024,7 +1024,17 @@ main.main--wide {
   font-size: var(--font-size-xs);
   border-top: 1px solid var(--color-border);
   padding-top: var(--space-2);
+  /* Stick to the bottom of the (potentially scrolling) tile viewport so
+   * the agent link and timestamp stay reachable when an interactive
+   * widget's form overflows the tile's max-height. Without this the
+   * footer scrolls with content and gets visually overlapped by tall
+   * inputs forms. `margin-top: auto` still pushes it to the bottom of
+   * the flex column when content is short. */
+  position: sticky;
+  bottom: 0;
   margin-top: auto;
+  background: var(--color-surface);
+  z-index: 1;
 }
 
 .pulse-tile__agent {


### PR DESCRIPTION
## Summary

Closes the layout bug from your screenshot: when a pulse tile renders an interactive widget (e.g. \`ashby-job-finder\`) whose inputs form is taller than the tile's \`max-height: 400px\`, the footer (\`ashby-job-finder\` link + run age) scrolled with the content and got visually overlapped by the form fields — making the agent link unreachable and the timestamp invisible.

### Fix

\`.pulse-tile__footer\` now uses \`position: sticky; bottom: 0\` with a solid background ([screens.css:1020](packages/dashboard/src/assets/screens.css#L1020)). It pins to the bottom of the visible tile area regardless of body height. \`margin-top: auto\` is preserved so when the content is short the footer still sits at the natural bottom of the flex column.

### Why not constrain widget height instead

Considered making the interactive widget's body scroll internally so the tile flex layout sees a fixed height — but that adds a nested scroll surface (form fields + result inside an inner scroller, while the tile itself never scrolls), which is worse UX than letting the tile scroll as a whole with a sticky chrome footer.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 1169/1169 (no test changes; CSS-only fix)
- [ ] After merge: refresh \`/agents/ashby-job-finder\` pulse → tile body scrolls when needed; footer (agent link + age) stays pinned at the bottom of the visible area; clicking the agent link works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)