### PR TITLE
feat: schema-aware save-time template validation (PR 4.C)

### DIFF
--- a/.changeset/integrations-schema-validation.md
+++ b/.changeset/integrations-schema-validation.md
@@ -1,0 +1,26 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Schema-aware save-time template validation (PR 4.C of Integrations).
+
+Catches typos in `{{upstream.<node>.<path>}}` references at agent save
+time instead of resolving silently to "" at run time. `ToolOutputField`
+now carries optional `items` / `properties`, and the CSV / Postgres
+generated tools populate per-row column schemas from their snapshots —
+so `{{upstream.fetch.rows.0.emial}}` fails save in the dashboard YAML
+editor with "Property 'emial' not found … Did you mean 'email'?".
+
+The validator is lenient: when a tool's output schema doesn't declare
+`items` / `properties` (legacy user tools, untyped built-ins), the
+walker stops without reporting. Field paths are only flagged when the
+schema is rich enough to disprove them.
+
+`parseAgent()` keeps its single-argument signature — the new
+`validateAgentTemplatePaths(agent, { resolveTool })` is opt-in and
+runs from the dashboard's YAML save handler, which already has the
+integrations + tool registries in scope.

--- a/packages/core/src/agent-template-validator.test.ts
+++ b/packages/core/src/agent-template-validator.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { validateAgentTemplatePaths } from './agent-template-validator.js';
+import type { Agent } from './agent-v2-types.js';
+import type { ToolDefinition, ToolOutputField } from './tool-types.js';
+
+const csvReadDef: ToolDefinition = {
+  id: 'csv.customers.read',
+  name: 'Read customers',
+  source: 'builtin',
+  inputs: {},
+  outputs: {
+    rows: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'number' } as ToolOutputField,
+          email: { type: 'string' } as ToolOutputField,
+          active: { type: 'boolean' } as ToolOutputField,
+        },
+      } as ToolOutputField,
+    } as ToolOutputField,
+    row_count: { type: 'number' } as ToolOutputField,
+  },
+  implementation: { type: 'builtin', builtinName: 'csv.customers.read' },
+};
+
+function agent(prompt: string): Agent {
+  return {
+    id: 'a',
+    name: 'a',
+    version: 1,
+    status: 'active' as const,
+    source: 'local' as const,
+    schedule: 'manual',
+    nodes: [
+      { id: 'fetch', type: 'claude-code' as const, tool: 'csv.customers.read' },
+      { id: 'consume', type: 'claude-code' as const, prompt, dependsOn: ['fetch'] },
+    ],
+  } as unknown as Agent;
+}
+
+const resolver = (id: string) => (id === 'csv.customers.read' ? csvReadDef : undefined);
+
+describe('validateAgentTemplatePaths', () => {
+  it('accepts a valid dot-path through array.items.properties', () => {
+    const issues = validateAgentTemplatePaths(agent('Email: {{upstream.fetch.rows.0.email}}'), { resolveTool: resolver });
+    expect(issues).toEqual([]);
+  });
+
+  it('always accepts {{upstream.X.result}}', () => {
+    const issues = validateAgentTemplatePaths(agent('{{upstream.fetch.result}}'), { resolveTool: resolver });
+    expect(issues).toEqual([]);
+  });
+
+  it('flags a column typo with a Did-you-mean suggestion', () => {
+    const issues = validateAgentTemplatePaths(agent('{{upstream.fetch.rows.0.emial}}'), { resolveTool: resolver });
+    expect(issues).toHaveLength(1);
+    expect(issues[0].upstreamNodeId).toBe('fetch');
+    expect(issues[0].fieldPath).toBe('rows.0.emial');
+    expect(issues[0].reason).toContain('"emial"');
+    expect(issues[0].reason).toContain('email');
+  });
+
+  it('flags an unknown top-level output field', () => {
+    const issues = validateAgentTemplatePaths(agent('{{upstream.fetch.bogus}}'), { resolveTool: resolver });
+    expect(issues).toHaveLength(1);
+    expect(issues[0].reason).toContain('"bogus" is not declared');
+  });
+
+  it('flags indexing an array with a non-numeric segment', () => {
+    const issues = validateAgentTemplatePaths(agent('{{upstream.fetch.rows.first.email}}'), { resolveTool: resolver });
+    expect(issues).toHaveLength(1);
+    expect(issues[0].reason).toContain('array');
+  });
+
+  it('is lenient when the upstream tool is unknown', () => {
+    const issues = validateAgentTemplatePaths(agent('{{upstream.fetch.rows.0.anything}}'), { resolveTool: () => undefined });
+    expect(issues).toEqual([]);
+  });
+
+  it('is lenient when the upstream tool lacks items/properties', () => {
+    const bareDef: ToolDefinition = {
+      ...csvReadDef,
+      outputs: { rows: { type: 'array' } as ToolOutputField },
+    };
+    const issues = validateAgentTemplatePaths(
+      agent('{{upstream.fetch.rows.0.email}}'),
+      { resolveTool: (id) => (id === 'csv.customers.read' ? bareDef : undefined) },
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('walks templates in env, content, path, and toolInputs', () => {
+    const a: Agent = {
+      id: 'a', name: 'a', version: 1, status: 'active' as const, source: 'local' as const,
+      schedule: 'manual',
+      nodes: [
+        { id: 'fetch', type: 'claude-code' as const, tool: 'csv.customers.read' },
+        {
+          id: 'sink', type: 'file-write' as const, dependsOn: ['fetch'],
+          path: 'out-{{upstream.fetch.rows.0.emial}}.txt',
+          content: '{{upstream.fetch.rows.0.email}}',
+          env: { TARGET: '{{upstream.fetch.rows.0.also_bad}}' },
+        },
+      ],
+    } as unknown as Agent;
+    const issues = validateAgentTemplatePaths(a, { resolveTool: resolver });
+    const fields = issues.map((i) => i.field).sort();
+    expect(fields).toEqual(['env.TARGET', 'path']);
+  });
+});

--- a/packages/core/src/agent-template-validator.ts
+++ b/packages/core/src/agent-template-validator.ts
@@ -1,0 +1,218 @@
+/**
+ * Schema-aware save-time validation for upstream template references.
+ *
+ * Catches typos like `{{upstream.fetch-rows.rows.0.emial}}` at agent-import
+ * time, when the upstream node's tool declares enough output schema to
+ * disprove the field path. Strictly opt-in for now: callers (today only
+ * the dashboard's YAML save path) pass a `resolveTool` callback so the
+ * CLI's `parseAgent` keeps its zero-dependency signature.
+ *
+ * Lenient by design: if the upstream tool's output schema doesn't declare
+ * `items` or `properties` for the part of the path being walked, the
+ * validator stops without reporting an issue. We only fail when the
+ * schema is rich enough to know the field is wrong. This keeps user-tools
+ * and partially-typed built-ins from producing false positives.
+ *
+ * The synthetic `{{upstream.<id>.result}}` reference is always accepted —
+ * every tool produces a `result` field for v0.15 backcompat.
+ */
+
+import type { Agent, AgentNode } from './agent-v2-types.js';
+import type { ToolDefinition, ToolOutputField } from './tool-types.js';
+
+export interface TemplatePathIssue {
+  /** Node whose template contains the bad reference. */
+  nodeId: string;
+  /** Which field on the node was being validated (`prompt`, `command`, `content`, `path`, `env.X`, `toolInputs.X`). */
+  field: string;
+  /** The whole `{{upstream.…}}` token text, for the error message. */
+  template: string;
+  /** Upstream node id referenced. */
+  upstreamNodeId: string;
+  /** Dot path that failed (e.g. `rows.0.emial`). */
+  fieldPath: string;
+  /** Human-readable reason — used directly in error surfaces. */
+  reason: string;
+}
+
+export interface TemplateValidatorDeps {
+  /** Resolve a tool definition by id. Returns undefined when unknown. */
+  resolveTool: (toolId: string) => ToolDefinition | undefined;
+}
+
+/** Matches `{{upstream.<id>.<path>}}`. Same regex as agent-v2-schema. */
+const UPSTREAM_REF_RE = /\{\{upstream\.([a-z0-9][a-z0-9_-]*)\.([a-zA-Z0-9_.]+)\}\}/g;
+
+/**
+ * Walk every templated string in `agent` and return a list of issues for
+ * field paths that don't match the upstream node's declared output schema.
+ * Empty array means "no issues" — including the case where no schemas
+ * were available to check against.
+ */
+export function validateAgentTemplatePaths(
+  agent: Agent,
+  deps: TemplateValidatorDeps,
+): TemplatePathIssue[] {
+  const issues: TemplatePathIssue[] = [];
+  const nodesById = new Map<string, AgentNode>(agent.nodes.map((n) => [n.id, n]));
+
+  for (const node of agent.nodes) {
+    const visit = (text: string | undefined, field: string) => {
+      if (!text) return;
+      for (const m of text.matchAll(UPSTREAM_REF_RE)) {
+        const [token, upstreamId, fieldPath] = m;
+        if (fieldPath === 'result') continue;
+
+        const upstream = nodesById.get(upstreamId);
+        if (!upstream) continue; // schema validator already catches this
+        const toolDef = resolveNodeTool(upstream, deps);
+        if (!toolDef) continue; // upstream is a legacy shell/claude-code node, or unknown tool
+        const outputs = resolveActionOutputs(toolDef, upstream.action);
+        if (!outputs) continue;
+
+        const reason = walkPath(outputs, fieldPath);
+        if (reason) {
+          issues.push({
+            nodeId: node.id,
+            field,
+            template: token,
+            upstreamNodeId: upstreamId,
+            fieldPath,
+            reason,
+          });
+        }
+      }
+    };
+
+    visit(node.prompt, 'prompt');
+    visit(node.command, 'command');
+    visit(node.content, 'content');
+    visit(node.path, 'path');
+    if (node.env) {
+      for (const [k, v] of Object.entries(node.env)) visit(v, `env.${k}`);
+    }
+    if (node.toolInputs) {
+      for (const [k, v] of Object.entries(node.toolInputs)) {
+        if (typeof v === 'string') visit(v, `toolInputs.${k}`);
+      }
+    }
+  }
+
+  return issues;
+}
+
+function resolveNodeTool(node: AgentNode, deps: TemplateValidatorDeps): ToolDefinition | undefined {
+  if (!node.tool) return undefined;
+  return deps.resolveTool(node.tool);
+}
+
+function resolveActionOutputs(
+  tool: ToolDefinition,
+  action: string | undefined,
+): Record<string, ToolOutputField> | undefined {
+  if (action && tool.actions && tool.actions[action]) {
+    return tool.actions[action].outputs;
+  }
+  return tool.outputs;
+}
+
+/**
+ * Walk a dot-path against an outputs map. Returns an error string if the
+ * path is provably invalid; returns undefined if the path is valid OR if
+ * the schema lacks the detail to disprove it (lenient mode).
+ */
+function walkPath(
+  rootOutputs: Record<string, ToolOutputField>,
+  fieldPath: string,
+): string | undefined {
+  const parts = fieldPath.split('.');
+  const first = parts[0];
+  const head = rootOutputs[first];
+  if (!head) {
+    const available = Object.keys(rootOutputs);
+    return `Output "${first}" is not declared by the upstream tool. Available: ${available.join(', ') || '(none)'}.`;
+  }
+
+  let current: ToolOutputField = head;
+  for (let i = 1; i < parts.length; i++) {
+    const seg = parts[i];
+    const next = step(current, seg, parts.slice(0, i).join('.') || '(root)');
+    if (typeof next === 'string') return next; // error
+    if (next === undefined) return undefined;  // lenient stop
+    current = next;
+  }
+  return undefined;
+}
+
+/**
+ * Take one step into `current` for segment `seg`. Returns the next
+ * ToolOutputField, undefined for "lenient stop" (schema unknown), or an
+ * error string when we can prove the segment is wrong.
+ */
+function step(
+  current: ToolOutputField,
+  seg: string,
+  pathSoFar: string,
+): ToolOutputField | string | undefined {
+  if (current.type === 'array') {
+    if (!/^\d+$/.test(seg)) {
+      return `"${pathSoFar}" is an array — index it with a number (e.g. \`${pathSoFar}.0\`), not "${seg}".`;
+    }
+    if (!current.items) return undefined; // lenient: array element schema not declared
+    return current.items;
+  }
+  if (current.type === 'object') {
+    if (!current.properties) return undefined; // lenient: properties not declared
+    const next = current.properties[seg];
+    if (!next) {
+      const available = Object.keys(current.properties);
+      const suggestion = suggest(seg, available);
+      const suggestText = suggestion ? ` Did you mean "${suggestion}"?` : '';
+      return `Property "${seg}" not found on "${pathSoFar}". Available: ${available.join(', ') || '(none)'}.${suggestText}`;
+    }
+    return next;
+  }
+  // Primitive: trying to descend further is wrong.
+  return `"${pathSoFar}" is a ${current.type}; cannot index into it with ".${seg}".`;
+}
+
+/** Simple typo suggestion via Levenshtein. Returns the closest candidate within distance 2. */
+function suggest(input: string, candidates: string[]): string | undefined {
+  let best: { name: string; dist: number } | undefined;
+  for (const c of candidates) {
+    const d = levenshtein(input, c);
+    if (d <= 2 && (!best || d < best.dist)) best = { name: c, dist: d };
+  }
+  return best?.name;
+}
+
+function levenshtein(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  if (m === 0) return n;
+  if (n === 0) return m;
+  const row = new Array<number>(n + 1);
+  for (let j = 0; j <= n; j++) row[j] = j;
+  for (let i = 1; i <= m; i++) {
+    let prev = row[0];
+    row[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const tmp = row[j];
+      row[j] = a[i - 1] === b[j - 1]
+        ? prev
+        : 1 + Math.min(prev, row[j], row[j - 1]);
+      prev = tmp;
+    }
+  }
+  return row[n];
+}
+
+/**
+ * Format a list of issues into a single human-readable error string —
+ * suitable for surfacing in route flash messages or thrown errors.
+ */
+export function formatTemplatePathIssues(issues: TemplatePathIssue[]): string {
+  return issues
+    .map((i) => `${i.nodeId}.${i.field}: ${i.reason} (in ${i.template})`)
+    .join('; ');
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,12 @@ export {
   type AgentV2Parsed,
 } from './agent-v2-schema.js';
 export { parseAgent, exportAgent, exportAgents, AgentYamlParseError } from './agent-yaml.js';
+export {
+  validateAgentTemplatePaths,
+  formatTemplatePathIssues,
+  type TemplatePathIssue,
+  type TemplateValidatorDeps,
+} from './agent-template-validator.js';
 export { AgentStore } from './agent-store.js';
 export * from './tool-types.js';
 export {

--- a/packages/core/src/integrations/generated-tools.test.ts
+++ b/packages/core/src/integrations/generated-tools.test.ts
@@ -57,6 +57,13 @@ describe('listGeneratedTools', () => {
     expect(readDef.source).toBe('builtin');
     expect(readDef.outputs.rows.type).toBe('array');
     expect(readDef.outputs.row_count.type).toBe('number');
+    // PR 4.C: nested per-row schema declared on `rows.items.properties`
+    // so save-time template validation can walk `rows.0.<col>` paths.
+    const rowItem = readDef.outputs.rows.items;
+    expect(rowItem?.type).toBe('object');
+    expect(rowItem?.properties?.email?.type).toBe('string');
+    expect(rowItem?.properties?.active?.type).toBe('boolean');
+    expect(rowItem?.properties?.id?.type).toBe('number');
     // The column list itself lives on the integration row (consulted at
     // execute time + by future schema-aware validation passes).
     const integ = store.getIntegration('user:customers')!;

--- a/packages/core/src/integrations/generated-tools.ts
+++ b/packages/core/src/integrations/generated-tools.ts
@@ -249,12 +249,16 @@ async function resolvePgConnection(
 
 // ── Tool synthesis ─────────────────────────────────────────────────────
 
+function csvRowProperties(snapshot: CsvSnapshot): Record<string, ToolOutputField> {
+  const props: Record<string, ToolOutputField> = {};
+  for (const col of snapshot.columns) {
+    props[col.name] = { type: col.type, description: col.format ? `${col.type} (${col.format})` : undefined };
+  }
+  return props;
+}
+
 function buildReadEntry(integ: Integration, path: string, snapshot: CsvSnapshot): BuiltinToolEntry {
-  // For now the synthesised tool declares the array/object shapes but
-  // not per-item column types — the existing ToolOutputField schema
-  // doesn't model item schemas. PR 4.C revisits when we add schema-
-  // aware save-time validation; the column list still lives on the
-  // integration row so future passes can consult it directly.
+  const rowProps = csvRowProperties(snapshot);
   const definition: ToolDefinition = {
     id: csvReadToolId(integ),
     name: `Read ${integ.name}`,
@@ -275,6 +279,7 @@ function buildReadEntry(integ: Integration, path: string, snapshot: CsvSnapshot)
       rows: {
         type: 'array',
         description: 'Matching rows, coerced to the inferred column types.',
+        items: { type: 'object', properties: rowProps },
       } as ToolOutputField,
       row_count: { type: 'number', description: 'Number of rows returned.' } as ToolOutputField,
     },
@@ -320,12 +325,21 @@ function buildCountEntry(integ: Integration, path: string, snapshot: CsvSnapshot
 
 // ── Postgres tool synthesis ────────────────────────────────────────────
 
+function pgRowProperties(table: PgTableSpec): Record<string, ToolOutputField> {
+  const props: Record<string, ToolOutputField> = {};
+  for (const col of table.columns) {
+    props[col.name] = { type: col.type, description: col.format ? `${col.pgType} (${col.format})` : col.pgType };
+  }
+  return props;
+}
+
 function buildPgFindEntry(
   integ: Integration,
   table: PgTableSpec,
   deps: GeneratedToolDeps,
 ): BuiltinToolEntry {
   const fqn = `${table.schema}.${table.name}`;
+  const rowProps = pgRowProperties(table);
   const definition: ToolDefinition = {
     id: pgFindToolId(integ, table.schema, table.name),
     name: `Find rows in ${fqn}`,
@@ -337,7 +351,11 @@ function buildPgFindEntry(
       order_by: { type: 'string', description: 'Column name optionally followed by ASC|DESC.' } as ToolInputField,
     },
     outputs: {
-      rows: { type: 'array', description: 'Matching rows in source-column order.' } as ToolOutputField,
+      rows: {
+        type: 'array',
+        description: 'Matching rows in source-column order.',
+        items: { type: 'object', properties: rowProps },
+      } as ToolOutputField,
       row_count: { type: 'number', description: 'Number of rows returned.' } as ToolOutputField,
     },
     implementation: { type: 'builtin', builtinName: pgFindToolId(integ, table.schema, table.name) },
@@ -362,6 +380,7 @@ function buildPgFindOneEntry(
   deps: GeneratedToolDeps,
 ): BuiltinToolEntry {
   const fqn = `${table.schema}.${table.name}`;
+  const rowProps = pgRowProperties(table);
   const definition: ToolDefinition = {
     id: pgFindOneToolId(integ, table.schema, table.name),
     name: `Find one row in ${fqn}`,
@@ -372,7 +391,7 @@ function buildPgFindOneEntry(
       order_by: { type: 'string', description: 'Column name optionally followed by ASC|DESC.' } as ToolInputField,
     },
     outputs: {
-      row: { type: 'object', description: 'Matching row, or null when no row matches.' } as ToolOutputField,
+      row: { type: 'object', description: 'Matching row, or null when no row matches.', properties: rowProps } as ToolOutputField,
     },
     implementation: { type: 'builtin', builtinName: pgFindOneToolId(integ, table.schema, table.name) },
   };

--- a/packages/core/src/tool-types.ts
+++ b/packages/core/src/tool-types.ts
@@ -28,6 +28,17 @@ export interface ToolInputField {
 export interface ToolOutputField {
   type: ToolFieldType;
   description?: string;
+  /**
+   * For `type: 'array'`: element schema. Used by save-time template
+   * validation so `{{upstream.<node>.rows.0.<col>}}` references can
+   * be checked against the declared per-row shape.
+   */
+  items?: ToolOutputField;
+  /**
+   * For `type: 'object'`: declared property schemas. Same role as
+   * `items` but for object outputs (e.g. pg find-one's `row`).
+   */
+  properties?: Record<string, ToolOutputField>;
 }
 
 export type ToolImplementationType = 'shell' | 'claude-code' | 'builtin' | 'mcp';

--- a/packages/dashboard/src/routes/agent-nodes.ts
+++ b/packages/dashboard/src/routes/agent-nodes.ts
@@ -1,6 +1,15 @@
 import { Router, type Request, type Response } from 'express';
 import type { Agent, AgentInputSpec } from '@some-useful-agents/core';
-import { exportAgent, parseAgent, AgentYamlParseError } from '@some-useful-agents/core';
+import {
+  exportAgent,
+  parseAgent,
+  AgentYamlParseError,
+  validateAgentTemplatePaths,
+  formatTemplatePathIssues,
+  getBuiltinTool,
+  getGeneratedTool,
+  type ToolDefinition,
+} from '@some-useful-agents/core';
 import { parse as parseRawYaml, stringify as stringifyRawYaml } from 'yaml';
 import { html as h, render as renderHtml } from '../views/html.js';
 import { layout } from '../views/layout.js';
@@ -417,6 +426,26 @@ agentNodesRouter.post('/agents/:name/yaml', (req: Request, res: Response) => {
   // Ensure the id matches — don't let YAML edits rename the agent.
   if (parsed.id !== agent.id) {
     res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/yaml?error=${encodeURIComponent(`Agent id in YAML ("${parsed.id}") must match the current agent id ("${agent.id}"). Renaming via YAML is not supported.`)}`);
+    return;
+  }
+
+  // Schema-aware template-path check. Walks each `{{upstream.X.field}}`
+  // reference against the upstream node's tool output schema so typos
+  // like `rows.0.emial` fail at save time instead of resolving to "" at
+  // run time. Lenient — only fires when the upstream tool declares
+  // enough output schema to prove the path wrong.
+  const resolveTool = (toolId: string): ToolDefinition | undefined => {
+    const builtin = getBuiltinTool(toolId)
+      ?? (ctx.integrationsStore
+        ? getGeneratedTool(ctx.integrationsStore, toolId, { secretsStore: ctx.secretsStore })
+        : undefined);
+    if (builtin) return builtin.definition;
+    return ctx.toolStore?.getTool(toolId);
+  };
+  const templateIssues = validateAgentTemplatePaths(parsed, { resolveTool });
+  if (templateIssues.length > 0) {
+    const msg = `Template validation failed: ${formatTemplatePathIssues(templateIssues)}`;
+    res.redirect(303, `/agents/${encodeURIComponent(agent.id)}/yaml?error=${encodeURIComponent(msg)}`);
     return;
   }
 


### PR DESCRIPTION
## Summary
- Catches `{{upstream.<node>.<path>}}` typos at agent save time instead of resolving silently to `""` at run time
- `ToolOutputField` gains optional `items` / `properties`; CSV + Postgres generated tools populate per-row column schemas from their snapshots
- New `validateAgentTemplatePaths(agent, { resolveTool })` in core — lenient walker; only flags paths the upstream tool's schema can disprove. Wired into the dashboard YAML save handler with a builtin → generated → user-tool resolver
- Includes Levenshtein-based "Did you mean …?" suggestions for column typos

## Why
PR 4.C from the Integrations workstream. Editing a CSV/Postgres agent's prompt to reference `rows.0.emial` used to fail at run time with an empty interpolation; now it fails at save time with `Property "emial" not found on "rows.0". Available: id, email, active. Did you mean "email"?`.

## Test plan
- [x] 8 new validator tests + 1 added to generated-tools.test (rows.items.properties shape)
- [x] Full suite: 1250 passing, 3 skipped (gated PG), no regressions
- [ ] Manual: open the YAML editor on a CSV-backed agent, mistype a column, confirm the flash error fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)