### PR TITLE
feat(dashboard): in-place "+ Add tile" modal on /dashboards/:id

### DIFF
--- a/.changeset/in-place-add-tile-modal.md
+++ b/.changeset/in-place-add-tile-modal.md
@@ -1,0 +1,11 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+dashboard: in-place "+ Add tile" modal on /dashboards/:id
+
+When a user dashboard is in Edit Layout mode, each section grows a "+ Add tile" button next to its title. Clicking it opens a searchable picker: a "Suggested" row ranked by last-fired recency, then the full grid of signal-bearing agents. Picking one POSTs to the existing tile-append route with returnTo=live and lands back on the live dashboard. Empty sections now render in edit mode so users can fill them in place without bouncing to /edit.

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -1746,3 +1746,146 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
+
+/* ── In-place "Add tile" modal for /dashboards/:id ──────────────────── */
+
+/* + Add tile button: visible only when the dashboard is in edit mode. */
+.add-tile-btn { display: none; }
+body.pulse-edit-mode .add-tile-btn { display: inline-flex; }
+
+/* Empty-section hint + the section shell itself hide outside edit mode
+   so the live view stays uncluttered for read-only viewers. */
+.add-tile-empty-hint { display: none; }
+body.pulse-edit-mode .add-tile-empty-hint { display: block; }
+.pulse-container--empty { display: none; }
+body.pulse-edit-mode .pulse-container--empty { display: block; }
+
+.add-tile-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(2px);
+}
+.add-tile-modal__content {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: 0 8px 30px rgb(0 0 0 / 0.4);
+  width: min(720px, 92vw);
+  max-height: 85vh;
+  overflow-y: auto;
+  padding: var(--space-6) var(--space-8);
+}
+.add-tile-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+}
+.add-tile-modal__header h3 {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-lg);
+  font-weight: var(--weight-bold);
+}
+.add-tile-modal__close {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: 1.25rem;
+  padding: var(--space-2);
+  line-height: 1;
+  border-radius: var(--radius-sm);
+}
+.add-tile-modal__close:hover {
+  color: var(--color-text);
+  background: var(--color-surface-raised);
+}
+.add-tile-search {
+  width: 100%;
+  margin-bottom: var(--space-4);
+}
+.add-tile-section-label {
+  font-size: var(--font-size-xs);
+  font-weight: var(--weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  margin: var(--space-3) 0 var(--space-2);
+}
+.add-tile-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+.add-tile-card {
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: border-color 100ms ease, background 100ms ease, transform 80ms ease;
+  font-family: inherit;
+  color: inherit;
+}
+.add-tile-card:hover {
+  border-color: var(--color-primary);
+  background: var(--color-surface);
+  transform: translateY(-1px);
+}
+.add-tile-card__head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.add-tile-card__icon {
+  font-size: 1.125rem;
+  line-height: 1;
+}
+.add-tile-card__name {
+  font-weight: var(--weight-semibold);
+  font-size: var(--font-size-sm);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.add-tile-card__desc {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.add-tile-card__foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-subtle);
+}
+.add-tile-card__tpl {
+  font-family: var(--font-mono);
+  background: var(--color-bg);
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+}
+.add-tile-card__age {
+  font-family: var(--font-mono);
+}

--- a/packages/dashboard/src/routes/dashboards-edit.test.ts
+++ b/packages/dashboard/src/routes/dashboards-edit.test.ts
@@ -176,6 +176,17 @@ describe('dashboards editor', () => {
     expect(dashboardsStore.getDashboard(id)?.layout.sections[0].agentIds).toEqual(['hello', 'world']);
   });
 
+  it('POST /sections/:idx/tiles with returnTo=live redirects to the live view', async () => {
+    const app = await makeApp();
+    const { id } = seed();
+    const res = await request(app).post(`/dashboards/${id}/sections/0/tiles`)
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .type('form').send({ agentId: 'world', returnTo: 'live' });
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(new RegExp(`^/dashboards/${encodeURIComponent(id)}\\?ok=`));
+    expect(res.headers.location).not.toContain('/edit');
+  });
+
   it('POST /sections/:idx/tiles/:tileIdx/delete removes a tile', async () => {
     const app = await makeApp();
     const { id } = seed();

--- a/packages/dashboard/src/routes/dashboards-edit.ts
+++ b/packages/dashboard/src/routes/dashboards-edit.ts
@@ -108,6 +108,12 @@ dashboardsEditRouter.post('/dashboards/:id/sections/:idx/tiles', (req: Request, 
       arr[idx] = { ...arr[idx], agentIds: [...arr[idx].agentIds, agentId] };
     });
     ctx.dashboardsStore!.updateLayout(id, { sections });
+    // returnTo=live = in-place add-tile modal on /dashboards/:id; default
+    // is the editor at /dashboards/:id/edit.
+    if (pickString(req.body, 'returnTo') === 'live') {
+      res.redirect(303, `/dashboards/${encodeURIComponent(id)}?ok=${encodeURIComponent(`Added "${agentId}".`)}`);
+      return;
+    }
     redirectOk(res, id, `Added "${agentId}".`);
   });
 });

--- a/packages/dashboard/src/routes/dashboards.test.ts
+++ b/packages/dashboard/src/routes/dashboards.test.ts
@@ -143,6 +143,36 @@ describe('dashboards routes', () => {
     expect(res.text).toContain('not installed');
   });
 
+  it('exposes the in-place add-tile picker on /dashboards/:id', async () => {
+    const app = await makeApp();
+    dashboardsStore.upsertDashboard({
+      id: 'user:in-place',
+      packId: null,
+      name: 'InPlace',
+      layout: { sections: [{ title: 'Empty', agentIds: [] }] },
+    });
+    const res = await request(app)
+      .get('/dashboards/user:in-place')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    // + Add tile button is in the section header, gated to edit mode by CSS.
+    expect(res.text).toContain('class="btn btn--ghost btn--sm add-tile-btn"');
+    expect(res.text).toContain('data-dashboard-id="user:in-place"');
+    expect(res.text).toContain('data-section-idx="0"');
+    // Empty section renders so the picker has an anchor — was previously skipped.
+    expect(res.text).toContain('class="pulse-container pulse-container--empty"');
+    // Available-agents JSON is embedded and includes the signal-bearing "hello".
+    expect(res.text).toContain('id="dashboard-available-agents"');
+    const m = res.text.match(/<script type="application\/json" id="dashboard-available-agents">([\s\S]*?)<\/script>/);
+    expect(m).not.toBeNull();
+    const agents = JSON.parse(m![1]);
+    expect(Array.isArray(agents)).toBe(true);
+    expect(agents.find((a: { id: string }) => a.id === 'hello')).toBeDefined();
+    expect(agents[0]).toMatchObject({ id: expect.any(String), name: expect.any(String) });
+    expect(agents[0]).toHaveProperty('lastFiredAt');
+  });
+
   it('GET /dashboards/unknown 404s', async () => {
     const app = await makeApp();
     const res = await request(app)

--- a/packages/dashboard/src/routes/dashboards.ts
+++ b/packages/dashboard/src/routes/dashboards.ts
@@ -13,6 +13,7 @@ import { dashboardToPackManifest, type Agent, type AgentSignal } from '@some-use
 import { getContext } from '../context.js';
 import {
   renderDashboardPage,
+  type AvailableAgent,
   type DashboardSectionRender,
 } from '../views/dashboards.js';
 import { buildPulseTile } from '../views/pulse-tile-builder.js';
@@ -52,16 +53,40 @@ dashboardsRouter.get('/dashboards/:id', (req: Request, res: Response) => {
       }
       tiles.push(buildPulseTile(agent as Agent & { signal: AgentSignal }, { runStore: ctx.runStore }));
     }
-    return { title: s.title, tiles, missingAgentIds };
+    return { title: s.title, tiles, missingAgentIds, agentIds: [...s.agentIds] };
   });
 
   const installedDashboards = ctx.dashboardsStore.listDashboards();
   const flash = parseFlash(req);
 
+  // Pool of agents the user could add to any section: every signal-bearing
+  // agent. The modal filters out ones already placed in the section it was
+  // opened from, but we expose the whole pool so the "Suggested" row (by
+  // recency) is stable across sections.
+  const availableAgents: AvailableAgent[] = ctx.agentStore
+    .listAgents()
+    .filter((a) => a.signal)
+    .map((a) => {
+      let lastFiredAt: string | null = null;
+      try {
+        const recent = ctx.runStore.listRuns({ agentName: a.id, limit: 1 });
+        if (recent.length > 0) lastFiredAt = recent[0].startedAt;
+      } catch { /* no runs */ }
+      return {
+        id: a.id,
+        name: a.name,
+        icon: a.signal?.icon ?? null,
+        template: a.signal?.template ?? null,
+        description: a.description ?? null,
+        lastFiredAt,
+      };
+    });
+
   res.type('html').send(renderDashboardPage({
     dashboard,
     sections,
     installedDashboards,
+    availableAgents,
     flash,
   }));
 });

--- a/packages/dashboard/src/views/add-tile-modal.js.ts
+++ b/packages/dashboard/src/views/add-tile-modal.js.ts
@@ -1,0 +1,177 @@
+/**
+ * In-place add-tile modal for /dashboards/:id. Opens when the
+ * "+ Add tile" button in a section header is clicked (visible only
+ * in edit mode). Renders a "Suggested" row (most-recently-fired
+ * signal-bearing agents) above a searchable grid of every other
+ * available agent. Picking a card POSTs to
+ * /dashboards/:id/sections/:idx/tiles with returnTo=live so the
+ * server redirects back to the live dashboard.
+ */
+export const ADD_TILE_MODAL_JS = `
+  (function () {
+    var modal = null;
+    var allAgents = null;
+
+    function getAvailable() {
+      if (allAgents) return allAgents;
+      var el = document.getElementById('dashboard-available-agents');
+      if (!el) return [];
+      try { allAgents = JSON.parse(el.textContent || '[]'); } catch { allAgents = []; }
+      return allAgents;
+    }
+
+    function esc(s) {
+      return String(s == null ? '' : s)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    }
+
+    function ensureModal() {
+      if (modal) return;
+      modal = document.createElement('div');
+      modal.className = 'add-tile-modal';
+      modal.style.display = 'none';
+      modal.addEventListener('click', function (e) {
+        if (e.target === modal) closeModal();
+      });
+      document.body.appendChild(modal);
+      document.addEventListener('keydown', function (e) {
+        if (modal.style.display !== 'none' && e.key === 'Escape') closeModal();
+      });
+    }
+
+    function closeModal() {
+      if (modal) modal.style.display = 'none';
+    }
+
+    function sortByRecency(agents) {
+      return agents.slice().sort(function (a, b) {
+        var aT = a.lastFiredAt ? Date.parse(a.lastFiredAt) : 0;
+        var bT = b.lastFiredAt ? Date.parse(b.lastFiredAt) : 0;
+        return bT - aT;
+      });
+    }
+
+    function relAge(iso) {
+      if (!iso) return 'never fired';
+      var t = Date.parse(iso);
+      if (isNaN(t)) return '';
+      var s = Math.max(0, Math.floor((Date.now() - t) / 1000));
+      if (s < 60) return s + 's ago';
+      if (s < 3600) return Math.floor(s / 60) + 'm ago';
+      if (s < 86400) return Math.floor(s / 3600) + 'h ago';
+      return Math.floor(s / 86400) + 'd ago';
+    }
+
+    function cardHtml(agent) {
+      var icon = agent.icon || '\\u25A1';
+      var tpl = agent.template ? '<span class="add-tile-card__tpl">' + esc(agent.template) + '</span>' : '';
+      var desc = agent.description ? '<div class="add-tile-card__desc">' + esc(agent.description) + '</div>' : '';
+      return '<button type="button" class="add-tile-card" data-agent-id="' + esc(agent.id) + '">' +
+        '<div class="add-tile-card__head">' +
+          '<span class="add-tile-card__icon">' + esc(icon) + '</span>' +
+          '<span class="add-tile-card__name">' + esc(agent.name) + '</span>' +
+        '</div>' +
+        desc +
+        '<div class="add-tile-card__foot">' + tpl +
+          '<span class="add-tile-card__age">' + esc(relAge(agent.lastFiredAt)) + '</span>' +
+        '</div>' +
+      '</button>';
+    }
+
+    function openModal(dashboardId, sectionIdx, alreadyInSection) {
+      ensureModal();
+      var all = getAvailable();
+      var skip = {};
+      for (var i = 0; i < alreadyInSection.length; i++) skip[alreadyInSection[i]] = true;
+      var pool = all.filter(function (a) { return !skip[a.id]; });
+
+      if (pool.length === 0) {
+        modal.innerHTML = '<div class="add-tile-modal__content">' +
+          '<div class="add-tile-modal__header">' +
+            '<h3 style="margin: 0;">Add tile</h3>' +
+            '<button type="button" class="add-tile-modal__close" title="Close" aria-label="Close">\\u00D7</button>' +
+          '</div>' +
+          '<p class="dim" style="padding: var(--space-4); text-align: center;">No more agents available.</p>' +
+          '<div style="text-align: center; padding-bottom: var(--space-4);">' +
+            '<a class="btn btn--primary btn--sm" href="/agents/new">Build a new agent \\u2192</a>' +
+          '</div>' +
+        '</div>';
+        modal.querySelector('.add-tile-modal__close').addEventListener('click', closeModal);
+        modal.style.display = 'flex';
+        return;
+      }
+
+      var sorted = sortByRecency(pool);
+      var suggestedCount = Math.min(4, sorted.length);
+      var suggested = sorted.slice(0, suggestedCount).filter(function (a) { return a.lastFiredAt; });
+
+      modal.innerHTML = '<div class="add-tile-modal__content">' +
+        '<div class="add-tile-modal__header">' +
+          '<h3 style="margin: 0;">Add tile</h3>' +
+          '<button type="button" class="add-tile-modal__close" title="Close" aria-label="Close">\\u00D7</button>' +
+        '</div>' +
+        '<form id="add-tile-form" method="POST" action="/dashboards/' + encodeURIComponent(dashboardId) + '/sections/' + encodeURIComponent(String(sectionIdx)) + '/tiles">' +
+          '<input type="hidden" name="returnTo" value="live">' +
+          '<input type="hidden" name="agentId" id="add-tile-agent-id" value="">' +
+        '</form>' +
+        '<input type="search" class="input add-tile-search" id="add-tile-search" placeholder="Search agents\\u2026" autocomplete="off">' +
+        (suggested.length > 0
+          ? '<div class="add-tile-section-label">Suggested</div>' +
+            '<div class="add-tile-grid" id="add-tile-suggested">' + suggested.map(cardHtml).join('') + '</div>'
+          : '') +
+        '<div class="add-tile-section-label">' + (suggested.length > 0 ? 'All agents' : 'Available agents') + ' (' + String(sorted.length) + ')</div>' +
+        '<div class="add-tile-grid" id="add-tile-all">' + sorted.map(cardHtml).join('') + '</div>' +
+        '<p class="add-tile-empty" id="add-tile-no-results" style="display: none; padding: var(--space-4); text-align: center;" class="dim">No agents match.</p>' +
+      '</div>';
+
+      modal.querySelector('.add-tile-modal__close').addEventListener('click', closeModal);
+
+      var form = document.getElementById('add-tile-form');
+      var hiddenAgent = document.getElementById('add-tile-agent-id');
+      var cards = modal.querySelectorAll('.add-tile-card');
+      for (var c = 0; c < cards.length; c++) {
+        cards[c].addEventListener('click', function () {
+          hiddenAgent.value = this.getAttribute('data-agent-id') || '';
+          if (hiddenAgent.value) form.submit();
+        });
+      }
+
+      var search = document.getElementById('add-tile-search');
+      var noResults = document.getElementById('add-tile-no-results');
+      var suggestedEl = document.getElementById('add-tile-suggested');
+      var allEl = document.getElementById('add-tile-all');
+      search.addEventListener('input', function () {
+        var q = this.value.toLowerCase().trim();
+        if (suggestedEl) suggestedEl.style.display = q ? 'none' : '';
+        var labels = modal.querySelectorAll('.add-tile-section-label');
+        if (labels[0] && suggestedEl) labels[0].style.display = q ? 'none' : '';
+        var visible = 0;
+        var allCards = allEl.querySelectorAll('.add-tile-card');
+        for (var i = 0; i < allCards.length; i++) {
+          var name = (allCards[i].querySelector('.add-tile-card__name') || {}).textContent || '';
+          var desc = (allCards[i].querySelector('.add-tile-card__desc') || {}).textContent || '';
+          var match = !q || (name + ' ' + desc).toLowerCase().indexOf(q) !== -1;
+          allCards[i].style.display = match ? '' : 'none';
+          if (match) visible++;
+        }
+        noResults.style.display = visible === 0 ? '' : 'none';
+      });
+
+      modal.style.display = 'flex';
+      setTimeout(function () { search.focus(); }, 0);
+    }
+
+    document.addEventListener('click', function (e) {
+      var btn = e.target.closest ? e.target.closest('.add-tile-btn') : null;
+      if (!btn) return;
+      // Only react when in edit mode (button is CSS-hidden otherwise, but
+      // belt-and-braces against keyboard-triggered clicks).
+      if (!document.body.classList.contains('pulse-edit-mode')) return;
+      var dashboardId = btn.getAttribute('data-dashboard-id') || '';
+      var sectionIdx = btn.getAttribute('data-section-idx') || '0';
+      var raw = btn.getAttribute('data-section-agent-ids') || '';
+      var already = raw ? raw.split(',').filter(function (x) { return x; }) : [];
+      openModal(dashboardId, parseInt(sectionIdx, 10), already);
+    });
+  })();
+`;

--- a/packages/dashboard/src/views/dashboards.ts
+++ b/packages/dashboard/src/views/dashboards.ts
@@ -26,6 +26,22 @@ export interface DashboardSectionRender {
   tiles: PulseTile[];
   /** Agent ids referenced by the section that aren't installed (rendered as muted placeholders). */
   missingAgentIds: string[];
+  /** Raw agentIds in the section — used to filter the add-tile picker. */
+  agentIds: string[];
+}
+
+/**
+ * One row of the in-place "+ Add tile" picker. Surfaced via a JSON
+ * <script> tag so the modal can render without a server round-trip.
+ */
+export interface AvailableAgent {
+  id: string;
+  name: string;
+  icon: string | null;
+  template: string | null;
+  description: string | null;
+  /** ISO timestamp of the most recent run, or null if never fired. */
+  lastFiredAt: string | null;
 }
 
 export interface RenderDashboardPageInput {
@@ -33,6 +49,8 @@ export interface RenderDashboardPageInput {
   sections: DashboardSectionRender[];
   /** All installed dashboards, used to populate the dropdown. */
   installedDashboards: Dashboard[];
+  /** Pool of signal-bearing agents for the in-place add-tile modal. */
+  availableAgents: AvailableAgent[];
   flash?: { kind: 'ok' | 'error' | 'info'; message: string };
 }
 
@@ -77,6 +95,9 @@ export function renderDashboardPage(input: RenderDashboardPageInput): string {
           systemTileIds: [],
         })}</script>`)}
       `}
+    ${unsafeHtml(`<script type="application/json" id="dashboard-available-agents">${
+      JSON.stringify(input.availableAgents).replace(/</g, '\\u003c')
+    }</script>`)}
   `;
 
   return render(layout({
@@ -92,10 +113,19 @@ function renderSection(
   sectionIdx: number,
 ): SafeHtml {
   const isEmpty = s.tiles.length === 0 && s.missingAgentIds.length === 0;
-  if (isEmpty) return html``;
   return html`
-    <section class="pulse-container" data-container-id="section-${String(sectionIdx)}" style="margin-bottom: var(--space-5);">
-      <h2 style="margin: 0 0 var(--space-3) 0; font-size: var(--font-size-md); font-weight: var(--weight-semibold);">${s.title}</h2>
+    <section class="pulse-container ${isEmpty ? 'pulse-container--empty' : ''}" data-container-id="section-${String(sectionIdx)}" style="margin-bottom: var(--space-5);">
+      <div style="display: flex; align-items: center; justify-content: space-between; margin: 0 0 var(--space-3) 0;">
+        <h2 style="margin: 0; font-size: var(--font-size-md); font-weight: var(--weight-semibold);">${s.title}</h2>
+        <button type="button" class="btn btn--ghost btn--sm add-tile-btn"
+          data-dashboard-id="${dashboardId}"
+          data-section-idx="${String(sectionIdx)}"
+          data-section-agent-ids="${s.agentIds.join(',')}"
+          title="Add a tile to this section">+ Add tile</button>
+      </div>
+      ${s.tiles.length === 0 && s.missingAgentIds.length === 0
+        ? html`<p class="dim add-tile-empty-hint" style="padding: var(--space-3); font-size: var(--font-size-sm); margin: 0;">No tiles yet. Click <strong>+ Add tile</strong> to fill this section.</p>`
+        : html``}
       <div class="pulse-grid" data-container-id="section-${String(sectionIdx)}" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: var(--space-3);">
         ${s.tiles.map((t, tileIdx) =>
           renderTile(t, (tile, content) => tileWrap(tile, content, {

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -10,6 +10,7 @@ import { OUTPUT_WIDGET_ACTIONS_JS } from './output-widget-actions.js.js';
 import { RUN_DETAIL_FILTER_JS } from './run-detail-filter.js.js';
 import { PULSE_CONFIGURE_JS } from './pulse-configure.js.js';
 import { PULSE_REFRESH_JS } from './pulse-refresh.js.js';
+import { ADD_TILE_MODAL_JS } from './add-tile-modal.js.js';
 import { footer } from './footer.js';
 
 export interface LayoutOptions {
@@ -70,7 +71,7 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
   ${body}
 </main>
 ${footer()}
-<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + HOME_LAYOUT_JS + DASHBOARDS_LAYOUT_JS + BUILD_FROM_GOAL_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS)}</script>
+<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + HOME_LAYOUT_JS + DASHBOARDS_LAYOUT_JS + BUILD_FROM_GOAL_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS + ADD_TILE_MODAL_JS)}</script>
 </body>
 </html>`;
 }


### PR DESCRIPTION
## Summary
- Edit mode grows a **+ Add tile** button in each section header. Modal opens a searchable picker: a **Suggested** row ranked by last-fired recency above the full grid of signal-bearing agents (already-placed ones hidden).
- Picking a card POSTs to the existing `/sections/:idx/tiles` route with `returnTo=live`, so the server redirects back to the live dashboard instead of `/edit`.
- Empty sections now render in edit mode so users can fill them without bouncing to the editor.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` → 1177/1177 passing (new view test + new returnTo route test)
- [ ] Live: open `/dashboards/<id>`, click **✎ Edit layout**, click **+ Add tile** on a section → modal opens with Suggested + All grid, search filters, picking a card adds the tile and reloads.
- [ ] Empty-section path: create a new section, enter edit mode, add tile via the modal — confirm no `/edit` bounce.
- [ ] Read-only check: leave edit mode → `+ Add tile` button hidden, empty sections hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)