### PR TITLE
fix(dashboard): clear edit-mode flag on pagehide

### DIFF
--- a/.changeset/clear-edit-mode-on-pagehide.md
+++ b/.changeset/clear-edit-mode-on-pagehide.md
@@ -1,0 +1,14 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+dashboard: clear edit-mode flag on pagehide
+
+Followup to #258. Edit mode persisted across navigations (from #242)
+so returning to a layout surface re-entered edit mode unexpectedly.
+`pagehide` now clears the flag — edit mode still survives drags
+within a page session, but resets when you actually leave.

--- a/packages/dashboard/src/views/widget-layout.js.ts
+++ b/packages/dashboard/src/views/widget-layout.js.ts
@@ -392,6 +392,14 @@ export function widgetLayoutJS(config: WidgetLayoutConfig): string {
       return '';
     });
 
+    // Whether the user confirms or refreshes, exit edit mode on the way
+    // out so coming back lands on the normal view. Edit mode is meant
+    // to be a focused arranging session, not a sticky surface state —
+    // re-entering edit mode unexpectedly on a return visit was confusing.
+    window.addEventListener('pagehide', function () {
+      saveEditMode(false);
+    });
+
     // ── Drag and drop ────────────────────────────────────────────────
     var draggedId = null;
     var draggedEl = null;


### PR DESCRIPTION
## Summary
Followup to #258. Edit mode persisted across navigations (from #242) so returning to a layout surface re-entered edit mode unexpectedly. `pagehide` now clears the flag — edit mode still survives drags within a page session, but resets when you actually leave.

## Test plan
- [x] `npm run build` clean
- [ ] Live: enter edit mode on /pulse → close tab (or nav away after dismissing the prompt) → return → page is in normal mode, not edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)