### PR TITLE
ci: gitleaks secret-scan on push + PR

### DIFF
--- a/.changeset/gitleaks-secret-scan.md
+++ b/.changeset/gitleaks-secret-scan.md
@@ -1,0 +1,22 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+ci: gitleaks secret-scan on push + PR
+
+Adds `.github/workflows/secret-scan.yml` running gitleaks on every
+push + pull request. Catches secret-shaped strings (`xoxb-…`,
+`ghp_…`, `AIza…`, base64 RSA keys, …) before they hit main on a
+public repo. Config in `.gitleaks.toml` extends the upstream default
+ruleset and allowlists test fixtures that intentionally hold
+secret-shaped strings (redactor self-tests, env-builder fixtures,
+ADR examples).
+
+`scripts/install-hooks.sh` is an opt-in local pre-commit hook that
+runs the same scan against staged changes so leaks die at commit
+time rather than after a force-push. Not auto-installed by
+`npm install` — explicit by design. Documented in docs/SECURITY.md.

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,29 @@
+name: Secret scan
+
+# Catches accidental secret commits before they hit the public branch.
+# Runs on every push + PR. Fail-loud — a flagged finding blocks merge.
+# Local devs can opt into the same check via scripts/install-hooks.sh.
+
+on:
+  push:
+    branches: [main, changeset-release/main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Full history so gitleaks can scan the whole tree, not just
+          # the diff. A leaked token in an old commit is still a leak.
+          fetch-depth: 0
+
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2.3.7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # No GITLEAKS_LICENSE — the action is free for public repos
+          # without a license; org-private repos need one.

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,31 @@
+# Extends the upstream default ruleset (https://github.com/gitleaks/gitleaks)
+# and allowlists test fixtures that intentionally contain secret-shaped
+# strings to exercise the redactor.
+#
+# Authoring note: this is the trust boundary. Any new file that holds
+# fake-but-real-looking secrets must be added to the `paths` list below,
+# OR (preferable) the test should generate the value at runtime instead
+# of hard-coding it.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Test fixtures + redactor self-tests with intentionally secret-shaped strings"
+paths = [
+  # secret-redactor tests construct fake tokens to verify masking
+  '''packages/core/src/secret-redactor\.test\.ts''',
+  # dag-executor test uses ghp_-shaped default to verify env scrubbing
+  '''packages/core/src/dag-executor\.test\.ts''',
+  # env-builder + local-provider tests assemble fake creds in fixtures
+  '''packages/core/src/env-builder\.test\.ts''',
+  '''packages/core/src/local-provider\.test\.ts''',
+  # node-env declares pattern constants used by the redactor
+  '''packages/core/src/node-env\.ts''',
+  '''packages/core/src/secret-redactor\.ts''',
+  # registry references known patterns
+  '''packages/core/src/registry\.ts''',
+  # ADRs and CHANGELOGs reference patterns in example form
+  '''docs/adr/.*\.md''',
+  '''.*CHANGELOG\.md''',
+]

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -117,6 +117,19 @@ CLI surface.
 to v2 under the caller's passphrase; `sua secrets migrate` does the same
 without requiring a value change.
 
+### Public-repo secret hygiene (v0.21+)
+
+The project source lives in a public GitHub repo. Secrets must never land in commits — `.gitignore` excludes the runtime homes that hold them (`data/`, `~/.sua/`, `.env*`, `agents/local/`) and the encrypted secrets store sits at `~/.sua/secrets.enc`, outside the working tree entirely.
+
+In addition to the gitignore:
+
+- **Gitleaks runs in CI** on every push + pull request via `.github/workflows/secret-scan.yml`. A finding fails the job; the PR can't merge until cleared. The scan reads `.gitleaks.toml`, which extends the upstream default ruleset and allowlists test fixtures that intentionally contain secret-shaped strings (the redactor self-tests, fake `ghp_…` defaults in dag-executor tests, etc.).
+- **Opt-in local hook**: `./scripts/install-hooks.sh` installs a `.git/hooks/pre-commit` that runs `gitleaks protect --staged` so leaks die at commit time rather than after a force-push. Not auto-installed by `npm install` — explicit by design.
+- **Test fixtures convention**: any value that could be mistaken for a real secret must either be generated at test runtime or live in one of the allowlisted paths in `.gitleaks.toml`. Don't add new hard-coded fake tokens outside that list.
+- **Bypassing**: `git commit --no-verify` skips the local hook. CI is the ground truth; don't rely on `--no-verify` to silence a real finding.
+
+If gitleaks fires on a file you believe is a true positive, **rotate the credential first**, then remove from history via `git filter-repo` or BFG. Treat any committed real-looking secret as compromised even if quickly reverted — `git push` is public.
+
 ### Supply chain (v0.4.0)
 
 - Third-party GitHub Actions are pinned to full SHAs with version comments (`actions/checkout`, `actions/setup-node`, `changesets/action`). A compromise of those orgs cannot ship malicious code through a moving tag. Dependabot refreshes the SHAs weekly in its own PRs for review.

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Opt-in local secret-scan pre-commit hook.
+#
+# Usage:  ./scripts/install-hooks.sh
+# Removes itself with:  rm .git/hooks/pre-commit
+#
+# Requires gitleaks installed locally. Install on macOS:  brew install gitleaks
+# Other platforms:  https://github.com/gitleaks/gitleaks#installing
+#
+# This is intentionally not auto-installed by `npm install` — keeps the
+# hook explicit. CI (.github/workflows/secret-scan.yml) catches anything
+# that slips past, but the local hook saves you a force-push.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOK_PATH="$REPO_ROOT/.git/hooks/pre-commit"
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "gitleaks not found on PATH." >&2
+  echo "Install:  brew install gitleaks  (or see https://github.com/gitleaks/gitleaks)" >&2
+  exit 1
+fi
+
+cat > "$HOOK_PATH" <<'HOOK'
+#!/usr/bin/env bash
+# Auto-installed by scripts/install-hooks.sh — runs gitleaks against
+# staged changes. To bypass for a single commit:  git commit --no-verify
+# (use sparingly; CI will still block).
+set -e
+exec gitleaks protect --staged --redact --no-banner --verbose --config "$(git rev-parse --show-toplevel)/.gitleaks.toml"
+HOOK
+
+chmod +x "$HOOK_PATH"
+echo "Installed pre-commit hook at $HOOK_PATH"
+echo "Test it:  gitleaks protect --staged --no-banner --config .gitleaks.toml"


### PR DESCRIPTION
## Summary
Adds gitleaks as a GitHub Action on every push + PR. Catches secret-shaped strings (`xoxb-…`, `ghp_…`, `AIza…`, base64 RSA keys, etc.) before they hit `main` on this public repo. Lands ahead of the Settings → Integrations work so the rails exist before new secret-adjacent surfaces ship.

- **`.github/workflows/secret-scan.yml`** — `gitleaks/gitleaks-action@v2` with `fetch-depth: 0` so the whole tree is scanned, not just the diff. Action is free for public repos.
- **`.gitleaks.toml`** — extends the upstream default ruleset and allowlists paths that intentionally contain fake secret-shaped strings (redactor self-tests, env-builder fixtures, ADRs that document the patterns). New fakes belong in the allowlist or should be runtime-generated.
- **`scripts/install-hooks.sh`** — opt-in pre-commit hook (`gitleaks protect --staged`) so leaks fail at commit time instead of post-push. Not auto-installed by `npm install` — explicit by design.
- **`docs/SECURITY.md`** — new "Public-repo secret hygiene" section under defenses. Documents the rails, the bypass posture, and the rotate-first response.

## Test plan
- [ ] CI gitleaks job runs green on this PR.
- [ ] Manually flip a known-bad token into a non-allowlisted file → push to a throwaway branch → CI fails as expected → revert. (I can do this in a follow-up if you want to validate the failure path explicitly.)
- [ ] `gitleaks --version && bash scripts/install-hooks.sh` then attempt to commit a token-shaped string → hook blocks.

## Followup
Once this lands, **PR 1** (Integrations storage + UI) starts on top of it — see [plan](https://github.com/anthropics/claude-code/blob/main/...) (local, `~/.claude/plans/does-it-make-more-joyful-wilkinson.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)