### PR TITLE
feat(dashboard): prompt before navigating away from edit mode

### DIFF
--- a/.changeset/edit-mode-leave-prompt.md
+++ b/.changeset/edit-mode-leave-prompt.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+dashboard: prompt before navigating away from edit mode
+
+Adds a `beforeunload` guard while a layout surface (Pulse, Home, or
+/dashboards/:id) is in edit mode, so accidentally closing the tab or
+clicking a nav link mid-arrange triggers the browser's "leave site?"
+dialog. Drag/resize/palette changes already persist to localStorage
+instantly — this is purely a guardrail against losing your visual focus
+while still in the middle of arranging tiles. Browsers ignore the
+returned string and show their own generic dialog text.

--- a/packages/dashboard/src/views/widget-layout.js.ts
+++ b/packages/dashboard/src/views/widget-layout.js.ts
@@ -379,6 +379,19 @@ export function widgetLayoutJS(config: WidgetLayoutConfig): string {
     // boolean read from localStorage above.
     if (editMode) setEditMode(true);
 
+    // Reassurance prompt when navigating away mid-edit. Drag/resize/etc.
+    // already write to localStorage instantly so nothing is "unsaved" —
+    // this just guards against accidental navigation while the user is
+    // still arranging tiles. Browsers ignore the returned string and
+    // show their own generic dialog text; presence of a return value
+    // is what triggers the prompt.
+    window.addEventListener('beforeunload', function (e) {
+      if (!editMode) return;
+      e.preventDefault();
+      e.returnValue = '';
+      return '';
+    });
+
     // ── Drag and drop ────────────────────────────────────────────────
     var draggedId = null;
     var draggedEl = null;


### PR DESCRIPTION
## Summary
Adds a `beforeunload` guard while any layout surface (Pulse, Home, or `/dashboards/:id`) is in edit mode. Triggers the browser's generic "leave site?" dialog so accidentally closing the tab or clicking a nav link mid-arrange isn't silent.

Edits already persist to localStorage on every drag/resize/palette change, so nothing is "unsaved" — this is purely a guardrail against losing visual focus while still in the middle of arranging tiles.

## Test plan
- [x] `npm test` → 1182/1182
- [ ] Live: visit /pulse, click ✎ Edit layout, then try to close the tab → browser confirms "leave?". Click Done editing first → no prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)