### PR TITLE
fix(dashboard): widget extractor recovers trailing JSON after prose

### DIFF
--- a/.changeset/widget-extract-embedded-json.md
+++ b/.changeset/widget-extract-embedded-json.md
@@ -1,0 +1,11 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Dashboard widget extractor now recovers a trailing JSON object embedded inside human prose. claude-code summarisers commonly emit a human-readable narrative followed by a final `{…}` line that drives the widget — the prior extractor only handled pure-JSON output or XML tags, so the widget rendered empty for any agent that produced both kinds of output.
+
+`extractField()` is now exported from `views/output-widgets.ts` and unit-tested. The recovery strategy walks `{` positions from rightmost to leftmost and slices to the last `}`, preferring the smallest trailing object so we don't accidentally engulf earlier prose that contains brace characters.

--- a/packages/dashboard/src/views/output-widgets.test.ts
+++ b/packages/dashboard/src/views/output-widgets.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { extractField } from './output-widgets.js';
+
+describe('extractField', () => {
+  // Whole-output JSON (the fast path)
+  it('reads a top-level key from pure JSON output', () => {
+    expect(extractField('{"total":4,"label":"hi"}', 'total')).toBe('4');
+    expect(extractField('{"total":4,"label":"hi"}', 'label')).toBe('hi');
+  });
+
+  it('falls back to deep search for branch-node merged shape', () => {
+    const out = '{"merged":{"node-a":{"answer":"yes"}}}';
+    expect(extractField(out, 'answer')).toBe('yes');
+  });
+
+  it('serialises non-string values as pretty JSON', () => {
+    const out = '{"items":[1,2,3]}';
+    expect(extractField(out, 'items')).toBe('[\n  1,\n  2,\n  3\n]');
+  });
+
+  // XML-tag mode (legacy agent-analyzer pattern)
+  it('reads <tag>value</tag> markers', () => {
+    expect(extractField('text <answer>42</answer> more', 'answer')).toBe('42');
+  });
+
+  it('XML-tag mode beats whole-output JSON when both match', () => {
+    const out = '<answer>tag wins</answer>{"answer":"json"}';
+    expect(extractField(out, 'answer')).toBe('tag wins');
+  });
+
+  // The bug this commit fixes: prose followed by a JSON object.
+  // claude-code summarisers commonly produce this shape — human-readable
+  // narrative for `run.result`, plus a final JSON line that drives the
+  // widget. Before this fix, `JSON.parse(entire output)` failed and the
+  // widget rendered empty.
+  it('extracts a trailing JSON object after human prose', () => {
+    const out = [
+      '**Churn Brief — 2026-05-14**',
+      '',
+      '- iris@example.com (pro)',
+      '- henry@example.com (team)',
+      '',
+      '{"total_churned": 4, "recent_count": 4, "summary": "..."}',
+    ].join('\n');
+    expect(extractField(out, 'total_churned')).toBe('4');
+    expect(extractField(out, 'recent_count')).toBe('4');
+    expect(extractField(out, 'summary')).toBe('...');
+  });
+
+  it('prefers the rightmost / smallest trailing object when multiple exist', () => {
+    // Agent wrote `{"draft":1}` mid-output, then the final widget JSON.
+    // The rightmost balanced object is what counts as the agent's verdict.
+    const out = 'draft attempt {"draft":1}\nfinal {"answer":"yes"}';
+    expect(extractField(out, 'answer')).toBe('yes');
+    // The earlier `draft` key isn't visible because we stop at the
+    // smallest trailing object — that's the intended contract.
+    expect(extractField('alone {"draft":1}', 'draft')).toBe('1');
+  });
+
+  it('handles strings that contain `{` or `}` inside values', () => {
+    const out = 'preface {"raw":"a{b}c","ok":true}';
+    expect(extractField(out, 'raw')).toBe('a{b}c');
+    expect(extractField(out, 'ok')).toBe('true');
+  });
+
+  it('returns undefined when no JSON or tag is present', () => {
+    expect(extractField('just plain prose, no markers', 'anything')).toBeUndefined();
+  });
+
+  it('returns undefined when the trailing brace is unmatched', () => {
+    // `}` exists but no preceding `{` parses → no rescue.
+    expect(extractField('text } end', 'x')).toBeUndefined();
+  });
+
+  it('ignores primitive JSON at root', () => {
+    // A bare quoted string parses as JSON but has no fields to extract.
+    expect(extractField('"just a string"', 'x')).toBeUndefined();
+    expect(extractField('42', 'x')).toBeUndefined();
+  });
+});

--- a/packages/dashboard/src/views/output-widgets.ts
+++ b/packages/dashboard/src/views/output-widgets.ts
@@ -26,32 +26,76 @@ export interface WidgetControlState {
 }
 
 /**
- * Extract a field value from run output text. Supports two extraction modes:
- *   1. XML tags: <fieldName>value</fieldName>
- *   2. JSON: parse as JSON and read the key
+ * Extract a field value from run output text. Supports three extraction
+ * modes, in order:
+ *
+ *   1. XML tags: `<fieldName>value</fieldName>` (used by agent-analyzer).
+ *   2. Whole-output JSON: `JSON.parse(output)` succeeds and the field is
+ *      a top-level key (or found via shallow deep search for branch-node
+ *      `{ merged: { nodeId: { field } } }` shapes).
+ *   3. Embedded trailing JSON: the agent emitted human prose followed by
+ *      a JSON object as the last block. Common shape for claude-code
+ *      summarisers that want both a human-readable run.result AND
+ *      machine-readable widget fields.
+ *
+ * Exported for direct testing; widgets call `extractFields` which loops
+ * over a schema's declared fields.
  */
-function extractField(output: string, fieldName: string): string | undefined {
+export function extractField(output: string, fieldName: string): string | undefined {
   // Try XML tag extraction first (used by agent-analyzer).
   const tagMatch = output.match(new RegExp(`<${fieldName}>([\\s\\S]*?)</${fieldName}>`, 'i'));
   if (tagMatch) return tagMatch[1].trim();
 
-  // Try JSON — top-level first, then deep search.
+  const parsed = parseJsonFromOutput(output);
+  if (parsed && typeof parsed === 'object') {
+    const record = parsed as Record<string, unknown>;
+    if (fieldName in record) {
+      const val = record[fieldName];
+      return typeof val === 'string' ? val : JSON.stringify(val, null, 2);
+    }
+    const found = deepFind(record, fieldName);
+    if (found !== undefined) {
+      return typeof found === 'string' ? found : JSON.stringify(found, null, 2);
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Try to recover a JSON object from the run output. Strategies, in order:
+ *   - Strict `JSON.parse(output)` — fast path for pure-JSON agents.
+ *   - Trailing-object scan: walk every `{` position from rightmost to
+ *     leftmost, slicing to the last `}`; the first slice that parses
+ *     wins. This finds the agent's final emitted JSON object even when
+ *     human prose precedes it.
+ *
+ * Returns the parsed object, or `undefined` when no JSON is recoverable.
+ * Limited to a few-KB outputs by construction — agent run output today
+ * is bounded by the output-framing layer.
+ */
+function parseJsonFromOutput(output: string): unknown {
+  // Fast path: the whole thing is JSON.
   try {
     const parsed = JSON.parse(output);
-    if (typeof parsed === 'object' && parsed !== null) {
-      // Top-level match (fast path).
-      if (fieldName in parsed) {
-        const val = parsed[fieldName];
-        return typeof val === 'string' ? val : JSON.stringify(val, null, 2);
-      }
-      // Deep search: walk nested objects to find the field.
-      const found = deepFind(parsed, fieldName);
-      if (found !== undefined) {
-        return typeof found === 'string' ? found : JSON.stringify(found, null, 2);
-      }
-    }
-  } catch { /* not JSON */ }
+    if (parsed !== null && typeof parsed === 'object') return parsed;
+  } catch { /* fall through */ }
 
+  // Embedded JSON: find the rightmost balanced object whose `}` is the
+  // last `}` in the text. Walking `{` from rightmost to leftmost gives
+  // the smallest trailing object first — preferred so we don't accidentally
+  // engulf earlier prose that happens to contain `{` characters.
+  const lastClose = output.lastIndexOf('}');
+  if (lastClose === -1) return undefined;
+  let openPos = output.lastIndexOf('{', lastClose);
+  while (openPos !== -1) {
+    try {
+      const candidate = JSON.parse(output.slice(openPos, lastClose + 1));
+      if (candidate !== null && typeof candidate === 'object') return candidate;
+    } catch { /* try the next `{` to the left */ }
+    if (openPos === 0) break;
+    openPos = output.lastIndexOf('{', openPos - 1);
+  }
   return undefined;
 }
 


### PR DESCRIPTION
## Summary
Dashboard widgets now correctly extract field values from agent output that mixes human prose with a trailing JSON object — the common shape for claude-code summarisers that want both a readable \`run.result\` AND machine-readable widget fields.

\`extractField()\` is now exported from [\`views/output-widgets.ts\`](packages/dashboard/src/views/output-widgets.ts) and gets a third extraction mode (after XML-tag and whole-output JSON): walk \`{\` positions from rightmost to leftmost, slice to the last \`}\`, return the first slice that parses. Prefers the smallest trailing object so we don't accidentally engulf earlier prose that contains brace characters.

## Why
Caught while QA'ing the [\`churn-watcher\`](agents/examples/churn-watcher.yaml) showcase agent on the dashboard. The agent emits a 3-bullet brief plus a final JSON line — exactly what its prompt asks for. The widget rendered three empty divs because \`JSON.parse(entire output)\` failed on the prose and there was no embedded-JSON fallback.

A future agent author writing the same dual-output prompt would hit the same wall. This is a platform fix, not an example-specific patch.

## Test plan
- [x] 11 new unit tests in \`output-widgets.test.ts\` covering: pure-JSON, branch-node deep-find, non-string serialization, XML-tag mode, XML-tag-beats-JSON priority, trailing JSON after prose, smallest-trailing preference, brace-in-string values, undefined-on-no-match, unmatched-trailing-brace, primitive-root JSON
- [x] Manual: rebuilt + restarted daemon, hit \`http://127.0.0.1:3000/agents/churn-watcher\`, widget now renders \`Churned (all-time): 4\` hero, \`Churned (recent batch): 4\` stat card, and the \`Notes\` text block with the LLM summary
- [x] Full suite: 1282 passing, 3 skipped (+11 new), no regressions

## Out-of-scope follow-up
Separately discovered that the dashboard's YAML editor and Pulse signal-config modal can silently strip \`outputWidget.fields\` on save (visible in the \`churn-watcher\` v3→v4→v5→v6 version history). Worth filing as a separate issue — the extractor fix is needed regardless and stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)