### PR TITLE
feat(widget): controls render everywhere; widget owns appearance

### DIFF
--- a/.changeset/widget-controls-everywhere-restylable.md
+++ b/.changeset/widget-controls-everywhere-restylable.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Widget controls (`sort` / `filter` / `paginate` / `view-switch` / `field-toggle` / `replay`) now render everywhere a widget appears — Pulse, home dashboard, interactive tiles, run detail, agent detail — and look-and-feel is owned by the widget author's `<style>` block instead of hardcoded inline styles.
+
+**Previously**: Pulse / home / interactive callers passed `controlState=undefined`, which short-circuited both the data-transform step (schema defaults like `sort.default: date desc` and `pageSize: 5` never applied) and the controls-row rendering. Tables looked unsorted/unpaged on every surface except the agent detail page.
+
+**Now**: those callers pass an empty `controlState ({})`. Schema defaults take effect on every surface; the interactive controls (chips, filter input, page nav) appear on every surface and respond to URL state the same way everywhere.
+
+**Styling contract**: control renderers emit semantic CSS classes (`.wc-row`, `.wc-group`, `.wc-chip`, `.wc-chip--active`, `.wc-clear`, `.wc-input`, `.wc-button`, `.wc-page-info`, etc.) with no inline `style="…"` attributes. The dashboard ships sensible defaults in `components.css`. Agent `<style>` blocks can override appearance — e.g. `<style>.wc-chip { background: var(--my-brand); }</style>` inside an `ai-template` template restyles the chips on that widget specifically.
+
+Two PRs ago (#278) we made the sanitizer preserve `<style>` blocks specifically so this pattern would work; this PR completes the loop.

--- a/packages/dashboard/src/assets/components.css
+++ b/packages/dashboard/src/assets/components.css
@@ -883,3 +883,131 @@
   word-break: break-all;
 }
 .modal-backdrop.open { display: flex; } /* legacy; new code uses .is-open */
+
+/* ── widget controls (sort / filter / paginate / view-switch / field-toggle) ──
+   Default styling for the controls row rendered above (or inside) output
+   widgets. Authors override appearance via their own <style> block inside
+   the ai-template — every visual property here is a low-specificity class
+   selector that a `.wc-row .wc-chip { ... }` or even bare `.wc-chip` rule
+   in the agent template can replace.
+
+   Class catalogue (stable contract):
+     .wc-row                     the controls row container
+     .wc-group                   one control's wrapper (modifier per type)
+     .wc-group--replay           Run-again form
+     .wc-group--view-switch
+     .wc-group--field-toggle
+     .wc-group--sort
+     .wc-group--filter
+     .wc-group--paginate
+     .wc-label                   "Sort:" / "Filter:" prefix
+     .wc-chip                    clickable token (sort cols, view chips, prev/next)
+     .wc-chip--active            currently-applied chip
+     .wc-chip--disabled          non-clickable (e.g. prev on page 1)
+     .wc-clear                   small "clear" link beside a chip group
+     .wc-field                   <label>-wrapped input+caption
+     .wc-field__name             input caption (label text)
+     .wc-input                   inputs / selects
+     .wc-input--text             text input variant
+     .wc-button                  primary button (Run again)
+     .wc-button--primary
+     .wc-page-info               "page N of M" indicator
+     .wc-page-info__current
+     .wc-page-info__total
+*/
+.wc-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  align-items: center;
+  margin-bottom: var(--space-3);
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+}
+.wc-group {
+  display: inline-flex;
+  gap: var(--space-2);
+  align-items: center;
+  margin: 0;
+}
+.wc-group--filter,
+.wc-group--replay { gap: var(--space-1); }
+.wc-label {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+.wc-chip {
+  display: inline-block;
+  padding: 2px var(--space-2);
+  font-size: var(--font-size-xs);
+  font-weight: var(--weight-medium, 500);
+  border-radius: 999px;
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border);
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+.wc-chip:hover {
+  background: var(--color-surface-raised);
+  color: var(--color-text);
+}
+.wc-chip--active {
+  background: var(--color-primary-soft, var(--color-surface-raised));
+  color: var(--color-text);
+  border-color: var(--color-primary, var(--color-border-strong));
+  cursor: default;
+}
+.wc-chip--disabled {
+  opacity: 0.4;
+  cursor: default;
+  pointer-events: none;
+}
+.wc-clear {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  text-decoration: none;
+  cursor: pointer;
+}
+.wc-clear:hover { color: var(--color-text); text-decoration: underline; }
+.wc-field {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--font-size-xs);
+  margin: 0;
+}
+.wc-field__name {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+.wc-input {
+  padding: 2px var(--space-2);
+  font-size: var(--font-size-xs);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+.wc-input--text { width: 12em; }
+.wc-button {
+  padding: 4px var(--space-3);
+  font-size: var(--font-size-xs);
+  font-weight: var(--weight-medium, 500);
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+.wc-button--primary {
+  background: var(--color-primary, var(--color-surface-raised));
+  color: var(--color-on-primary, var(--color-text));
+}
+.wc-button--primary:hover { filter: brightness(1.05); }
+.wc-page-info {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+.wc-page-info__total { opacity: 0.7; }
+.wc-page-info--empty { opacity: 0.6; }

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -2625,7 +2625,7 @@ describe('Widget controls (PR H)', () => {
       .set('Host', `127.0.0.1:${PORT}`)
       .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
     expect(res.status).toBe(200);
-    expect(res.text).toContain('output-widget__controls');
+    expect(res.text).toContain('wc-row');
     expect(res.text).toContain('data-widget-control="replay"');
     expect(res.text).toContain('data-widget-control="view-switch"');
     expect(res.text).toContain('data-widget-control="field-toggle"');
@@ -2660,7 +2660,7 @@ describe('Widget controls (PR H)', () => {
     // The chip for imperial should be styled active (badge, not badge--muted).
     // Active chip uses class="badge" (not badge--muted). Look for the
     // specific imperial chip's class via the surrounding anchor tag.
-    expect(imp.text).toMatch(/<a[^>]*class="badge"[^>]*data-view-id="imperial"/);
+    expect(imp.text).toMatch(/<a[^>]*class="[^"]*wc-chip--active[^"]*"[^>]*data-view-id="imperial"/);
   });
 
   it('field-toggle hides default-hidden fields by default and reveals them via ?wh', async () => {
@@ -2691,8 +2691,8 @@ describe('Widget controls (PR H)', () => {
       .set('Host', `127.0.0.1:${PORT}`)
       .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
     expect(res.status).toBe(200);
-    expect(res.text).toContain('output-widget__controls');
-    expect(res.text).toMatch(/<a[^>]*class="badge"[^>]*data-view-id="imperial"/);
+    expect(res.text).toContain('wc-row');
+    expect(res.text).toMatch(/<a[^>]*class="[^"]*wc-chip--active[^"]*"[^>]*data-view-id="imperial"/);
   });
 });
 

--- a/packages/dashboard/src/views/home-widgets.ts
+++ b/packages/dashboard/src/views/home-widgets.ts
@@ -54,7 +54,7 @@ function buildRunsToday(data: HomeWidgetData): SystemWidget {
     ],
   };
   const output = JSON.stringify({ total: String(todayRuns.length), completed: String(completed), failed: String(failed) });
-  const widgetHtml = renderOutputWidget(schema, output, '_home-runs-today');
+  const widgetHtml = renderOutputWidget(schema, output, '_home-runs-today', {});
 
   return {
     id: '_home-runs-today',
@@ -78,7 +78,7 @@ function buildFailureRate(data: HomeWidgetData): SystemWidget {
     ],
   };
   const output = JSON.stringify({ rate: `${String(rate)}%`, detail: label });
-  const widgetHtml = renderOutputWidget(schema, output, '_home-failure-rate');
+  const widgetHtml = renderOutputWidget(schema, output, '_home-failure-rate', {});
 
   return {
     id: '_home-failure-rate',
@@ -100,7 +100,7 @@ function buildInFlight(data: HomeWidgetData): SystemWidget {
       ],
     };
     const output = JSON.stringify({ count: '0', status: 'Nothing running' });
-    const widgetHtml = renderOutputWidget(schema, output, '_home-in-flight');
+    const widgetHtml = renderOutputWidget(schema, output, '_home-in-flight', {});
     return {
       id: '_home-in-flight',
       title: 'In Flight',
@@ -149,7 +149,7 @@ function buildAgents(data: HomeWidgetData): SystemWidget {
     active: String(active),
     scheduled: String(scheduledAgents.length),
   });
-  const widgetHtml = renderOutputWidget(schema, output, '_home-agents');
+  const widgetHtml = renderOutputWidget(schema, output, '_home-agents', {});
 
   return {
     id: '_home-agents',

--- a/packages/dashboard/src/views/interactive-widget.ts
+++ b/packages/dashboard/src/views/interactive-widget.ts
@@ -108,8 +108,11 @@ export function renderInteractiveWidget(args: {
   `);
 
   // Initial idle body — render the widget against the last result.
+  // Pass an empty controlState so schema defaults (sort / paginate) apply
+  // and the interactive controls row renders. The widget owns visual
+  // styling via its own <style> block.
   const idleBody = hasResult
-    ? renderOutputWidget(widget, String(lastRun!.result), agent.id) ?? html`<p class="dim">Widget render failed.</p>`
+    ? renderOutputWidget(widget, String(lastRun!.result), agent.id, {}) ?? html`<p class="dim">Widget render failed.</p>`
     : html``;
 
   return html`

--- a/packages/dashboard/src/views/output-widgets.ts
+++ b/packages/dashboard/src/views/output-widgets.ts
@@ -509,8 +509,12 @@ function renderControlsRow(
     if (c.type === 'paginate') return renderPaginateControl(c, state, arrayMeta);
     return html``;
   });
+  // Classes are intentionally minimal — appearance is owned by the
+  // dashboard's default widget-controls CSS plus any agent <style> block
+  // that wants to restyle. See packages/dashboard/src/assets/components.css
+  // for the full class catalogue.
   return html`
-    <div class="output-widget__controls" style="display: flex; flex-wrap: wrap; gap: var(--space-3); align-items: center; margin-bottom: var(--space-3); padding-bottom: var(--space-3); border-bottom: 1px solid var(--color-border);">
+    <div class="wc-row" data-widget-control-row="">
       ${groups as unknown as SafeHtml[]}
     </div>
   `;
@@ -522,45 +526,38 @@ function renderReplayControl(
   agentInputs?: Record<string, AgentInputSpec>,
 ): SafeHtml {
   const label = c.label ?? 'Run again';
-  const FIELD = 'padding: 2px var(--space-2); font-size: var(--font-size-xs); border: 1px solid var(--color-border); border-radius: var(--radius-sm);';
   const inlineInputs = (c.inputs ?? []).map((name) => {
     const spec = agentInputs?.[name];
     const defVal = spec?.default !== undefined ? String(spec.default) : '';
     let inputEl: SafeHtml;
     if (spec?.type === 'enum' && Array.isArray(spec.values) && spec.values.length > 0) {
-      // Render <select> so users get a dropdown of declared enum values
-      // rather than a bare text input where they'd have to remember the
-      // valid options.
       const options = spec.values.map((v) => {
         const val = String(v);
         const selected = val === defVal ? ' selected' : '';
         return `<option value="${val}"${selected}>${val}</option>`;
       });
-      inputEl = unsafeHtml(`<select name="input_${name}" style="${FIELD}">${options.join('')}</select>`);
+      inputEl = unsafeHtml(`<select class="wc-input" name="input_${name}">${options.join('')}</select>`);
     } else if (spec?.type === 'boolean') {
       inputEl = unsafeHtml(
-        `<select name="input_${name}" style="${FIELD}">` +
+        `<select class="wc-input" name="input_${name}">` +
         `<option value="true"${defVal === 'true' ? ' selected' : ''}>true</option>` +
         `<option value="false"${defVal !== 'true' ? ' selected' : ''}>false</option>` +
         `</select>`
       );
     } else {
-      // Pre-fill with the spec default so users see what would run if they
-      // hit Re-run without typing anything (the wizard form already does
-      // this — inline replay should match).
-      inputEl = html`<input type="text" name="input_${name}" value="${defVal}" placeholder="${defVal || '(empty)'}" style="${FIELD} width: 8em;">`;
+      inputEl = html`<input class="wc-input wc-input--text" type="text" name="input_${name}" value="${defVal}" placeholder="${defVal || '(empty)'}">`;
     }
     return html`
-      <label style="display: inline-flex; align-items: center; gap: var(--space-1); font-size: var(--font-size-xs);">
-        <span class="dim">${name}</span>
+      <label class="wc-field">
+        <span class="wc-field__name">${name}</span>
         ${inputEl}
       </label>
     `;
   });
   return html`
-    <form method="POST" action="/agents/${encodeURIComponent(agentId)}/run" style="display: inline-flex; gap: var(--space-2); align-items: center; margin: 0;">
+    <form class="wc-group wc-group--replay" method="POST" action="/agents/${encodeURIComponent(agentId)}/run">
       ${inlineInputs as unknown as SafeHtml[]}
-      <button type="submit" class="btn btn--sm btn--primary" data-widget-control="replay">${label}</button>
+      <button type="submit" class="wc-button wc-button--primary" data-widget-control="replay">${label}</button>
     </form>
   `;
 }
@@ -572,20 +569,13 @@ function renderViewSwitchControl(
   const activeId = state.view ?? c.default;
   const chips = c.views.map((v) => {
     const isActive = v.id === activeId;
-    const cls = isActive ? 'badge' : 'badge badge--muted';
-    const style = isActive
-      ? 'cursor: default; text-decoration: none;'
-      : 'cursor: pointer; text-decoration: none;';
-    // The default view's URL omits `?wv=` (cleaner share links). All other
-    // views set it explicitly. `wh` is preserved by the caller via the form/
-    // link grammar — controls share state through query string only, so
-    // clicking a view-switch resets the hidden-fields list. Acceptable for v1.
+    const cls = isActive ? 'wc-chip wc-chip--active' : 'wc-chip';
     const href = v.id === c.default ? '?' : `?wv=${encodeURIComponent(v.id)}`;
-    return html`<a href="${href}" class="${cls}" style="${style}" data-widget-control="view-switch" data-view-id="${v.id}">${v.id}</a>`;
+    return html`<a href="${href}" class="${cls}" data-widget-control="view-switch" data-view-id="${v.id}" data-active="${isActive ? 'true' : 'false'}">${v.id}</a>`;
   });
   return html`
-    <div style="display: inline-flex; gap: var(--space-2); align-items: center;">
-      <span class="dim" style="font-size: var(--font-size-xs);">${c.label}:</span>
+    <div class="wc-group wc-group--view-switch">
+      <span class="wc-label">${c.label}:</span>
       ${chips as unknown as SafeHtml[]}
     </div>
   `;
@@ -599,30 +589,23 @@ function renderFieldToggleControl(
   const labelByName = new Map<string, string>();
   for (const f of schema.fields ?? []) labelByName.set(f.name, f.label ?? f.name);
 
-  // Reconstruct the effective hidden set so each chip can render its
-  // current state and link to the toggled URL. ?wh present (even empty) =
-  // authoritative; absent = per-control defaults.
   const effectiveHidden = state.hiddenFields !== undefined
     ? new Set(state.hiddenFields)
     : new Set(c.default === 'hidden' ? c.fields : []);
 
   const chips = c.fields.map((name) => {
     const isHidden = effectiveHidden.has(name);
-    // Build the toggled hidden set for this chip's link.
     const next = new Set(effectiveHidden);
     if (isHidden) next.delete(name); else next.add(name);
     const wh = [...next].join(',');
-    // Always emit ?wh=... (even empty) so the URL is authoritative — without
-    // this, revealing the only default-hidden field would produce a bare ?
-    // that falls back to defaults, locking the field hidden forever.
     const href = `?wh=${encodeURIComponent(wh)}`;
-    const cls = isHidden ? 'badge badge--muted' : 'badge';
+    const cls = isHidden ? 'wc-chip' : 'wc-chip wc-chip--active';
     const symbol = isHidden ? '○' : '●';
-    return html`<a href="${href}" class="${cls}" style="cursor: pointer; text-decoration: none;" data-widget-control="field-toggle" data-field="${name}" data-hidden="${isHidden ? '1' : '0'}">${symbol} ${labelByName.get(name) ?? name}</a>`;
+    return html`<a href="${href}" class="${cls}" data-widget-control="field-toggle" data-field="${name}" data-hidden="${isHidden ? '1' : '0'}">${symbol} ${labelByName.get(name) ?? name}</a>`;
   });
   return html`
-    <div style="display: inline-flex; gap: var(--space-2); align-items: center;">
-      <span class="dim" style="font-size: var(--font-size-xs);">${c.label}:</span>
+    <div class="wc-group wc-group--field-toggle">
+      <span class="wc-label">${c.label}:</span>
       ${chips as unknown as SafeHtml[]}
     </div>
   `;
@@ -705,15 +688,15 @@ function renderSortControl(
     const nextDir: 'asc' | 'desc' = isActive && active?.direction === 'asc' ? 'desc' : 'asc';
     const href = buildWidgetUrl(state, c.field, { sort: { column: col, direction: nextDir } });
     const arrow = isActive ? (active!.direction === 'asc' ? '↑' : '↓') : '';
-    const cls = isActive ? 'badge' : 'badge badge--muted';
-    return html`<a href="${href}" class="${cls}" style="cursor: pointer; text-decoration: none;" data-widget-control="sort" data-field="${c.field}" data-column="${col}">${col}${arrow ? html` ${arrow}` : html``}</a>`;
+    const cls = isActive ? 'wc-chip wc-chip--active' : 'wc-chip';
+    return html`<a href="${href}" class="${cls}" data-widget-control="sort" data-field="${c.field}" data-column="${col}" data-active="${isActive ? 'true' : 'false'}">${col}${arrow ? html` ${arrow}` : html``}</a>`;
   });
   const clear = active
-    ? html`<a href="${buildWidgetUrl(state, c.field, { sort: null })}" class="dim" style="font-size: var(--font-size-xs); text-decoration: none;" data-widget-control="sort-clear" data-field="${c.field}">clear</a>`
+    ? html`<a href="${buildWidgetUrl(state, c.field, { sort: null })}" class="wc-clear" data-widget-control="sort-clear" data-field="${c.field}">clear</a>`
     : html``;
   return html`
-    <div style="display: inline-flex; gap: var(--space-2); align-items: center;">
-      <span class="dim" style="font-size: var(--font-size-xs);">${label}:</span>
+    <div class="wc-group wc-group--sort" data-field="${c.field}">
+      <span class="wc-label">${label}:</span>
       ${chips as unknown as SafeHtml[]}
       ${clear}
     </div>
@@ -727,10 +710,6 @@ function renderFilterControl(
 ): SafeHtml {
   const current = arrayMeta?.appliedFilter.get(c.field) ?? state.filter?.get(c.field) ?? '';
   const label = c.label ?? 'Filter';
-  // GET form so the submission lands as `?wf_<field>=...` plus preserved params.
-  // Hidden inputs carry every other widget param forward — including other
-  // fields' sort/filter/page state — so submitting this form doesn't lose
-  // a sibling table's settings.
   const hiddens: SafeHtml[] = [];
   if (state.view) hiddens.push(html`<input type="hidden" name="wv" value="${state.view}">`);
   if (state.hiddenFields !== undefined) {
@@ -740,25 +719,22 @@ function renderFilterControl(
     hiddens.push(html`<input type="hidden" name="ws_${f}" value="${v.column}-${v.direction}">`);
   }
   for (const [f, v] of state.filter ?? []) {
-    if (f === c.field) continue; // this control owns its own input below
+    if (f === c.field) continue;
     hiddens.push(html`<input type="hidden" name="wf_${f}" value="${v}">`);
   }
-  // Other fields' pages preserved. THIS field's page is intentionally
-  // omitted so the filter submission resets it to 1.
   for (const [f, v] of state.page ?? []) {
     if (f === c.field) continue;
     hiddens.push(html`<input type="hidden" name="wp_${f}" value="${String(v)}">`);
   }
   const placeholder = c.placeholder ?? `filter ${c.columns.join(', ')}`;
-  const FIELD = 'padding: 2px var(--space-2); font-size: var(--font-size-xs); border: 1px solid var(--color-border); border-radius: var(--radius-sm);';
   return html`
-    <form method="get" action="" style="display: inline-flex; gap: var(--space-1); align-items: center; margin: 0;">
+    <form class="wc-group wc-group--filter" method="get" action="" data-field="${c.field}">
       ${hiddens as unknown as SafeHtml[]}
-      <label style="display: inline-flex; gap: var(--space-1); align-items: center; font-size: var(--font-size-xs);">
-        <span class="dim">${label}:</span>
-        <input type="text" name="wf_${c.field}" value="${current}" placeholder="${placeholder}" style="${FIELD} width: 12em;" data-widget-control="filter" data-field="${c.field}">
+      <label class="wc-field">
+        <span class="wc-label">${label}:</span>
+        <input type="text" class="wc-input wc-input--text" name="wf_${c.field}" value="${current}" placeholder="${placeholder}" data-widget-control="filter" data-field="${c.field}">
       </label>
-      ${current ? html`<a href="${buildWidgetUrl(state, c.field, { filter: null })}" class="dim" style="font-size: var(--font-size-xs); text-decoration: none;" data-widget-control="filter-clear" data-field="${c.field}">clear</a>` : html``}
+      ${current ? html`<a href="${buildWidgetUrl(state, c.field, { filter: null })}" class="wc-clear" data-widget-control="filter-clear" data-field="${c.field}">clear</a>` : html``}
     </form>
   `;
 }
@@ -770,19 +746,19 @@ function renderPaginateControl(
 ): SafeHtml {
   const info = arrayMeta?.pageInfo.get(c.field);
   if (!info) {
-    return html`<span class="dim" style="font-size: var(--font-size-xs);">page —</span>`;
+    return html`<span class="wc-group wc-group--paginate wc-page-info wc-page-info--empty">page —</span>`;
   }
   const prevHref = info.currentPage > 1 ? buildWidgetUrl(state, c.field, { page: info.currentPage - 1 }) : null;
   const nextHref = info.currentPage < info.pageCount ? buildWidgetUrl(state, c.field, { page: info.currentPage + 1 }) : null;
-  const cls = 'badge badge--muted';
-  const dis = (label: SafeHtml) => html`<span class="${cls}" style="opacity: 0.4; cursor: default;">${label}</span>`;
-  const link = (href: string, label: SafeHtml, dataKey: string) =>
-    html`<a href="${href}" class="${cls}" style="cursor: pointer; text-decoration: none;" data-widget-control="${dataKey}" data-field="${c.field}">${label}</a>`;
+  const dis = (label: SafeHtml, key: string) =>
+    html`<span class="wc-chip wc-chip--disabled" data-widget-control="${key}-disabled" data-field="${c.field}">${label}</span>`;
+  const link = (href: string, label: SafeHtml, key: string) =>
+    html`<a href="${href}" class="wc-chip" data-widget-control="${key}" data-field="${c.field}">${label}</a>`;
   return html`
-    <div style="display: inline-flex; gap: var(--space-2); align-items: center;">
-      ${prevHref ? link(prevHref, html`← prev`, 'paginate-prev') : dis(html`← prev`)}
-      <span class="dim" style="font-size: var(--font-size-xs); font-variant-numeric: tabular-nums;">page ${String(info.currentPage)} of ${String(info.pageCount)} <span style="opacity: 0.7;">(${String(info.totalAfterFilter)} rows)</span></span>
-      ${nextHref ? link(nextHref, html`next →`, 'paginate-next') : dis(html`next →`)}
+    <div class="wc-group wc-group--paginate" data-field="${c.field}">
+      ${prevHref ? link(prevHref, html`← prev`, 'paginate-prev') : dis(html`← prev`, 'paginate-prev')}
+      <span class="wc-page-info"><span class="wc-page-info__current">page ${String(info.currentPage)} of ${String(info.pageCount)}</span> <span class="wc-page-info__total">(${String(info.totalAfterFilter)} rows)</span></span>
+      ${nextHref ? link(nextHref, html`next →`, 'paginate-next') : dis(html`next →`, 'paginate-next')}
     </div>
   `;
 }

--- a/packages/dashboard/src/views/pulse-renderers.ts
+++ b/packages/dashboard/src/views/pulse-renderers.ts
@@ -359,6 +359,11 @@ function renderWidgetTile(tile: PulseTile, wrap: TileWrapFn): SafeHtml {
   if (!agent.outputWidget || !tile.lastRun?.result) {
     return wrap(tile, html`<p class="dim" style="font-size: var(--font-size-xs);">No widget output yet.</p>`);
   }
-  const widgetHtml = renderOutputWidget(agent.outputWidget, tile.lastRun.result, agent.id);
+  // Pass an empty controlState (not undefined) so:
+  //   1. Schema defaults (`sort.default`, `paginate.pageSize`) take effect
+  //      — Pulse tables match what's seen on the agent detail page
+  //   2. The interactive controls row renders, with appearance owned by
+  //      the widget's own <style> block (see widget-controls CSS classes)
+  const widgetHtml = renderOutputWidget(agent.outputWidget, tile.lastRun.result, agent.id, {});
   return wrap(tile, widgetHtml ?? html`<p class="dim" style="font-size: var(--font-size-xs);">Widget render failed.</p>`);
 }


### PR DESCRIPTION
## Summary
Two coupled fixes that resolve the "sorts don't show up on pulse" complaint:

1. **Schema defaults + interactive controls now render on every widget surface** — Pulse tiles, home dashboard, interactive tiles, run detail, agent detail. Previously only agent detail honored \`sort.default\` / \`paginate.pageSize\` and showed the controls row; everywhere else silently dropped them
2. **Visual appearance of the controls is now owned by the widget author**, not the renderer. Semantic CSS classes only, no inline \`style=\"…\"\` attributes. Defaults ship in [\`components.css\`](packages/dashboard/src/assets/components.css); agents override via their own \`<style>\` block inside an \`ai-template\`

## Why
The original [#279](https://github.com/gregmeyer/some-useful-agents/pull/279) had Pulse/home/interactive callers pass \`controlState=undefined\`, which short-circuited both:
- \`applyControlsToArrayData\` (so schema defaults didn't apply → tables looked unsorted/unpaged)
- The controls-row render (so the chips weren't visible)

Net effect: a widget with declared \`sort: { default: date desc }\` looked correct on \`/agents/<id>\` but rendered raw, unsorted on \`/pulse\`. User flagged this and asked for the controls to *be there*, but with the widget author controlling appearance instead of hardcoded inline styling.

## Class catalogue (stable contract)
\`\`\`
.wc-row                      controls row container
.wc-group + modifier         one control's wrapper (--sort, --filter, --paginate, etc.)
.wc-label                    "Sort:" / "Filter:" prefix
.wc-chip + --active          clickable tokens (sort cols, view chips, prev/next)
        + --disabled         non-clickable (e.g. prev on page 1)
.wc-clear                    small "clear" link
.wc-field + __name           <label>-wrapped input + caption
.wc-input + --text           inputs / selects
.wc-button + --primary       primary buttons
.wc-page-info + __current/__total
\`\`\`

Defaults in \`components.css\` use existing design tokens (\`--color-surface\`, \`--space-2\`, etc.). To restyle a single widget, an agent template can drop in:

\`\`\`html
<style>
  .wc-row { gap: 8px; }
  .wc-chip { background: #1a1f2e; }
  .wc-chip--active { background: #5eead4; color: #0f172a; }
</style>
\`\`\`

PR [#278](https://github.com/gregmeyer/some-useful-agents/pull/278) already made the sanitizer preserve \`<style>\` blocks specifically so this pattern would work.

## Test plan
- [x] 24 existing widget tests still pass (rendered text content + data-attribute assertions still hold)
- [x] 3 existing dashboard tests updated to use new class names (\`wc-row\`, \`wc-chip--active\` instead of \`output-widget__controls\`, \`badge\`)
- [x] Full suite: 1309 passing, 3 skipped, no regressions
- [x] Live verification on \`/pulse\`: ccusage-daily tile shows the Run-again button + Filter daily input + Sort daily chips + page nav; previously absent

## What's next
PR D (first-class \`table\` field type) is still queued. This PR doesn't change widget data-flow contracts, just rendering + styling. D will reuse the same \`.wc-*\` class system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)