### PR TITLE
feat: OAuth infrastructure + Gmail integration kind (PR 3 of 4)

### DIFF
--- a/.changeset/oauth-gmail-integration.md
+++ b/.changeset/oauth-gmail-integration.md
@@ -1,0 +1,36 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+OAuth infrastructure + Gmail integration kind (PR 3 of 4)
+
+Third PR of the Settings → Integrations workstream. Adds a generic
+OAuth flow (PKCE + S256 challenge, in-memory state map, single-use
+state consumption, stable `/oauth/callback` redirect_uri on the
+dashboard's existing port) and uses it to land the first OAuth-backed
+integration kind: `gmail`.
+
+How it works:
+- User creates a Google Cloud OAuth client (type "Desktop app"),
+  registers `http://127.0.0.1:3000/oauth/callback` as a redirect URI.
+- User adds the client_id + client_secret in `/settings/secrets`.
+- User creates a Gmail integration in `/settings/integrations` and
+  clicks **Connect Google**. The dashboard generates state + PKCE
+  verifier, redirects to Google consent, and on callback exchanges
+  the code for tokens.
+- Refresh token is stored in the encrypted secrets store as
+  `<INTEGRATION_ID>__REFRESH_TOKEN`. The integration row gains
+  `connected_account` (the user's email), `connected_at`, and
+  `refresh_token_secret` so handlers know what to read.
+- Notify handlers of type `gmail` reference the integration by id +
+  the inline per-message fields (`to`, `subject`, `body`). The
+  dispatcher refreshes the access token per send and calls Gmail's
+  messages.send API. Disconnect deletes the refresh token + clears
+  the connected state.
+
+Tests: +18 (PKCE, state store, OAuth route flow, dispatcher Gmail
+handler success + missing-connection failure). Total 1218 passing.

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -261,6 +261,15 @@ export const agentV2Schema = z.object({
         method: z.enum(['POST', 'PUT']).optional(),
         headers_secret: z.string().regex(SECRET_NAME_RE, 'headers_secret must be UPPERCASE_WITH_UNDERSCORES').optional(),
       }),
+      z.object({
+        type: z.literal('gmail'),
+        /** Required — Gmail handlers always go through a saved integration
+         *  (OAuth credentials don't fit cleanly inline in YAML). */
+        integration: z.string().min(1),
+        to: z.string().email(),
+        subject: z.string().min(1),
+        body: z.string().optional(),
+      }),
     ])).min(1, 'notify.handlers must list at least one handler'),
   }).superRefine((data, ctx) => {
     const declared = new Set(data.secrets ?? []);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,6 +71,26 @@ export {
   type IntegrationKind,
 } from './integrations-store.js';
 export {
+  generatePkcePair,
+  generateOauthState,
+  type PkcePair,
+} from './oauth/pkce.js';
+export {
+  createOauthStateStore,
+  type OauthFlowState,
+  type OauthStateStore,
+} from './oauth/state-store.js';
+export {
+  GMAIL_SCOPES,
+  buildGoogleAuthUrl,
+  exchangeGoogleCode,
+  refreshGoogleToken,
+  fetchGoogleUserInfo,
+  sendGmail,
+  type GoogleTokenResponse,
+  type UserInfo as GoogleUserInfo,
+} from './oauth/google.js';
+export {
   PlannerTelemetryStore,
   type PlannerTelemetryRow,
   type PlannerTelemetryStats,

--- a/packages/core/src/notify-dispatcher.test.ts
+++ b/packages/core/src/notify-dispatcher.test.ts
@@ -452,6 +452,85 @@ describe('integration resolution', () => {
     expect(warn).toHaveBeenCalledWith(expect.stringMatching(/kind="file" but handler is type="slack"/));
   });
 
+  it('gmail handler refreshes the token and posts to Gmail send', async () => {
+    const store = makeIntegrationsStore();
+    store.upsertIntegration({
+      id: 'user:gmail-oncall', packId: null, kind: 'gmail', name: 'Oncall Gmail',
+      config: {
+        client_id_secret: 'GMAIL_CLIENT_ID',
+        client_secret_secret: 'GMAIL_CLIENT_SECRET',
+        refresh_token_secret: 'USER_GMAIL_ONCALL__REFRESH_TOKEN',
+        connected_account: 'oncall@example.com',
+      },
+      secretRefs: ['GMAIL_CLIENT_ID', 'GMAIL_CLIENT_SECRET', 'USER_GMAIL_ONCALL__REFRESH_TOKEN'],
+    });
+    const secrets = new MemorySecretsStore();
+    await secrets.set('GMAIL_CLIENT_ID', 'cid');
+    await secrets.set('GMAIL_CLIENT_SECRET', 'csec');
+    await secrets.set('USER_GMAIL_ONCALL__REFRESH_TOKEN', 'rt-xyz');
+
+    // First fetch: token refresh; second fetch: Gmail send.
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, text: async () => JSON.stringify({ access_token: 'AT', expires_in: 3600, scope: 's', token_type: 'Bearer' }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, text: async () => '{}' });
+
+    const notify: NotifyConfig = {
+      on: ['failure'],
+      handlers: [{
+        type: 'gmail',
+        integration: 'user:gmail-oncall',
+        to: 'someone@example.com',
+        subject: 'Run failed',
+      }],
+    };
+    const result = await dispatchNotify(notify, {
+      agent: makeAgent(),
+      run: makeRun(),
+      integrationsStore: store,
+      secretsStore: secrets,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      logger: silentLogger,
+    });
+    expect(result.succeeded).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [tokenUrl, tokenInit] = fetchMock.mock.calls[0];
+    expect(String(tokenUrl)).toContain('oauth2.googleapis.com/token');
+    expect(String(tokenInit.body)).toContain('refresh_token=rt-xyz');
+    const [sendUrl, sendInit] = fetchMock.mock.calls[1];
+    expect(String(sendUrl)).toContain('gmail.googleapis.com');
+    expect(sendInit.headers.Authorization).toBe('Bearer AT');
+    const sendBody = JSON.parse(sendInit.body as string);
+    expect(typeof sendBody.raw).toBe('string');
+    const decoded = Buffer.from(sendBody.raw.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf-8');
+    expect(decoded).toContain('To: someone@example.com');
+    expect(decoded).toContain('Subject: Run failed');
+    expect(decoded).toContain('From: oncall@example.com');
+  });
+
+  it('gmail handler reports a missing-connection error when refresh_token_secret is absent', async () => {
+    const store = makeIntegrationsStore();
+    store.upsertIntegration({
+      id: 'user:gmail-half', packId: null, kind: 'gmail', name: 'Half-Configured',
+      config: { client_id_secret: 'GMAIL_CLIENT_ID', client_secret_secret: 'GMAIL_CLIENT_SECRET' },
+      secretRefs: ['GMAIL_CLIENT_ID', 'GMAIL_CLIENT_SECRET'],
+    });
+    const warn = vi.fn();
+    const fetchMock = vi.fn();
+    const notify: NotifyConfig = {
+      on: ['failure'],
+      handlers: [{ type: 'gmail', integration: 'user:gmail-half', to: 'a@b.example.com', subject: 's' }],
+    };
+    const result = await dispatchNotify(notify, {
+      agent: makeAgent(), run: makeRun(),
+      integrationsStore: store,
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      logger: { warn },
+    });
+    expect(result.succeeded).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/not connected/));
+  });
+
   it('pulls integration secret refs into the resolution bag even when notify.secrets omits them', async () => {
     const store = makeIntegrationsStore();
     store.upsertIntegration({

--- a/packages/core/src/notify-dispatcher.ts
+++ b/packages/core/src/notify-dispatcher.ts
@@ -36,6 +36,7 @@ import type { VariablesStore } from './variables-store.js';
 import type { IntegrationsStore, Integration } from './integrations-store.js';
 import { assertSafeUrl } from './builtin-tools.js';
 import { resolveVarsTemplate } from './node-templates.js';
+import { refreshGoogleToken, sendGmail } from './oauth/google.js';
 
 export type NotifyTrigger = 'failure' | 'success' | 'always';
 
@@ -81,10 +82,26 @@ export interface WebhookHandlerConfig {
   headers_secret?: string;
 }
 
+/**
+ * Gmail notify handler. Always uses a connected `gmail` integration —
+ * OAuth credentials don't fit cleanly inline in YAML. The handler
+ * carries the per-message fields (to / subject / body); the integration
+ * provides the connected account + the refresh-token secret name.
+ */
+export interface GmailHandlerConfig {
+  type: 'gmail';
+  /** Required — id of a connected `gmail` integration. */
+  integration: string;
+  to: string;
+  subject: string;
+  body?: string;
+}
+
 export type NotifyHandlerConfig =
   | SlackHandlerConfig
   | FileHandlerConfig
-  | WebhookHandlerConfig;
+  | WebhookHandlerConfig
+  | GmailHandlerConfig;
 
 export interface NotifyConfig {
   on: NotifyTrigger[];
@@ -214,6 +231,12 @@ function mergeIntegrationIntoHandler(
   row: Integration,
 ): NotifyHandlerConfig {
   const c = row.config;
+  // Gmail keeps the `integration` ref on the handler — the runner uses
+  // it to look up the integration row again at send time (refresh
+  // token secret name lives on the row, not on the handler).
+  if (handler.type === 'gmail') {
+    return handler;
+  }
   if (handler.type === 'slack') {
     return {
       type: 'slack',
@@ -263,6 +286,8 @@ async function runHandler(handler: NotifyHandlerConfig, ctx: HandlerContext): Pr
       return fileHandler(handler, ctx);
     case 'webhook':
       return webhookHandler(handler, ctx);
+    case 'gmail':
+      return gmailHandler(handler, ctx);
     default: {
       const exhaustive: never = handler;
       throw new Error(`Unknown notify handler type: ${JSON.stringify(exhaustive)}`);
@@ -368,6 +393,69 @@ async function fileHandler(handler: FileHandlerConfig, ctx: HandlerContext): Pro
 }
 
 // ── Webhook ────────────────────────────────────────────────────────────
+
+// ── Gmail ──────────────────────────────────────────────────────────────
+
+async function gmailHandler(handler: GmailHandlerConfig, ctx: HandlerContext): Promise<void> {
+  if (!ctx.integrationsStore) {
+    throw new Error('gmail handler needs an integrationsStore (none provided).');
+  }
+  const row = ctx.integrationsStore.getIntegration(handler.integration);
+  if (!row) {
+    throw new Error(`gmail integration "${handler.integration}" not found.`);
+  }
+  if (row.kind !== 'gmail') {
+    throw new Error(`integration "${handler.integration}" is kind="${row.kind}" but handler is gmail.`);
+  }
+  const clientIdSecret = (row.config.client_id_secret as string | undefined) ?? 'GMAIL_CLIENT_ID';
+  const clientSecretSecret = (row.config.client_secret_secret as string | undefined) ?? 'GMAIL_CLIENT_SECRET';
+  const refreshTokenSecret = row.config.refresh_token_secret as string | undefined;
+  if (!refreshTokenSecret) {
+    throw new Error(`gmail integration "${handler.integration}" is not connected — visit Settings → Integrations and click Connect.`);
+  }
+  const clientId = ctx.secrets[clientIdSecret];
+  const clientSecret = ctx.secrets[clientSecretSecret];
+  const refreshToken = ctx.secrets[refreshTokenSecret];
+  if (!clientId || !clientSecret || !refreshToken) {
+    const missing = [
+      !clientId && clientIdSecret,
+      !clientSecret && clientSecretSecret,
+      !refreshToken && refreshTokenSecret,
+    ].filter(Boolean).join(', ');
+    throw new Error(`gmail integration missing secrets in store: ${missing}`);
+  }
+
+  const fetchFn = ctx.fetchImpl ?? fetch;
+  const tokens = await refreshGoogleToken({
+    clientId,
+    clientSecret,
+    refreshToken,
+    fetchImpl: fetchFn,
+  });
+  const to = resolveVarsTemplate(handler.to, ctx.vars);
+  const subject = resolveVarsTemplate(handler.subject, ctx.vars);
+  const body = handler.body ? resolveVarsTemplate(handler.body, ctx.vars) : defaultGmailBody(ctx.agent, ctx.run);
+  await sendGmail({
+    accessToken: tokens.access_token,
+    to,
+    subject,
+    body,
+    from: typeof row.config.connected_account === 'string' ? row.config.connected_account as string : undefined,
+    fetchImpl: fetchFn,
+  });
+}
+
+function defaultGmailBody(agent: Agent, run: Run): string {
+  const lines = [
+    `Agent: ${agent.id} (${agent.name})`,
+    `Run: ${run.id}`,
+    `Status: ${run.status}`,
+    run.startedAt ? `Started: ${run.startedAt}` : '',
+    run.completedAt ? `Completed: ${run.completedAt}` : '',
+    run.error ? `\nError:\n${run.error.slice(0, 2000)}` : '',
+  ].filter(Boolean);
+  return lines.join('\n');
+}
 
 async function webhookHandler(handler: WebhookHandlerConfig, ctx: HandlerContext): Promise<void> {
   if (!handler.url) {

--- a/packages/core/src/oauth/google.ts
+++ b/packages/core/src/oauth/google.ts
@@ -1,0 +1,199 @@
+/**
+ * Google OAuth + Gmail driver.
+ *
+ * - Builds the authorisation URL for the consent step.
+ * - Exchanges the post-consent `code` for tokens.
+ * - Refreshes an access token from a stored refresh token.
+ * - Sends an email via the Gmail "users.messages.send" API.
+ *
+ * Trust model: sua does NOT ship a Google client_id / client_secret.
+ * The user creates their own OAuth client in the Google Cloud console
+ * ("Installed app" / "Desktop") and pastes the values into Settings →
+ * Secrets. The integration row references those secret names. Refresh
+ * tokens are written back to the secrets store under a name derived
+ * from the integration id.
+ */
+
+const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const GOOGLE_USERINFO_URL = 'https://www.googleapis.com/oauth2/v3/userinfo';
+const GMAIL_SEND_URL = 'https://gmail.googleapis.com/gmail/v1/users/me/messages/send';
+
+/** Minimal scope to send mail as the user + read their email address. */
+export const GMAIL_SCOPES = [
+  'https://www.googleapis.com/auth/gmail.send',
+  'openid',
+  'email',
+];
+
+export interface BuildAuthUrlArgs {
+  clientId: string;
+  redirectUri: string;
+  scopes: string[];
+  state: string;
+  codeChallenge: string;
+  /** 'offline' so Google returns a refresh_token on first consent. */
+  accessType?: 'online' | 'offline';
+  /** 'consent' forces re-consent each time — gives us a refresh_token even
+   *  if the user previously consented without one. */
+  prompt?: 'consent' | 'none' | 'select_account';
+  loginHint?: string;
+}
+
+export function buildGoogleAuthUrl(args: BuildAuthUrlArgs): string {
+  const params = new URLSearchParams({
+    client_id: args.clientId,
+    redirect_uri: args.redirectUri,
+    response_type: 'code',
+    scope: args.scopes.join(' '),
+    state: args.state,
+    code_challenge: args.codeChallenge,
+    code_challenge_method: 'S256',
+    access_type: args.accessType ?? 'offline',
+    prompt: args.prompt ?? 'consent',
+    include_granted_scopes: 'true',
+  });
+  if (args.loginHint) params.set('login_hint', args.loginHint);
+  return `${GOOGLE_AUTH_URL}?${params.toString()}`;
+}
+
+export interface TokenExchangeArgs {
+  clientId: string;
+  clientSecret: string;
+  code: string;
+  codeVerifier: string;
+  redirectUri: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface GoogleTokenResponse {
+  access_token: string;
+  /** Lifetime in seconds; typically 3600. */
+  expires_in: number;
+  /** Present on first consent with access_type=offline + prompt=consent. */
+  refresh_token?: string;
+  scope: string;
+  token_type: 'Bearer';
+  id_token?: string;
+}
+
+export async function exchangeGoogleCode(args: TokenExchangeArgs): Promise<GoogleTokenResponse> {
+  const body = new URLSearchParams({
+    code: args.code,
+    client_id: args.clientId,
+    client_secret: args.clientSecret,
+    code_verifier: args.codeVerifier,
+    redirect_uri: args.redirectUri,
+    grant_type: 'authorization_code',
+  });
+  return doTokenPost(body, args.fetchImpl);
+}
+
+export interface RefreshArgs {
+  clientId: string;
+  clientSecret: string;
+  refreshToken: string;
+  fetchImpl?: typeof fetch;
+}
+
+export async function refreshGoogleToken(args: RefreshArgs): Promise<GoogleTokenResponse> {
+  const body = new URLSearchParams({
+    client_id: args.clientId,
+    client_secret: args.clientSecret,
+    refresh_token: args.refreshToken,
+    grant_type: 'refresh_token',
+  });
+  return doTokenPost(body, args.fetchImpl);
+}
+
+async function doTokenPost(body: URLSearchParams, fetchImpl?: typeof fetch): Promise<GoogleTokenResponse> {
+  const fetchFn = fetchImpl ?? fetch;
+  const res = await fetchFn(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`Google token endpoint returned ${res.status}: ${text}`);
+  }
+  try {
+    return JSON.parse(text) as GoogleTokenResponse;
+  } catch {
+    throw new Error(`Google token endpoint returned non-JSON: ${text.slice(0, 200)}`);
+  }
+}
+
+export interface UserInfo {
+  email?: string;
+  name?: string;
+  sub: string;
+}
+
+export async function fetchGoogleUserInfo(accessToken: string, fetchImpl?: typeof fetch): Promise<UserInfo> {
+  const fetchFn = fetchImpl ?? fetch;
+  const res = await fetchFn(GOOGLE_USERINFO_URL, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!res.ok) {
+    throw new Error(`Google userinfo returned ${res.status}`);
+  }
+  return res.json() as Promise<UserInfo>;
+}
+
+export interface SendGmailArgs {
+  accessToken: string;
+  to: string;
+  subject: string;
+  body: string;
+  /** Optional From override — defaults to "me" (the authenticated account). */
+  from?: string;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Send an email via Gmail. Constructs an RFC 2822 message, base64url-
+ * encodes it, and POSTs to the messages.send endpoint. Throws on any
+ * non-2xx response so the dispatcher's per-handler try/catch logs +
+ * skips.
+ */
+export async function sendGmail(args: SendGmailArgs): Promise<void> {
+  const lines = [
+    `To: ${args.to}`,
+    args.from ? `From: ${args.from}` : '',
+    `Subject: ${encodeRfc2047(args.subject)}`,
+    'Content-Type: text/plain; charset="UTF-8"',
+    'MIME-Version: 1.0',
+    '',
+    args.body,
+  ].filter(Boolean);
+  const raw = Buffer.from(lines.join('\r\n'), 'utf-8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  const fetchFn = args.fetchImpl ?? fetch;
+  const res = await fetchFn(GMAIL_SEND_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${args.accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ raw }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Gmail send returned ${res.status}: ${text.slice(0, 200)}`);
+  }
+}
+
+/**
+ * RFC 2047 "encoded-word" wrapper for non-ASCII subject lines. ASCII
+ * subjects pass through unchanged so the test fixture stays readable.
+ */
+function encodeRfc2047(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  if (/^[\x00-\x7F]*$/.test(s)) return s;
+  const b64 = Buffer.from(s, 'utf-8').toString('base64');
+  return `=?UTF-8?B?${b64}?=`;
+}

--- a/packages/core/src/oauth/pkce.test.ts
+++ b/packages/core/src/oauth/pkce.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import { generatePkcePair, generateOauthState } from './pkce.js';
+
+describe('generatePkcePair', () => {
+  it('returns a base64url verifier between 43 and 128 chars (RFC 7636)', () => {
+    const { codeVerifier } = generatePkcePair();
+    expect(codeVerifier.length).toBeGreaterThanOrEqual(43);
+    expect(codeVerifier.length).toBeLessThanOrEqual(128);
+    expect(codeVerifier).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it('challenge is base64url(SHA-256(verifier))', () => {
+    const { codeVerifier, codeChallenge, codeChallengeMethod } = generatePkcePair();
+    expect(codeChallengeMethod).toBe('S256');
+    const expected = createHash('sha256').update(codeVerifier).digest('base64')
+      .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    expect(codeChallenge).toBe(expected);
+  });
+
+  it('produces unique pairs each call', () => {
+    const a = generatePkcePair();
+    const b = generatePkcePair();
+    expect(a.codeVerifier).not.toBe(b.codeVerifier);
+    expect(a.codeChallenge).not.toBe(b.codeChallenge);
+  });
+});
+
+describe('generateOauthState', () => {
+  it('is base64url, at least 30 chars (24 random bytes -> 32 chars)', () => {
+    const s = generateOauthState();
+    expect(s.length).toBeGreaterThanOrEqual(30);
+    expect(s).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(generateOauthState()).not.toBe(s);
+  });
+});

--- a/packages/core/src/oauth/pkce.ts
+++ b/packages/core/src/oauth/pkce.ts
@@ -1,0 +1,48 @@
+import { randomBytes, createHash } from 'node:crypto';
+
+/**
+ * PKCE (Proof Key for Code Exchange) helpers — RFC 7636.
+ *
+ * Why: sua's OAuth flow exposes `/oauth/callback` on a fixed loopback
+ * port (the dashboard's own port). Anyone on the same machine can
+ * theoretically race to that callback. PKCE binds the authorisation
+ * code to the verifier we generated server-side, so even if an
+ * attacker intercepts the code they can't exchange it without our
+ * verifier.
+ *
+ * We use S256 (SHA-256) — the only method Google accepts beyond the
+ * deprecated `plain` method.
+ */
+
+const VERIFIER_BYTES = 48;            // → 64-char base64url, well under the 128-char RFC max
+
+export interface PkcePair {
+  /** Random URL-safe string. Stored server-side, sent with the token exchange. */
+  codeVerifier: string;
+  /** Base64url(SHA-256(verifier)). Sent to the authorisation endpoint. */
+  codeChallenge: string;
+  /** Always 'S256' for sua — Google rejects 'plain' on installed apps anyway. */
+  codeChallengeMethod: 'S256';
+}
+
+export function generatePkcePair(): PkcePair {
+  const codeVerifier = base64UrlEncode(randomBytes(VERIFIER_BYTES));
+  const hash = createHash('sha256').update(codeVerifier).digest();
+  return {
+    codeVerifier,
+    codeChallenge: base64UrlEncode(hash),
+    codeChallengeMethod: 'S256',
+  };
+}
+
+/** OAuth state token — opaque, used for CSRF protection on the callback. */
+export function generateOauthState(): string {
+  return base64UrlEncode(randomBytes(24));
+}
+
+function base64UrlEncode(buf: Buffer): string {
+  return buf.toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}

--- a/packages/core/src/oauth/state-store.test.ts
+++ b/packages/core/src/oauth/state-store.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createOauthStateStore } from './state-store.js';
+
+function sampleFlow(overrides: Partial<Parameters<ReturnType<typeof createOauthStateStore>['put']>[1]> = {}) {
+  return {
+    integrationId: 'user:gmail-oncall',
+    codeVerifier: 'verifier-abc',
+    provider: 'gmail',
+    returnTo: '/settings/integrations',
+    expiresAt: Date.now() + 60_000,
+    ...overrides,
+  };
+}
+
+describe('createOauthStateStore', () => {
+  it('round-trips put → consume', () => {
+    const store = createOauthStateStore();
+    const flow = sampleFlow();
+    store.put('s1', flow);
+    expect(store.consume('s1')).toEqual(flow);
+  });
+
+  it('consume is single-use', () => {
+    const store = createOauthStateStore();
+    store.put('s1', sampleFlow());
+    store.consume('s1');
+    expect(store.consume('s1')).toBeNull();
+  });
+
+  it('returns null for unknown state', () => {
+    const store = createOauthStateStore();
+    expect(store.consume('nope')).toBeNull();
+  });
+
+  it('refuses to overwrite a live state token', () => {
+    const store = createOauthStateStore();
+    store.put('s1', sampleFlow());
+    expect(() => store.put('s1', sampleFlow())).toThrow(/reused/);
+  });
+
+  it('expires entries silently and reissues the state token', () => {
+    const store = createOauthStateStore();
+    const past = sampleFlow({ expiresAt: Date.now() - 1_000 });
+    store.put('s1', past);
+    expect(store.consume('s1')).toBeNull();
+    // After consume cleared the expired entry, the state is available again.
+    store.put('s1', sampleFlow());
+    expect(store.consume('s1')).not.toBeNull();
+  });
+
+  it('clear wipes everything', () => {
+    const store = createOauthStateStore();
+    store.put('s1', sampleFlow());
+    store.put('s2', sampleFlow({ integrationId: 'user:other' }));
+    store.clear();
+    expect(store.consume('s1')).toBeNull();
+    expect(store.consume('s2')).toBeNull();
+  });
+});

--- a/packages/core/src/oauth/state-store.ts
+++ b/packages/core/src/oauth/state-store.ts
@@ -1,0 +1,70 @@
+/**
+ * In-memory OAuth state map.
+ *
+ * Each `state` token issued for an in-flight OAuth flow maps to a small
+ * record (integration id + PKCE verifier + expiry). The /oauth/callback
+ * route consumes the entry — single-use — when the provider redirects
+ * the user back with `?code=…&state=…`.
+ *
+ * Lifetime: process memory only. A daemon restart cancels every
+ * in-flight flow, which is fine — the user just clicks Connect again.
+ * Persisting the verifier on disk would defeat the point of PKCE.
+ *
+ * The store is also self-pruning: entries past their expiry are
+ * removed lazily on each `consume`, and `clear` is exposed for tests.
+ */
+
+export interface OauthFlowState {
+  /** Integration id this flow is connecting (used to write back on success). */
+  integrationId: string;
+  /** PKCE verifier sent back to the provider during token exchange. */
+  codeVerifier: string;
+  /** Driver/provider kind ('gmail', etc.) — distinguishes endpoint URLs. */
+  provider: string;
+  /** Where the user came from. We redirect back here after success/failure. */
+  returnTo: string;
+  /** ms since epoch when this entry expires. */
+  expiresAt: number;
+}
+
+export interface OauthStateStore {
+  /** Store a flow under `state`. Throws if the same state is reused. */
+  put(state: string, flow: OauthFlowState): void;
+  /** Read + delete in one call. Returns null if expired or unknown. */
+  consume(state: string): OauthFlowState | null;
+  /** Test helper. */
+  clear(): void;
+}
+
+export function createOauthStateStore(): OauthStateStore {
+  const entries = new Map<string, OauthFlowState>();
+
+  function pruneExpired(now: number): void {
+    for (const [k, v] of entries) {
+      if (v.expiresAt <= now) entries.delete(k);
+    }
+  }
+
+  return {
+    put(state, flow): void {
+      const now = Date.now();
+      pruneExpired(now);
+      if (entries.has(state)) {
+        throw new Error(`OAuth state "${state.slice(0, 6)}…" reused — refuse to overwrite.`);
+      }
+      entries.set(state, flow);
+    },
+    consume(state): OauthFlowState | null {
+      const now = Date.now();
+      pruneExpired(now);
+      const got = entries.get(state);
+      if (!got) return null;
+      entries.delete(state);
+      if (got.expiresAt <= now) return null;
+      return got;
+    },
+    clear(): void {
+      entries.clear();
+    },
+  };
+}

--- a/packages/dashboard/src/context.ts
+++ b/packages/dashboard/src/context.ts
@@ -1,4 +1,4 @@
-import type { LocalProvider, RunStore, SecretsStore, AgentDefinition, AgentStore, ToolStore, VariablesStore, PacksStore, DashboardsStore, IntegrationsStore, PlannerTelemetryStore } from '@some-useful-agents/core';
+import type { LocalProvider, RunStore, SecretsStore, AgentDefinition, AgentStore, ToolStore, VariablesStore, PacksStore, DashboardsStore, IntegrationsStore, OauthStateStore, PlannerTelemetryStore } from '@some-useful-agents/core';
 import type { SecretsSession } from './secrets-session.js';
 
 /**
@@ -90,6 +90,12 @@ export interface DashboardContext {
    * Optional so the dashboard boots even if the table can't be created.
    */
   integrationsStore?: IntegrationsStore;
+  /**
+   * In-memory store for in-flight OAuth flows. Each Connect click writes
+   * one entry keyed by `state`; the /oauth/callback route consumes it
+   * single-use. Process memory only — daemon restart cancels any flow.
+   */
+  oauthStateStore?: OauthStateStore;
   /**
    * Build-planner telemetry store. Records one row per planner run with
    * timing + failure-class counters; feeds `/metrics/planner`. Optional so

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -9,6 +9,7 @@ import {
   PacksStore,
   DashboardsStore,
   IntegrationsStore,
+  createOauthStateStore,
   PlannerTelemetryStore,
   loadBuiltinPacks,
   defaultBuiltinPacksDir,
@@ -44,6 +45,7 @@ import { nodesRouter } from './routes/nodes.js';
 import { assetsRouter } from './routes/assets.js';
 import { outputFilesRouter } from './routes/output-files.js';
 import { settingsRouter } from './routes/settings.js';
+import { oauthRouter } from './routes/oauth.js';
 import { settingsMcpRouter } from './routes/settings-mcp.js';
 import { helpRouter } from './routes/help.js';
 import { versionsRouter } from './routes/versions.js';
@@ -235,6 +237,7 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   app.use(widgetRunRouter);
   app.use(settingsMcpRouter);
   app.use(settingsRouter);
+  app.use(oauthRouter);
   app.use(helpRouter);
   app.use(versionsRouter);
   app.use(toolsRouter);
@@ -318,6 +321,10 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     // Non-fatal: settings/integrations surface stays absent.
   }
 
+  // OAuth flow state — in-memory, single store per dashboard process.
+  // Survives a Connect-then-callback round-trip; cleared on daemon restart.
+  const oauthStateStore = createOauthStateStore();
+
   // Planner telemetry store. Records one row per planner run; feeds /metrics/planner.
   let plannerTelemetryStore: PlannerTelemetryStore | undefined;
   try {
@@ -346,6 +353,7 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     packsStore,
     dashboardsStore,
     integrationsStore,
+    oauthStateStore,
     plannerTelemetryStore,
     allowUntrustedShell: opts.allowUntrustedShell ?? new Set(),
     activeRuns: new Map(),

--- a/packages/dashboard/src/routes/oauth.test.ts
+++ b/packages/dashboard/src/routes/oauth.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import request from 'supertest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AgentStore,
+  DashboardsStore,
+  IntegrationsStore,
+  LocalProvider,
+  MemorySecretsStore,
+  PacksStore,
+  RunStore,
+  buildLoopbackAllowlist,
+  createOauthStateStore,
+  loadAgents,
+} from '@some-useful-agents/core';
+import { buildDashboardApp } from '../index.js';
+import type { DashboardContext } from '../context.js';
+import { SESSION_COOKIE } from '../auth-middleware.js';
+import { MemorySecretsSession } from '../secrets-session.js';
+import { refreshTokenSecretName } from './oauth.js';
+
+const TOKEN = 'a'.repeat(64);
+const PORT = 3998;
+const COOKIE = `${SESSION_COOKIE}=${TOKEN}`;
+
+let dir: string;
+let provider: LocalProvider;
+let runStore: RunStore;
+let agentStore: AgentStore;
+let packsStore: PacksStore;
+let dashboardsStore: DashboardsStore;
+let integrationsStore: IntegrationsStore;
+let secretsStore: MemorySecretsStore;
+
+async function makeApp() {
+  dir = mkdtempSync(join(tmpdir(), 'sua-oauth-routes-'));
+  const dbPath = join(dir, 'runs.db');
+  const agentsDir = join(dir, 'agents', 'local');
+  mkdirSync(agentsDir, { recursive: true });
+
+  secretsStore = new MemorySecretsStore();
+  runStore = new RunStore(dbPath);
+  agentStore = new AgentStore(dbPath);
+  packsStore = new PacksStore(dbPath);
+  dashboardsStore = new DashboardsStore(dbPath);
+  integrationsStore = new IntegrationsStore(dbPath);
+  provider = new LocalProvider(dbPath, secretsStore);
+  await provider.initialize();
+
+  const ctx: DashboardContext = {
+    token: TOKEN,
+    allowlist: buildLoopbackAllowlist(PORT),
+    port: PORT,
+    provider,
+    runStore,
+    agentStore,
+    loadAgents: () => loadAgents({ directories: [agentsDir] }),
+    secretsStore,
+    secretsSession: new MemorySecretsSession({ backing: secretsStore }),
+    tokenPath: join(dir, 'mcp-token'),
+    retentionDays: 30,
+    dbPath,
+    secretsPath: join(dir, 'secrets.enc'),
+    rotateToken: () => 'r'.repeat(64),
+    packsStore,
+    dashboardsStore,
+    integrationsStore,
+    oauthStateStore: createOauthStateStore(),
+    allowUntrustedShell: new Set(),
+    activeRuns: new Map(),
+    dataDir: dir,
+    dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
+  };
+
+  return { app: buildDashboardApp(ctx), ctx };
+}
+
+afterEach(async () => {
+  if (provider) {
+    await provider.shutdown();
+  }
+  try { runStore?.close(); } catch { /* ignore */ }
+  try { agentStore?.close(); } catch { /* ignore */ }
+  try { packsStore?.close(); } catch { /* ignore */ }
+  try { dashboardsStore?.close(); } catch { /* ignore */ }
+  try { integrationsStore?.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('refreshTokenSecretName', () => {
+  it('uppercases + sanitises the integration id', () => {
+    expect(refreshTokenSecretName('user:gmail-oncall')).toBe('USER_GMAIL_ONCALL__REFRESH_TOKEN');
+    expect(refreshTokenSecretName('starter:hi-there')).toBe('STARTER_HI_THERE__REFRESH_TOKEN');
+  });
+});
+
+describe('POST /settings/integrations/:id/connect', () => {
+  it('redirects to Google with state + PKCE challenge when secrets are present', async () => {
+    const { app } = await makeApp();
+    integrationsStore.upsertIntegration({
+      id: 'user:gmail-oncall', packId: null, kind: 'gmail', name: 'Oncall',
+      config: { client_id_secret: 'GMAIL_CLIENT_ID', client_secret_secret: 'GMAIL_CLIENT_SECRET' },
+      secretRefs: ['GMAIL_CLIENT_ID', 'GMAIL_CLIENT_SECRET'],
+    });
+    await secretsStore.set('GMAIL_CLIENT_ID', 'cid-value');
+    await secretsStore.set('GMAIL_CLIENT_SECRET', 'csec-value');
+
+    const res = await request(app)
+      .post('/settings/integrations/user:gmail-oncall/connect')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toContain('accounts.google.com/o/oauth2/v2/auth');
+    expect(res.headers.location).toContain('client_id=cid-value');
+    expect(res.headers.location).toContain('code_challenge=');
+    expect(res.headers.location).toContain('code_challenge_method=S256');
+    expect(res.headers.location).toContain('state=');
+    expect(res.headers.location).toContain('access_type=offline');
+  });
+
+  it('refuses to start the flow when credentials are missing in the secrets store', async () => {
+    const { app } = await makeApp();
+    integrationsStore.upsertIntegration({
+      id: 'user:gmail-bare', packId: null, kind: 'gmail', name: 'Bare',
+      config: { client_id_secret: 'GMAIL_CLIENT_ID', client_secret_secret: 'GMAIL_CLIENT_SECRET' },
+      secretRefs: ['GMAIL_CLIENT_ID', 'GMAIL_CLIENT_SECRET'],
+    });
+    const res = await request(app)
+      .post('/settings/integrations/user:gmail-bare/connect')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toContain('/settings/integrations');
+    expect(res.headers.location).toMatch(/Set(\+|%20)GMAIL_CLIENT/);
+  });
+
+  it('refuses to connect a non-OAuth kind', async () => {
+    const { app } = await makeApp();
+    integrationsStore.upsertIntegration({
+      id: 'user:slack-oncall', packId: null, kind: 'slack', name: 'Slack',
+      config: { webhook_secret: 'SLACK_WEBHOOK' }, secretRefs: ['SLACK_WEBHOOK'],
+    });
+    const res = await request(app)
+      .post('/settings/integrations/user:slack-oncall/connect')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/does(\+|%20)not(\+|%20)support(\+|%20)OAuth/);
+  });
+});
+
+describe('GET /oauth/callback', () => {
+  it('rejects with an error redirect when state is unknown', async () => {
+    const { app } = await makeApp();
+    const res = await request(app)
+      .get('/oauth/callback?state=unknown-state&code=anything')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/expired\+or\+state\+unknown/);
+  });
+
+  it('surfaces provider-side errors back to the user', async () => {
+    const { app } = await makeApp();
+    const res = await request(app)
+      .get('/oauth/callback?error=access_denied')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/OAuth(\+|%20)denied/);
+  });
+});
+
+describe('POST /settings/integrations/:id/disconnect', () => {
+  it('clears connected state + deletes the persisted refresh token', async () => {
+    const { app } = await makeApp();
+    const id = 'user:gmail-discon';
+    integrationsStore.upsertIntegration({
+      id, packId: null, kind: 'gmail', name: 'Disconnect Test',
+      config: {
+        client_id_secret: 'GMAIL_CLIENT_ID',
+        client_secret_secret: 'GMAIL_CLIENT_SECRET',
+        refresh_token_secret: 'USER_GMAIL_DISCON__REFRESH_TOKEN',
+        connected_account: 'foo@example.com',
+        connected_at: Date.now(),
+      },
+      secretRefs: ['GMAIL_CLIENT_ID', 'GMAIL_CLIENT_SECRET', 'USER_GMAIL_DISCON__REFRESH_TOKEN'],
+    });
+    await secretsStore.set('USER_GMAIL_DISCON__REFRESH_TOKEN', 'rt-zzz');
+
+    const res = await request(app)
+      .post(`/settings/integrations/${id}/disconnect`)
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/Disconnected/);
+    expect(await secretsStore.has('USER_GMAIL_DISCON__REFRESH_TOKEN')).toBe(false);
+    const after = integrationsStore.getIntegration(id)!;
+    expect(after.config.connected_account).toBeUndefined();
+    expect(after.config.connected_at).toBeUndefined();
+    expect(after.config.refresh_token_secret).toBeUndefined();
+    expect(after.secretRefs).not.toContain('USER_GMAIL_DISCON__REFRESH_TOKEN');
+  });
+});

--- a/packages/dashboard/src/routes/oauth.ts
+++ b/packages/dashboard/src/routes/oauth.ts
@@ -1,0 +1,301 @@
+/**
+ * OAuth callback route + connect/disconnect actions for integration kinds
+ * that need provider authorisation (currently only `gmail`).
+ *
+ * Trust model — see docs/SECURITY.md "Public-repo secret hygiene":
+ *  - Client credentials live in the encrypted secrets store, referenced
+ *    by name from the integration row. The user creates their own
+ *    Google OAuth client (Desktop app) and pastes the values via
+ *    Settings → Secrets.
+ *  - PKCE binds the authorisation code to a verifier we generated
+ *    server-side. An attacker on the same loopback can't redeem a
+ *    code they didn't authorise without our verifier.
+ *  - State token (random 24 bytes, base64url) is consumed single-use
+ *    by the callback. A replayed callback returns 400.
+ *  - Refresh tokens are stored under a name derived from the
+ *    integration id (`<id>__refresh_token`). Access tokens are
+ *    short-lived and re-fetched per use; never persisted.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import {
+  generatePkcePair,
+  generateOauthState,
+  buildGoogleAuthUrl,
+  exchangeGoogleCode,
+  fetchGoogleUserInfo,
+  GMAIL_SCOPES,
+} from '@some-useful-agents/core';
+import { getContext } from '../context.js';
+
+export const oauthRouter: Router = Router();
+
+/** ms a single Connect flow stays in the in-memory state map. */
+const FLOW_TTL_MS = 5 * 60 * 1000;
+
+/** Suffix appended to integration id to name its persisted refresh-token secret. */
+export function refreshTokenSecretName(integrationId: string): string {
+  // Secret name regex is `[A-Z_][A-Z0-9_]*`. Convert the integration id
+  // (lowercase with `:`/`-`) into that shape so a single namespace is
+  // searchable in Settings → Secrets.
+  const suffix = integrationId.toUpperCase().replace(/[^A-Z0-9]/g, '_');
+  return `${suffix}__REFRESH_TOKEN`;
+}
+
+/**
+ * POST /settings/integrations/:id/connect — kick off OAuth.
+ *
+ * Reads the integration's referenced client_id + client_secret from
+ * the secrets store, generates state + PKCE, persists the flow in the
+ * state store, redirects the user to the provider's consent screen.
+ */
+oauthRouter.post('/settings/integrations/:id/connect', async (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.integrationsStore || !ctx.oauthStateStore) {
+    res.redirect(303, '/settings/integrations?error=OAuth+infrastructure+unavailable.');
+    return;
+  }
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const integration = ctx.integrationsStore.getIntegration(id);
+  if (!integration) {
+    res.redirect(303, '/settings/integrations?error=Integration+not+found.');
+    return;
+  }
+  if (integration.kind !== 'gmail') {
+    res.redirect(303, `/settings/integrations?error=${encodeURIComponent(`Kind "${integration.kind}" does not support OAuth connection.`)}`);
+    return;
+  }
+
+  // Pull the two credential secret names from the integration row.
+  // Default to GMAIL_CLIENT_ID / GMAIL_CLIENT_SECRET so a user who left
+  // the field blank in the add-form still works after pasting those.
+  const clientIdSecret = typeof integration.config.client_id_secret === 'string'
+    ? integration.config.client_id_secret as string
+    : 'GMAIL_CLIENT_ID';
+  const clientSecretSecret = typeof integration.config.client_secret_secret === 'string'
+    ? integration.config.client_secret_secret as string
+    : 'GMAIL_CLIENT_SECRET';
+
+  let clientId: string;
+  let clientSecret: string;
+  try {
+    const all = await ctx.secretsStore.getAll();
+    clientId = all[clientIdSecret] ?? '';
+    clientSecret = all[clientSecretSecret] ?? '';
+  } catch (err) {
+    res.redirect(303, `/settings/integrations?error=${encodeURIComponent(`Could not read secrets store: ${(err as Error).message}`)}`);
+    return;
+  }
+  if (!clientId || !clientSecret) {
+    const missing = [!clientId && clientIdSecret, !clientSecret && clientSecretSecret].filter(Boolean).join(', ');
+    res.redirect(303, `/settings/integrations?error=${encodeURIComponent(`Set ${missing} in Settings → Secrets before connecting.`)}`);
+    return;
+  }
+
+  const pkce = generatePkcePair();
+  const state = generateOauthState();
+  const redirectUri = computeRedirectUri(req);
+
+  try {
+    ctx.oauthStateStore.put(state, {
+      integrationId: id,
+      codeVerifier: pkce.codeVerifier,
+      provider: 'gmail',
+      returnTo: '/settings/integrations',
+      expiresAt: Date.now() + FLOW_TTL_MS,
+    });
+  } catch (err) {
+    res.redirect(303, `/settings/integrations?error=${encodeURIComponent((err as Error).message)}`);
+    return;
+  }
+
+  const authUrl = buildGoogleAuthUrl({
+    clientId,
+    redirectUri,
+    scopes: GMAIL_SCOPES,
+    state,
+    codeChallenge: pkce.codeChallenge,
+  });
+  res.redirect(303, authUrl);
+});
+
+/**
+ * GET /oauth/callback — the redirect_uri Google calls back to.
+ *
+ * Validates `state`, exchanges the `code` for tokens, persists the
+ * refresh token + the user's email on the integration row.
+ */
+oauthRouter.get('/oauth/callback', async (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.integrationsStore || !ctx.oauthStateStore) {
+    res.status(503).redirect(303, '/settings/integrations?error=OAuth+infrastructure+unavailable.');
+    return;
+  }
+
+  const stateParam = typeof req.query.state === 'string' ? req.query.state : '';
+  const errorParam = typeof req.query.error === 'string' ? req.query.error : '';
+  const codeParam = typeof req.query.code === 'string' ? req.query.code : '';
+
+  if (errorParam) {
+    res.redirect(303, `/settings/integrations?error=${encodeURIComponent(`OAuth denied: ${errorParam}`)}`);
+    return;
+  }
+  if (!stateParam || !codeParam) {
+    res.redirect(303, '/settings/integrations?error=Missing+state+or+code+on+callback.');
+    return;
+  }
+
+  const flow = ctx.oauthStateStore.consume(stateParam);
+  if (!flow) {
+    res.redirect(303, '/settings/integrations?error=OAuth+flow+expired+or+state+unknown.+Try+Connect+again.');
+    return;
+  }
+
+  const integration = ctx.integrationsStore.getIntegration(flow.integrationId);
+  if (!integration) {
+    res.redirect(303, '/settings/integrations?error=Integration+disappeared+mid-flow.');
+    return;
+  }
+
+  // Re-resolve client credentials from the secrets store. Mirrors the
+  // /connect handler so a credential rotation between consent and
+  // callback surfaces here rather than at the token endpoint.
+  const clientIdSecret = (integration.config.client_id_secret as string | undefined) ?? 'GMAIL_CLIENT_ID';
+  const clientSecretSecret = (integration.config.client_secret_secret as string | undefined) ?? 'GMAIL_CLIENT_SECRET';
+  let clientId: string;
+  let clientSecret: string;
+  try {
+    const all = await ctx.secretsStore.getAll();
+    clientId = all[clientIdSecret] ?? '';
+    clientSecret = all[clientSecretSecret] ?? '';
+  } catch (err) {
+    res.redirect(303, `/settings/integrations?error=${encodeURIComponent(`Could not read secrets store on callback: ${(err as Error).message}`)}`);
+    return;
+  }
+  if (!clientId || !clientSecret) {
+    res.redirect(303, '/settings/integrations?error=Client+credentials+disappeared+mid-flow.');
+    return;
+  }
+
+  const redirectUri = computeRedirectUri(req);
+  let tokens;
+  try {
+    tokens = await exchangeGoogleCode({
+      clientId,
+      clientSecret,
+      code: codeParam,
+      codeVerifier: flow.codeVerifier,
+      redirectUri,
+    });
+  } catch (err) {
+    res.redirect(303, `/settings/integrations?error=${encodeURIComponent(`Token exchange failed: ${(err as Error).message}`)}`);
+    return;
+  }
+  if (!tokens.refresh_token) {
+    // We asked with prompt=consent so Google should always issue one
+    // on a fresh consent. If not, the user likely consented before
+    // with a different prompt; re-Connect with prompt=consent will fix it.
+    res.redirect(303, '/settings/integrations?error=Google+did+not+return+a+refresh_token.+Try+Connect+again.');
+    return;
+  }
+
+  // Persist the refresh token under a derived secret name.
+  const refreshSecretName = refreshTokenSecretName(integration.id);
+  try {
+    await ctx.secretsStore.set(refreshSecretName, tokens.refresh_token);
+  } catch (err) {
+    res.redirect(303, `/settings/integrations?error=${encodeURIComponent(`Could not persist refresh token: ${(err as Error).message}`)}`);
+    return;
+  }
+
+  // Fetch the user's email so the UI can show "Connected as foo@bar.com".
+  let email = '';
+  try {
+    const info = await fetchGoogleUserInfo(tokens.access_token);
+    email = info.email ?? '';
+  } catch { /* non-fatal — leave email blank */ }
+
+  // Update the integration row: mark connected + remember the account
+  // and refresh-token secret name (so notify handlers know what to read).
+  const nextConfig: Record<string, unknown> = { ...integration.config };
+  nextConfig.connected_account = email || nextConfig.connected_account || '';
+  nextConfig.connected_at = Date.now();
+  nextConfig.refresh_token_secret = refreshSecretName;
+  const secretRefs = Array.from(new Set([
+    ...integration.secretRefs,
+    clientIdSecret,
+    clientSecretSecret,
+    refreshSecretName,
+  ]));
+  try {
+    ctx.integrationsStore.upsertIntegration({
+      id: integration.id,
+      packId: integration.packId,
+      kind: integration.kind,
+      name: integration.name,
+      config: nextConfig,
+      secretRefs,
+    });
+  } catch (err) {
+    res.redirect(303, `/settings/integrations?error=${encodeURIComponent(`Could not save integration: ${(err as Error).message}`)}`);
+    return;
+  }
+
+  res.redirect(303, `${flow.returnTo}?flash=${encodeURIComponent(email ? `Connected as ${email}.` : 'Connected.')}`);
+});
+
+/**
+ * POST /settings/integrations/:id/disconnect — clear the connected
+ * state. Leaves the integration row but removes `connected_account`,
+ * `connected_at`, and the refresh-token secret reference. The actual
+ * refresh-token secret is also deleted from the encrypted store so a
+ * stale token can't be used after the user explicitly disconnected.
+ */
+oauthRouter.post('/settings/integrations/:id/disconnect', async (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.integrationsStore) {
+    res.redirect(303, '/settings/integrations?error=Integrations+store+unavailable.');
+    return;
+  }
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const integration = ctx.integrationsStore.getIntegration(id);
+  if (!integration) {
+    res.redirect(303, '/settings/integrations?error=Integration+not+found.');
+    return;
+  }
+
+  const refreshSecretName = (integration.config.refresh_token_secret as string | undefined)
+    ?? refreshTokenSecretName(integration.id);
+  try {
+    await ctx.secretsStore.delete(refreshSecretName);
+  } catch { /* missing is fine — disconnect should be idempotent */ }
+
+  const nextConfig: Record<string, unknown> = { ...integration.config };
+  delete nextConfig.connected_account;
+  delete nextConfig.connected_at;
+  delete nextConfig.refresh_token_secret;
+  const secretRefs = integration.secretRefs.filter((s) => s !== refreshSecretName);
+  ctx.integrationsStore.upsertIntegration({
+    id: integration.id,
+    packId: integration.packId,
+    kind: integration.kind,
+    name: integration.name,
+    config: nextConfig,
+    secretRefs,
+  });
+  res.redirect(303, `/settings/integrations?flash=${encodeURIComponent(`Disconnected ${integration.id}.`)}`);
+});
+
+/**
+ * Build the absolute redirect_uri the user registered with Google. We
+ * derive it from the request's host so loopback works in dev, in CI,
+ * and behind a port-forwarded production deployment without needing
+ * an env var.
+ */
+function computeRedirectUri(req: Request): string {
+  // Express's req.protocol respects `app.set('trust proxy', true)`. Sua
+  // doesn't, so over loopback this is always 'http'.
+  const proto = req.protocol;
+  const host = req.get('host') ?? `127.0.0.1:${process.env.SUA_DASHBOARD_PORT ?? '3000'}`;
+  return `${proto}://${host}/oauth/callback`;
+}

--- a/packages/dashboard/src/routes/settings.ts
+++ b/packages/dashboard/src/routes/settings.ts
@@ -382,6 +382,20 @@ settingsRouter.post('/settings/integrations/add', (req: Request, res: Response) 
       secretRefs = [];
       break;
     }
+    case 'gmail': {
+      const clientIdSecret = typeof body.client_id_secret === 'string' ? body.client_id_secret.trim() : '';
+      const clientSecretSecret = typeof body.client_secret_secret === 'string' ? body.client_secret_secret.trim() : '';
+      if (!INTEGRATION_SECRET_NAME_RE.test(clientIdSecret)) return fail('client_id secret name must be UPPERCASE_WITH_UNDERSCORES.');
+      if (!INTEGRATION_SECRET_NAME_RE.test(clientSecretSecret)) return fail('client_secret secret name must be UPPERCASE_WITH_UNDERSCORES.');
+      // Connection state lands on the row only after the OAuth callback
+      // succeeds; for now we just record the credential secret names.
+      config = {
+        client_id_secret: clientIdSecret,
+        client_secret_secret: clientSecretSecret,
+      };
+      secretRefs = [clientIdSecret, clientSecretSecret];
+      break;
+    }
     default:
       return fail(`Unknown kind "${kind}".`);
   }

--- a/packages/dashboard/src/views/settings-integrations.ts
+++ b/packages/dashboard/src/views/settings-integrations.ts
@@ -36,6 +36,7 @@ export function renderSettingsIntegrations(args: SettingsIntegrationsArgs): Safe
     ${renderSlackForm(args)}
     ${renderWebhookForm(args)}
     ${renderFileForm(args)}
+    ${renderGmailForm(args)}
   `;
 }
 
@@ -97,6 +98,18 @@ function describeConfig(i: Integration): SafeHtml {
       const path = typeof i.config.path === 'string' ? i.config.path : '';
       const append = i.config.append !== false;
       return unsafeHtml(`${esc(path)} <span class="dim">(${append ? 'append' : 'overwrite'})</span>`);
+    }
+    case 'gmail': {
+      const connected = typeof i.config.connected_account === 'string' && i.config.connected_account.length > 0;
+      const account = typeof i.config.connected_account === 'string' ? i.config.connected_account : '';
+      if (connected) {
+        const form = `<form action="/settings/integrations/${esc(i.id)}/disconnect" method="post" style="display: inline; margin-left: var(--space-2);">` +
+          `<button type="submit" class="btn btn--sm btn--ghost">Disconnect</button></form>`;
+        return unsafeHtml(`<span class="badge badge--ok">connected as ${esc(account)}</span>${form}`);
+      }
+      const form = `<form action="/settings/integrations/${esc(i.id)}/connect" method="post" style="display: inline; margin-left: var(--space-2);">` +
+        `<button type="submit" class="btn btn--sm">Connect Google</button></form>`;
+      return unsafeHtml(`<span class="badge badge--muted">not connected</span>${form}`);
     }
     default:
       return unsafeHtml('<span class="dim">—</span>');
@@ -175,6 +188,46 @@ function renderWebhookForm(args: SettingsIntegrationsArgs): SafeHtml {
 
         <div class="settings-form__actions">
           <button type="submit" class="btn btn--primary">Add Webhook integration</button>
+        </div>
+      </form>
+    </div>
+  `;
+}
+
+function renderGmailForm(args: SettingsIntegrationsArgs): SafeHtml {
+  const err = args.addError?.kind === 'gmail' ? args.addError : undefined;
+  const v = err?.values ?? {};
+  return html`
+    <div class="card">
+      <p class="card__title">Add Gmail (OAuth)</p>
+      <p class="dim">
+        Connect a Google account via OAuth so notify handlers can send
+        email. Bring your own Google Cloud OAuth client (type "Desktop
+        app"). Register <code>http://127.0.0.1:3000/oauth/callback</code>
+        as a redirect URI. Paste the client_id + client_secret into
+        <a href="/settings/secrets">Settings → Secrets</a> first, then
+        add this integration and click <strong>Connect Google</strong>.
+      </p>
+      ${err ? html`<div class="flash flash--error mb-3">${err.message}</div>` : unsafeHtml('')}
+      <form action="/settings/integrations/add" method="post" class="settings-form">
+        <input type="hidden" name="kind" value="gmail">
+        ${idAndNameFields(v)}
+        <label class="settings-form__label" for="gmail-client-id-secret">client_id secret name</label>
+        <input id="gmail-client-id-secret" name="client_id_secret" type="text" required
+          pattern="[A-Z_][A-Z0-9_]*"
+          placeholder="GMAIL_CLIENT_ID"
+          value="${v.client_id_secret ?? 'GMAIL_CLIENT_ID'}"
+          autocapitalize="off" autocorrect="off" spellcheck="false">
+
+        <label class="settings-form__label" for="gmail-client-secret-secret">client_secret secret name</label>
+        <input id="gmail-client-secret-secret" name="client_secret_secret" type="text" required
+          pattern="[A-Z_][A-Z0-9_]*"
+          placeholder="GMAIL_CLIENT_SECRET"
+          value="${v.client_secret_secret ?? 'GMAIL_CLIENT_SECRET'}"
+          autocapitalize="off" autocorrect="off" spellcheck="false">
+
+        <div class="settings-form__actions">
+          <button type="submit" class="btn btn--primary">Add Gmail integration</button>
         </div>
       </form>
     </div>


### PR DESCRIPTION
## Summary
PR 3 of 4 of the **Settings → Integrations** workstream. Lands generic OAuth infrastructure on top of #262/#263 and uses it to ship the first OAuth-backed integration kind: `gmail`.

## Flow end-to-end
1. User creates a Google Cloud OAuth client (Desktop app) and registers `http://127.0.0.1:3000/oauth/callback` as a redirect URI.
2. User pastes `client_id` + `client_secret` into `/settings/secrets`.
3. User creates a Gmail integration at `/settings/integrations` referencing those secret names, then clicks **Connect Google**.
4. Server generates state + PKCE verifier, redirects to Google consent.
5. On callback (`/oauth/callback?code=…&state=…`), server validates state (single-use), exchanges the code for tokens, persists the refresh token in the encrypted secrets store as `<INTEGRATION_ID>__REFRESH_TOKEN`, fetches userinfo, marks the integration `connected_account: 'foo@bar.com'`.
6. Agents reference the integration via a new `gmail` notify handler:
   ```yaml
   notify:
     on: [failure]
     handlers:
       - type: gmail
         integration: user:gmail-oncall
         to: alerts@example.com
         subject: "Run failed: {{run.id}}"
   ```
   At fire time the dispatcher refreshes the access token, RFC 2822-encodes the message, and POSTs to Gmail `users.messages.send`.

## Trust model
- **No embedded credentials.** sua doesn't ship a Google client_id/secret. Users bring their own.
- **PKCE (S256)** binds the auth code to a server-generated verifier — an attacker on the same loopback can't redeem a code without it.
- **State token** is consumed single-use from an in-memory map (5-min TTL, never persisted). A replayed callback returns an error redirect.
- **Refresh tokens** live only in the encrypted secrets store (`~/.sua/secrets.enc`). Access tokens are short-lived and re-fetched per use; never persisted.
- **Disconnect** deletes the refresh token from the secrets store + clears `connected_account` / `connected_at` / `refresh_token_secret` from the integration row.

Lands on the public-repo secret hygiene rails from #261 — committed test fixtures use clearly-fake placeholder secret names.

## Files
- `packages/core/src/oauth/pkce.ts` — code_verifier + S256 code_challenge.
- `packages/core/src/oauth/state-store.ts` — in-memory state map with single-use consume + TTL pruning.
- `packages/core/src/oauth/google.ts` — auth URL builder, code exchange, refresh, userinfo, Gmail send.
- `packages/dashboard/src/routes/oauth.ts` — `/oauth/callback`, `/settings/integrations/:id/connect`, `/settings/integrations/:id/disconnect`.
- `packages/core/src/notify-dispatcher.ts` — new `gmail` handler.
- `packages/core/src/agent-v2-schema.ts` — `gmail` variant of the handlers discriminated union; `integration` required.
- `packages/dashboard/src/views/settings-integrations.ts` — Gmail add-form + connected-state badge with Connect/Disconnect buttons.
- 3 new test files (+19 tests). 1218/1218 total.

## Test plan
- [x] `npm test` → 1218/1218
- [ ] Live (requires a real Google OAuth client): paste `GMAIL_CLIENT_ID` + `GMAIL_CLIENT_SECRET` into Settings → Secrets; add a Gmail integration; click Connect; complete Google consent; verify integration row shows "connected as your@email"; on an agent, add a gmail notify handler pointing at the integration; trigger a failed run; verify email lands.
- [ ] Disconnect → secret deleted, row reverts to "not connected".

## Followups (queued)
- PR 4: `csv` + `postgres` integration kinds (folds in the `connectors-v0.17` plan).
- Future: token refresh caching (currently re-fetched per dispatch — fine for low-volume notify, matters for high-frequency tool use).
- Future: Gmail-as-connector-tools (search inbox, get messages) — separate concern from notify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)