### PR TITLE
feat(build-planner): wrap user goal with /goal steering keyword

### DIFF
--- a/agents/examples/build-planner.yaml
+++ b/agents/examples/build-planner.yaml
@@ -58,7 +58,7 @@ nodes:
       then emit a structured BuildPlan JSON describing what to do.
 
       ════════════════════════════════════════════════════════════════
-      USER'S GOAL:
+      /goal
       {{inputs.GOAL}}
 
       OPTIONAL FOCUS / CONSTRAINTS:


### PR DESCRIPTION
## Summary
Prefixes the \`{{inputs.GOAL}}\` block in [\`build-planner.yaml\`](agents/examples/build-planner.yaml) with Claude's \`/goal\` steering keyword so the planner gets the right framing signal during goal-seeking.

One-line YAML change. Total diff:

\`\`\`diff
-      USER'S GOAL:
+      /goal
       {{inputs.GOAL}}
\`\`\`

## Why
The Build-from-goal wizard hands the user's free-form goal to Claude inside a ~170-line planner prompt with no semantic marker — just a \`USER'S GOAL:\` heading. \`/goal\` is a Claude steering keyword that improves goal-seeking when it brackets the actual goal text. Putting it on the user's goal segment specifically (not the whole planner invocation) isolates the signal to the part it applies to.

## Test plan
- [x] \`parseAgent\` on the new YAML — parses, single node, no errors
- [x] PR 4.C template validator — 0 issues, \`{{inputs.GOAL}}\` reference stays intact
- [x] Full suite: 1284 passing, 3 skipped, no regressions
- [ ] Manual qualitative check after \`sua examples install\`: run the same goal before/after and eyeball whether classify/survey/draft output is tighter

## Out of scope
- No code, schema, or test changes — this is data, not behavior
- No \`/end-goal\` closer (deliberately omitted — the planner's existing section headings make the goal boundary obvious)
- Not propagating \`/goal\` to other claude-code nodes yet (e.g. \`agent-builder.yaml\`) — land in one agent first, confirm steering effect is real, then propagate
- No changeset — \`agents/examples/\` exempt per CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)