### PR TITLE
feat(dashboard): Permissions card on agent Config tab

### DIFF
--- a/.changeset/permissions-card.md
+++ b/.changeset/permissions-card.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+dashboard: Permissions card on agent Config tab
+
+Surfaces the `permissions.imgSrc` allowlist (added in #256) on the
+agent detail Config tab. New POST /agents/:id/permissions route accepts
+a newline / comma / space-separated host list, normalises (lowercases,
+strips https:// + paths + ports so users can paste full URLs), dedupes,
+validates each entry against the host regex, and creates a new agent
+version. Empty input clears the allowlist. Pack-installed agents pick
+up the same UI — edits become a local user-version on top of the pack.

--- a/packages/dashboard/src/routes/schedule-edit.test.ts
+++ b/packages/dashboard/src/routes/schedule-edit.test.ts
@@ -165,3 +165,57 @@ describe('POST /agents/:id/schedule', () => {
     expect(res.headers.location).toBe('/agents');
   });
 });
+
+describe('POST /agents/:id/permissions', () => {
+  it('accepts a newline-separated list of valid hosts and bumps the agent version', async () => {
+    const app = await makeApp();
+    const initial = agentStore.getAgent('sched-agent')!.version;
+    const res = await request(app).post('/agents/sched-agent/permissions')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .type('form').send({ imgSrc: 'images.unsplash.com\n*.unsplash.com' });
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toContain('img-src%20updated');
+    const after = agentStore.getAgent('sched-agent')!;
+    expect(after.permissions?.imgSrc).toEqual(['images.unsplash.com', '*.unsplash.com']);
+    expect(after.version).toBe(initial + 1);
+  });
+
+  it('strips https:// + paths + ports so users can paste full URLs', async () => {
+    const app = await makeApp();
+    const res = await request(app).post('/agents/sched-agent/permissions')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .type('form').send({ imgSrc: 'https://images.unsplash.com/foo/bar, http://other.example.com:8080/x' });
+    expect(res.status).toBe(303);
+    expect(agentStore.getAgent('sched-agent')!.permissions?.imgSrc).toEqual([
+      'images.unsplash.com',
+      'other.example.com',
+    ]);
+  });
+
+  it('rejects malformed hosts with a flash message and leaves the agent unchanged', async () => {
+    const app = await makeApp();
+    const before = agentStore.getAgent('sched-agent')!.version;
+    const res = await request(app).post('/agents/sched-agent/permissions')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .type('form').send({ imgSrc: 'bad_host_with_underscore' });
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/Invalid%20host/);
+    expect(agentStore.getAgent('sched-agent')!.version).toBe(before);
+  });
+
+  it('clears imgSrc when given an empty list', async () => {
+    const app = await makeApp();
+    // Seed permissions first.
+    await request(app).post('/agents/sched-agent/permissions')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .type('form').send({ imgSrc: 'images.unsplash.com' });
+    expect(agentStore.getAgent('sched-agent')!.permissions?.imgSrc).toEqual(['images.unsplash.com']);
+
+    const res = await request(app).post('/agents/sched-agent/permissions')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .type('form').send({ imgSrc: '' });
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toContain('cleared');
+    expect(agentStore.getAgent('sched-agent')!.permissions).toBeUndefined();
+  });
+});

--- a/packages/dashboard/src/routes/versions.ts
+++ b/packages/dashboard/src/routes/versions.ts
@@ -327,3 +327,75 @@ versionsRouter.post('/agents/:id/llm', (req: Request, res: Response) => {
     res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent(`LLM update failed: ${msg}`)}`);
   }
 });
+
+// CSP host syntax — must match the regex in agent-v2-schema.ts
+// (`permissions.imgSrc` items). Lowercase host name with optional
+// leading "*." for wildcard subdomains. Schemes/ports are stripped on
+// input and re-added by the dashboard middleware.
+const IMG_SRC_HOST_RE = /^(\*\.)?[a-z0-9]([a-z0-9.-]*[a-z0-9])?$/;
+
+/**
+ * POST /agents/:id/permissions — update CSP allowlists declared by the
+ * agent. Accepts `imgSrc` as a newline-separated host list (textarea-
+ * friendly), normalises (lowercase, strip scheme + trailing path),
+ * dedupes, and validates each entry. Creates a new agent version since
+ * permissions live in the versioned DAG.
+ */
+versionsRouter.post('/agents/:id/permissions', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const raw = typeof body.imgSrc === 'string' ? body.imgSrc : '';
+
+  const agent = ctx.agentStore.getAgent(id);
+  if (!agent) {
+    res.status(404).redirect(303, '/agents');
+    return;
+  }
+
+  // Normalise: split on whitespace/commas, trim, lowercase, strip
+  // common prefixes/paths so users can paste full URLs without
+  // tripping the regex.
+  const seen = new Set<string>();
+  const hosts: string[] = [];
+  const invalid: string[] = [];
+  for (const piece of raw.split(/[\s,]+/)) {
+    if (!piece) continue;
+    let h = piece.trim().toLowerCase();
+    h = h.replace(/^https?:\/\//, '').replace(/\/.*$/, '').replace(/:\d+$/, '');
+    if (!h || seen.has(h)) continue;
+    seen.add(h);
+    if (!IMG_SRC_HOST_RE.test(h)) { invalid.push(h); continue; }
+    hosts.push(h);
+  }
+  if (invalid.length > 0) {
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent(
+      `Invalid host${invalid.length === 1 ? '' : 's'}: ${invalid.join(', ')}. Use lowercase host names like images.unsplash.com or *.unsplash.com.`,
+    )}`);
+    return;
+  }
+
+  const existing = (agent.permissions?.imgSrc ?? []).slice().sort();
+  const next = hosts.slice().sort();
+  if (existing.length === next.length && existing.every((h, i) => h === next[i])) {
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent('Permissions unchanged.')}`);
+    return;
+  }
+
+  try {
+    const newPermissions = hosts.length > 0 ? { ...agent.permissions, imgSrc: hosts } : (() => {
+      // Drop imgSrc; if no other permissions remain, drop the whole field.
+      const rest = { ...agent.permissions };
+      delete rest.imgSrc;
+      return Object.keys(rest).length > 0 ? rest : undefined;
+    })();
+    const updated = { ...agent, permissions: newPermissions };
+    ctx.agentStore.upsertAgent(updated, 'dashboard', `Updated img-src permissions (${hosts.length} host${hosts.length === 1 ? '' : 's'})`);
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent(
+      hosts.length === 0 ? 'img-src permissions cleared.' : `img-src updated (${hosts.length} host${hosts.length === 1 ? '' : 's'}).`,
+    )}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent(`Permissions update failed: ${msg}`)}`);
+  }
+});

--- a/packages/dashboard/src/views/agent-detail/config.ts
+++ b/packages/dashboard/src/views/agent-detail/config.ts
@@ -176,6 +176,30 @@ export async function renderAgentConfig(args: AgentDetailArgs): Promise<string> 
     </form>
   `);
 
+  const permImgSrc = agent.permissions?.imgSrc ?? [];
+  const permissionsCard = configCard('Permissions', html`
+    <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-3);">
+      Hosts this agent's widgets can load images from. Each line widens the
+      page CSP <code>img-src</code> directive (prefixed with <code>https://</code>).
+      Wildcards like <code>*.unsplash.com</code> are allowed. Saving creates a
+      new agent version.
+    </p>
+    <form method="POST" action="/agents/${agent.id}/permissions" style="display: flex; flex-direction: column; gap: var(--space-2);">
+      <label style="font-size: var(--font-size-xs); color: var(--color-text-muted);">img-src hosts (one per line)</label>
+      <textarea name="imgSrc" rows="3" placeholder="images.unsplash.com&#10;*.unsplash.com"
+        class="form-field mono"
+        style="padding: var(--space-1) var(--space-2); font-size: var(--font-size-sm); resize: vertical;">${permImgSrc.join('\n')}</textarea>
+      <div style="display: flex; justify-content: space-between; align-items: center;">
+        <span class="dim" style="font-size: var(--font-size-xs);">
+          ${permImgSrc.length === 0
+            ? html`No hosts declared.`
+            : html`${String(permImgSrc.length)} host${permImgSrc.length === 1 ? '' : 's'} declared.`}
+        </span>
+        <button type="submit" class="btn btn--sm">Save</button>
+      </div>
+    </form>
+  `);
+
   const llmCard = configCard('LLM defaults', html`
     <form method="POST" action="/agents/${agent.id}/llm" id="llm-form" style="display: flex; flex-direction: column; gap: var(--space-2);">
       <div style="display: flex; gap: var(--space-2); align-items: center;">
@@ -265,6 +289,7 @@ export async function renderAgentConfig(args: AgentDetailArgs): Promise<string> 
         ${scheduleCard}
         ${visibilityCard}
         ${mcpCard}
+        ${permissionsCard}
         ${secretsCard}
       </div>
       <div class="config-grid__col">


### PR DESCRIPTION
## Summary
Followup to #256. The `permissions.imgSrc` allowlist was YAML-only; this surfaces it as an editable card on the agent Config tab so users can manage hosts without editing YAML or patching SQL.

- New card between **MCP exposure** and **Secrets**.
- Textarea takes hosts one per line (commas + whitespace also accepted).
- Server normalises before validating: lowercase, strip `https://`, strip `/path`, strip `:port` — so users can paste a full URL and have it work.
- Validates against the same regex used by `agent-v2-schema.ts` (`^(\\*\\.)?[a-z0-9]([a-z0-9.-]*[a-z0-9])?$`).
- Wildcards (`*.unsplash.com`) supported.
- Saves create a new agent version since permissions live in the versioned DAG.
- Empty input clears the field; if no other permissions remain, the whole `permissions` field is dropped.

## Test plan
- [x] `npm test` → 1182/1182 (4 new POST tests: valid hosts + version bump, URL normalisation, invalid host rejection, clear)
- [ ] Live: visit any agent's Config tab → Permissions card appears below MCP exposure. Paste \`https://images.unsplash.com/foo, plus.unsplash.com\` → save → flash says "img-src updated (2 hosts)", textarea shows normalised hosts. Reload pulse — image renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)