### PR TITLE
feat(dashboard): Build-from-goal wizard asks where to land

### DIFF
--- a/.changeset/build-from-goal-target-picker.md
+++ b/.changeset/build-from-goal-target-picker.md
@@ -1,0 +1,16 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+dashboard: Build-from-goal wizard asks where to land the result
+
+The wizard now opens with a target picker:
+1. Just create the agent(s) (default — backwards-compatible)
+2. Create agent(s) + a new dashboard
+3. Add to an existing dashboard (with a dropdown of user dashboards)
+
+The commit endpoint honors the choice: agents-only drops any planner-proposed dashboard, new-dashboard synthesizes one with the created agents if needed, and existing-dashboard appends the new agents to section 0 of the chosen user dashboard (pack-owned dashboards aren't selectable). On `/dashboards/:id`, the current dashboard is pre-selected as the target so you can iterate on it without picking again. Available on every surface that runs the wizard (/, /agents, /dashboards/:id).

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -175,6 +175,10 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
         if (result.rows[0]?.startedAt) lastScheduledFires[a.id] = result.rows[0].startedAt;
       }
 
+      const availableDashboards = ctx.dashboardsStore
+        ? ctx.dashboardsStore.listDashboards().filter((d) => !d.packId).map((d) => ({ id: d.id, name: d.name }))
+        : [];
+
       res.type('html').send(renderHomePage({
         agents,
         recentRuns: recentResult.rows,
@@ -187,6 +191,7 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
         schedulerStatus,
         schedulerHeartbeat,
         lastScheduledFires,
+        availableDashboards,
       }));
     }).catch(() => {
       res.redirect(302, '/agents');

--- a/packages/dashboard/src/routes/agents/list.ts
+++ b/packages/dashboard/src/routes/agents/list.ts
@@ -137,6 +137,10 @@ agentListRouter.get('/agents', (req: Request, res: Response) => {
     ? { kind: 'ok' as const, message: flashOk }
     : undefined;
 
+  const availableDashboards = ctx.dashboardsStore
+    ? ctx.dashboardsStore.listDashboards().filter((d) => !d.packId).map((d) => ({ id: d.id, name: d.name }))
+    : [];
+
   res.type('html').send(renderAgentsList({
     v1: mergedV1,
     v2: paginatedV2,
@@ -150,5 +154,6 @@ agentListRouter.get('/agents', (req: Request, res: Response) => {
     offset,
     total: totalV2,
     flash,
+    availableDashboards,
   }));
 });

--- a/packages/dashboard/src/routes/run-now-build.ts
+++ b/packages/dashboard/src/routes/run-now-build.ts
@@ -1007,6 +1007,28 @@ buildRouter.post('/agents/build/commit', (req: Request, res: Response) => {
   }
   const plan = result.data;
 
+  // Optional landing target from the wizard. Three shapes:
+  //   { kind: 'agents-only' }
+  //   { kind: 'new-dashboard' }
+  //   { kind: 'existing-dashboard', dashboardId: string }
+  // Older clients send no target — fall back to planner's plan.dashboard.
+  let target: { kind: 'agents-only' } | { kind: 'new-dashboard' } | { kind: 'existing-dashboard'; dashboardId: string } | null = null;
+  if (body.target && typeof body.target === 'object') {
+    const t = body.target as Record<string, unknown>;
+    if (t.kind === 'agents-only') target = { kind: 'agents-only' };
+    else if (t.kind === 'new-dashboard') target = { kind: 'new-dashboard' };
+    else if (t.kind === 'existing-dashboard' && typeof t.dashboardId === 'string') target = { kind: 'existing-dashboard', dashboardId: t.dashboardId };
+  }
+  // Honor "agents-only": drop the planner's dashboard so nothing extra lands.
+  if (target?.kind === 'agents-only') {
+    plan.dashboard = null;
+  }
+  // "existing-dashboard": drop the planner's new dashboard — we'll merge into
+  // the user-selected one after the agents commit.
+  if (target?.kind === 'existing-dashboard') {
+    plan.dashboard = null;
+  }
+
   const agentsCreated: string[] = [];
   const agentsSkipped: Array<{ id: string; reason: string }> = [];
 
@@ -1078,6 +1100,58 @@ buildRouter.post('/agents/build/commit', (req: Request, res: Response) => {
     dashboardError = 'Dashboards store unavailable.';
   }
 
+  // Target = "new-dashboard": synthesize a user dashboard with every agent
+  // we just created, if the planner didn't already produce one.
+  if (target?.kind === 'new-dashboard' && !dashboardCreated && agentsCreated.length > 0 && ctx.dashboardsStore) {
+    const baseId = 'user:goal';
+    let dashId = baseId;
+    if (ctx.dashboardsStore.getDashboard(dashId)) dashId = `${baseId}-${Date.now().toString(36)}`;
+    const name = 'Built from goal';
+    try {
+      ctx.dashboardsStore.upsertDashboard({
+        id: dashId,
+        packId: null,
+        name,
+        layout: { sections: [{ title: 'Agents', agentIds: agentsCreated.slice() }] },
+      });
+      dashboardCreated = dashId;
+    } catch (e) {
+      dashboardError = (e as Error).message;
+    }
+  }
+
+  // Target = "existing-dashboard": append every agent we just created to
+  // section 0 of the user-selected dashboard. New tiles are added (existing
+  // agentIds in section 0 are preserved).
+  let dashboardUpdated: string | null = null;
+  if (target?.kind === 'existing-dashboard' && agentsCreated.length > 0 && ctx.dashboardsStore) {
+    const dash = ctx.dashboardsStore.getDashboard(target.dashboardId);
+    if (!dash) {
+      dashboardError = `Dashboard "${target.dashboardId}" not found.`;
+    } else if (dash.packId) {
+      dashboardError = 'Cannot add to a pack-owned dashboard. Pick a user dashboard.';
+    } else if (dash.layout.sections.length === 0) {
+      // No sections to append to — create one.
+      try {
+        ctx.dashboardsStore.updateLayout(dash.id, {
+          sections: [{ title: 'Agents', agentIds: agentsCreated.slice() }],
+        });
+        dashboardUpdated = dash.id;
+      } catch (e) { dashboardError = (e as Error).message; }
+    } else {
+      const sections = dash.layout.sections.map((s, i) => {
+        if (i !== 0) return s;
+        const existing = new Set(s.agentIds);
+        const merged = [...s.agentIds, ...agentsCreated.filter((id) => !existing.has(id))];
+        return { ...s, agentIds: merged };
+      });
+      try {
+        ctx.dashboardsStore.updateLayout(dash.id, { sections });
+        dashboardUpdated = dash.id;
+      } catch (e) { dashboardError = (e as Error).message; }
+    }
+  }
+
   // Telemetry: stamp the commit time + total time-to-commit. Only fires
   // when the wizard supplied plannerRunId (correlates this commit back
   // to its planner-run row) AND something actually landed (an agent was
@@ -1095,10 +1169,11 @@ buildRouter.post('/agents/build/commit', (req: Request, res: Response) => {
     } catch { /* swallow */ }
   }
 
-  // Choose a redirect target: prefer the new dashboard, fall back to
-  // the first new agent, fall back to /agents.
-  const redirectUrl = dashboardCreated
-    ? `/dashboards/${encodeURIComponent(dashboardCreated)}`
+  // Choose a redirect target: prefer the dashboard we created or updated,
+  // then the first new agent, then /agents.
+  const redirectDashId = dashboardCreated ?? dashboardUpdated;
+  const redirectUrl = redirectDashId
+    ? `/dashboards/${encodeURIComponent(redirectDashId)}`
     : agentsCreated[0]
       ? `/agents/${encodeURIComponent(agentsCreated[0])}`
       : '/agents';
@@ -1108,6 +1183,7 @@ buildRouter.post('/agents/build/commit', (req: Request, res: Response) => {
     agentsCreated,
     agentsSkipped,
     dashboardCreated,
+    dashboardUpdated,
     dashboardError,
     redirectUrl,
   });

--- a/packages/dashboard/src/views/agents-list.ts
+++ b/packages/dashboard/src/views/agents-list.ts
@@ -40,6 +40,8 @@ export interface AgentsListInput {
   total: number;
   /** Banner shown above the page (redirected from a mutation route). */
   flash?: { kind: 'error' | 'info' | 'ok'; message: string };
+  /** User-owned dashboards offered as targets in the Build-from-goal wizard. */
+  availableDashboards?: Array<{ id: string; name: string }>;
 }
 
 export function renderAgentsList(input: AgentsListInput): string {
@@ -94,7 +96,7 @@ export function renderAgentsList(input: AgentsListInput): string {
       </footer>
     `}
 
-    ${buildFromGoalModal()}
+    ${buildFromGoalModal({ availableDashboards: input.availableDashboards })}
   `;
 
   return render(layout({ title: 'Agents', activeNav: 'agents', flash: input.flash }, body));

--- a/packages/dashboard/src/views/build-from-goal-modal.ts
+++ b/packages/dashboard/src/views/build-from-goal-modal.ts
@@ -12,14 +12,25 @@
  * the page body. Both the home page and the agents list page use this.
  */
 
-import { html, type SafeHtml } from './html.js';
+import { html, unsafeHtml, type SafeHtml } from './html.js';
+
+export interface BuildFromGoalModalOptions {
+  /** User-owned dashboards offered as "Add to existing dashboard" targets. Pack-owned dashboards are intentionally excluded. */
+  availableDashboards?: Array<{ id: string; name: string }>;
+  /** If set, the existing-dashboard radio is pre-selected and this id is pre-chosen in the dropdown. */
+  defaultDashboardId?: string;
+}
 
 export function buildFromGoalButton(opts: { variant?: 'primary' | 'ghost' } = {}): SafeHtml {
   const cls = opts.variant === 'primary' ? 'btn btn--primary btn--sm' : 'btn btn--sm';
   return html`<button type="button" class="${cls}" id="build-from-goal-btn">Build from goal</button>`;
 }
 
-export function buildFromGoalModal(): SafeHtml {
+export function buildFromGoalModal(opts: BuildFromGoalModalOptions = {}): SafeHtml {
+  const dashboards = opts.availableDashboards ?? [];
+  const defaultId = opts.defaultDashboardId ?? '';
+  const preselect = defaultId && dashboards.some((d) => d.id === defaultId) ? 'existing' : 'agents';
+  const optionsJson = JSON.stringify(dashboards).replace(/</g, '\\u003c');
   return html`
     <div id="build-modal" class="modal-backdrop">
       <div class="modal" style="max-width: 600px; max-height: 85vh; overflow-y: auto;">
@@ -28,6 +39,31 @@ export function buildFromGoalModal(): SafeHtml {
           <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-3);">
             Describe an agent <em>or</em> a dashboard. Claude surveys what's already installed, drafts any missing agents, and assembles the dashboard. Review the plan before anything is created.
           </p>
+
+          <fieldset style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--space-2) var(--space-3); margin-bottom: var(--space-3);">
+            <legend style="font-size: var(--font-size-xs); color: var(--color-text-muted); padding: 0 var(--space-1);">Land where?</legend>
+            <label style="display: flex; gap: var(--space-2); align-items: center; font-size: var(--font-size-sm); padding: var(--space-1) 0;">
+              <input type="radio" name="build-target" value="agents" ${preselect === 'agents' ? 'checked' : ''}>
+              <span>Just create the agent(s)</span>
+            </label>
+            <label style="display: flex; gap: var(--space-2); align-items: center; font-size: var(--font-size-sm); padding: var(--space-1) 0;">
+              <input type="radio" name="build-target" value="new-dashboard">
+              <span>Create agent(s) + a new dashboard</span>
+            </label>
+            <label style="display: flex; gap: var(--space-2); align-items: center; font-size: var(--font-size-sm); padding: var(--space-1) 0;">
+              <input type="radio" name="build-target" value="existing" ${preselect === 'existing' ? 'checked' : ''} ${dashboards.length === 0 ? 'disabled' : ''}>
+              <span>Add to existing dashboard</span>
+              ${dashboards.length === 0
+                ? html`<span class="dim" style="font-size: var(--font-size-xs);">(none yet)</span>`
+                : html``}
+            </label>
+            <div id="build-target-dashboard-row" style="display: ${preselect === 'existing' ? 'block' : 'none'}; padding: var(--space-1) 0 var(--space-1) var(--space-6);">
+              <select id="build-target-dashboard" class="input" style="width: 100%; font-size: var(--font-size-sm);">
+                ${dashboards.map((d) => html`<option value="${d.id}" ${d.id === defaultId ? 'selected' : ''}>${d.name}</option>`) as unknown as SafeHtml[]}
+              </select>
+            </div>
+          </fieldset>
+
           <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-3);">
             <strong style="font-size: var(--font-size-sm);">Goal</strong>
             <textarea id="build-goal" rows="3" placeholder="e.g. a daily morning dashboard with HN top stories, today's weather, and my notes folder"
@@ -44,6 +80,7 @@ export function buildFromGoalModal(): SafeHtml {
           </div>
         </div>
       </div>
+      ${unsafeHtml(`<script type="application/json" id="build-target-dashboards">${optionsJson}</script>`)}
     </div>
   `;
 }

--- a/packages/dashboard/src/views/build-from-goal.js.ts
+++ b/packages/dashboard/src/views/build-from-goal.js.ts
@@ -29,6 +29,19 @@ export const BUILD_FROM_GOAL_JS = `
       if (e.target && e.target.getAttribute && e.target.getAttribute('data-close-build')) closeModal();
     });
 
+    // Toggle the existing-dashboard dropdown when the radio changes.
+    var targetRadios = document.querySelectorAll('input[name="build-target"]');
+    var dashRow = document.getElementById('build-target-dashboard-row');
+    function syncTargetUi() {
+      if (!dashRow) return;
+      var sel = document.querySelector('input[name="build-target"]:checked');
+      dashRow.style.display = sel && sel.value === 'existing' ? 'block' : 'none';
+    }
+    for (var ti = 0; ti < targetRadios.length; ti++) {
+      targetRadios[ti].addEventListener('change', syncTargetUi);
+    }
+    syncTargetUi();
+
     var submitBtn = document.getElementById('build-submit-btn');
     if (!submitBtn) return;
 
@@ -271,9 +284,24 @@ export const BUILD_FROM_GOAL_JS = `
             var ta = document.querySelector('[data-new-agent-idx="' + i + '"]');
             return { id: a.id, purpose: a.purpose, yaml: ta ? ta.value : a.yaml };
           });
+          // Read the target picker. Defaults to 'agents' if the picker
+          // isn't present on the page (older surfaces that haven't been
+          // updated still get the old just-create-agents behavior).
+          var targetRadio = document.querySelector('input[name="build-target"]:checked');
+          var target = { kind: 'agents-only' };
+          if (targetRadio) {
+            var v = targetRadio.value;
+            if (v === 'new-dashboard') {
+              target = { kind: 'new-dashboard' };
+            } else if (v === 'existing') {
+              var sel = document.getElementById('build-target-dashboard');
+              if (sel && sel.value) target = { kind: 'existing-dashboard', dashboardId: sel.value };
+            }
+          }
           var payload = {
             plan: Object.assign({}, plan, { newAgents: editedNewAgents }),
             plannerRunId: runId,
+            target: target,
           };
 
           commitBtn.disabled = true;
@@ -305,6 +333,9 @@ export const BUILD_FROM_GOAL_JS = `
             }
             if (result.dashboardCreated) {
               summary += '<div>Created dashboard: <code>' + esc(result.dashboardCreated) + '</code></div>';
+            }
+            if (result.dashboardUpdated) {
+              summary += '<div>Added to dashboard: <code>' + esc(result.dashboardUpdated) + '</code></div>';
             }
             if (result.dashboardError) {
               summary += '<div class="dim" style="color:var(--color-danger,#a00);">Dashboard error: ' + esc(result.dashboardError) + '</div>';

--- a/packages/dashboard/src/views/dashboards.ts
+++ b/packages/dashboard/src/views/dashboards.ts
@@ -105,7 +105,10 @@ export function renderDashboardPage(input: RenderDashboardPageInput): string {
       JSON.stringify(input.availableAgents).replace(/</g, '\\u003c')
     }</script>`)}
     <span style="display: none;">${buildFromGoalButton()}</span>
-    ${buildFromGoalModal()}
+    ${buildFromGoalModal({
+      availableDashboards: input.installedDashboards.filter((d) => !d.packId).map((d) => ({ id: d.id, name: d.name })),
+      defaultDashboardId: input.dashboard.packId ? undefined : input.dashboard.id,
+    })}
   `;
 
   return render(layout({

--- a/packages/dashboard/src/views/home-widgets.ts
+++ b/packages/dashboard/src/views/home-widgets.ts
@@ -27,6 +27,8 @@ export interface HomeWidgetData {
   schedulerHeartbeat?: SchedulerHeartbeat | null;
   /** Last scheduled fire time per agent (from run store). */
   lastScheduledFires?: Record<string, string>;
+  /** User-owned dashboards offered as targets in the Build-from-goal wizard. */
+  availableDashboards?: Array<{ id: string; name: string }>;
 }
 
 interface SystemWidget {

--- a/packages/dashboard/src/views/home.ts
+++ b/packages/dashboard/src/views/home.ts
@@ -43,7 +43,7 @@ export function renderHomePage(input: HomeWidgetData): string {
 
     ${unsafeHtml(`<script type="application/json" id="home-widget-data">${JSON.stringify({ allTileIds, systemTileIds })}</script>`)}
 
-    ${buildFromGoalModal()}
+    ${buildFromGoalModal({ availableDashboards: input.availableDashboards })}
   `;
 
   return render(layout({ title: 'Dashboard', activeNav: 'agents' }, body));


### PR DESCRIPTION
## Summary
The Build-from-goal wizard now opens with a **Land where?** picker so the user explicitly chooses the outcome shape:

1. **Just create the agent(s)** — default; backwards-compatible (any planner-proposed dashboard is dropped).
2. **Create agent(s) + a new dashboard** — server synthesizes a user dashboard with the created agents if the planner didn't already produce one.
3. **Add to an existing dashboard** — dropdown of user dashboards; created agents are appended to section 0. Pack-owned dashboards aren't selectable.

On `/dashboards/<id>`, the current dashboard is pre-selected so iterating on an existing dashboard requires zero clicks.

## Wiring
- `buildFromGoalModal()` takes `availableDashboards` + optional `defaultDashboardId`.
- Threaded through home view + route, agents-list view + route, dashboards view (already had `installedDashboards`).
- `build-from-goal.js.ts` reads the radio + dropdown and sends `target` on the commit POST.
- `/agents/build/commit` parses target and applies it after agent creation. New `dashboardUpdated` field in the response so the wizard summary can say "Added to dashboard: X".

## Test plan
- [x] `npm test` → 1177/1177
- [ ] /agents page, click Build from goal → picker visible. Pick "Just agents", enter a goal, commit → only agents land, no dashboard.
- [ ] /agents, pick "New dashboard", commit → agents created + new `user:goal*` dashboard, redirect lands on the dashboard.
- [ ] /dashboards/<existing user dashboard>, click Build from goal → "Add to existing" is pre-selected with this dashboard. Commit → new agents appear in section 0 of the dashboard.
- [ ] Pack dashboard (`/dashboards/starter:media`) → "Add to existing" still selectable for *other* user dashboards but not the current pack one (pre-selection skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)