### PR TITLE
fix(dashboard): reject empty-fields save on typed output widgets

### DIFF
--- a/.changeset/widget-editor-reject-empty-fields.md
+++ b/.changeset/widget-editor-reject-empty-fields.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Output-widget editor now rejects a save that would silently wipe `outputWidget.fields` for typed widgets (`dashboard`, `key-value`, `diff-apply`, `raw`).
+
+Regression path: switching widget type from `ai-template` back to a typed widget via the editor cards shows an empty field table (the JS doesn't restore the prior rows). Clicking Save used to store `{ type: 'dashboard', fields: [] }`, which renders three blank divs AND silently dropped the previously-saved fields.
+
+POST `/agents/:id/output-widget/update` now returns a 303 redirect with a flash error like *"Add at least one field for 'dashboard', or click Remove output widget to delete it entirely. The previous version had 3 fields — they were dropped because the form posted no rows."* — and leaves the stored widget untouched. The user either adds a row or uses the explicit Remove button.

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -2277,6 +2277,52 @@ describe('Output widget editor UI', () => {
     expect(res.text).not.toContain('<script');
   });
 
+  it('POST /output-widget/update rejects a typed widget with zero fields', async () => {
+    // Regression: switching widgetType from `ai-template` back to
+    // `dashboard` via the editor cards shows an empty field table.
+    // Clicking Save here used to silently store `fields: []`, which
+    // renders three blank divs and wipes the previously-saved fields.
+    // Server now rejects, surfaces a flash with a count of fields
+    // that would have been dropped, and preserves the existing widget.
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'ow-empty-fields',
+      name: 'ow-empty-fields',
+      status: 'active',
+      source: 'local',
+      mcp: false,
+      nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
+      outputWidget: {
+        type: 'dashboard',
+        fields: [
+          { name: 'score', type: 'metric', label: 'Score' },
+          { name: 'notes', type: 'text', label: 'Notes' },
+        ],
+      },
+    }, 'cli');
+
+    const res = await request(app).post('/agents/ow-empty-fields/output-widget/update')
+      .type('form').send({
+        action: 'save',
+        widgetType: 'dashboard',
+        // No fieldName_N rows — simulates the type-switch-then-save flow.
+      })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toContain('/output-widget?flash=');
+    const flash = decodeURIComponent((res.headers.location.match(/flash=(.+)$/) ?? [, ''])[1]);
+    expect(flash).toContain('Add at least one field');
+    // The hint should call out the count of fields that would have been dropped.
+    expect(flash).toContain('2 fields');
+
+    // Existing widget must be preserved on disk — no new version created.
+    const saved = agentStore.getAgent('ow-empty-fields');
+    expect(saved?.outputWidget?.fields?.length).toBe(2);
+    expect(saved?.outputWidget?.fields?.[0].name).toBe('score');
+  });
+
   it('POST /output-widget/update saves an ai-template widget', async () => {
     const app = await makeApp();
     agentStore.createAgent({

--- a/packages/dashboard/src/routes/agent-inputs.ts
+++ b/packages/dashboard/src/routes/agent-inputs.ts
@@ -278,6 +278,28 @@ agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res:
       ...(interactive && replayLabel ? { replayLabel } : {}),
     };
   } else {
+    // Typed widgets (dashboard / key-value / diff-apply / raw) are
+    // useless without fields — they render three empty divs and the
+    // widget extractor has nothing to populate. Silently accepting
+    // an empty `fields[]` has bitten us before: switching widgetType
+    // from `ai-template` back to `dashboard` shows an empty field
+    // table, and clicking Save here used to wipe the previously-saved
+    // fields. Fail loudly with a clear message instead. The user can
+    // either add a field row or use the Remove button to delete the
+    // widget entirely.
+    if (fields.length === 0) {
+      const existingCount = agent.outputWidget?.fields?.length ?? 0;
+      const hint = existingCount > 0
+        ? ` The previous version had ${existingCount} field${existingCount === 1 ? '' : 's'} — they were dropped because the form posted no rows.`
+        : '';
+      res.redirect(
+        303,
+        `/agents/${encodeURIComponent(agent.id)}/output-widget?flash=${encodeURIComponent(
+          `Add at least one field for "${widgetType}", or click Remove output widget to delete it entirely.${hint}`,
+        )}`,
+      );
+      return;
+    }
     outputWidget = {
       type: widgetType as OutputWidgetType,
       fields,


### PR DESCRIPTION
## Summary
Output-widget editor now rejects a save that would silently wipe \`outputWidget.fields\` for typed widgets (\`dashboard\` / \`key-value\` / \`diff-apply\` / \`raw\`). Returns a 303 + flash error with a count of fields that would have been dropped; the stored widget is left untouched.

## Why
While debugging the churn-watcher widget rendering empty (#274), I dug into its version history and found a real regression path:

\`\`\`
v3  widget editor   → 5 fields (typed dashboard)
v4  YAML editor     → switched to ai-template with a big HTML template
v5  YAML editor     → tweaked the ai-template
v6  widget editor   → fields: []   ← here
v7  Pulse signal    → still fields: []
\`\`\`

At v6 someone clicked the \"Dashboard\" card in the widget editor (coming from \`ai-template\` state). The editor JS shows the field table BUT doesn't restore the previously-saved rows when switching type — so the table is empty. Clicking Save POSTed \`widgetType=dashboard\` with no \`fieldName_*\` rows, and the server happily stored \`fields: []\`.

The result: widget renders three blank divs (visible at /agents/churn-watcher) AND the previously-saved field config is silently gone forever (no \"undo\" without re-importing the YAML).

This was the root cause of yesterday's \"widget output isn't good\" debugging session — my [#274 extractor fix](https://github.com/gregmeyer/some-useful-agents/pull/274) was necessary but not sufficient; the agent in the user's store also had \`fields: []\` from this path.

## Test plan
- [x] New vitest case (\`POST /output-widget/update rejects a typed widget with zero fields\`) — seeds an agent with 2 fields, POSTs empty save, asserts 303 + flash + \"2 fields\" hint + unchanged DB
- [x] Full suite: 1272 passing, 3 skipped, no regressions
- [x] Live repro against the running daemon:
  ```
  --- BEFORE: 3 fields ---
  --- attempting empty-fields save ---
  HTTP 303 → flash=\"Add at least one field… 3 fields — they were dropped because the form posted no rows.\"
  --- AFTER: 3 fields (unchanged) ---
  ```

## Scope / what this PR does NOT cover
- The editor JS itself doesn't restore field rows when switching from \`ai-template\` back to a typed widget. That's a separate UX improvement worth doing (preserve rows across type switches) — out of scope here. The server-side guard is the safety net.
- The \"Remove output widget\" path still works as before — explicit user intent, distinct from accidental wipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)