### PR TITLE
fix(cli): wire integration/variables/tool stores into `sua workflow run`

### DIFF
--- a/.changeset/cli-workflow-run-integrations.md
+++ b/.changeset/cli-workflow-run-integrations.md
@@ -1,0 +1,11 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Wire `integrationsStore` / `variablesStore` / `toolStore` into the `sua workflow run` CLI so one-shot CLI runs can resolve csv/postgres/sqlite generated tools, user MCP tools, and `{{vars.*}}` references.
+
+Previously only the daemon's schedule path and the dashboard run-now path opened these stores; the CLI runner skipped them and any v2 agent that referenced a generated tool failed setup with "Shell node 'X' has no command" (the executor falls through to legacy shell dispatch when the tool can't be resolved). Mirrors the existing wiring in `cli/src/commands/schedule.ts`. Each store opens best-effort — absence just means that feature doesn't resolve, same as the schedule path.

--- a/packages/cli/src/commands/workflow.ts
+++ b/packages/cli/src/commands/workflow.ts
@@ -7,6 +7,9 @@ import {
   AgentStore,
   RunStore,
   EncryptedFileStore,
+  IntegrationsStore,
+  VariablesStore,
+  ToolStore,
   loadAgents,
   executeAgentDag,
   executeAgentWithRetry,
@@ -290,6 +293,22 @@ workflowCommand
     const config = loadConfig();
     const stores = openStores();
     const secretsStore = new EncryptedFileStore(getSecretsPath(config));
+    // Optional stores — mirror the daemon's schedule wiring so CLI runs
+    // can resolve csv/postgres/sqlite generated tools, vars, and user
+    // tools the same way scheduled fires can. Each open is best-effort:
+    // an absent store just means that feature doesn't resolve.
+    const variablesStore = (() => {
+      try { return new VariablesStore(join(config.dataDir, '.sua', 'variables.json')); }
+      catch { return undefined; }
+    })();
+    const integrationsStore = (() => {
+      try { return new IntegrationsStore(getDbPath(config)); }
+      catch { return undefined; }
+    })();
+    const toolStore = (() => {
+      try { return new ToolStore(getDbPath(config)); }
+      catch { return undefined; }
+    })();
     const spinner = ora(`Running ${ui.agent(id)}...`).start();
     try {
       const agent = stores.agents.getAgent(id);
@@ -305,6 +324,9 @@ workflowCommand
           runStore: stores.runs,
           secretsStore,
           agentStore: stores.agents,
+          variablesStore,
+          integrationsStore,
+          toolStore,
           allowUntrustedShell: new Set(options.allowUntrustedShell),
           dashboardBaseUrl: getDashboardBaseUrl(config),
           dataRoot: stores.agents.dataRoot,


### PR DESCRIPTION
## Summary
Mirror the daemon's schedule wiring on the CLI's one-shot run path so v2 agents that reference auto-generated tools (\`csv.*\`, \`postgres.*\`, \`sqlite.*\`), user MCP tools, or \`{{vars.*}}\` work the same way under \`sua workflow run\` as they do under the schedule daemon and dashboard run-now.

## Why
Caught during manual verification of the churn-watcher example (PR #271). With the SQLite integration registered, the daemon's schedule path and dashboard \`POST /agents/:name/run\` both ran the agent end-to-end. But \`sua workflow run churn-watcher\` failed at the first node with \"Shell node 'recent' has no command\" — the executor's tool-resolution chain only consults \`integrationsStore\` if it's present, so the CLI's omitted store made every generated tool unresolvable, and the node fell through to legacy shell dispatch.

Same one-liner-pattern fix as the existing \`schedule.ts\` (\`packages/cli/src/commands/schedule.ts:245-256\`).

## Test plan
- [x] \`sua workflow run churn-watcher\` now completes (verified locally — output below)
- [x] Full suite: 1271 passing, 3 skipped, no regressions
- [ ] Smoke any other example agent to confirm no regression on the \"no integration needed\" path

\`\`\`
✔ churn-watcher completed
╭── output ──
│ **Churn Brief — 2026-05-14**
│ - **Who churned (last 5 days):** iris@…, henry@…, grace@…, frank@…
│ ...
│ {\"total_churned\": 4, \"recent_count\": 4, \"summary\": \"…\"}
╰────────────
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)