### PR TITLE
fix(dashboard): + Add tile button always visible

### DIFF
--- a/.changeset/add-tile-always-visible.md
+++ b/.changeset/add-tile-always-visible.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+dashboard: + Add tile button is always visible on /dashboards/:id
+
+Previously the button was CSS-gated to edit mode, which made it
+invisible to users who hadn't clicked Edit Layout first. Adding a
+tile is non-destructive, so the gate was friction without payoff.
+The button (and the empty-section "no tiles yet" hint) now show
+without entering edit mode.

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -1749,16 +1749,9 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
 
 /* ── In-place "Add tile" modal for /dashboards/:id ──────────────────── */
 
-/* + Add tile button: visible only when the dashboard is in edit mode. */
-.add-tile-btn { display: none; }
-body.pulse-edit-mode .add-tile-btn { display: inline-flex; }
-
-/* Empty-section hint + the section shell itself hide outside edit mode
-   so the live view stays uncluttered for read-only viewers. */
-.add-tile-empty-hint { display: none; }
-body.pulse-edit-mode .add-tile-empty-hint { display: block; }
-.pulse-container--empty { display: none; }
-body.pulse-edit-mode .pulse-container--empty { display: block; }
+/* + Add tile button is always visible — it's non-destructive and adding
+   a tile shouldn't require entering edit mode first. Empty sections
+   render their shell + hint so users can fill them in place. */
 
 .add-tile-modal {
   position: fixed;

--- a/packages/dashboard/src/views/add-tile-modal.js.ts
+++ b/packages/dashboard/src/views/add-tile-modal.js.ts
@@ -164,9 +164,6 @@ export const ADD_TILE_MODAL_JS = `
     document.addEventListener('click', function (e) {
       var btn = e.target.closest ? e.target.closest('.add-tile-btn') : null;
       if (!btn) return;
-      // Only react when in edit mode (button is CSS-hidden otherwise, but
-      // belt-and-braces against keyboard-triggered clicks).
-      if (!document.body.classList.contains('pulse-edit-mode')) return;
       var dashboardId = btn.getAttribute('data-dashboard-id') || '';
       var sectionIdx = btn.getAttribute('data-section-idx') || '0';
       var raw = btn.getAttribute('data-section-agent-ids') || '';


### PR DESCRIPTION
## Summary
- Followup to #247. The `+ Add tile` button was CSS-gated to `body.pulse-edit-mode`, making it invisible until the user clicked **✎ Edit layout** first.
- Adding a tile is non-destructive — gating it behind edit mode is friction without payoff. Drop the CSS visibility rules and the matching JS guard in the modal's click handler.
- Empty sections + the "no tiles yet" hint also show outside edit mode now so users can fill new dashboards in place.

## Test plan
- [x] `npm test` → 1177/1177 passing
- [ ] Live: hard-refresh `/dashboards/<id>` → **+ Add tile** appears at the right of each section header without entering edit mode. Click it → modal opens, picking an agent adds the tile and reloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)