### PR TITLE
fix(mcp-server): support port=0 + return bound port on handle

### DIFF
--- a/.changeset/mcp-test-os-port.md
+++ b/.changeset/mcp-test-os-port.md
@@ -1,0 +1,9 @@
+---
+"@some-useful-agents/mcp-server": minor
+---
+
+`startMcpServer` now accepts `port: 0` and returns the kernel-assigned port on the handle.
+
+`McpServerHandle` gains a `port` field — same as `options.port` when the caller asked for a specific port; the OS-assigned port when the caller passed `port: 0`. The Host/Origin allowlist is rebuilt after the listen completes so requests against the bound port are accepted.
+
+Internal: tests in `packages/mcp-server/src/server.test.ts` now use this, eliminating the random-port-pool collision that surfaced as intermittent `UND_ERR_SOCKET` flakes on CI.

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -67,6 +67,14 @@ function rejectIfNotOk(res: ServerResponse, check: AuthCheckResult): boolean {
 
 /** Handle returned by `startMcpServer` so callers (tests, CLI) can shut down cleanly. */
 export interface McpServerHandle {
+  /**
+   * The actual TCP port the server bound to. Same as `options.port` when
+   * the caller asked for a specific port; the OS-assigned port when the
+   * caller passed `port: 0`. Tests rely on the latter so each instance
+   * gets a guaranteed-unique port and parallel runs don't collide on a
+   * narrow random pool.
+   */
+  port: number;
   /** Stop accepting new connections, drain the provider, and close the http server. */
   shutdown(): Promise<void>;
 }
@@ -103,7 +111,11 @@ export async function startMcpServer(options: McpServerOptions): Promise<McpServ
   };
 
   const sessions = new Map<string, SessionEntry>();
-  const allowlist = buildLoopbackAllowlist(options.port);
+  // Allowlist is reassigned once the server has actually bound — when
+  // the caller passes `port: 0`, options.port is meaningless and we
+  // need to authorize the kernel-assigned port instead. `let` so the
+  // request-handler closure picks up the post-listen value.
+  let allowlist = buildLoopbackAllowlist(options.port);
 
   const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
     const url = new URL(req.url ?? '/', `http://${host}:${options.port}`);
@@ -208,13 +220,26 @@ export async function startMcpServer(options: McpServerOptions): Promise<McpServ
     httpServer.once('error', reject);
     httpServer.listen(options.port, host, () => {
       httpServer.removeListener('error', reject);
-      const displayHost = host === '0.0.0.0' || host === '::' ? '<all interfaces>' : host;
-      console.log(`MCP server listening on http://${displayHost}:${options.port}/mcp`);
-      console.log(`Health check: http://${displayHost}:${options.port}/health`);
-      console.log(`Bearer token: ${tokenPath}`);
       resolve();
     });
   });
+
+  // Resolve the actual bound port. `options.port` may be 0 (OS chooses)
+  // — `httpServer.address()` returns the kernel-assigned port we should
+  // report to callers and log to the operator.
+  const addr = httpServer.address();
+  const actualPort = typeof addr === 'object' && addr !== null ? addr.port : options.port;
+  // Rebuild the Host/Origin allowlist now that we know the real port.
+  // Skipping this when port=0 leaves the allowlist pointing at the
+  // sentinel and every incoming request gets rejected with
+  // `Host header "..." is not allowed`.
+  if (actualPort !== options.port) {
+    allowlist = buildLoopbackAllowlist(actualPort);
+  }
+  const displayHost = host === '0.0.0.0' || host === '::' ? '<all interfaces>' : host;
+  console.log(`MCP server listening on http://${displayHost}:${actualPort}/mcp`);
+  console.log(`Health check: http://${displayHost}:${actualPort}/health`);
+  console.log(`Bearer token: ${tokenPath}`);
 
   let shuttingDown = false;
   const shutdown = async (): Promise<void> => {
@@ -238,5 +263,5 @@ export async function startMcpServer(options: McpServerOptions): Promise<McpServ
     process.exit(0);
   });
 
-  return { shutdown };
+  return { port: actualPort, shutdown };
 }

--- a/packages/mcp-server/src/server.test.ts
+++ b/packages/mcp-server/src/server.test.ts
@@ -19,13 +19,13 @@ describe('MCP server multi-session', () => {
   let dataDir: string;
   let tokenPath: string;
   let secretsPath: string;
+  // Bound port populated from `serverHandle.port` after startMcpServer
+  // returns. We pass `port: 0` so the OS picks an available port — this
+  // eliminates the collision class that came from `Math.random()` against
+  // a narrow pool, which surfaced as `UND_ERR_SOCKET` flakes in CI when a
+  // prior test's half-torn-down connection lingered.
   let port: number;
-  // Handle from startMcpServer; afterEach uses it to drain the http server
-  // before deleting the tmpdir + ending the test. Without this the http
-  // server keeps listening on the random port and a future test that hits
-  // the same port talks to a server pointing at a deleted agentDir,
-  // surfacing as flaky "Agent ... not found" in CI.
-  let serverHandle: { shutdown: () => Promise<void> } | undefined;
+  let serverHandle: { port: number; shutdown: () => Promise<void> } | undefined;
 
   beforeEach(() => {
     dataDir = mkdtempSync(join(tmpdir(), 'sua-mcp-multi-'));
@@ -33,8 +33,7 @@ describe('MCP server multi-session', () => {
     writeFileSync(tokenPath, 't'.repeat(64));
     chmodSync(tokenPath, 0o600);
     secretsPath = join(dataDir, 'secrets.enc');
-    // Pick a high random port to avoid stomping on the user's running server.
-    port = 18000 + Math.floor(Math.random() * 1000);
+    port = 0; // populated from serverHandle.port once the server boots
   });
 
   afterEach(async () => {
@@ -47,13 +46,14 @@ describe('MCP server multi-session', () => {
 
   it('serves two independent initialize requests without crashing', async () => {
     serverHandle = await startMcpServer({
-      port,
+      port: 0,
       host: '127.0.0.1',
       agentDirs: [dataDir], // empty dir — agent loader returns no agents
       dbPath: join(dataDir, 'runs.db'),
       secretsPath,
       tokenPath,
     });
+    port = serverHandle.port;
 
     const token = 't'.repeat(64);
     const init = {
@@ -113,11 +113,11 @@ describe('MCP run-agent with inputs', () => {
   let agentDir: string;
   let tokenPath: string;
   let secretsPath: string;
+  // Populated from serverHandle.port after startMcpServer returns. Each
+  // test passes `port: 0` so the OS picks a guaranteed-unique port —
+  // see the note in the first describe block.
   let port: number;
-  // See note in the first describe block — without this the random-port
-  // pool collides across tests and a fresh test ends up talking to a
-  // prior test's still-running server (whose agentDir was rm'd).
-  let serverHandle: { shutdown: () => Promise<void> } | undefined;
+  let serverHandle: { port: number; shutdown: () => Promise<void> } | undefined;
 
   beforeEach(() => {
     dataDir = mkdtempSync(join(tmpdir(), 'sua-mcp-run-'));
@@ -127,7 +127,7 @@ describe('MCP run-agent with inputs', () => {
     writeFileSync(tokenPath, 't'.repeat(64));
     chmodSync(tokenPath, 0o600);
     secretsPath = join(dataDir, 'secrets.enc');
-    port = 19000 + Math.floor(Math.random() * 500);
+    port = 0; // populated from serverHandle.port once the server boots
 
     // A simple shell agent that echoes the TOPIC input. The shell command
     // template-substitutes inputs.TOPIC at execute time. Single-quoted so
@@ -172,13 +172,14 @@ describe('MCP run-agent with inputs', () => {
 
   it('list-agents returns the declared input schema', async () => {
     serverHandle = await startMcpServer({
-      port,
+      port: 0,
       host: '127.0.0.1',
       agentDirs: [agentDir],
       dbPath: join(dataDir, 'runs.db'),
       secretsPath,
       tokenPath,
     });
+    port = serverHandle.port;
 
     const client = await connectClient();
     try {
@@ -196,13 +197,14 @@ describe('MCP run-agent with inputs', () => {
 
   it('run-agent threads inputs through to the run', async () => {
     serverHandle = await startMcpServer({
-      port,
+      port: 0,
       host: '127.0.0.1',
       agentDirs: [agentDir],
       dbPath: join(dataDir, 'runs.db'),
       secretsPath,
       tokenPath,
     });
+    port = serverHandle.port;
 
     const client = await connectClient();
     try {
@@ -221,13 +223,14 @@ describe('MCP run-agent with inputs', () => {
 
   it('run-agent returns an MCP error when a required input is missing', async () => {
     serverHandle = await startMcpServer({
-      port,
+      port: 0,
       host: '127.0.0.1',
       agentDirs: [agentDir],
       dbPath: join(dataDir, 'runs.db'),
       secretsPath,
       tokenPath,
     });
+    port = serverHandle.port;
 
     const client = await connectClient();
     try {
@@ -245,13 +248,14 @@ describe('MCP run-agent with inputs', () => {
 
   it('run-agent rejects oversize input values before submitting', async () => {
     serverHandle = await startMcpServer({
-      port,
+      port: 0,
       host: '127.0.0.1',
       agentDirs: [agentDir],
       dbPath: join(dataDir, 'runs.db'),
       secretsPath,
       tokenPath,
     });
+    port = serverHandle.port;
 
     const client = await connectClient();
     try {


### PR DESCRIPTION
## Summary

Hardens the MCP server tests against the random-port-pool race that surfaced as the \`UND_ERR_SOCKET\` flake on #244's CI. \`startMcpServer\` now accepts \`port: 0\` and returns the kernel-assigned port on its handle.

### Changes

- **\`McpServerHandle.port\`** — the actually-bound port. Same as \`options.port\` when the caller asked for a specific port; the OS-assigned port when the caller passed \`0\`.
- **Host/Origin allowlist rebuilt after \`listen()\`** — without this, every request against the kernel-assigned port was rejected as "Host header not allowed". Closure captures the \`let\` binding so the request handler picks up the new value.
- **Console logging** uses the actual port instead of \`options.port\` (which is meaningless when the caller passed \`0\`).
- **\`server.test.ts\` uses \`port: 0\` everywhere** + reads \`serverHandle.port\` to build URLs. Eliminates the random-pool collision class entirely.

### Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 1175/1175. Local re-runs no longer produce the flake.
- [x] Verified the new \`McpServerHandle.port\` is the OS-assigned port (51061/51063/etc. across the run, all unique).

🤖 Generated with [Claude Code](https://claude.com/claude-code)