### PR TITLE
fix(sanitizer): preserve <style> blocks with scrubbed bodies

### DIFF
--- a/.changeset/sanitizer-allow-style-blocks.md
+++ b/.changeset/sanitizer-allow-style-blocks.md
@@ -1,0 +1,11 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+`sanitizeHtml` now preserves `<style>` blocks (with their bodies scrubbed for `javascript:` / `expression()` / `behavior:` / external `@import`) instead of stripping them entirely. ai-template widgets that rely on CSS-grid or flex layout — e.g. hero stat cards, dashboard hero sections — render with their intended layout instead of falling back to vertical block stacking.
+
+Threat model unchanged in practice: the dashboard's CSP already permits `'unsafe-inline'` styles, and the new `sanitizeStyleBlock` helper applies the same scrubbing the existing inline-`style="…"` sanitizer uses (kills `javascript:`/`expression()`) plus stylesheet-specific defenses (`behavior:`, external `@import`). `<script>` and other dangerous block constructs still get stripped.

--- a/packages/core/src/html-sanitizer.test.ts
+++ b/packages/core/src/html-sanitizer.test.ts
@@ -23,6 +23,51 @@ describe('sanitizeHtml', () => {
     }
   });
 
+  describe('<style> blocks', () => {
+    // ai-template widgets need <style> for CSS-grid / flex layout. The
+    // previous sanitizer stripped these entirely, which broke top-level
+    // stat-card layouts in widgets like ccusage-daily.
+    it('preserves a benign <style> block with class rules', () => {
+      const css = '.stat { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }';
+      const out = sanitizeHtml(`<style>${css}</style><div class="stat"><span>a</span></div>`);
+      expect(out).toContain('<style');
+      expect(out).toContain('display: grid');
+      expect(out).toContain('grid-template-columns: 1fr 1fr');
+      expect(out).toContain('<div class="stat"');
+    });
+
+    it('scrubs javascript: / expression() / behavior: from style body', () => {
+      const evil = [
+        '.a { background: url(javascript:alert(1)); }',
+        '.b { width: expression(alert(1)); }',
+        '.c { background-image: url(vbscript:bad); }',
+        '.d { behavior: url(#default#evil); }',
+      ].join('\n');
+      const out = sanitizeHtml(`<style>${evil}</style>`);
+      expect(out.toLowerCase()).not.toContain('javascript');
+      expect(out.toLowerCase()).not.toContain('vbscript');
+      expect(out.toLowerCase()).not.toContain('expression(');
+      expect(out.toLowerCase()).not.toContain('behavior:');
+      // Benign rule structure survives — just the dangerous parts got stripped.
+      expect(out).toContain('<style');
+    });
+
+    it('strips external @import statements', () => {
+      const out = sanitizeHtml('<style>@import url("https://evil.com/x.css"); .ok { color: red; }</style>');
+      expect(out).not.toContain('@import');
+      expect(out).not.toContain('evil.com');
+      expect(out).toContain('.ok');
+    });
+
+    it('still strips <script> even when CSS allows <style> through', () => {
+      // Make sure my regex narrowing didn't accidentally permit <script>.
+      const out = sanitizeHtml('<style>.a{color:red;}</style><script>alert(1)</script>');
+      expect(out).toContain('<style');
+      expect(out.toLowerCase()).not.toContain('<script');
+      expect(out).not.toContain('alert');
+    });
+  });
+
   it('strips on* event handlers', () => {
     const out = sanitizeHtml('<div onclick="alert(1)" onmouseover="x()">hi</div>');
     expect(out).not.toContain('onclick');

--- a/packages/core/src/html-sanitizer.ts
+++ b/packages/core/src/html-sanitizer.ts
@@ -15,6 +15,11 @@
 const ALLOWED_TAGS = new Set<string>([
   // Block + inline text
   'div', 'span', 'p', 'br', 'hr', 'pre', 'code', 'small', 'strong', 'em', 'b', 'i', 'u',
+  // <style> for ai-template widgets that need CSS-grid / flex layout rules.
+  // The body is sanitised by sanitizeStyleBlock() in a pre-pass; the dashboard
+  // CSP already restricts where stylesheets can fetch from (`style-src 'self'
+  // 'unsafe-inline'`, no external imports).
+  'style',
   'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
   // Lists
   'ul', 'ol', 'li', 'dl', 'dt', 'dd',
@@ -167,6 +172,24 @@ function sanitizeStyle(value: string): string {
   return s;
 }
 
+/**
+ * Sanitize the BODY of a `<style>` block. Same threats as inline
+ * `style="…"` (which `sanitizeStyle` handles) plus stylesheet-specific
+ * vectors:
+ *   - external `@import url(http://…)` — CSP blocks the fetch but we
+ *     strip anyway for defense in depth
+ *   - `behavior:` — legacy IE script-execution hook
+ * Leaves benign CSS rules untouched.
+ */
+function sanitizeStyleBlock(body: string): string {
+  let s = body.replace(/expression\s*\(/gi, '');
+  s = s.replace(/url\s*\(\s*['"]?\s*(?:javascript|vbscript):[^)]*\)/gi, 'url()');
+  s = s.replace(/javascript\s*:/gi, '');
+  s = s.replace(/behavior\s*:/gi, '');
+  s = s.replace(/@import[^;]*;/gi, '');
+  return s;
+}
+
 interface ParsedAttrs {
   rawTagBody: string;
   attrs: Record<string, string>;
@@ -209,23 +232,35 @@ function buildAttrString(tag: string, attrs: Record<string, string>): string {
 
 /**
  * Sanitize untrusted HTML to a tag/attr allowlist. Strips:
- *  - all <script>, <style>, <object>, <embed>, <link>, <form>, <input>...
+ *  - all <script>, <object>, <embed>, <link>, <form>, <input>...
  *  - any tag not in ALLOWED_TAGS (preserving inner text)
  *  - any attribute not in the per-tag allowlist
  *  - on*, javascript:, vbscript:, data: (except data:image/*)
  *  - HTML comments (which can hide IE-conditional script)
  *  - <iframe> whose src isn't HTTPS + on the IFRAME_ALLOWED_HOSTS allowlist;
  *    accepted iframes get a forced `sandbox` attribute regardless of input.
+ *
+ * `<style>` blocks are PRESERVED (ai-template widgets need CSS for grid /
+ * flex layout). Their bodies are scrubbed via sanitizeStyleBlock() — kills
+ * `javascript:`, `expression()`, `behavior:`, and external `@import`.
  */
 export function sanitizeHtml(input: string): string {
   // Strip dangerous block constructs entirely first. Note: iframe is NOT in
   // this list — it's allowed conditionally (HTTPS + host allowlist) and
-  // gets a forced sandbox in the walker below.
+  // gets a forced sandbox in the walker below. `<style>` is also NOT in
+  // this list — ai-template widgets need it for layout CSS; the body is
+  // scrubbed by sanitizeStyleBlock() just below, and CSP restricts where
+  // any url(…) inside can fetch from.
   let s = input;
   s = s.replace(/<!--[\s\S]*?-->/g, '');
-  s = s.replace(/<(script|style|object|embed|noscript|template|xml|head|meta|link|form|input|button|select|textarea|frame|frameset|applet|base)[^>]*>[\s\S]*?<\/\1\s*>/gi, '');
+  // Scrub the body of <style> blocks before the rest of the pipeline runs.
+  s = s.replace(
+    /<style([^>]*)>([\s\S]*?)<\/style\s*>/gi,
+    (_, attrs: string, body: string) => `<style${attrs}>${sanitizeStyleBlock(body)}</style>`,
+  );
+  s = s.replace(/<(script|object|embed|noscript|template|xml|head|meta|link|form|input|button|select|textarea|frame|frameset|applet|base)[^>]*>[\s\S]*?<\/\1\s*>/gi, '');
   // And any orphan opening of those that lacks a closing tag.
-  s = s.replace(/<(script|style|object|embed|noscript|template|xml|head|meta|link|form|input|button|select|textarea|frame|frameset|applet|base)[^>]*\/?>/gi, '');
+  s = s.replace(/<(script|object|embed|noscript|template|xml|head|meta|link|form|input|button|select|textarea|frame|frameset|applet|base)[^>]*\/?>/gi, '');
 
   // Walk all remaining tags.
   return s.replace(/<\/?([a-zA-Z][a-zA-Z0-9-]*)([^>]*)>/g, (match, rawTag, body) => {


### PR DESCRIPTION
## Summary
\`sanitizeHtml\` now keeps \`<style>\` blocks (with bodies scrubbed for \`javascript:\` / \`expression()\` / \`behavior:\` / external \`@import\`) instead of stripping them entirely. ai-template widgets that use CSS-grid or flex for stat-card layouts now render with the intended layout.

## Why
Caught in the ccusage-daily widget. After [#277](https://github.com/gregmeyer/some-useful-agents/pull/277) fixed array population, the *Model Breakdown* and *Daily Log* tables rendered correctly — but the upper "Total Tokens / Avg Daily / Peak Day / Days" stat cards collapsed to a vertical stack instead of a 4-up grid.

Diagnosis: the template's \`<style>\` block defines \`.ccu-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); … }\`. The sanitizer stripped the whole \`<style>\` block, the rule was gone, and the \`<div class="ccu-stats">\` flex/grid container reverted to default block flow. Tables still rendered because \`<table>\` doesn't need CSS to be tabular.

## Threat model
Dashboard CSP already permits \`'unsafe-inline'\` for styles and restricts where any \`url(…)\` inside CSS can fetch from. Sanitizer was stricter than CSP required, hurting legit use without measurable security benefit.

New \`sanitizeStyleBlock()\` helper applies the same scrubbing the existing inline-\`style="…"\` sanitizer uses, plus stylesheet-specific defenses:
- \`javascript:\` / \`vbscript:\` in \`url(…)\` → stripped
- \`expression(…)\` → stripped
- \`behavior:\` (legacy IE script hook) → stripped
- External \`@import\` statements → stripped (CSP would block the fetch anyway, defense-in-depth)
- \`<script>\` and other dangerous block tags → still rejected

## Test plan
- [x] 4 new tests in [\`html-sanitizer.test.ts\`](packages/core/src/html-sanitizer.test.ts):
  - benign \`<style>\` with class rules survives
  - \`javascript:\` / \`expression()\` / \`vbscript:\` / \`behavior:\` scrubbed from body
  - external \`@import\` stripped
  - \`<script>\` still rejected when \`<style>\` is permitted (guards the narrowed regex)
- [x] Full suite: 1290 passing, 3 skipped (+4 new), no regressions
- [x] Manual: hard-refresh \`http://127.0.0.1:3000/agents/ccusage-daily\` and the stat cards lay out as a 4-up grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)