### PR TITLE
fix(dashboard): ai-template arrays populate from prose-wrapped JSON

### DIFF
--- a/.changeset/ai-template-recovers-embedded-json.md
+++ b/.changeset/ai-template-recovers-embedded-json.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+`ai-template` widgets now populate `{{#each}}` blocks from JSON wrapped in prose or a markdown fence — the common shape for claude-code summarisers that lead with a note and emit their JSON inside a ```json fence.
+
+`renderAiTemplate` previously did a bare `JSON.parse(output)` to seed top-level arrays / objects into the outputs map. Anything other than pure JSON threw, the outputs map stayed empty for top-level keys, and `{{#each outputs.rows as r}}` blocks rendered to nothing. Scalar fields (`{{outputs.total}}`) survived via the existing `extractField` backfill, but arrays didn't — extractField returns stringified JSON, which breaks `Array.isArray()` inside `#each`.
+
+Switching to `parseJsonFromOutput` (same recovery logic PR #274 added for scalar extraction) closes the asymmetry: arrays + objects now reach the template from prose-wrapped JSON the same way scalars already did.

--- a/packages/dashboard/src/views/output-widgets.test.ts
+++ b/packages/dashboard/src/views/output-widgets.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractField } from './output-widgets.js';
+import { extractField, renderOutputWidget } from './output-widgets.js';
 
 describe('extractField', () => {
   // Whole-output JSON (the fast path)
@@ -76,5 +76,54 @@ describe('extractField', () => {
     // A bare quoted string parses as JSON but has no fields to extract.
     expect(extractField('"just a string"', 'x')).toBeUndefined();
     expect(extractField('42', 'x')).toBeUndefined();
+  });
+});
+
+describe('renderOutputWidget — ai-template arrays', () => {
+  // Regression for ccusage-daily and similar agents: claude-code
+  // summarisers wrap their JSON in prose / markdown fences, e.g.
+  //   "Note: data is incomplete\n```json\n{ ... }\n```\nCaveat: ..."
+  // The prior renderer did a bare `JSON.parse(output)` which threw on
+  // anything other than pure JSON, so top-level arrays never reached
+  // the outputs map and `{{#each}}` blocks rendered empty. Switching
+  // to `parseJsonFromOutput` recovers the embedded object.
+  it('populates {{#each}} from JSON wrapped in prose + a markdown fence', () => {
+    const schema = {
+      type: 'ai-template' as const,
+      template: '<ul>{{#each outputs.rows as row}}<li data-d="{{row.date}}">{{row.label}}</li>{{/each}}</ul>',
+    };
+    const output = [
+      'Heads up: the upstream feed was truncated.',
+      '```json',
+      JSON.stringify({
+        rows: [
+          { date: '2026-05-10', label: 'alpha' },
+          { date: '2026-05-11', label: 'beta' },
+          { date: '2026-05-12', label: 'gamma' },
+        ],
+      }),
+      '```',
+      'Note: I used the most recent three days.',
+    ].join('\n');
+
+    const out = String(renderOutputWidget(schema, output, 'test-agent') ?? '');
+    expect(out).toContain('data-d="2026-05-10"');
+    expect(out).toContain('alpha');
+    expect(out).toContain('beta');
+    expect(out).toContain('gamma');
+    // Sanity: the loop body fired three times (one <li> per row).
+    expect((out.match(/<li /g) ?? []).length).toBe(3);
+  });
+
+  it('still works for a pure-JSON output (no regression on the fast path)', () => {
+    const schema = {
+      type: 'ai-template' as const,
+      template: '<p>{{outputs.count}}</p><ul>{{#each outputs.items as i}}<li>{{i}}</li>{{/each}}</ul>',
+    };
+    const out = String(renderOutputWidget(schema, '{"count":3,"items":["a","b","c"]}', 'test-agent') ?? '');
+    expect(out).toContain('<p>3</p>');
+    expect(out).toContain('<li>a</li>');
+    expect(out).toContain('<li>b</li>');
+    expect(out).toContain('<li>c</li>');
   });
 });

--- a/packages/dashboard/src/views/output-widgets.ts
+++ b/packages/dashboard/src/views/output-widgets.ts
@@ -457,9 +457,16 @@ function renderAiTemplate(
   // Build a unified outputs map. Start with the parsed JSON's top-level
   // keys (so arrays/objects are accessible to {{#each}} and {{{var}}}),
   // then layer declared scalar fields on top so explicit field config wins.
+  //
+  // We use `parseJsonFromOutput` (same recovery PR #274 added for
+  // extractField) instead of a bare `JSON.parse(output)` so prose-wrapped
+  // or markdown-fenced JSON still surfaces arrays / objects to the
+  // template. Without this, `{{#each outputs.rows as r}}` blocks render
+  // empty whenever the agent emits anything other than pure JSON —
+  // which most claude-code summarisers do (markdown fences, leading
+  // notes, trailing commentary).
   const outputsForSub: Record<string, unknown> = {};
-  let parsed: unknown = null;
-  try { parsed = JSON.parse(output); } catch { /* output isn't JSON; that's fine */ }
+  const parsed = parseJsonFromOutput(output);
   if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
     for (const [k, v] of Object.entries(parsed)) outputsForSub[k] = v;
   }


### PR DESCRIPTION
## Summary
Two-line core change in [\`renderAiTemplate\`](packages/dashboard/src/views/output-widgets.ts) — replace bare \`JSON.parse(output)\` with \`parseJsonFromOutput()\` so top-level arrays and objects survive when the agent's output is prose-wrapped JSON or has a markdown code fence.

## Why
Discovered while debugging the [\`ccusage-daily\`](http://127.0.0.1:3000/agents/ccusage-daily) widget: the table grids for Model Breakdown and Daily Log were rendering empty even though the agent emitted the right shape:

\`\`\`
Heads up: data is truncated after May 3.
\`\`\`json
{ \"models\": [...], \"daily\": [...], ... }
\`\`\`
Note: I used the 7 most recent days available.
\`\`\`

\`JSON.parse(entire output)\` threw on the leading prose, \`parsed\` stayed null, and the top-level \`models\` / \`daily\` arrays never reached the \`outputs\` map passed to the template. The \`{{#each outputs.models as model}}\` block found \`undefined\` and rendered to empty string.

Scalar fields like \`{{outputs.total_tokens_fmt}}\` *did* render — they were rescued by the existing \`extractField\` backfill which uses \`parseJsonFromOutput\` (added by #274). But that path stringifies non-string values, so it couldn't help \`{{#each}}\` which needs a real \`Array.isArray()\`.

This finishes #274: scalars and arrays both recover from prose-wrapped JSON in ai-template widgets now.

## Test plan
- [x] 2 new vitest cases in \`output-widgets.test.ts\`:
  - \`populates {{#each}} from JSON wrapped in prose + a markdown fence\` — asserts 3 \`<li>\` rows render from a prose-wrapped 3-row array
  - \`still works for a pure-JSON output (no regression on the fast path)\` — guards the existing happy path
- [x] Full suite: 1286 passing, 3 skipped, no regressions (+2 new)
- [x] Manual live verification on ccusage-daily: Model Breakdown now shows 3 rows (\`claude-opus-4-7 | \$605.83 | 95% | 974.1M\` etc.), Daily Log shows 7 rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)