### PR TITLE
fix(dashboard): wizard Update-plan form + runId scoping bug

### DIFF
--- a/.changeset/wizard-update-plan-and-runid.md
+++ b/.changeset/wizard-update-plan-and-runid.md
@@ -1,0 +1,20 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+dashboard: Build-from-goal Plan-ready stage gets an "Update plan" form
+
+The Questions block now renders a textarea + **Update plan** button. Typing
+clarifications and clicking Update plan re-runs the planner with the
+original goal plus the appended answer, instead of asking the user to
+copy-paste their reply into the (now-hidden) goal field and start over.
+
+Also fixes a long-standing bug where clicking **Commit** threw
+`ReferenceError: runId is not defined` because `wireCommit` referenced a
+variable that lived inside an inner `.then` scope. The planner runId is
+now lifted to the outer planner-run scope so commit-time telemetry
+correlation works.

--- a/packages/dashboard/src/views/build-from-goal.js.ts
+++ b/packages/dashboard/src/views/build-from-goal.js.ts
@@ -45,16 +45,29 @@ export const BUILD_FROM_GOAL_JS = `
     var submitBtn = document.getElementById('build-submit-btn');
     if (!submitBtn) return;
 
+    // Track the most recent goal/focus so the "Update plan" button in the
+    // Questions block can re-run the planner with appended clarifications
+    // (the original goal field is gone from the DOM by then).
+    var lastGoal = '';
+    var lastFocus = '';
+
     submitBtn.addEventListener('click', function () {
       var goalEl = document.getElementById('build-goal');
       var focusEl = document.getElementById('build-focus');
       var goal = goalEl ? goalEl.value.trim() : '';
       if (!goal) { goalEl && goalEl.focus(); return; }
       var focus = focusEl ? focusEl.value.trim() : '';
+      runPlanner(goal, focus);
+    });
 
+    function runPlanner(goal, focus) {
+      lastGoal = goal;
+      lastFocus = focus;
       var t0 = Date.now();
       var cancelled = false;
       var pollTimer = null;
+      // Lifted so wireCommit (a sibling of the .then) can reference it.
+      var runId = null;
       var PHASES = [[0,'Planning...'],[10,'Surveying installed agents...'],[25,'Drafting new agents...'],[55,'Designing dashboard...'],[90,'Almost there...']];
 
       content.innerHTML =
@@ -98,7 +111,7 @@ export const BUILD_FROM_GOAL_JS = `
           renderError(startData.error || 'Failed to start planner');
           return;
         }
-        var runId = startData.runId;
+        runId = startData.runId;
 
         function poll() {
           if (cancelled) return;
@@ -243,17 +256,24 @@ export const BUILD_FROM_GOAL_JS = `
           h += '</div>';
         }
 
-        // Questions block
+        // Questions block — answer inline + Update plan re-runs the planner
+        // with original goal + appended clarifications.
         if (plan.questions && plan.questions.length) {
           h += '<div class="card card--muted" style="padding:var(--space-2) var(--space-3);margin-bottom:var(--space-3);font-size:var(--font-size-xs);">' +
                '<div class="dim" style="font-weight:var(--weight-semibold);margin-bottom:var(--space-1);">Questions</div>';
           for (var k = 0; k < plan.questions.length; k++) {
             var q = plan.questions[k];
-            h += '<div style="margin-top:var(--space-1);">• ' + esc(q.text);
+            h += '<div style="margin-top:var(--space-1);">\\u2022 ' + esc(q.text);
             if (q.suggestedAnswer) h += ' <span class="dim">(suggested: ' + esc(q.suggestedAnswer) + ')</span>';
             h += '</div>';
           }
-          h += '<div class="dim" style="margin-top:var(--space-2);font-size:var(--font-size-xs);">To answer, append your reply to the goal and re-run.</div>' +
+          h += '<div style="margin-top:var(--space-2);">' +
+                 '<textarea id="build-answers" rows="2" placeholder="Your answers / clarifications..." ' +
+                 'style="width:100%;padding:var(--space-2);border:1px solid var(--color-border-strong);border-radius:var(--radius-sm);font-size:var(--font-size-xs);resize:vertical;"></textarea>' +
+                 '<div style="display:flex;justify-content:flex-end;margin-top:var(--space-1);">' +
+                   '<button type="button" class="btn btn--sm" id="build-update-plan">Update plan</button>' +
+                 '</div>' +
+               '</div>' +
                '</div>';
         }
 
@@ -273,6 +293,18 @@ export const BUILD_FROM_GOAL_JS = `
 
         // Stash the plan so commit can rebuild it with edited YAMLs.
         wireCommit(plan);
+
+        // "Update plan" — re-run the planner with the original goal plus
+        // any clarifications the user typed in the answers textarea.
+        var updateBtn = document.getElementById('build-update-plan');
+        if (updateBtn) {
+          updateBtn.addEventListener('click', function () {
+            var ansEl = document.getElementById('build-answers');
+            var ans = ansEl ? ansEl.value.trim() : '';
+            if (!ans) { ansEl && ansEl.focus(); return; }
+            runPlanner(lastGoal + '\\n\\nClarifications: ' + ans, lastFocus);
+          });
+        }
       }
 
       function wireCommit(plan) {


### PR DESCRIPTION
## Summary
Two fixes to the Build-from-goal wizard:

1. **Plan-ready Questions block gets an Update-plan form.** Per [your screenshot](https://github.com/gregmeyer/some-useful-agents/issues), the planner asks clarifying questions but tells the user to *"append your reply to the goal and re-run"* — meanwhile the goal field is gone from the DOM. The Questions block now renders a textarea + **Update plan** button. Typing clarifications re-runs the planner with `originalGoal + "\n\nClarifications: " + answer`. Refactored the planner-run into a callable `runPlanner(goal, focus)` function so the same flow re-fires from the answer button.

2. **Fixes `ReferenceError: runId is not defined` on Commit.** `wireCommit` referenced a `runId` declared with `var` inside an inner `.then` callback — invisible to siblings. Lifted to the outer planner-run scope so commit-time telemetry correlation actually works (this was probably silently broken since the planner-runId telemetry shipped).

## Test plan
- [x] `npm test` → 1177/1177
- [ ] Live: open Build-from-goal, enter a goal that produces clarifying questions ("scheduled agent that fetches a daily landscape photo from Unsplash by keyword"). On the Plan-ready stage, type an answer, click **Update plan** → modal returns to the Planning state and the planner re-runs with the appended clarification.
- [ ] Same flow, click **Commit** → no console error, agents land.

## Re: that 4000-line file

The "user:job-search:3953" file in your error is the rendered HTML page — not a source file. All wizard JS is inlined into `<script>` tags in the page body (see [layout.ts:73](packages/dashboard/src/views/layout.ts#L73)). So the line count reflects every inlined JS module concatenated. The actual source files are under [packages/dashboard/src/views/*.js.ts](packages/dashboard/src/views/) and they're all <600 lines. No real refactor needed — could split the inline script into separate `/assets/wizard.js` etc. for caching/debugging, but that's a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)