### PR TITLE
fix(dashboard): pulse tile body scrolls; chrome stays pinned

### DIFF
--- a/.changeset/tile-body-scroll.md
+++ b/.changeset/tile-body-scroll.md
@@ -1,0 +1,9 @@
+---
+"@some-useful-agents/dashboard": patch
+---
+
+Pulse tile body now scrolls; chrome (header + footer) stays pinned.
+
+The previous fix for tall interactive-widget tiles used a sticky footer, which sat on top of the form's last input and obscured it because both used the same surface colour. New layout splits the tile into a static frame (header + footer + resize handle) and a `.pulse-tile__body` wrapper that owns the scroll. The agent link in the footer now stays reachable AND visually separate from the form, regardless of widget content height.
+
+Same `.pulse-tile__body` class the home widgets already used; CSS adds `flex: 1; min-height: 0; overflow-y: auto` plus a flex column with the existing gap so renderers don't have to think about it.

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -954,8 +954,25 @@ main.main--wide {
   gap: var(--space-3);
   min-height: 120px;
   max-height: 400px;
-  overflow-y: auto;
+  /* The tile itself doesn't scroll — the body wrapper inside does. This
+   * keeps the chrome (header + footer) reachable regardless of how tall
+   * the content gets. Overflow:hidden also stops absolutely-positioned
+   * descendants from spilling outside the rounded corners. */
+  overflow: hidden;
   transition: padding 150ms ease-out, min-height 150ms ease-out, gap 150ms ease-out;
+}
+
+/* Scrollable inner region between header and footer. `min-height: 0`
+ * is the magic flex incantation that lets a scrolling child shrink
+ * below its content's intrinsic size — without it the body would
+ * happily grow to its full height and break the parent's max-height. */
+.pulse-tile__body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
 }
 
 .pulse-tile--2x2 { max-height: 600px; }
@@ -1024,17 +1041,11 @@ main.main--wide {
   font-size: var(--font-size-xs);
   border-top: 1px solid var(--color-border);
   padding-top: var(--space-2);
-  /* Stick to the bottom of the (potentially scrolling) tile viewport so
-   * the agent link and timestamp stay reachable when an interactive
-   * widget's form overflows the tile's max-height. Without this the
-   * footer scrolls with content and gets visually overlapped by tall
-   * inputs forms. `margin-top: auto` still pushes it to the bottom of
-   * the flex column when content is short. */
-  position: sticky;
-  bottom: 0;
-  margin-top: auto;
-  background: var(--color-surface);
-  z-index: 1;
+  /* Footer is the last flex child of `.pulse-tile`. The body wrapper
+   * above us scrolls; we sit just below it as static chrome, always
+   * reachable regardless of content height. `flex-shrink: 0` keeps us
+   * from being squeezed when the body's intrinsic content is tall. */
+  flex-shrink: 0;
 }
 
 .pulse-tile__agent {

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -45,10 +45,18 @@ export function tileWrap(
   const accentAttr = tile.signal.accent
     ? ` data-accent="${esc(tile.signal.accent)}"`
     : '';
+  // Tile chrome (header + footer) sits *outside* the scrolling body so
+  // long content (notably interactive-widget forms whose stacked panes
+  // dominate the grid cell height) can't push the agent link below the
+  // visible bottom edge. The `pulse-tile__body` wrapper is the same
+  // class the home widgets already use; the CSS lets it `flex: 1` and
+  // own the overflow.
   return unsafeHtml(
     `<div class="pulse-tile ${sizeClass(sizeAttr)}" data-agent-id="${esc(tile.agent.id)}" data-tile-size="${esc(sizeAttr)}"${paletteAttr}${accentAttr}>` +
     tileHeader(tile, isSystem, ctx).toString() +
+    `<div class="pulse-tile__body">` +
     content.toString() +
+    `</div>` +
     (isSystem ? '' : tileFooter(tile).toString()) +
     '<div class="pulse-tile__resize-handle" data-agent-id="' + esc(tile.agent.id) + '"></div>' +
     '</div>'


### PR DESCRIPTION
## Summary

Replaces the sticky-footer hack from #240 (which obscured the last form input because both shared the same surface colour) with a cleaner layout: tile chrome (header + footer + resize handle) sits **outside** the scroll surface; a new \`.pulse-tile__body\` wrapper owns the overflow.

### Layout

\`\`\`
.pulse-tile (overflow: hidden)
  ├── .pulse-tile__header     (chrome, always visible)
  ├── .pulse-tile__body       (flex: 1; min-height: 0; overflow-y: auto)
  │     └── widget content    (scrolls when tall)
  └── .pulse-tile__footer     (chrome, always visible)
\`\`\`

\`min-height: 0\` is the magic flex incantation that lets a scrolling child shrink below its content's intrinsic size — without it the body would happily grow to its full height and break the parent's max-height.

\`.pulse-tile__body\` is already the class home widgets used — reusing it means the home page tiles inherit the same behaviour.

### Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 1169/1169 (CSS-only behavior change)
- [x] Eyeballed live: \`/agents/weather-dashboard\` pulse — widget result + form scroll inside; agent link in footer stays pinned and clickable; nothing visually overlaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)