### PR TITLE
fix(dashboard): pulse tile × button toggles pulseVisible, not signal.hidden

### DIFF
--- a/.changeset/fix-pulse-x-toggle.md
+++ b/.changeset/fix-pulse-x-toggle.md
@@ -1,0 +1,7 @@
+---
+"@some-useful-agents/dashboard": patch
+---
+
+Fix the × button on pulse tiles — it was toggling the legacy `signal.hidden` field, but the pulse-visibility filter has preferred `pulseVisible` since v0.19. Once any agent had `pulseVisible` set (which the Config-tab visibility toggle does on first click), clicking × posted successfully but the tile stayed visible.
+
+`POST /agents/:id/signal/toggle` now flips `pulseVisible` instead. The hide-all / show-all handlers + the Config-tab toggles all use the same field, so behaviour is consistent across surfaces.

--- a/packages/dashboard/src/routes/pulse-toggle.test.ts
+++ b/packages/dashboard/src/routes/pulse-toggle.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Regression test for the X-button on a pulse tile.
+ *
+ * The handler used to toggle the legacy `signal.hidden` field, but the
+ * pulse-visibility filter has preferred `pulseVisible` since v0.19 —
+ * once any agent had pulseVisible set (which the Config-tab visibility
+ * toggle does on the first click), the X button posted successfully
+ * but the tile stayed visible. This test locks in the new behaviour:
+ * clicking X flips pulseVisible so the next render hides the tile.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import request from 'supertest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AgentStore,
+  DashboardsStore,
+  LocalProvider,
+  MemorySecretsStore,
+  PacksStore,
+  RunStore,
+  buildLoopbackAllowlist,
+  loadAgents,
+} from '@some-useful-agents/core';
+import { buildDashboardApp } from '../index.js';
+import type { DashboardContext } from '../context.js';
+import { SESSION_COOKIE } from '../auth-middleware.js';
+import { MemorySecretsSession } from '../secrets-session.js';
+
+const TOKEN = 'a'.repeat(64);
+const PORT = 3997;
+const COOKIE = `${SESSION_COOKIE}=${TOKEN}`;
+
+let dir: string;
+let provider: LocalProvider;
+let runStore: RunStore;
+let agentStore: AgentStore;
+let packsStore: PacksStore;
+let dashboardsStore: DashboardsStore;
+
+async function makeApp(initial: { pulseVisible?: boolean }) {
+  dir = mkdtempSync(join(tmpdir(), 'sua-pulse-toggle-'));
+  const dbPath = join(dir, 'runs.db');
+  const agentsDir = join(dir, 'agents', 'local');
+  mkdirSync(agentsDir, { recursive: true });
+
+  const secretsStore = new MemorySecretsStore();
+  runStore = new RunStore(dbPath);
+  agentStore = new AgentStore(dbPath);
+  packsStore = new PacksStore(dbPath);
+  dashboardsStore = new DashboardsStore(dbPath);
+  provider = new LocalProvider(dbPath, secretsStore);
+  await provider.initialize();
+
+  agentStore.createAgent({
+    id: 'tile-a',
+    name: 'Tile A',
+    status: 'active',
+    source: 'local',
+    mcp: false,
+    pulseVisible: initial.pulseVisible,
+    nodes: [{ id: 'n', type: 'shell', command: 'echo hi', dependsOn: [] }],
+    signal: { title: 'A', template: 'text-headline', mapping: { headline: 'result' } },
+  }, 'cli');
+
+  const ctx: DashboardContext = {
+    token: TOKEN,
+    allowlist: buildLoopbackAllowlist(PORT),
+    port: PORT,
+    provider,
+    runStore,
+    agentStore,
+    loadAgents: () => loadAgents({ directories: [agentsDir] }),
+    secretsStore,
+    secretsSession: new MemorySecretsSession({ backing: secretsStore }),
+    tokenPath: join(dir, 'mcp-token'),
+    retentionDays: 30,
+    dbPath,
+    secretsPath: join(dir, 'secrets.enc'),
+    rotateToken: () => 'r'.repeat(64),
+    packsStore,
+    dashboardsStore,
+    allowUntrustedShell: new Set(),
+    activeRuns: new Map(),
+    dataDir: dir,
+    dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
+  };
+
+  return buildDashboardApp(ctx);
+}
+
+afterEach(async () => {
+  if (provider) {
+    const start = Date.now();
+    while ((provider as unknown as { running?: { size: number } }).running?.size && Date.now() - start < 2000) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    await provider.shutdown();
+  }
+  try { runStore?.close(); } catch { /* ignore */ }
+  try { agentStore?.close(); } catch { /* ignore */ }
+  try { packsStore?.close(); } catch { /* ignore */ }
+  try { dashboardsStore?.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('POST /agents/:id/signal/toggle', () => {
+  it('hides a tile whose pulseVisible was previously true', async () => {
+    const app = await makeApp({ pulseVisible: true });
+    expect(agentStore.getAgent('tile-a')!.pulseVisible).toBe(true);
+    const res = await request(app).post('/agents/tile-a/signal/toggle')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(303);
+    expect(agentStore.getAgent('tile-a')!.pulseVisible).toBe(false);
+  });
+
+  it('hides a tile whose pulseVisible was undefined (default visible)', async () => {
+    const app = await makeApp({});
+    expect(agentStore.getAgent('tile-a')!.pulseVisible).toBeUndefined();
+    const res = await request(app).post('/agents/tile-a/signal/toggle')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(303);
+    expect(agentStore.getAgent('tile-a')!.pulseVisible).toBe(false);
+  });
+
+  it('restores a tile whose pulseVisible was false', async () => {
+    const app = await makeApp({ pulseVisible: false });
+    expect(agentStore.getAgent('tile-a')!.pulseVisible).toBe(false);
+    const res = await request(app).post('/agents/tile-a/signal/toggle')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(303);
+    expect(agentStore.getAgent('tile-a')!.pulseVisible).toBe(true);
+  });
+});

--- a/packages/dashboard/src/routes/pulse.ts
+++ b/packages/dashboard/src/routes/pulse.ts
@@ -166,12 +166,15 @@ pulseRouter.post('/agents/:id/signal/toggle', (req: Request, res: Response) => {
     return;
   }
 
+  // Flip pulseVisible — the master visibility switch that the pulse
+  // page filter actually reads. Toggling signal.hidden here used to
+  // appear to do nothing once an agent had pulseVisible set, because
+  // the filter prefers pulseVisible when it's not undefined.
+  // Currently-visible includes `undefined` (default) and `true`; we
+  // collapse both to false on the click.
+  const currentlyVisible = agent.pulseVisible !== false;
   try {
-    const updated = {
-      ...agent,
-      signal: { ...agent.signal, hidden: !agent.signal.hidden },
-    };
-    ctx.agentStore.upsertAgent(updated, 'dashboard', agent.signal.hidden ? 'Unhide signal tile' : 'Hide signal tile');
+    ctx.agentStore.updateAgentMeta(id, { pulseVisible: !currentlyVisible });
     res.redirect(303, '/pulse');
   } catch {
     res.redirect(303, '/pulse');


### PR DESCRIPTION
## Summary

You reported the × button on pulse tiles doesn't work. It POSTs successfully but the tile stays visible.

Root cause: \`POST /agents/:id/signal/toggle\` flipped the legacy \`signal.hidden\` field, but the pulse-visibility filter ([pulse.ts:133-134](packages/dashboard/src/routes/pulse.ts#L133-L134)) has preferred \`pulseVisible\` since v0.19:

\`\`\`ts
const pulseHidden = agent.pulseVisible === false
  || (agent.pulseVisible === undefined && agent.signal.hidden === true);
\`\`\`

Once an agent has \`pulseVisible\` set (which the Config-tab Show on Pulse toggle does on first click), \`signal.hidden\` is ignored. So × posted, server flipped the wrong field, render skipped it.

### Fix

Handler now flips \`pulseVisible\` via \`updateAgentMeta\`. Matches the hide-all / show-all handlers and the Config-tab toggle on the same field.

### Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 1172/1172 (+3 new regression tests covering pulseVisible starting at \`true\` / \`undefined\` / \`false\`)
- [ ] After merge + daemon restart: enter Edit Layout on /pulse, click × on a tile, the tile is gone on reload. Tile reappears under "Hidden tiles" — click "Show" to bring it back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)