### PR TITLE
fix(dashboard): persist edit mode across page reloads

### DIFF
--- a/.changeset/persistent-edit-mode.md
+++ b/.changeset/persistent-edit-mode.md
@@ -1,0 +1,9 @@
+---
+"@some-useful-agents/dashboard": patch
+---
+
+Edit mode on Pulse + dashboards now persists across page reloads.
+
+Edit Layout was a JS-only toggle that reset to off on every full page reload. Since most edit actions (configure tile, change palette, hide signal, drag-and-drop save, container delete) trigger a form POST + redirect, every tweak kicked the user out of edit mode and they had to click Edit Layout again before the next change.
+
+Persisted now in localStorage under `${storageKey}-edit-mode` (matched the existing `-palettes` / `-sizes` / `-collapsed` keys). Per-dashboard isolation is automatic via the runtime key suffix already used for the other keys.

--- a/packages/dashboard/src/views/widget-layout.js.ts
+++ b/packages/dashboard/src/views/widget-layout.js.ts
@@ -45,6 +45,7 @@ export function widgetLayoutJS(config: WidgetLayoutConfig): string {
   const paletteKey = config.paletteKey ?? `${config.storageKey}-palettes`;
   const sizesKey = config.sizesKey ?? `${config.storageKey}-sizes`;
   const collapsedKey = config.collapsedKey ?? `${config.storageKey}-collapsed`;
+  const editModeKey = `${config.storageKey}-edit-mode`;
 
   return `
   // ── Widget layout: containers, drag-and-drop, palette (${config.prefix}) ──
@@ -63,6 +64,7 @@ export function widgetLayoutJS(config: WidgetLayoutConfig): string {
     var PALETTE_KEY = '${paletteKey}' + (KEY_SUFFIX ? '-' + KEY_SUFFIX : '');
     var SIZES_KEY = '${sizesKey}' + (KEY_SUFFIX ? '-' + KEY_SUFFIX : '');
     var COLLAPSED_KEY = '${collapsedKey}' + (KEY_SUFFIX ? '-' + KEY_SUFFIX : '');
+    var EDIT_MODE_KEY = '${editModeKey}' + (KEY_SUFFIX ? '-' + KEY_SUFFIX : '');
     var PALETTES = ['default', 'dark', 'light', 'accent-teal', 'accent-red', 'accent-green'];
 
     function isProtected(id) {
@@ -328,12 +330,27 @@ export function widgetLayoutJS(config: WidgetLayoutConfig): string {
     });
 
     // ── Edit mode toggle ─────────────────────────────────────────────
-    var editMode = false;
+    // Persist edit mode in localStorage so it survives the full page
+    // reloads our form-driven actions trigger (configure tile, change
+    // palette, hide signal, etc.). Without this, every tweak kicked the
+    // user out of edit mode and they had to click Edit Layout again.
+    function getEditMode() {
+      try { return localStorage.getItem(EDIT_MODE_KEY) === '1'; } catch { return false; }
+    }
+    function saveEditMode(on) {
+      try {
+        if (on) localStorage.setItem(EDIT_MODE_KEY, '1');
+        else localStorage.removeItem(EDIT_MODE_KEY);
+      } catch {}
+    }
+
+    var editMode = getEditMode();
     var editBtn = document.getElementById('${config.editToggleId}');
     var addContainerBtn = document.getElementById('${config.addContainerId}');
 
     function setEditMode(on) {
       editMode = on;
+      saveEditMode(on);
       document.body.classList.toggle('pulse-edit-mode', on);
       if (editBtn) editBtn.textContent = on ? '\\u2713 Done editing' : '\\u270E Edit layout';
       if (editBtn) editBtn.classList.toggle('btn--primary', on);
@@ -356,6 +373,11 @@ export function widgetLayoutJS(config: WidgetLayoutConfig): string {
     if (editBtn) {
       editBtn.addEventListener('click', function() { setEditMode(!editMode); });
     }
+
+    // Apply persisted edit mode on initial load. Runs *after* the
+    // setEditMode definition so the visual state catches up with the
+    // boolean read from localStorage above.
+    if (editMode) setEditMode(true);
 
     // ── Drag and drop ────────────────────────────────────────────────
     var draggedId = null;


### PR DESCRIPTION
## Summary

Edit Layout was a JS-only toggle that reset to off on every full page reload. Most edit actions trigger a form POST + redirect (configure tile, change palette, hide signal, drag-and-drop save, container delete) — so every tweak kicked the user out of edit mode and they had to click Edit Layout *again* before the next change. Hence your "we need an affordance to keep the dashboard in edit mode beyond a single widget change" ask.

### Fix

Persisted in localStorage under \`\${storageKey}-edit-mode\` ([widget-layout.js.ts:48](packages/dashboard/src/views/widget-layout.js.ts#L48)). Same pattern + suffix scheme as the existing \`-palettes\` / \`-sizes\` / \`-collapsed\` keys, so each dashboard remembers its own edit-mode state via the runtime key suffix.

\`\`\`js
function getEditMode() {
  try { return localStorage.getItem(EDIT_MODE_KEY) === '1'; } catch { return false; }
}
function saveEditMode(on) {
  try {
    if (on) localStorage.setItem(EDIT_MODE_KEY, '1');
    else localStorage.removeItem(EDIT_MODE_KEY);
  } catch {}
}

var editMode = getEditMode();
// ... setEditMode now calls saveEditMode(on) on every toggle
if (editMode) setEditMode(true);  // restore visual state on init
\`\`\`

### Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 1169/1169 (no test changes; pure JS-snippet behaviour)
- [ ] After merge: enter Edit Layout on \`/pulse\`, change a palette, the page reloads — you stay in edit mode. Click Done editing to exit; reload — you stay out. Same on \`/dashboards/<id>\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)