### PR TITLE
fix(dashboard): move + Add tile to top action bar

### DIFF
--- a/.changeset/add-tile-button-top-bar.md
+++ b/.changeset/add-tile-button-top-bar.md
@@ -1,0 +1,19 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+dashboard: + Add tile moves to the top action bar (was being DOM-wiped)
+
+The previous per-section + Add tile buttons were rendered server-side
+inside #dashboard-containers, but widget-layout.js.ts wipes that host
+on load and re-renders sections from a client-side layout. So the
+buttons disappeared the moment the page hydrated.
+
+Move to a single + Add tile primary button in the top action bar
+alongside Edit layout / Edit sections / Save as pack. Modal still
+posts to section 0 (server-side section structure isn't visible in
+the live view anyway).

--- a/packages/dashboard/src/routes/dashboards.test.ts
+++ b/packages/dashboard/src/routes/dashboards.test.ts
@@ -143,7 +143,7 @@ describe('dashboards routes', () => {
     expect(res.text).toContain('not installed');
   });
 
-  it('exposes the in-place add-tile picker on /dashboards/:id', async () => {
+  it('exposes the add-tile picker on /dashboards/:id', async () => {
     const app = await makeApp();
     dashboardsStore.upsertDashboard({
       id: 'user:in-place',
@@ -156,12 +156,11 @@ describe('dashboards routes', () => {
       .set('Host', `127.0.0.1:${PORT}`)
       .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
     expect(res.status).toBe(200);
-    // + Add tile button is in the section header, gated to edit mode by CSS.
-    expect(res.text).toContain('class="btn btn--ghost btn--sm add-tile-btn"');
+    // Single + Add tile button lives in the top action bar, outside the
+    // widget-layout host that gets client-side wiped on render.
+    expect(res.text).toContain('add-tile-btn');
     expect(res.text).toContain('data-dashboard-id="user:in-place"');
     expect(res.text).toContain('data-section-idx="0"');
-    // Empty section renders so the picker has an anchor — was previously skipped.
-    expect(res.text).toContain('class="pulse-container pulse-container--empty"');
     // Available-agents JSON is embedded and includes the signal-bearing "hello".
     expect(res.text).toContain('id="dashboard-available-agents"');
     const m = res.text.match(/<script type="application\/json" id="dashboard-available-agents">([\s\S]*?)<\/script>/);

--- a/packages/dashboard/src/views/dashboards.ts
+++ b/packages/dashboard/src/views/dashboards.ts
@@ -73,6 +73,11 @@ export function renderDashboardPage(input: RenderDashboardPageInput): string {
         · ${sourceLabel}
       </span>
       <div style="margin-left: auto; display: flex; gap: var(--space-2);">
+        <button type="button" class="btn btn--primary btn--sm add-tile-btn"
+          data-dashboard-id="${input.dashboard.id}"
+          data-section-idx="0"
+          data-section-agent-ids="${input.sections.flatMap((s) => s.agentIds).join(',')}"
+          title="Add a tile to this dashboard">+ Add tile</button>
         <button type="button" class="btn btn--ghost btn--sm" id="dashboard-edit-toggle">✎ Edit layout</button>
         <a class="btn btn--ghost btn--sm" href="/dashboards/${encodeURIComponent(input.dashboard.id)}/edit">Edit sections</a>
         <a class="btn btn--ghost btn--sm" href="/dashboards/${encodeURIComponent(input.dashboard.id)}/export" title="Download as a pack manifest YAML">Save as pack</a>
@@ -113,19 +118,10 @@ function renderSection(
   sectionIdx: number,
 ): SafeHtml {
   const isEmpty = s.tiles.length === 0 && s.missingAgentIds.length === 0;
+  if (isEmpty) return html``;
   return html`
-    <section class="pulse-container ${isEmpty ? 'pulse-container--empty' : ''}" data-container-id="section-${String(sectionIdx)}" style="margin-bottom: var(--space-5);">
-      <div style="display: flex; align-items: center; justify-content: space-between; margin: 0 0 var(--space-3) 0;">
-        <h2 style="margin: 0; font-size: var(--font-size-md); font-weight: var(--weight-semibold);">${s.title}</h2>
-        <button type="button" class="btn btn--ghost btn--sm add-tile-btn"
-          data-dashboard-id="${dashboardId}"
-          data-section-idx="${String(sectionIdx)}"
-          data-section-agent-ids="${s.agentIds.join(',')}"
-          title="Add a tile to this section">+ Add tile</button>
-      </div>
-      ${s.tiles.length === 0 && s.missingAgentIds.length === 0
-        ? html`<p class="dim add-tile-empty-hint" style="padding: var(--space-3); font-size: var(--font-size-sm); margin: 0;">No tiles yet. Click <strong>+ Add tile</strong> to fill this section.</p>`
-        : html``}
+    <section class="pulse-container" data-container-id="section-${String(sectionIdx)}" style="margin-bottom: var(--space-5);">
+      <h2 style="margin: 0 0 var(--space-3) 0; font-size: var(--font-size-md); font-weight: var(--weight-semibold);">${s.title}</h2>
       <div class="pulse-grid" data-container-id="section-${String(sectionIdx)}" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: var(--space-3);">
         ${s.tiles.map((t, tileIdx) =>
           renderTile(t, (tile, content) => tileWrap(tile, content, {


### PR DESCRIPTION
## Summary
- Followup to #247/#248. The per-section + Add tile buttons were rendered server-side inside `#dashboard-containers`, but [widget-layout.js.ts:149](packages/dashboard/src/views/widget-layout.js.ts#L149) does `host.innerHTML = ''` on load and re-renders containers from a client-side layout stored in localStorage. The buttons disappeared the instant the page hydrated.
- Move to a single **+ Add tile** primary button in the top action bar alongside Edit layout / Edit sections / Save as pack. The modal still POSTs to section 0 — and since the visible HEALTH/AGENTS containers are client-side groupings, not server sections, "section 0" is the right place.

## Test plan
- [x] `npm test` → 1177/1177 passing
- [ ] Live: hard-refresh `/dashboards/<id>` → green **+ Add tile** button visible in the top-right action bar (no need for edit mode). Click → modal opens with Suggested + All grid. Picking a card adds the tile, page reloads, new tile appears under the AGENTS container.

## Followups (not in this PR)
- Per-section + buttons require teaching `widget-layout.js.ts` to render add-tile chrome, which touches the shared renderer used by pulse and home too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)