### PR TITLE
feat(notify): handlers can reference saved integrations by id

### DIFF
--- a/.changeset/notify-integration-ref.md
+++ b/.changeset/notify-integration-ref.md
@@ -1,0 +1,34 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+notify: handlers can reference a saved integration by id
+
+PR 2 of 4 of the Settings → Integrations workstream. Notify handlers
+gain an optional `integration: <id>` field. When set, the dispatcher
+resolves the named integration from #262's store at fire time, merges
+its config (webhook URL secret, channel, path, etc.) into the handler,
+and unions the integration's `secretRefs` into the resolution bag so
+agents no longer need to repeat them in `notify.secrets`.
+
+Inline fields on the handler still override the integration's config
+— useful when one agent wants a different channel than the saved
+default. Missing or wrong-kind integration logs and skips the
+handler, never failing the run (matches the existing reliability
+contract).
+
+YAML schema gates: each handler must EITHER reference an integration
+OR carry its kind-specific required inline fields (webhook_secret /
+url / path). Existing YAML keeps working unchanged.
+
+Dashboard: the per-agent Notify card now shows a per-handler
+"Integration" dropdown listing matching kinds (with a link to manage),
+plus a fall-through "Inline config (legacy)" option.
+
+Tests: +5 dispatcher tests covering successful resolution, inline
+overrides, missing-integration skip, kind-mismatch skip, and the
+integration-driven secret union.

--- a/packages/cli/src/commands/schedule.ts
+++ b/packages/cli/src/commands/schedule.ts
@@ -11,6 +11,7 @@ import {
   RunStore,
   AgentStore,
   VariablesStore,
+  IntegrationsStore,
   EncryptedFileStore,
   cronToHuman,
   getSchedulerStatus,
@@ -245,6 +246,10 @@ scheduleCommand
       try { return new VariablesStore(join(config.dataDir, '.sua', 'variables.json')); }
       catch { return undefined; }
     })();
+    const integrationsStore = (() => {
+      try { return new IntegrationsStore(getDbPath(config)); }
+      catch { return undefined; }
+    })();
     const secretsStore = (() => {
       try { return new EncryptedFileStore(getSecretsPath(config)); }
       catch { return undefined; }
@@ -258,6 +263,7 @@ scheduleCommand
         runStore,
         secretsStore,
         variablesStore,
+        integrationsStore,
         agentStore,
         allowUntrustedShell: new Set(options.allowUntrustedShell),
         dashboardBaseUrl: getDashboardBaseUrl(config),

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -236,38 +236,66 @@ export const agentV2Schema = z.object({
     handlers: z.array(z.discriminatedUnion('type', [
       z.object({
         type: z.literal('slack'),
-        webhook_secret: z.string().regex(SECRET_NAME_RE, 'webhook_secret must be UPPERCASE_WITH_UNDERSCORES'),
+        /**
+         * Reference a named Slack integration from Settings → Integrations.
+         * When set, the handler resolves its webhook_secret + channel +
+         * mention from that integration; the inline fields below become
+         * optional overrides. When omitted, the inline form (legacy) is
+         * required.
+         */
+        integration: z.string().min(1).optional(),
+        webhook_secret: z.string().regex(SECRET_NAME_RE, 'webhook_secret must be UPPERCASE_WITH_UNDERSCORES').optional(),
         channel: z.string().optional(),
         mention: z.string().optional(),
       }),
       z.object({
         type: z.literal('file'),
-        path: z.string().min(1),
+        integration: z.string().min(1).optional(),
+        path: z.string().min(1).optional(),
         append: z.boolean().optional(),
       }),
       z.object({
         type: z.literal('webhook'),
-        url: z.string().url(),
+        integration: z.string().min(1).optional(),
+        url: z.string().url().optional(),
         method: z.enum(['POST', 'PUT']).optional(),
         headers_secret: z.string().regex(SECRET_NAME_RE, 'headers_secret must be UPPERCASE_WITH_UNDERSCORES').optional(),
       }),
     ])).min(1, 'notify.handlers must list at least one handler'),
   }).superRefine((data, ctx) => {
-    // Cross-check: every handler that names a secret must declare it in
-    // notify.secrets. Mirrors the node-level rule that secrets must be
-    // declared per consumer; keeps audits simple.
     const declared = new Set(data.secrets ?? []);
     for (let i = 0; i < data.handlers.length; i++) {
       const h = data.handlers[i];
-      const needed = h.type === 'slack' ? h.webhook_secret
-        : h.type === 'webhook' ? h.headers_secret
-        : undefined;
-      if (needed && !declared.has(needed)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['handlers', i],
-          message: `Handler references secret "${needed}" but it isn't listed in notify.secrets.`,
-        });
+      // Each handler must either reference a saved integration OR carry
+      // its required inline fields. We don't reach into the integration
+      // here — the dispatcher resolves it at fire time. This validation
+      // is purely "the YAML is internally consistent."
+      if (h.integration) {
+        // Integration ref: inline secret refs (if any) are still allowed
+        // as overrides, but the kind-specific required inline fields go
+        // optional. Nothing to validate at the schema level beyond that.
+        continue;
+      }
+      if (h.type === 'slack') {
+        if (!h.webhook_secret) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['handlers', i], message: 'slack handler needs either `integration` or `webhook_secret`.' });
+          continue;
+        }
+        if (!declared.has(h.webhook_secret)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['handlers', i], message: `Handler references secret "${h.webhook_secret}" but it isn't listed in notify.secrets.` });
+        }
+      } else if (h.type === 'webhook') {
+        if (!h.url) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['handlers', i], message: 'webhook handler needs either `integration` or `url`.' });
+          continue;
+        }
+        if (h.headers_secret && !declared.has(h.headers_secret)) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['handlers', i], message: `Handler references secret "${h.headers_secret}" but it isn't listed in notify.secrets.` });
+        }
+      } else if (h.type === 'file') {
+        if (!h.path) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['handlers', i], message: 'file handler needs either `integration` or `path`.' });
+        }
       }
     }
   }).optional(),

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -27,6 +27,7 @@ import type { AgentStore } from './agent-store.js';
 import type { SecretsStore } from './secrets-store.js';
 import type { ToolStore } from './tool-store.js';
 import type { VariablesStore } from './variables-store.js';
+import type { IntegrationsStore } from './integrations-store.js';
 import type { ToolOutput, BuiltinToolContext } from './tool-types.js';
 import { getBuiltinTool } from './builtin-tools.js';
 import { evaluatePolicy, DEFAULT_POLICY_DOCUMENT, PolicyDeniedError, type PolicyDocument, type PolicyEvaluationRequest } from './policy-store.js';
@@ -76,6 +77,12 @@ export interface DagExecutorDeps {
    * (claude-code). Precedence: --input > agent default > variable > secret.
    */
   variablesStore?: VariablesStore;
+  /**
+   * Resolves named integrations referenced by `notify.handlers[i].integration`.
+   * Optional — if absent, integration-ref handlers log + skip; inline-form
+   * handlers keep working unchanged.
+   */
+  integrationsStore?: IntegrationsStore;
   /**
    * Agent ids the operator has pre-audited for community shell execution.
    * Propagated into each node's spawn; a shell node inside a `source:
@@ -940,6 +947,7 @@ export async function executeAgentDag(
         run,
         secretsStore: deps.secretsStore,
         variablesStore: deps.variablesStore,
+        integrationsStore: deps.integrationsStore,
         dashboardBaseUrl: deps.dashboardBaseUrl,
         fetchImpl: deps.notifyFetch,
         logger: deps.notifyLogger,

--- a/packages/core/src/notify-dispatcher.test.ts
+++ b/packages/core/src/notify-dispatcher.test.ts
@@ -8,6 +8,7 @@ import {
   type NotifyConfig,
 } from './notify-dispatcher.js';
 import { MemorySecretsStore } from './secrets-store.js';
+import { IntegrationsStore } from './integrations-store.js';
 import type { Agent } from './agent-v2-types.js';
 import type { Run } from './types.js';
 
@@ -347,5 +348,135 @@ describe('handler isolation', () => {
     expect(result.succeeded).toBe(1);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe('integration resolution', () => {
+  function makeIntegrationsStore() {
+    return new IntegrationsStore(join(dir, 'runs.db'));
+  }
+
+  it('resolves a slack handler by integration id and merges config', async () => {
+    const store = makeIntegrationsStore();
+    store.upsertIntegration({
+      id: 'user:oncall', packId: null, kind: 'slack', name: 'Oncall',
+      config: { webhook_secret: 'SLACK_WEBHOOK', channel: '#alerts' },
+      secretRefs: ['SLACK_WEBHOOK'],
+    });
+    const secrets = new MemorySecretsStore();
+    await secrets.set('SLACK_WEBHOOK', 'https://hooks.slack.com/services/T/B/x');
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+
+    const notify: NotifyConfig = {
+      on: ['failure'],
+      handlers: [{ type: 'slack', integration: 'user:oncall' }],
+    };
+    const result = await dispatchNotify(notify, {
+      agent: makeAgent(),
+      run: makeRun(),
+      integrationsStore: store,
+      secretsStore: secrets,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      logger: silentLogger,
+    });
+    expect(result.fired).toBe(1);
+    expect(result.succeeded).toBe(1);
+    // Channel from the integration row made it into the Block Kit payload.
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.channel).toBe('#alerts');
+  });
+
+  it('inline handler fields override the integration', async () => {
+    const store = makeIntegrationsStore();
+    store.upsertIntegration({
+      id: 'user:oncall', packId: null, kind: 'slack', name: 'Oncall',
+      config: { webhook_secret: 'SLACK_WEBHOOK', channel: '#alerts' },
+      secretRefs: ['SLACK_WEBHOOK'],
+    });
+    const secrets = new MemorySecretsStore();
+    await secrets.set('SLACK_WEBHOOK', 'https://hooks.slack.com/services/T/B/x');
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+
+    const notify: NotifyConfig = {
+      on: ['failure'],
+      handlers: [{ type: 'slack', integration: 'user:oncall', channel: '#war-room' }],
+    };
+    await dispatchNotify(notify, {
+      agent: makeAgent(), run: makeRun(),
+      integrationsStore: store, secretsStore: secrets,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      logger: silentLogger,
+    });
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.channel).toBe('#war-room');
+  });
+
+  it('skips a handler whose integration is missing and logs', async () => {
+    const store = makeIntegrationsStore();
+    const warn = vi.fn();
+    const fetchMock = vi.fn();
+    const notify: NotifyConfig = {
+      on: ['failure'],
+      handlers: [{ type: 'slack', integration: 'user:nope' }],
+    };
+    const result = await dispatchNotify(notify, {
+      agent: makeAgent(), run: makeRun(),
+      integrationsStore: store,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      logger: { warn },
+    });
+    expect(result.fired).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/not found/));
+  });
+
+  it('skips a handler whose integration kind mismatches', async () => {
+    const store = makeIntegrationsStore();
+    store.upsertIntegration({
+      id: 'user:wrong', packId: null, kind: 'file', name: 'Log',
+      config: { path: 'out.log' }, secretRefs: [],
+    });
+    const warn = vi.fn();
+    const fetchMock = vi.fn();
+    const notify: NotifyConfig = {
+      on: ['failure'],
+      handlers: [{ type: 'slack', integration: 'user:wrong' }],
+    };
+    const result = await dispatchNotify(notify, {
+      agent: makeAgent(), run: makeRun(),
+      integrationsStore: store,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      logger: { warn },
+    });
+    expect(result.fired).toBe(0);
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/kind="file" but handler is type="slack"/));
+  });
+
+  it('pulls integration secret refs into the resolution bag even when notify.secrets omits them', async () => {
+    const store = makeIntegrationsStore();
+    store.upsertIntegration({
+      id: 'user:hook', packId: null, kind: 'webhook', name: 'Hook',
+      config: { url: 'https://example.com/hook', method: 'POST', headers_secret: 'HOOK_TOKEN' },
+      secretRefs: ['HOOK_TOKEN'],
+    });
+    const secrets = new MemorySecretsStore();
+    await secrets.set('HOOK_TOKEN', 'shhhhh');
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+
+    // Note: notify.secrets is deliberately empty here. The dispatcher should
+    // still pull HOOK_TOKEN because the integration declared it.
+    const notify: NotifyConfig = {
+      on: ['failure'],
+      handlers: [{ type: 'webhook', integration: 'user:hook' }],
+    };
+    await dispatchNotify(notify, {
+      agent: makeAgent(), run: makeRun(),
+      integrationsStore: store, secretsStore: secrets,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      logger: silentLogger,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers.Authorization).toBe('Bearer shhhhh');
   });
 });

--- a/packages/core/src/notify-dispatcher.ts
+++ b/packages/core/src/notify-dispatcher.ts
@@ -33,31 +33,48 @@ import type { Agent } from './agent-v2-types.js';
 import type { Run } from './types.js';
 import type { SecretsStore } from './secrets-store.js';
 import type { VariablesStore } from './variables-store.js';
+import type { IntegrationsStore, Integration } from './integrations-store.js';
 import { assertSafeUrl } from './builtin-tools.js';
 import { resolveVarsTemplate } from './node-templates.js';
 
 export type NotifyTrigger = 'failure' | 'success' | 'always';
 
+/**
+ * Each handler may set `integration: <id>` to reference a named
+ * Slack/file/webhook entry from Settings → Integrations. When set, the
+ * dispatcher resolves the integration row at fire time and merges its
+ * config into the handler — inline fields on the handler still override
+ * the integration's values, so users can customise per-agent without
+ * editing the shared integration. The kind-specific required fields
+ * (webhook_secret, path, url) become optional when `integration` is
+ * present; if both are absent the schema rejects the YAML.
+ */
 export interface SlackHandlerConfig {
   type: 'slack';
+  /** Reference to a saved slack integration (resolved at fire time). */
+  integration?: string;
   /** Name of the secret holding the Slack incoming webhook URL. */
-  webhook_secret: string;
+  webhook_secret?: string;
   channel?: string;
   mention?: string;
 }
 
 export interface FileHandlerConfig {
   type: 'file';
+  /** Reference to a saved file integration. */
+  integration?: string;
   /** Path relative to the working directory; absolute paths are allowed
    *  only if they resolve inside cwd. Path traversal is rejected. */
-  path: string;
+  path?: string;
   /** When true (default), append. When false, overwrite each notify. */
   append?: boolean;
 }
 
 export interface WebhookHandlerConfig {
   type: 'webhook';
-  url: string;
+  /** Reference to a saved webhook integration. */
+  integration?: string;
+  url?: string;
   method?: 'POST' | 'PUT';
   /** Name of the secret holding a Bearer token; injected as
    *  `Authorization: Bearer <secret>` if present. */
@@ -91,6 +108,8 @@ export interface DispatchNotifyOptions {
   run: Run;
   secretsStore?: SecretsStore;
   variablesStore?: VariablesStore;
+  /** Resolves named integrations referenced by `handlers[i].integration`. */
+  integrationsStore?: IntegrationsStore;
   /** Project-cwd for the file handler's path-traversal guard. Defaults to process.cwd(). */
   cwd?: string;
   /** Optional URL prefix for dashboard run links inside Slack messages. */
@@ -117,14 +136,45 @@ export async function dispatchNotify(
     return { fired: 0, succeeded: 0 };
   }
 
-  // Resolve declared secrets up-front. If the store is locked / a secret
-  // is missing, we still fire handlers that don't need it; broken handlers
-  // log and continue. This matches the "never break the run" contract.
+  // Resolve handlers that reference a saved integration. Pulls config +
+  // secret refs from the integration row; inline fields on the handler
+  // override (so users can customise per-agent without editing the
+  // shared integration). A missing or wrong-kind integration logs and
+  // skips the handler — the contract says we never break the run.
+  const resolvedHandlers: NotifyHandlerConfig[] = [];
+  const integrationSecretNames = new Set<string>();
+  for (const handler of notify.handlers) {
+    if (!handler.integration) {
+      resolvedHandlers.push(handler);
+      continue;
+    }
+    if (!opts.integrationsStore) {
+      logger.warn(`handler references integration "${handler.integration}" but no integrations store is wired; skipping.`);
+      continue;
+    }
+    const row = opts.integrationsStore.getIntegration(handler.integration);
+    if (!row) {
+      logger.warn(`integration "${handler.integration}" not found; skipping handler.`);
+      continue;
+    }
+    if (row.kind !== handler.type) {
+      logger.warn(`integration "${handler.integration}" is kind="${row.kind}" but handler is type="${handler.type}"; skipping.`);
+      continue;
+    }
+    resolvedHandlers.push(mergeIntegrationIntoHandler(handler, row));
+    for (const s of row.secretRefs) integrationSecretNames.add(s);
+  }
+
+  // Resolve declared secrets up-front. Union: agent-declared
+  // `notify.secrets` + every secret referenced by a resolved integration.
+  // If the store is locked / a secret is missing, we still fire handlers
+  // that don't need it; broken handlers log and continue.
   const secrets: Record<string, string> = {};
-  if (notify.secrets && notify.secrets.length > 0 && opts.secretsStore) {
+  const needed = new Set<string>([...(notify.secrets ?? []), ...integrationSecretNames]);
+  if (needed.size > 0 && opts.secretsStore) {
     try {
       const all = await opts.secretsStore.getAll();
-      for (const name of notify.secrets) {
+      for (const name of needed) {
         if (name in all) secrets[name] = all[name];
       }
     } catch (err) {
@@ -135,7 +185,7 @@ export async function dispatchNotify(
   const vars = opts.variablesStore?.getAll() ?? {};
 
   const results = await Promise.all(
-    notify.handlers.map(async (handler) => {
+    resolvedHandlers.map(async (handler) => {
       try {
         await runHandler(handler, { ...opts, secrets, vars, logger });
         return true;
@@ -150,6 +200,46 @@ export async function dispatchNotify(
     fired: results.length,
     succeeded: results.filter(Boolean).length,
   };
+}
+
+/**
+ * Merge an integration row into a handler that referenced it. Inline
+ * handler fields win — the integration provides defaults the user can
+ * override. Returns a handler that no longer carries `integration` (it's
+ * already resolved) so the downstream runHandler switch sees a normal
+ * inline shape.
+ */
+function mergeIntegrationIntoHandler(
+  handler: NotifyHandlerConfig,
+  row: Integration,
+): NotifyHandlerConfig {
+  const c = row.config;
+  if (handler.type === 'slack') {
+    return {
+      type: 'slack',
+      webhook_secret: handler.webhook_secret ?? (typeof c.webhook_secret === 'string' ? c.webhook_secret : ''),
+      ...((handler.channel ?? (typeof c.channel === 'string' ? c.channel : '')) ? { channel: handler.channel ?? (c.channel as string) } : {}),
+      ...((handler.mention ?? (typeof c.mention === 'string' ? c.mention : '')) ? { mention: handler.mention ?? (c.mention as string) } : {}),
+    };
+  }
+  if (handler.type === 'webhook') {
+    return {
+      type: 'webhook',
+      url: handler.url ?? (typeof c.url === 'string' ? c.url : ''),
+      method: handler.method ?? (c.method === 'PUT' ? 'PUT' : c.method === 'POST' ? 'POST' : undefined),
+      ...((handler.headers_secret ?? (typeof c.headers_secret === 'string' ? c.headers_secret : '')) ? {
+        headers_secret: handler.headers_secret ?? (c.headers_secret as string),
+      } : {}),
+    };
+  }
+  if (handler.type === 'file') {
+    return {
+      type: 'file',
+      path: handler.path ?? (typeof c.path === 'string' ? c.path : ''),
+      append: handler.append ?? (c.append !== false),
+    };
+  }
+  return handler;
 }
 
 function shouldFire(triggers: NotifyTrigger[], status: Run['status']): boolean {
@@ -223,6 +313,13 @@ function stripMarkdown(text: string): string {
 }
 
 async function slackHandler(handler: SlackHandlerConfig, ctx: HandlerContext): Promise<void> {
+  // Post-resolution invariant: integration refs have been merged in by
+  // dispatchNotify, so webhook_secret is always set here. If it isn't,
+  // the YAML was wrong (schema should have caught it) or the integration
+  // row was missing fields.
+  if (!handler.webhook_secret) {
+    throw new Error('slack handler missing webhook_secret (integration may be misconfigured).');
+  }
   const url = ctx.secrets[handler.webhook_secret];
   if (!url) {
     throw new Error(`secret "${handler.webhook_secret}" not declared in notify.secrets or not present in store`);
@@ -252,6 +349,9 @@ async function slackHandler(handler: SlackHandlerConfig, ctx: HandlerContext): P
 // ── File ───────────────────────────────────────────────────────────────
 
 async function fileHandler(handler: FileHandlerConfig, ctx: HandlerContext): Promise<void> {
+  if (!handler.path) {
+    throw new Error('file handler missing path (integration may be misconfigured).');
+  }
   const cwd = resolve(ctx.cwd ?? process.cwd());
   const rawPath = resolveVarsTemplate(handler.path, ctx.vars);
   const filePath = resolve(cwd, rawPath);
@@ -270,6 +370,9 @@ async function fileHandler(handler: FileHandlerConfig, ctx: HandlerContext): Pro
 // ── Webhook ────────────────────────────────────────────────────────────
 
 async function webhookHandler(handler: WebhookHandlerConfig, ctx: HandlerContext): Promise<void> {
+  if (!handler.url) {
+    throw new Error('webhook handler missing url (integration may be misconfigured).');
+  }
   const url = resolveVarsTemplate(handler.url, ctx.vars);
   await assertSafeUrl(url);
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -188,6 +188,7 @@ export async function executeAgentWithRetry(
         run: currentRun,
         secretsStore: deps.secretsStore,
         variablesStore: deps.variablesStore,
+        integrationsStore: deps.integrationsStore,
         dashboardBaseUrl: deps.dashboardBaseUrl,
         fetchImpl: deps.notifyFetch,
         logger: deps.notifyLogger,

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -12,6 +12,7 @@ import { hasMissedFire, nextFireTime } from './scheduler-catchup.js';
 import type { RunStore } from './run-store.js';
 import type { SecretsStore } from './secrets-store.js';
 import type { VariablesStore } from './variables-store.js';
+import type { IntegrationsStore } from './integrations-store.js';
 import type { AgentStore } from './agent-store.js';
 import type { ToolStore } from './tool-store.js';
 import { executeAgentWithRetry } from './retry.js';
@@ -37,6 +38,7 @@ export interface V2SchedulerDeps {
   runStore: RunStore;
   secretsStore?: SecretsStore;
   variablesStore?: VariablesStore;
+  integrationsStore?: IntegrationsStore;
   agentStore?: AgentStore;
   toolStore?: ToolStore;
   allowUntrustedShell?: ReadonlySet<string>;
@@ -303,6 +305,7 @@ export class LocalScheduler {
         runStore: this.v2Deps.runStore,
         secretsStore: this.v2Deps.secretsStore,
         variablesStore: this.v2Deps.variablesStore,
+        integrationsStore: this.v2Deps.integrationsStore,
         agentStore: this.v2Deps.agentStore,
         toolStore: this.v2Deps.toolStore,
         allowUntrustedShell: this.v2Deps.allowUntrustedShell,

--- a/packages/dashboard/src/routes/agents/tabs.ts
+++ b/packages/dashboard/src/routes/agents/tabs.ts
@@ -42,7 +42,13 @@ agentTabsRouter.get('/agents/:name/config', async (req: Request, res: Response) 
   const name = Array.isArray(req.params.name) ? req.params.name[0] : req.params.name;
   const args = await buildTabArgs(req, ctx, name);
   if (!args) { res.status(404).redirect(303, '/agents'); return; }
-  res.type('html').send(await renderAgentConfig({ ...args, activeTab: 'config' }));
+  // Surface available integrations so the Notify card's per-handler
+  // dropdowns can offer them. Missing store → empty list → editor falls
+  // back to the inline form unchanged.
+  const availableIntegrations = ctx.integrationsStore
+    ? ctx.integrationsStore.listIntegrations().map((i) => ({ id: i.id, kind: i.kind as string, name: i.name }))
+    : [];
+  res.type('html').send(await renderAgentConfig({ ...args, activeTab: 'config', availableIntegrations }));
 });
 
 agentTabsRouter.get('/agents/:name/runs', async (req: Request, res: Response) => {

--- a/packages/dashboard/src/routes/run-mutations.ts
+++ b/packages/dashboard/src/routes/run-mutations.ts
@@ -159,6 +159,7 @@ runMutationsRouter.post('/runs/:id/replay', async (req: Request, res: Response) 
     {
       runStore: ctx.runStore,
       secretsStore: ctx.secretsStore,
+      integrationsStore: ctx.integrationsStore,
       agentStore: ctx.agentStore,
       allowUntrustedShell: ctx.allowUntrustedShell,
       dashboardBaseUrl: ctx.dashboardBaseUrl,
@@ -276,6 +277,7 @@ runMutationsRouter.post('/runs/:id/retry', async (req: Request, res: Response) =
       runStore: ctx.runStore,
       secretsStore: ctx.secretsStore,
       variablesStore: ctx.variablesStore,
+      integrationsStore: ctx.integrationsStore,
       toolStore: ctx.toolStore,
       agentStore: ctx.agentStore,
       allowUntrustedShell: ctx.allowUntrustedShell,

--- a/packages/dashboard/src/routes/run-now.ts
+++ b/packages/dashboard/src/routes/run-now.ts
@@ -63,6 +63,7 @@ runNowRouter.post('/agents/:name/run', async (req: Request, res: Response) => {
         runStore: ctx.runStore,
         secretsStore: ctx.secretsStore,
         variablesStore: ctx.variablesStore,
+        integrationsStore: ctx.integrationsStore,
         toolStore: ctx.toolStore,
         agentStore: ctx.agentStore,
         allowUntrustedShell: ctx.allowUntrustedShell,

--- a/packages/dashboard/src/routes/widget-run.ts
+++ b/packages/dashboard/src/routes/widget-run.ts
@@ -39,6 +39,7 @@ widgetRunRouter.post('/agents/:name/widget-run', (req: Request, res: Response) =
       runStore: ctx.runStore,
       secretsStore: ctx.secretsStore,
       variablesStore: ctx.variablesStore,
+      integrationsStore: ctx.integrationsStore,
       toolStore: ctx.toolStore,
       agentStore: ctx.agentStore,
       allowUntrustedShell: ctx.allowUntrustedShell,

--- a/packages/dashboard/src/views/agent-detail-helpers.ts
+++ b/packages/dashboard/src/views/agent-detail-helpers.ts
@@ -577,7 +577,17 @@ function fieldTypeSelectWithTooltip(name: string, current: string, _widgetType: 
  * would be more clicks than typing it. Save round-trips through the
  * agent-v2 schema, so any error surfaces inline as a flash.
  */
-export function renderNotifyEditor(agent: Agent): SafeHtml {
+export interface NotifyEditorOptions {
+  /**
+   * Available integrations from Settings → Integrations, grouped by kind on
+   * the client side so the per-handler dropdowns can show matching options.
+   * Pass an empty list (or omit) to render the editor without integration
+   * dropdowns — handlers fall back to the inline form.
+   */
+  integrations?: Array<{ id: string; kind: string; name: string }>;
+}
+
+export function renderNotifyEditor(agent: Agent, opts: NotifyEditorOptions = {}): SafeHtml {
   const FIELD = 'padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs);';
   const FIELD_MONO = `${FIELD} font-family: var(--font-mono);`;
 
@@ -586,6 +596,7 @@ export function renderNotifyEditor(agent: Agent): SafeHtml {
   const initialJson = JSON.stringify(
     agent.notify ?? { on: ['failure'], secrets: [], handlers: [] },
   );
+  const integrationsJson = JSON.stringify(opts.integrations ?? []);
 
   return html`
     <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-3);">
@@ -636,8 +647,13 @@ export function renderNotifyEditor(agent: Agent): SafeHtml {
     ${unsafeHtml(`<script>
     (function () {
       var INITIAL = ${initialJson};
+      var INTEGRATIONS = ${integrationsJson};
       var FIELD = ${JSON.stringify(FIELD)};
       var FIELD_MONO = ${JSON.stringify(FIELD_MONO)};
+
+      function integrationsForKind(kind) {
+        return INTEGRATIONS.filter(function (i) { return i.kind === kind; });
+      }
 
       var form = document.getElementById('notify-form');
       var jsonOut = document.getElementById('notify-json-out');
@@ -681,10 +697,23 @@ export function renderNotifyEditor(agent: Agent): SafeHtml {
         row.setAttribute('data-handler-row', type);
         row.style.cssText = 'padding: var(--space-3);';
         var inner = '';
+        var matchingIntegrations = integrationsForKind(type);
+        var integrationPickerHtml = '';
+        if (matchingIntegrations.length > 0) {
+          var opts = '<option value="">Inline config (legacy)</option>' +
+            matchingIntegrations.map(function (i) {
+              return '<option value="' + i.id + '">' + i.name + ' (' + i.id + ')</option>';
+            }).join('');
+          integrationPickerHtml =
+            '<label style="display: block; margin-bottom: var(--space-2); font-size: var(--font-size-xs);">' +
+              'Integration <select data-field="integration" data-integration-picker style="' + FIELD + ' margin-left: var(--space-2);">' + opts + '</select>' +
+              ' <span class="dim" style="margin-left: var(--space-2);">(<a href="/settings/integrations" target="_blank">manage</a>)</span>' +
+            '</label>';
+        }
         var header = '<div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--space-2);">' +
           '<strong style="font-size: var(--font-size-xs); text-transform: uppercase; letter-spacing: 0.05em;">' + type + '</strong>' +
           '<button type="button" class="btn btn--ghost btn--sm" data-remove-handler style="color: var(--color-err);">Remove</button>' +
-          '</div>';
+          '</div>' + integrationPickerHtml;
         if (type === 'slack') {
           inner = header +
             '<label style="display: block; margin-bottom: var(--space-2); font-size: var(--font-size-xs);">Webhook secret <select data-field="webhook_secret" data-secret-picker="required" style="' + FIELD + ' margin-left: var(--space-2);"></select></label>' +

--- a/packages/dashboard/src/views/agent-detail/config.ts
+++ b/packages/dashboard/src/views/agent-detail/config.ts
@@ -270,11 +270,11 @@ export async function renderAgentConfig(args: AgentDetailArgs): Promise<string> 
       <details class="config-empty-cta">
         <summary><span class="btn btn--sm">Set up notify</span></summary>
         <div style="margin-top: var(--space-3);">
-          ${renderNotifyEditor(agent)}
+          ${renderNotifyEditor(agent, { integrations: args.availableIntegrations })}
         </div>
       </details>
     `,
-    editor: renderNotifyEditor(agent),
+    editor: renderNotifyEditor(agent, { integrations: args.availableIntegrations }),
   });
 
   // Variables runs full-width because its editor is a 5-column table that

--- a/packages/dashboard/src/views/agent-detail/shell.ts
+++ b/packages/dashboard/src/views/agent-detail/shell.ts
@@ -20,6 +20,12 @@ export interface AgentDetailArgs {
   previousInputs?: Record<string, string>;
   /** URL-driven state for the latest-run output-widget preview's controls. */
   widgetControls?: WidgetControlState;
+  /**
+   * Available integrations (from `/settings/integrations`) surfaced in the
+   * Notify card's per-handler dropdowns. Empty when the route can't reach
+   * the integrations store — the inline form keeps working.
+   */
+  availableIntegrations?: Array<{ id: string; kind: string; name: string }>;
 }
 
 export function agentTabStrip(agentId: string, active: AgentTab): SafeHtml {


### PR DESCRIPTION
## Summary
PR 2 of 4 of the **Settings → Integrations** workstream (plan: `~/.claude/plans/does-it-make-more-joyful-wilkinson.md`). Closes the loop on #262: notify handlers can now point at a named integration instead of re-declaring webhook secrets per agent.

```yaml
notify:
  on: [failure]
  handlers:
    - type: slack
      integration: user:oncall    # NEW — references Settings → Integrations
```

At fire time the dispatcher loads the integration row, merges its config into the handler, and pulls every secret the integration declared. The agent no longer needs `notify.secrets: [SLACK_WEBHOOK]` for those — though it can still list extras if any inline overrides reference more.

**Inline overrides still win.** Setting `channel: '#war-room'` on a handler that uses an `oncall-slack` integration sends to the war room, not the integration's `#alerts`. Handy for one-off agents.

**Failure mode.** Missing integration or wrong kind → log + skip the handler. Never fails the run (matches the existing reliability contract).

## What changed

- `agent-v2-schema.ts` — `handlers[].integration` optional on every kind; kind-specific required inline fields go optional when `integration` is set; existing YAML keeps working.
- `notify-dispatcher.ts` — pre-pass resolves integrations before iterating handlers; secret bag unions in the integration's `secretRefs`; inline overrides via shallow merge.
- `dag-executor.ts` + `retry.ts` + `scheduler.ts` — `integrationsStore` plumbed through `DagExecutorDeps` and `V2SchedulerDeps`.
- Dashboard call sites — `run-now`, `widget-run`, `run-mutations`, scheduler CLI all pass `ctx.integrationsStore`.
- Notify card on agent Config tab — per-handler **Integration** dropdown lists matching kinds; legacy inline form is still available as the first option ("Inline config (legacy)").
- Tests: +5 dispatcher tests (resolution, inline override wins, missing skip, kind-mismatch skip, integration-driven secret union). 1199/1199 total.

## Test plan
- [x] `npm test` → 1199/1199
- [ ] Live: add a slack integration at `/settings/integrations`. Open an agent's Config → Notify, add a slack handler → the new **Integration** dropdown lists it. Select it, save, trigger a failed run → Slack message lands on the integration's channel without per-agent secret declaration.
- [ ] Override path: set the handler's channel inline → run lands in the override channel, not the integration's default.
- [ ] Backwards compat: an agent with legacy inline-form notify (no `integration:` field) still fires normally.

## Follow-ups
- **PR 3**: OAuth callback server + Gmail kind (send-email handler).
- **PR 4**: `csv` + `postgres` integration kinds (folds in `connectors-v0.17` plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)