### PR TITLE
feat: Settings → Integrations (PR 1) — storage + UI for slack/webhook/file

### DIFF
--- a/.changeset/integrations-storage.md
+++ b/.changeset/integrations-storage.md
@@ -1,0 +1,32 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Settings → Integrations (PR 1 of 4): storage + UI for slack/webhook/file
+
+Adds the `integrations` SQLite table + `IntegrationsStore` (core),
+context wiring (dashboard), and a real `/settings/integrations` page
+that replaces the "coming in a later release" placeholder. Today
+covers three kinds — `slack`, `webhook`, `file` — lifted from the
+per-agent notify handlers so the model carries over unchanged.
+
+Each integration row stores names only: kind-specific config (URL,
+path, channel, mention, method) and `secretRefs` pointing at the
+encrypted secrets store. Actual secret values never touch the
+integrations table.
+
+Per-agent notify still reads its existing inline handlers; PR 2 of
+this series adds the `handlers[].integration: <id>` form so agents
+can reference these by id. PR 3 adds OAuth (loopback callback + Gmail
+kind). PR 4 folds the connectors-v0.17 plan in as `kind: csv` /
+`kind: postgres`.
+
+Includes 8 store tests (round-trip, slug validation, list-by-kind /
+by-user / pack ownership, cascade-delete, JSON corruption fallback)
+and 5 dashboard route tests (render, add, slug rejection, duplicate
+guard, delete). Pack-owned integrations show but their Delete button
+is disabled — pack uninstall remains the path to remove them.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -65,6 +65,12 @@ export {
   type DashboardLayout,
 } from './dashboards-store.js';
 export {
+  IntegrationsStore,
+  INTEGRATION_ID_RE,
+  type Integration,
+  type IntegrationKind,
+} from './integrations-store.js';
+export {
   PlannerTelemetryStore,
   type PlannerTelemetryRow,
   type PlannerTelemetryStats,

--- a/packages/core/src/integrations-store.test.ts
+++ b/packages/core/src/integrations-store.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { IntegrationsStore } from './integrations-store.js';
+
+let dir: string;
+let store: IntegrationsStore;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'sua-integrations-store-'));
+  store = new IntegrationsStore(join(dir, 'runs.db'));
+});
+
+afterEach(() => {
+  try { store.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('IntegrationsStore', () => {
+  it('upserts and retrieves an integration', () => {
+    store.upsertIntegration({
+      id: 'user:oncall-slack',
+      packId: null,
+      kind: 'slack',
+      name: 'Oncall Slack',
+      config: { channel: '#alerts' },
+      secretRefs: ['SLACK_WEBHOOK'],
+    });
+    const got = store.getIntegration('user:oncall-slack');
+    expect(got).not.toBeNull();
+    expect(got!.kind).toBe('slack');
+    expect(got!.name).toBe('Oncall Slack');
+    expect(got!.config).toEqual({ channel: '#alerts' });
+    expect(got!.secretRefs).toEqual(['SLACK_WEBHOOK']);
+    expect(got!.packId).toBeNull();
+    expect(typeof got!.createdAt).toBe('number');
+    expect(got!.updatedAt).toBe(got!.createdAt);
+  });
+
+  it('preserves createdAt + bumps updatedAt on update', async () => {
+    store.upsertIntegration({
+      id: 'user:oncall-slack',
+      packId: null,
+      kind: 'slack',
+      name: 'Oncall Slack',
+      config: { channel: '#alerts' },
+      secretRefs: ['SLACK_WEBHOOK'],
+    });
+    const initial = store.getIntegration('user:oncall-slack')!;
+    await new Promise((r) => setTimeout(r, 5));
+    store.upsertIntegration({
+      id: 'user:oncall-slack',
+      packId: null,
+      kind: 'slack',
+      name: 'Oncall Slack (renamed)',
+      config: { channel: '#oncall' },
+      secretRefs: ['SLACK_WEBHOOK'],
+    });
+    const updated = store.getIntegration('user:oncall-slack')!;
+    expect(updated.createdAt).toBe(initial.createdAt);
+    expect(updated.updatedAt).toBeGreaterThan(initial.updatedAt);
+    expect(updated.name).toBe('Oncall Slack (renamed)');
+    expect(updated.config).toEqual({ channel: '#oncall' });
+  });
+
+  it('rejects ids that violate the slug regex', () => {
+    expect(() =>
+      store.upsertIntegration({
+        id: 'NotLowercase',
+        packId: null,
+        kind: 'slack',
+        name: 'x',
+        config: {},
+        secretRefs: [],
+      }),
+    ).toThrow(/Invalid integration id/);
+    expect(() =>
+      store.upsertIntegration({
+        id: 'spaces not allowed',
+        packId: null,
+        kind: 'slack',
+        name: 'x',
+        config: {},
+        secretRefs: [],
+      }),
+    ).toThrow(/Invalid integration id/);
+  });
+
+  it('lists by kind + by user, ordered by name', () => {
+    store.upsertIntegration({ id: 'user:b-webhook', packId: null, kind: 'webhook', name: 'B Webhook', config: { url: 'https://b.example.com' }, secretRefs: [] });
+    store.upsertIntegration({ id: 'user:a-slack', packId: null, kind: 'slack', name: 'A Slack', config: { channel: '#a' }, secretRefs: ['SLACK_A'] });
+    store.upsertIntegration({ id: 'starter:notify', packId: 'starter', kind: 'webhook', name: 'C Webhook (pack)', config: { url: 'https://c.example.com' }, secretRefs: [] });
+
+    expect(store.listIntegrations().map((i) => i.id)).toEqual(['user:a-slack', 'user:b-webhook', 'starter:notify']);
+    expect(store.listByKind('webhook').map((i) => i.id)).toEqual(['user:b-webhook', 'starter:notify']);
+    expect(store.listUserIntegrations().map((i) => i.id)).toEqual(['user:a-slack', 'user:b-webhook']);
+  });
+
+  it('returns null for unknown id', () => {
+    expect(store.getIntegration('user:nope')).toBeNull();
+  });
+
+  it('deletes a single integration and reports the result', () => {
+    store.upsertIntegration({ id: 'user:x', packId: null, kind: 'slack', name: 'X', config: {}, secretRefs: [] });
+    expect(store.deleteIntegration('user:x')).toBe(true);
+    expect(store.getIntegration('user:x')).toBeNull();
+    expect(store.deleteIntegration('user:x')).toBe(false);
+  });
+
+  it('cascades pack-owned deletes via deleteByPack', () => {
+    store.upsertIntegration({ id: 'starter:a', packId: 'starter', kind: 'slack', name: 'A', config: {}, secretRefs: [] });
+    store.upsertIntegration({ id: 'starter:b', packId: 'starter', kind: 'file', name: 'B', config: { path: 'out.log' }, secretRefs: [] });
+    store.upsertIntegration({ id: 'user:keep', packId: null, kind: 'slack', name: 'Keep', config: {}, secretRefs: [] });
+
+    const removed = store.deleteByPack('starter');
+    expect(removed).toBe(2);
+    expect(store.listIntegrations().map((i) => i.id)).toEqual(['user:keep']);
+  });
+
+  it('survives malformed JSON in legacy rows by defaulting', () => {
+    // Sneak a row in with broken JSON to make sure rowToIntegration doesn't crash.
+    const dbPath = join(dir, 'runs.db');
+    const { DatabaseSync } = require('node:sqlite');
+    const raw = new DatabaseSync(dbPath);
+    const now = Date.now();
+    raw.prepare(`
+      INSERT INTO integrations (id, pack_id, kind, name, config_json, secret_refs_json, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `).run('user:broken', null, 'slack', 'Broken', '{not json', '[not json', now, now);
+    raw.close();
+
+    const got = store.getIntegration('user:broken');
+    expect(got).not.toBeNull();
+    expect(got!.config).toEqual({});
+    expect(got!.secretRefs).toEqual([]);
+  });
+});

--- a/packages/core/src/integrations-store.ts
+++ b/packages/core/src/integrations-store.ts
@@ -1,0 +1,188 @@
+import { DatabaseSync } from 'node:sqlite';
+import { mkdirSync, existsSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { chmod600Safe } from './fs-utils.js';
+
+/**
+ * The kinds an integration row can declare. The store accepts any string so
+ * new kinds (gmail, postgres, csv, …) can land without a schema bump — the
+ * dashboard/route layer is responsible for validating that the kind is one
+ * it knows how to render and dispatch.
+ *
+ * Today: lifted from the per-agent notify handlers so PR 1 is purely
+ * additive — notify keeps working unchanged, and PR 2 will let agents
+ * reference these integrations by id.
+ */
+export type IntegrationKind = 'slack' | 'webhook' | 'file' | (string & {});
+
+export interface Integration {
+  /** Namespaced slug: "user:<name>" for user-created, "<packId>:<name>" for pack-installed. */
+  id: string;
+  /** Pack ownership. NULL for user-created. Pack-installed integrations are not deletable until the pack is uninstalled. */
+  packId: string | null;
+  /** Driver kind (slack / webhook / file / ...) — see IntegrationKind. */
+  kind: IntegrationKind;
+  /** Human-readable display name, separate from the slug. */
+  name: string;
+  /** Kind-specific config. Never holds secret values — only URLs, paths, channel names, etc. */
+  config: Record<string, unknown>;
+  /** Names of secrets this integration resolves from the encrypted secrets store at use time. */
+  secretRefs: string[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+/**
+ * Allowed id format. Matches DashboardsStore's convention: lowercase with
+ * `:` for namespacing. Enforced at the store boundary so callers can't
+ * smuggle in arbitrary text that would later break URL routing.
+ */
+export const INTEGRATION_ID_RE = /^[a-z0-9][a-z0-9:_-]*$/;
+
+/** SQLite-backed store for named external-service integrations. */
+export class IntegrationsStore {
+  private db: DatabaseSync;
+  private readonly ownsConnection: boolean;
+  public readonly dataRoot: string;
+
+  constructor(dbPath: string) {
+    const dir = dirname(dbPath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    this.db = new DatabaseSync(dbPath);
+    this.ownsConnection = true;
+    chmod600Safe(dbPath);
+    this.dataRoot = dir;
+    this.ensureSchema();
+  }
+
+  static fromHandle(db: DatabaseSync): IntegrationsStore {
+    const store = Object.create(IntegrationsStore.prototype) as IntegrationsStore;
+    (store as unknown as { db: DatabaseSync }).db = db;
+    (store as unknown as { ownsConnection: boolean }).ownsConnection = false;
+    (store as unknown as { dataRoot: string }).dataRoot = '';
+    store.ensureSchema();
+    return store;
+  }
+
+  private ensureSchema(): void {
+    this.db.exec('PRAGMA journal_mode = WAL');
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS integrations (
+        id TEXT PRIMARY KEY,
+        pack_id TEXT,
+        kind TEXT NOT NULL,
+        name TEXT NOT NULL,
+        config_json TEXT NOT NULL,
+        secret_refs_json TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `);
+    this.db.exec(`CREATE INDEX IF NOT EXISTS idx_integrations_kind ON integrations(kind)`);
+    this.db.exec(`CREATE INDEX IF NOT EXISTS idx_integrations_pack_id ON integrations(pack_id)`);
+  }
+
+  /**
+   * Insert or replace. `createdAt` is preserved on update; `updatedAt` is bumped.
+   * Throws on invalid id format so callers know early — the URL surface depends on it.
+   */
+  upsertIntegration(args: {
+    id: string;
+    packId: string | null;
+    kind: IntegrationKind;
+    name: string;
+    config: Record<string, unknown>;
+    secretRefs: string[];
+  }): void {
+    if (!INTEGRATION_ID_RE.test(args.id)) {
+      throw new Error(`Invalid integration id "${args.id}": must match ${INTEGRATION_ID_RE}`);
+    }
+    if (!args.kind || typeof args.kind !== 'string') {
+      throw new Error(`Integration kind is required`);
+    }
+    if (!args.name || typeof args.name !== 'string') {
+      throw new Error(`Integration name is required`);
+    }
+    const now = Date.now();
+    const existing = this.getIntegration(args.id);
+    const createdAt = existing?.createdAt ?? now;
+    this.db.prepare(`
+      INSERT INTO integrations (id, pack_id, kind, name, config_json, secret_refs_json, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        pack_id = excluded.pack_id,
+        kind = excluded.kind,
+        name = excluded.name,
+        config_json = excluded.config_json,
+        secret_refs_json = excluded.secret_refs_json,
+        updated_at = excluded.updated_at
+    `).run(
+      args.id,
+      args.packId,
+      args.kind,
+      args.name,
+      JSON.stringify(args.config),
+      JSON.stringify(args.secretRefs),
+      createdAt,
+      now,
+    );
+  }
+
+  getIntegration(id: string): Integration | null {
+    const row = this.db.prepare(`SELECT * FROM integrations WHERE id = ?`).get(id) as Record<string, unknown> | undefined;
+    return row ? this.rowToIntegration(row) : null;
+  }
+
+  listIntegrations(): Integration[] {
+    const rows = this.db.prepare(`SELECT * FROM integrations ORDER BY name`).all() as Array<Record<string, unknown>>;
+    return rows.map((r) => this.rowToIntegration(r));
+  }
+
+  listByKind(kind: IntegrationKind): Integration[] {
+    const rows = this.db.prepare(`SELECT * FROM integrations WHERE kind = ? ORDER BY name`).all(kind) as Array<Record<string, unknown>>;
+    return rows.map((r) => this.rowToIntegration(r));
+  }
+
+  listUserIntegrations(): Integration[] {
+    const rows = this.db.prepare(`SELECT * FROM integrations WHERE pack_id IS NULL ORDER BY name`).all() as Array<Record<string, unknown>>;
+    return rows.map((r) => this.rowToIntegration(r));
+  }
+
+  /** Delete a single integration. Returns true if a row was removed. */
+  deleteIntegration(id: string): boolean {
+    const result = this.db.prepare(`DELETE FROM integrations WHERE id = ?`).run(id);
+    return Number(result.changes) > 0;
+  }
+
+  /** Delete every integration owned by a pack. Used by PacksStore.deletePack. */
+  deleteByPack(packId: string): number {
+    const result = this.db.prepare(`DELETE FROM integrations WHERE pack_id = ?`).run(packId);
+    return Number(result.changes);
+  }
+
+  close(): void {
+    if (this.ownsConnection) this.db.close();
+  }
+
+  private rowToIntegration(row: Record<string, unknown>): Integration {
+    let config: Record<string, unknown> = {};
+    try { config = JSON.parse(row.config_json as string) as Record<string, unknown>; } catch { /* default */ }
+    let secretRefs: string[] = [];
+    try {
+      const parsed = JSON.parse(row.secret_refs_json as string) as unknown;
+      if (Array.isArray(parsed)) secretRefs = parsed.filter((s) => typeof s === 'string');
+    } catch { /* default */ }
+    return {
+      id: row.id as string,
+      packId: (row.pack_id as string | null) ?? null,
+      kind: row.kind as IntegrationKind,
+      name: row.name as string,
+      config,
+      secretRefs,
+      createdAt: row.created_at as number,
+      updatedAt: row.updated_at as number,
+    };
+  }
+}

--- a/packages/dashboard/src/context.ts
+++ b/packages/dashboard/src/context.ts
@@ -1,4 +1,4 @@
-import type { LocalProvider, RunStore, SecretsStore, AgentDefinition, AgentStore, ToolStore, VariablesStore, PacksStore, DashboardsStore, PlannerTelemetryStore } from '@some-useful-agents/core';
+import type { LocalProvider, RunStore, SecretsStore, AgentDefinition, AgentStore, ToolStore, VariablesStore, PacksStore, DashboardsStore, IntegrationsStore, PlannerTelemetryStore } from '@some-useful-agents/core';
 import type { SecretsSession } from './secrets-session.js';
 
 /**
@@ -83,6 +83,13 @@ export interface DashboardContext {
    * because no routes consume it yet; later PRs make it required.
    */
   dashboardsStore?: DashboardsStore;
+  /**
+   * Integrations store. Holds project-scoped named external-service configs
+   * (slack, webhook, file, …) that agents and notify handlers reference by
+   * id. PR 1 wires the storage + UI; PR 2 onward connects them to notify.
+   * Optional so the dashboard boots even if the table can't be created.
+   */
+  integrationsStore?: IntegrationsStore;
   /**
    * Build-planner telemetry store. Records one row per planner run with
    * timing + failure-class counters; feeds `/metrics/planner`. Optional so

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -3,7 +3,7 @@ import request from 'supertest';
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { LocalProvider, RunStore, AgentStore, MemorySecretsStore, ToolStore, loadAgents, type Agent, type OutputWidgetSchema } from '@some-useful-agents/core';
+import { LocalProvider, RunStore, AgentStore, MemorySecretsStore, ToolStore, IntegrationsStore, loadAgents, type Agent, type OutputWidgetSchema } from '@some-useful-agents/core';
 import { renderInteractiveWidget } from './views/interactive-widget.js';
 import { render } from './views/html.js';
 import { buildDashboardApp } from './index.js';
@@ -63,6 +63,7 @@ command: echo from-the-internet
   const secretsStore = new MemorySecretsStore();
   runStore = new RunStore(dbPath);
   agentStore = new AgentStore(dbPath);
+  const integrationsStore = new IntegrationsStore(dbPath);
   provider = new LocalProvider(dbPath, secretsStore);
   await provider.initialize();
 
@@ -75,6 +76,7 @@ command: echo from-the-internet
     provider,
     runStore,
     agentStore,
+    integrationsStore,
     loadAgents: () => loadAgents({
       directories: [agentsDir, join(dir, 'agents', 'community')],
     }),
@@ -1463,14 +1465,73 @@ describe('Dashboard /settings/general', () => {
 });
 
 describe('Dashboard /settings/integrations', () => {
-  it('renders placeholder copy', async () => {
+  it('renders the integrations surface with empty state + add forms', async () => {
     const app = await makeApp();
     const res = await request(app).get('/settings/integrations')
       .set('Host', `127.0.0.1:${PORT}`)
       .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
     expect(res.status).toBe(200);
     expect(res.text).toContain('Integrations');
-    expect(res.text).toContain('coming in a later release');
+    // Empty state copy.
+    expect(res.text).toContain('No integrations yet.');
+    // All three add forms render.
+    expect(res.text).toContain('Add Slack');
+    expect(res.text).toContain('Add Webhook');
+    expect(res.text).toContain('Add File');
+  });
+
+  it('adds a Slack integration via POST and lists it', async () => {
+    const app = await makeApp();
+    const add = await request(app).post('/settings/integrations/add')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', `${SESSION_COOKIE}=${TOKEN}`)
+      .type('form').send({ kind: 'slack', id: 'oncall', name: 'Oncall', webhook_secret: 'SLACK_WEBHOOK', channel: '#alerts' });
+    expect(add.status).toBe(303);
+    expect(add.headers.location).toContain('Added%20slack%20integration');
+
+    const list = await request(app).get('/settings/integrations')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(list.text).toContain('user:oncall');
+    expect(list.text).toContain('SLACK_WEBHOOK');
+    expect(list.text).toContain('#alerts');
+  });
+
+  it('rejects an invalid slug with a useful flash + preserved values', async () => {
+    const app = await makeApp();
+    const add = await request(app).post('/settings/integrations/add')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', `${SESSION_COOKIE}=${TOKEN}`)
+      .type('form').send({ kind: 'slack', id: 'Has Spaces', name: 'x', webhook_secret: 'SLACK_WEBHOOK' });
+    expect(add.status).toBe(303);
+    expect(add.headers.location).toMatch(/errKind=slack/);
+    expect(add.headers.location).toMatch(/errMsg=ID/);
+    // Form values round-trip so the user doesn't retype.
+    expect(add.headers.location).toMatch(/f_id=Has\+Spaces/);
+  });
+
+  it('refuses to add a duplicate id', async () => {
+    const app = await makeApp();
+    const post = () => request(app).post('/settings/integrations/add')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', `${SESSION_COOKIE}=${TOKEN}`)
+      .type('form').send({ kind: 'webhook', id: 'dup', name: 'D', url: 'https://x.example.com', method: 'POST' });
+    await post();
+    const second = await post();
+    expect(second.status).toBe(303);
+    expect(second.headers.location).toMatch(/already(\+|%20)exists/);
+  });
+
+  it('deletes a user integration', async () => {
+    const app = await makeApp();
+    await request(app).post('/settings/integrations/add')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', `${SESSION_COOKIE}=${TOKEN}`)
+      .type('form').send({ kind: 'file', id: 'log', name: 'Log', path: 'out.log', mode: 'append' });
+    const del = await request(app).post('/settings/integrations/delete')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', `${SESSION_COOKIE}=${TOKEN}`)
+      .type('form').send({ id: 'user:log' });
+    expect(del.status).toBe(303);
+    expect(del.headers.location).toContain('Deleted%20integration');
+
+    const list = await request(app).get('/settings/integrations')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(list.text).not.toContain('user:log');
   });
 });
 

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -8,6 +8,7 @@ import {
   ToolStore,
   PacksStore,
   DashboardsStore,
+  IntegrationsStore,
   PlannerTelemetryStore,
   loadBuiltinPacks,
   defaultBuiltinPacksDir,
@@ -308,6 +309,15 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     // wire routes that depend on these stores.
   }
 
+  // Integrations store. Same DB file. Independently optional from packs/
+  // dashboards so a schema issue in either doesn't keep the other offline.
+  let integrationsStore: IntegrationsStore | undefined;
+  try {
+    integrationsStore = new IntegrationsStore(opts.dbPath);
+  } catch {
+    // Non-fatal: settings/integrations surface stays absent.
+  }
+
   // Planner telemetry store. Records one row per planner run; feeds /metrics/planner.
   let plannerTelemetryStore: PlannerTelemetryStore | undefined;
   try {
@@ -335,6 +345,7 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     variablesStore,
     packsStore,
     dashboardsStore,
+    integrationsStore,
     plannerTelemetryStore,
     allowUntrustedShell: opts.allowUntrustedShell ?? new Set(),
     activeRuns: new Map(),

--- a/packages/dashboard/src/routes/settings.ts
+++ b/packages/dashboard/src/routes/settings.ts
@@ -7,6 +7,7 @@ import { renderSettingsVariables } from '../views/settings-variables.js';
 import { renderSettingsMcpServers } from '../views/settings-mcp-servers.js';
 import { renderSettingsGeneral } from '../views/settings-general.js';
 import { renderSettingsAppearance } from '../views/settings-appearance.js';
+import { renderSettingsIntegrations } from '../views/settings-integrations.js';
 import { getContext, type DashboardContext } from '../context.js';
 import { SESSION_COOKIE } from '../auth-middleware.js';
 
@@ -294,20 +295,138 @@ settingsRouter.post('/settings/mcp-servers/delete', (req: Request, res: Response
   redirectWith(res, '/settings/mcp-servers', 'flash', `Deleted ${id} and ${toolsDeleted} tool${toolsDeleted === 1 ? '' : 's'}.`);
 });
 
+// ── Integrations ─────────────────────────────────────────────────────────
+// Slug used in IDs. The store gates the full ID format (with `user:` prefix);
+// this is just the user-typed portion so the prefix stays implementation-detail.
+const INTEGRATION_SLUG_RE = /^[a-z0-9][a-z0-9_-]*$/;
+const INTEGRATION_SECRET_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
+
 settingsRouter.get('/settings/integrations', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
   const { flash } = readQueryBanners(req);
-  const body = html`
-    <div class="settings-empty">
-      <h3 style="margin-top: 0;">Integrations</h3>
-      <p>Integrations are coming in a later release.</p>
-      <p class="dim">Today, external services are wired up through
-        secrets (e.g. <code>SLACK_WEBHOOK</code>) referenced from agent nodes.
-        Integrations will add a metadata layer on top so agents can
-        reference named services instead of raw secret names.</p>
-    </div>
-  `;
+  if (!ctx.integrationsStore) {
+    const body = html`<p class="settings-empty">Integrations store unavailable on this dashboard.</p>`;
+    res.type('html').send(renderSettingsShell({ active: 'integrations', body, flash }));
+    return;
+  }
+
+  // Inline error after a failed add is round-tripped via query string so the
+  // user keeps their typed values without us needing a session/flash store.
+  const errKind = typeof req.query.errKind === 'string' ? req.query.errKind : undefined;
+  const errMsg = typeof req.query.errMsg === 'string' ? req.query.errMsg : undefined;
+  const formValues = pickFormValuesFromQuery(req);
+  const addError = errKind && errMsg ? { kind: errKind, message: errMsg, values: formValues } : undefined;
+
+  const integrations = ctx.integrationsStore.listIntegrations();
+  const body = renderSettingsIntegrations({ integrations, addError });
   res.type('html').send(renderSettingsShell({ active: 'integrations', body, flash }));
 });
+
+settingsRouter.post('/settings/integrations/add', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.integrationsStore) {
+    res.redirect(303, '/settings/integrations?error=Integrations+store+unavailable.');
+    return;
+  }
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const kind = typeof body.kind === 'string' ? body.kind.trim() : '';
+  const slug = typeof body.id === 'string' ? body.id.trim() : '';
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+
+  const fail = (message: string): void => {
+    const qs = new URLSearchParams({ errKind: kind, errMsg: message });
+    for (const [k, v] of Object.entries(body)) {
+      if (typeof v === 'string' && k !== 'errKind' && k !== 'errMsg') qs.append(`f_${k}`, v);
+    }
+    res.redirect(303, `/settings/integrations?${qs.toString()}`);
+  };
+
+  if (!INTEGRATION_SLUG_RE.test(slug)) return fail('ID must be lowercase letters/digits/dashes/underscores, starting with a letter or digit.');
+  if (!name) return fail('Name is required.');
+
+  let config: Record<string, unknown>;
+  let secretRefs: string[];
+  switch (kind) {
+    case 'slack': {
+      const webhookSecret = typeof body.webhook_secret === 'string' ? body.webhook_secret.trim() : '';
+      if (!INTEGRATION_SECRET_NAME_RE.test(webhookSecret)) return fail('Webhook secret name must be UPPERCASE_WITH_UNDERSCORES.');
+      const channel = typeof body.channel === 'string' ? body.channel.trim() : '';
+      const mention = typeof body.mention === 'string' ? body.mention.trim() : '';
+      config = {
+        webhook_secret: webhookSecret,
+        ...(channel ? { channel } : {}),
+        ...(mention ? { mention } : {}),
+      };
+      secretRefs = [webhookSecret];
+      break;
+    }
+    case 'webhook': {
+      const url = typeof body.url === 'string' ? body.url.trim() : '';
+      if (!/^https?:\/\//i.test(url)) return fail('URL must start with http:// or https://.');
+      const method = body.method === 'PUT' ? 'PUT' : 'POST';
+      const headersSecret = typeof body.headers_secret === 'string' ? body.headers_secret.trim() : '';
+      if (headersSecret && !INTEGRATION_SECRET_NAME_RE.test(headersSecret)) return fail('Headers secret name must be UPPERCASE_WITH_UNDERSCORES.');
+      config = {
+        url,
+        method,
+        ...(headersSecret ? { headers_secret: headersSecret } : {}),
+      };
+      secretRefs = headersSecret ? [headersSecret] : [];
+      break;
+    }
+    case 'file': {
+      const path = typeof body.path === 'string' ? body.path.trim() : '';
+      if (!path) return fail('Path is required.');
+      const mode = body.mode === 'overwrite' ? 'overwrite' : 'append';
+      config = { path, append: mode === 'append' };
+      secretRefs = [];
+      break;
+    }
+    default:
+      return fail(`Unknown kind "${kind}".`);
+  }
+
+  const id = `user:${slug}`;
+  if (ctx.integrationsStore.getIntegration(id)) return fail(`An integration with id "${id}" already exists.`);
+
+  try {
+    ctx.integrationsStore.upsertIntegration({ id, packId: null, kind, name, config, secretRefs });
+  } catch (err) {
+    return fail(err instanceof Error ? err.message : String(err));
+  }
+  res.redirect(303, `/settings/integrations?flash=${encodeURIComponent(`Added ${kind} integration "${id}".`)}`);
+});
+
+settingsRouter.post('/settings/integrations/delete', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.integrationsStore) {
+    res.redirect(303, '/settings/integrations?error=Integrations+store+unavailable.');
+    return;
+  }
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const id = typeof body.id === 'string' ? body.id.trim() : '';
+  if (!id) {
+    res.redirect(303, '/settings/integrations?error=Missing+id.');
+    return;
+  }
+  const existing = ctx.integrationsStore.getIntegration(id);
+  if (existing?.packId) {
+    res.redirect(303, '/settings/integrations?error=Pack-owned+integrations+can%27t+be+deleted+directly.');
+    return;
+  }
+  const removed = ctx.integrationsStore.deleteIntegration(id);
+  res.redirect(303, removed
+    ? `/settings/integrations?flash=${encodeURIComponent(`Deleted integration "${id}".`)}`
+    : '/settings/integrations?error=No+such+integration.');
+});
+
+function pickFormValuesFromQuery(req: Request): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(req.query)) {
+    if (typeof v === 'string' && k.startsWith('f_')) out[k.slice(2)] = v;
+  }
+  return out;
+}
 
 settingsRouter.get('/settings/appearance', (req: Request, res: Response) => {
   const { flash } = readQueryBanners(req);

--- a/packages/dashboard/src/views/settings-integrations.ts
+++ b/packages/dashboard/src/views/settings-integrations.ts
@@ -1,0 +1,235 @@
+import type { Integration } from '@some-useful-agents/core';
+import { html, unsafeHtml, type SafeHtml } from './html.js';
+
+export interface SettingsIntegrationsArgs {
+  integrations: Integration[];
+  /** Preserved form values + error after a failed add. Keyed by kind. */
+  addError?: { kind: string; message: string; values: Record<string, string> };
+  /** Optional flash banner (test-send result, etc.) rendered above the table. */
+  inlineNote?: { kind: 'ok' | 'error' | 'info'; message: string };
+}
+
+/**
+ * Render the `/settings/integrations` body. Three "kinds" in PR 1 —
+ * slack (incoming webhook), webhook (generic POST/PUT), file (local
+ * append/overwrite). Each gets its own dedicated form to keep the
+ * surface zero-JS; kinds with very different fields don't share a UI.
+ *
+ * The "ID" field is the slug agents will reference, prefixed with
+ * `user:` server-side. Pack-installed integrations show up here too
+ * but their Delete button is disabled (they belong to the pack).
+ */
+export function renderSettingsIntegrations(args: SettingsIntegrationsArgs): SafeHtml {
+  return html`
+    <div class="card">
+      <p class="card__title">Integrations</p>
+      <p class="dim">
+        Named external-service configurations. Agents will reference
+        these by id in notify handlers (and later, connectors) instead
+        of declaring raw secret names per-agent. Today only the storage
+        + UI exist — wiring agents to read them lands in the next PR.
+      </p>
+      ${args.inlineNote ? html`<div class="flash flash--${args.inlineNote.kind} mb-3">${args.inlineNote.message}</div>` : unsafeHtml('')}
+      ${renderIntegrationsTable(args.integrations)}
+    </div>
+
+    ${renderSlackForm(args)}
+    ${renderWebhookForm(args)}
+    ${renderFileForm(args)}
+  `;
+}
+
+function renderIntegrationsTable(integrations: Integration[]): SafeHtml {
+  if (integrations.length === 0) {
+    return html`<p class="settings-empty mt-3">No integrations yet. Add one below.</p>`;
+  }
+  const rows = integrations.map((i) => html`
+    <tr>
+      <td class="mono">${i.id}</td>
+      <td><span class="badge">${i.kind}</span></td>
+      <td>${i.name}</td>
+      <td class="dim mono" style="font-size: var(--font-size-xs);">${describeConfig(i)}</td>
+      <td class="mono" style="font-size: var(--font-size-xs);">${i.secretRefs.join(', ') || html`<span class="dim">none</span>`}</td>
+      <td class="text-right">
+        ${i.packId
+          ? html`<button type="button" class="btn btn--sm btn--ghost" disabled title="Pack-owned — uninstall the pack to remove">Delete</button>`
+          : html`
+            <form action="/settings/integrations/delete" method="post" style="display: inline;"
+              data-confirm="Delete integration ${i.id}? Agents that reference it will fall back to inline handlers.">
+              <input type="hidden" name="id" value="${i.id}">
+              <button type="submit" class="btn btn--sm btn--ghost">Delete</button>
+            </form>
+          `}
+      </td>
+    </tr>
+  `);
+  return html`
+    <table class="table mt-3">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Kind</th>
+          <th>Name</th>
+          <th>Config</th>
+          <th>Secrets</th>
+          <th class="text-right">Action</th>
+        </tr>
+      </thead>
+      <tbody>${rows as unknown as SafeHtml[]}</tbody>
+    </table>
+  `;
+}
+
+function describeConfig(i: Integration): SafeHtml {
+  switch (i.kind) {
+    case 'slack': {
+      const channel = typeof i.config.channel === 'string' ? i.config.channel : '';
+      const mention = typeof i.config.mention === 'string' ? i.config.mention : '';
+      const bits = [channel && `channel=${channel}`, mention && `mention=${mention}`].filter(Boolean) as string[];
+      return unsafeHtml(escAll(bits.join(', ')) || '<span class="dim">webhook only</span>');
+    }
+    case 'webhook': {
+      const url = typeof i.config.url === 'string' ? i.config.url : '';
+      const method = typeof i.config.method === 'string' ? i.config.method : 'POST';
+      return unsafeHtml(`${esc(method)} ${esc(url)}`);
+    }
+    case 'file': {
+      const path = typeof i.config.path === 'string' ? i.config.path : '';
+      const append = i.config.append !== false;
+      return unsafeHtml(`${esc(path)} <span class="dim">(${append ? 'append' : 'overwrite'})</span>`);
+    }
+    default:
+      return unsafeHtml('<span class="dim">—</span>');
+  }
+}
+
+function renderSlackForm(args: SettingsIntegrationsArgs): SafeHtml {
+  const err = args.addError?.kind === 'slack' ? args.addError : undefined;
+  const v = err?.values ?? {};
+  return html`
+    <div class="card">
+      <p class="card__title">Add Slack</p>
+      <p class="dim">
+        Posts a Block Kit message to a Slack workspace via an
+        <a href="https://api.slack.com/messaging/webhooks">incoming webhook URL</a>.
+        The URL itself is stored in <a href="/settings/secrets">Secrets</a> —
+        only the name is referenced here.
+      </p>
+      ${err ? html`<div class="flash flash--error mb-3">${err.message}</div>` : unsafeHtml('')}
+      <form action="/settings/integrations/add" method="post" class="settings-form">
+        <input type="hidden" name="kind" value="slack">
+        ${idAndNameFields(v)}
+        <label class="settings-form__label" for="slack-webhook-secret">Webhook secret name</label>
+        <input id="slack-webhook-secret" name="webhook_secret" type="text" required
+          pattern="[A-Z_][A-Z0-9_]*"
+          placeholder="SLACK_WEBHOOK"
+          value="${v.webhook_secret ?? ''}"
+          autocapitalize="off" autocorrect="off" spellcheck="false">
+
+        <label class="settings-form__label" for="slack-channel">Channel (optional)</label>
+        <input id="slack-channel" name="channel" type="text"
+          placeholder="#alerts"
+          value="${v.channel ?? ''}">
+
+        <label class="settings-form__label" for="slack-mention">Mention (optional)</label>
+        <input id="slack-mention" name="mention" type="text"
+          placeholder="@oncall"
+          value="${v.mention ?? ''}">
+
+        <div class="settings-form__actions">
+          <button type="submit" class="btn btn--primary">Add Slack integration</button>
+        </div>
+      </form>
+    </div>
+  `;
+}
+
+function renderWebhookForm(args: SettingsIntegrationsArgs): SafeHtml {
+  const err = args.addError?.kind === 'webhook' ? args.addError : undefined;
+  const v = err?.values ?? {};
+  return html`
+    <div class="card">
+      <p class="card__title">Add Webhook</p>
+      <p class="dim">Generic HTTPS POST or PUT. Optional bearer token in <code>Authorization</code> header.</p>
+      ${err ? html`<div class="flash flash--error mb-3">${err.message}</div>` : unsafeHtml('')}
+      <form action="/settings/integrations/add" method="post" class="settings-form">
+        <input type="hidden" name="kind" value="webhook">
+        ${idAndNameFields(v)}
+        <label class="settings-form__label" for="webhook-url">URL</label>
+        <input id="webhook-url" name="url" type="url" required
+          placeholder="https://hooks.example.com/incoming"
+          value="${v.url ?? ''}">
+
+        <label class="settings-form__label" for="webhook-method">Method</label>
+        <select id="webhook-method" name="method">
+          <option value="POST" ${(v.method ?? 'POST') === 'POST' ? 'selected' : ''}>POST</option>
+          <option value="PUT" ${v.method === 'PUT' ? 'selected' : ''}>PUT</option>
+        </select>
+
+        <label class="settings-form__label" for="webhook-headers-secret">Bearer token secret (optional)</label>
+        <input id="webhook-headers-secret" name="headers_secret" type="text"
+          pattern="[A-Z_][A-Z0-9_]*"
+          placeholder="WEBHOOK_TOKEN"
+          value="${v.headers_secret ?? ''}"
+          autocapitalize="off" autocorrect="off" spellcheck="false">
+
+        <div class="settings-form__actions">
+          <button type="submit" class="btn btn--primary">Add Webhook integration</button>
+        </div>
+      </form>
+    </div>
+  `;
+}
+
+function renderFileForm(args: SettingsIntegrationsArgs): SafeHtml {
+  const err = args.addError?.kind === 'file' ? args.addError : undefined;
+  const v = err?.values ?? {};
+  return html`
+    <div class="card">
+      <p class="card__title">Add File</p>
+      <p class="dim">Append a JSON line (or overwrite a JSON document) to a local file each time the trigger fires.</p>
+      ${err ? html`<div class="flash flash--error mb-3">${err.message}</div>` : unsafeHtml('')}
+      <form action="/settings/integrations/add" method="post" class="settings-form">
+        <input type="hidden" name="kind" value="file">
+        ${idAndNameFields(v)}
+        <label class="settings-form__label" for="file-path">Path</label>
+        <input id="file-path" name="path" type="text" required
+          placeholder="logs/notifications.jsonl"
+          value="${v.path ?? ''}">
+
+        <label class="settings-form__label" for="file-mode">Mode</label>
+        <select id="file-mode" name="mode">
+          <option value="append" ${(v.mode ?? 'append') === 'append' ? 'selected' : ''}>Append (JSONL)</option>
+          <option value="overwrite" ${v.mode === 'overwrite' ? 'selected' : ''}>Overwrite</option>
+        </select>
+
+        <div class="settings-form__actions">
+          <button type="submit" class="btn btn--primary">Add File integration</button>
+        </div>
+      </form>
+    </div>
+  `;
+}
+
+function idAndNameFields(v: Record<string, string>): SafeHtml {
+  return html`
+    <label class="settings-form__label" for="i-id">ID slug</label>
+    <input id="i-id" name="id" type="text" required
+      pattern="[a-z0-9][a-z0-9_-]*"
+      placeholder="oncall"
+      value="${v.id ?? ''}"
+      autocapitalize="off" autocorrect="off" spellcheck="false">
+
+    <label class="settings-form__label" for="i-name">Display name</label>
+    <input id="i-name" name="name" type="text" required
+      placeholder="Oncall channel"
+      value="${v.name ?? ''}">
+  `;
+}
+
+function esc(s: string): string {
+  return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+function escAll(s: string): string {
+  return esc(s);
+}


### PR DESCRIPTION
## Summary
First PR of the **Settings → Integrations** workstream (plan: `~/.claude/plans/does-it-make-more-joyful-wilkinson.md`).

Replaces the placeholder `/settings/integrations` page ("coming in a later release") with a real surface backed by a new SQLite table.

**Three kinds today** — `slack`, `webhook`, `file` — lifted from the existing per-agent notify handlers so the data model maps 1:1. Per-agent notify keeps working unchanged; PR 2 will add `handlers[].integration: <id>` so agents can reference these by id.

## What lands
- **`packages/core/src/integrations-store.ts`** — new SQLite table + `IntegrationsStore` (mirrors `DashboardsStore`). Strict slug validation, `kind` accepted as open string so PR 3/4 can land Gmail/OAuth and CSV/Postgres without schema migrations.
- **`packages/core/src/integrations-store.test.ts`** — 8 tests: round-trip, slug rejection, list-by-kind / by-user / pack ownership, cascade delete, malformed-JSON fallback.
- **`packages/dashboard/src/views/settings-integrations.ts`** — table of existing rows + three dedicated add forms (zero JS).
- **`packages/dashboard/src/routes/settings.ts`** — `GET/POST /settings/integrations`, `POST /settings/integrations/add`, `POST /settings/integrations/delete`. Errors round-trip via query string so users keep their typed values after a failed submit.
- **`packages/dashboard/src/dashboard.test.ts`** — 5 route tests (render, add, slug rejection, duplicate guard, delete) and constructor wiring for `IntegrationsStore` in `makeApp`.

## Trust + secret hygiene
Integration rows store **names only** — `secretRefs: string[]` pointing at the encrypted secrets store. Webhook URLs, channel names, and file paths are config (non-secret) and live in the row. Actual webhook tokens, bearer tokens, etc. never touch the integrations table. Lands on top of #261's gitleaks rails.

Pack-owned integration rows render with their Delete button disabled — pack uninstall is the path to remove them, same as dashboards.

## Test plan
- [x] `npm test` → 1194/1194 (13 new).
- [ ] Live: `/settings/integrations` → empty state + three add forms. Add a slack integration with `id=oncall`, `name=Oncall`, `webhook_secret=SLACK_WEBHOOK`, `channel=#alerts` → row appears as `user:oncall`. Delete → row disappears.
- [ ] Invalid submit: `id="Has Spaces"` → returns to form with the value still in the field + flash error.

## Follow-ups (queued, not in this PR)
- **PR 2**: notify schema gains `handlers[].integration: <id>` (back-compat preserved).
- **PR 3**: OAuth loopback callback server + first OAuth kind (`gmail`).
- **PR 4**: `csv` + `postgres` kinds (folds in the `connectors-v0.17` plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)