### PR TITLE
feat(dashboard): home tiles get palette + collapse parity with pulse

### DIFF
--- a/.changeset/home-tile-affordances.md
+++ b/.changeset/home-tile-affordances.md
@@ -1,0 +1,9 @@
+---
+"@some-useful-agents/dashboard": minor
+---
+
+Home-page tiles get palette + collapse parity with pulse + dashboard tiles.
+
+The root home page (`/`) renders system widgets via a separate code path (`renderHomeWidget`) that stripped the tile chrome — no palette button, no collapse chevron — so users in edit mode couldn't change tile appearance the way they can on `/pulse` or `/dashboards/<id>`. Now both are rendered on home tiles too. The configure (⚙) and × delete buttons remain omitted: system widgets are hardcoded renderers (Scheduled, Recent Activity, etc.), not template-driven — the template picker / slot mapping in the configure modal don't apply, and these tiles are persistent by design.
+
+The collapse click handler moved from `pulse-layout.js.ts` (which used a hardcoded `sua-pulse-collapsed` storage key) into `widget-layout.js.ts` so each surface scopes its persistence correctly. The duplicate handler in `dashboards-layout.js.ts` was also removed to avoid double-toggle. Net result: pulse, home, and per-dashboard collapse state all persist under their own keys.

--- a/packages/dashboard/src/views/dashboards-layout.js.ts
+++ b/packages/dashboard/src/views/dashboards-layout.js.ts
@@ -23,53 +23,8 @@ export const DASHBOARDS_LAYOUT_JS = widgetLayoutJS({
   sizesKey: 'sua-dashboard-sizes',
   collapsedKey: 'sua-dashboard-collapsed',
   runtimeKeySuffixAttr: 'data-dashboard-id',
-}) + `
-  // ── Dashboard tile collapse/expand ──────────────────────────────────
-  // Mirrors the Pulse collapse handler. Lives here (not in pulse-layout)
-  // because the storage key needs the runtime dashboard-id suffix.
-  (function () {
-    var host = document.getElementById('dashboard-containers');
-    if (!host) return;
-    var dashId = host.getAttribute('data-dashboard-id') || '';
-    var STORAGE_KEY = 'sua-dashboard-collapsed' + (dashId ? '-' + dashId : '');
+});
+// Collapse/expand handler now lives in widget-layout.js.ts so each
+// surface scopes its persistence properly; removed the duplicate here
+// to avoid double-toggling.
 
-    function getCollapsed() {
-      try { return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}'); } catch { return {}; }
-    }
-    function setCollapsed(map) {
-      try { localStorage.setItem(STORAGE_KEY, JSON.stringify(map)); } catch {}
-    }
-
-    var collapsed = getCollapsed();
-    var tiles = host.querySelectorAll('.pulse-tile');
-    for (var i = 0; i < tiles.length; i++) {
-      var btn = tiles[i].querySelector('.pulse-tile__collapse');
-      if (btn) {
-        var id = btn.getAttribute('data-tile-id');
-        if (id && collapsed[id]) tiles[i].classList.add('pulse-tile--collapsed');
-      }
-    }
-
-    document.addEventListener('click', function (e) {
-      var target = e.target;
-      var tileId = null;
-      if (target.classList && target.classList.contains('pulse-tile__collapse')) {
-        tileId = target.getAttribute('data-tile-id');
-      } else if (target.closest && target.closest('[data-collapse-trigger]')) {
-        tileId = target.closest('[data-collapse-trigger]').getAttribute('data-tile-id');
-      }
-      if (!tileId) return;
-      var tile = target.closest('.pulse-tile');
-      if (!tile || !host.contains(tile)) return; // only act on dashboards-page tiles
-
-      tile.classList.toggle('pulse-tile--collapsed');
-      var map = getCollapsed();
-      if (tile.classList.contains('pulse-tile--collapsed')) {
-        map[tileId] = true;
-      } else {
-        delete map[tileId];
-      }
-      setCollapsed(map);
-    });
-  })();
-`;

--- a/packages/dashboard/src/views/home-widgets.ts
+++ b/packages/dashboard/src/views/home-widgets.ts
@@ -359,16 +359,32 @@ export function buildHomeWidgets(data: HomeWidgetData): SystemWidget[] {
  * Matches the Pulse tile chrome so the shared layout JS can manage it.
  */
 export function renderHomeWidget(widget: SystemWidget): SafeHtml {
+  // Mirrors the chrome on pulse tiles (collapse + palette buttons + resize
+  // handle) so users can recolor + collapse system widgets in edit mode.
+  // The configure (⚙) and × delete buttons are intentionally omitted:
+  // - configure: system widgets are hardcoded renderers, not template-driven
+  //   — the template picker / slot mapping in the configure modal don't apply.
+  // - delete: system widgets are persistent; removing one would just leave a
+  //   gap on every refresh.
+  // Palette + collapse parity covers the "I want to customise these tiles"
+  // ask without dragging template-picker complexity onto fixed renderers.
+  const id = escHtml(widget.id);
   return unsafeHtml(
-    `<div class="pulse-tile" data-agent-id="${escHtml(widget.id)}">` +
+    `<div class="pulse-tile" data-agent-id="${id}">` +
     `<div class="pulse-tile__header">` +
+    `<button type="button" class="pulse-tile__collapse" data-tile-id="${id}" title="Collapse/expand">▼</button>` +
+    `<div style="display: flex; align-items: center; gap: var(--space-2); flex: 1; cursor: pointer;" data-tile-id="${id}" data-collapse-trigger>` +
     `<span class="pulse-tile__icon">${widget.icon}</span>` +
     `<span class="pulse-tile__title">${escHtml(widget.title)}</span>` +
+    `</div>` +
+    `<div style="display: flex; gap: var(--space-1); align-items: center;">` +
+    `<button type="button" class="pulse-tile__palette-btn" data-tile-id="${id}" title="Change palette">●</button>` +
+    `</div>` +
     `</div>` +
     `<div class="pulse-tile__body" style="padding: var(--space-3);">` +
     widget.html.toString() +
     `</div>` +
-    `<div class="pulse-tile__resize-handle" data-agent-id="${escHtml(widget.id)}"></div>` +
+    `<div class="pulse-tile__resize-handle" data-agent-id="${id}"></div>` +
     `</div>`
   );
 }

--- a/packages/dashboard/src/views/pulse-layout.js.ts
+++ b/packages/dashboard/src/views/pulse-layout.js.ts
@@ -16,55 +16,9 @@ export const PULSE_LAYOUT_JS = widgetLayoutJS({
   sizesKey: 'sua-pulse-sizes',
   collapsedKey: 'sua-pulse-collapsed',
 }) + `
-  // ── Pulse tile collapse/expand ──────────────────────────────────────
-  // Clicking the chevron or header title toggles the tile body.
-  // Collapsed state persists in localStorage per agent id.
-  (function () {
-    var STORAGE_KEY = 'sua-pulse-collapsed';
-    function getCollapsed() {
-      try { return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}'); } catch { return {}; }
-    }
-    function setCollapsed(map) {
-      try { localStorage.setItem(STORAGE_KEY, JSON.stringify(map)); } catch {}
-    }
-
-    // Restore collapsed state on load.
-    var collapsed = getCollapsed();
-    var tiles = document.querySelectorAll('.pulse-tile');
-    for (var i = 0; i < tiles.length; i++) {
-      var btn = tiles[i].querySelector('.pulse-tile__collapse');
-      if (btn) {
-        var id = btn.getAttribute('data-tile-id');
-        if (id && collapsed[id]) tiles[i].classList.add('pulse-tile--collapsed');
-      }
-    }
-
-    // Toggle on click.
-    document.addEventListener('click', function (e) {
-      var target = e.target;
-      // Check if click is on the collapse button or the header trigger area.
-      var tileId = null;
-      if (target.classList && target.classList.contains('pulse-tile__collapse')) {
-        tileId = target.getAttribute('data-tile-id');
-      } else if (target.closest && target.closest('[data-collapse-trigger]')) {
-        tileId = target.closest('[data-collapse-trigger]').getAttribute('data-tile-id');
-      }
-      if (!tileId) return;
-
-      // Find the parent tile.
-      var tile = target.closest('.pulse-tile');
-      if (!tile) return;
-
-      tile.classList.toggle('pulse-tile--collapsed');
-      var map = getCollapsed();
-      if (tile.classList.contains('pulse-tile--collapsed')) {
-        map[tileId] = true;
-      } else {
-        delete map[tileId];
-      }
-      setCollapsed(map);
-    });
-  })();
+  // Collapse/expand handler moved into widget-layout.js.ts so each
+  // surface scopes its persistence properly; see the host.contains
+  // check there.
 
   // ── Pulse media: click-to-play YouTube embeds ───────────────────────
   // Click thumbnail to swap to iframe embed. If embed fails (video

--- a/packages/dashboard/src/views/widget-layout.js.ts
+++ b/packages/dashboard/src/views/widget-layout.js.ts
@@ -686,6 +686,35 @@ export function widgetLayoutJS(config: WidgetLayoutConfig): string {
       } catch {}
     }
     restoreCollapsed();
+
+    // ── Collapse/expand click handler ───────────────────────────────
+    // Lives here (not in pulse-layout.js.ts) so the COLLAPSED_KEY
+    // scoping is shared across pulse + home + per-dashboard surfaces.
+    // Previously pulse-layout.js.ts hardcoded 'sua-pulse-collapsed' and
+    // home tiles' collapse state was saved to the wrong key.
+    document.addEventListener('click', function (e) {
+      var target = e.target;
+      if (!target || !target.closest) return;
+      // Match either the collapse chevron itself or the title trigger area.
+      var fromChevron = target.classList && target.classList.contains('pulse-tile__collapse');
+      var fromTrigger = target.closest('[data-collapse-trigger]');
+      var tileId = null;
+      if (fromChevron) tileId = target.getAttribute('data-tile-id');
+      else if (fromTrigger) tileId = fromTrigger.getAttribute('data-tile-id');
+      if (!tileId) return;
+      var tile = target.closest('.pulse-tile');
+      // Only handle collapse for tiles that belong to OUR host —
+      // otherwise a click on a pulse tile would fire the home handler
+      // too (both run on every page since the inline scripts are concatenated).
+      if (!tile || !host.contains(tile)) return;
+      tile.classList.toggle('pulse-tile--collapsed');
+      try {
+        var map = JSON.parse(localStorage.getItem(COLLAPSED_KEY) || '{}');
+        if (tile.classList.contains('pulse-tile--collapsed')) map[tileId] = true;
+        else delete map[tileId];
+        localStorage.setItem(COLLAPSED_KEY, JSON.stringify(map));
+      } catch {}
+    });
   })();
 `;
 }


### PR DESCRIPTION
## Summary

You flagged that the root home page (\`/\`) in edit mode doesn't have the configure-tile affordance that other dashboards have. Two parts to the answer:

1. **The configure (⚙) button on /pulse + /dashboards/<id> opens a modal that picks signal template + slot mapping** — neither applies to home widgets. Home widgets are hardcoded renderers (Scheduled, Recent Activity, Failure Rate, etc.), not template-driven. Surfacing the modal there would mostly show greyed-out controls.

2. **But palette + collapse DO apply** to any tile, and home widgets were missing both. That's the real parity gap. This PR adds them.

### Changes

- **\`renderHomeWidget\`** now emits the collapse chevron + a wrapped title trigger + a palette button, matching the pulse-tile header layout. ⚙ and × stay omitted (see #1 above).
- **Collapse click handler moved into \`widget-layout.js.ts\`** so each surface (pulse / home / per-dashboard) scopes its \`COLLAPSED_KEY\` correctly. Previously the pulse-layout handler hardcoded \`sua-pulse-collapsed\` — clicking collapse on a home tile would save to the wrong key.
- **Duplicate handler removed from \`dashboards-layout.js.ts\`** to avoid double-toggle.

Net result: pulse, home, and per-dashboard collapse state all persist under their own keys. Palette cycling works on all three via the shared handler that was already in widget-layout.

### Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 1175/1175 (no test changes; pure UI plumbing)
- [x] Live-checked \`/\` — 13 palette buttons rendered (one per home tile)
- [ ] After merge + daemon restart: enter Edit Layout on \`/\`, hover a tile, see the ● palette button; click it to cycle colors; collapse with chevron; refresh — state persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)