### PR TITLE
fix(template): strip leftover handlebars block tokens instead of leaking to UI

### DIFF
--- a/.changeset/template-leftover-block-tokens.md
+++ b/.changeset/template-leftover-block-tokens.md
@@ -1,0 +1,11 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Template renderer drops leftover handlebars block tokens instead of leaking them to rendered widgets.
+
+When an ai-template uses an unsupported handlebars form (helpers like `{{#if (eq …)}}`, `{{else}}` branches, or item-scoped `{{#if item.field}}` inside an `{{#each}}` body), the renderer previously left the raw `{{#if …}}` / `{{/if}}` tokens in the output. A safety net now strips any remaining `{{#X}}…{{/X}}` blocks (and bare `{{else}}` / `{{#X}}` / `{{/X}}` tokens) after all supported substitution passes, so unsupported syntax fails closed rather than dumping handlebars source to the page.

--- a/packages/core/src/html-sanitizer.test.ts
+++ b/packages/core/src/html-sanitizer.test.ts
@@ -357,13 +357,34 @@ describe('substitutePlaceholders', () => {
       expect(substitutePlaceholders(t, { outputs: {} })).toBe('B');
     });
 
-    it('does not match Handlebars helpers like (eq …) — renders as literal', () => {
-      // Documents the deliberate non-feature: only {{#if outputs.NAME}} is
-      // supported. Helpers must be caught by catalog guidance, not silently
-      // partially-evaluated.
+    it('drops unsupported helper-style blocks like {{#if (eq …)}} instead of leaking syntax', () => {
+      // Only {{#if outputs.NAME}} is supported. Anything else (helpers,
+      // {{else}}, item-scoped item.X conditionals not consumed by #each)
+      // gets stripped by the safety net so raw handlebars tokens never leak
+      // into rendered widgets.
       const t = '{{#if (eq outputs.status "found")}}A{{/if}}';
       const out = substitutePlaceholders(t, { outputs: { status: 'found' } });
-      expect(out).toBe(t);
+      expect(out).toBe('');
+    });
+  });
+
+  // ── Safety net: leftover handlebars block tokens ──────────────────────
+  describe('leftover block-token stripping', () => {
+    it('drops {{#if item.X}}…{{/if}} that leaked out of an #each body', () => {
+      // Regression: LLMs commonly write {{#if item.X}} inside {{#each}}.
+      // That form isn't part of the grammar, but the inner {{item.X}} was
+      // still being substituted, so both branches and the literal {{#if}} /
+      // {{/if}} tokens leaked to the page. Safety net drops the whole block.
+      const t = '{{#each outputs.rows as item}}<tr>{{#if item.url}}{{item.url}}{{/if}}</tr>{{/each}}';
+      const out = substitutePlaceholders(t, {
+        outputs: { rows: [{ url: 'a' }, { url: 'b' }] },
+      });
+      expect(out).toBe('<tr></tr><tr></tr>');
+    });
+
+    it('drops bare {{else}} and other stray handlebars tokens', () => {
+      const t = 'A{{else}}B{{#with foo}}C{{/with}}D';
+      expect(substitutePlaceholders(t, {})).toBe('ABD');
     });
   });
 });

--- a/packages/core/src/html-sanitizer.ts
+++ b/packages/core/src/html-sanitizer.ts
@@ -396,5 +396,21 @@ export function substitutePlaceholders(
   );
   out = out.replace(/\{\{\s*result\s*\}\}/g, () => escape(values.result ?? ''));
 
+  // 4. Safety net: drop any remaining {{#...}}...{{/...}} block pairs and
+  //    bare {{#...}} / {{/...}} / {{else}} tokens. Anything still here is an
+  //    unsupported handlebars form (helpers like `(eq …)`, `{{else}}`
+  //    branches, or item-scoped conditionals inside an #each that wrote them
+  //    in a way the loop body rewriter didn't recognise). Leaving the raw
+  //    syntax in the output leaks `{{#if …}}` / `{{/if}}` text into rendered
+  //    widgets, which is much worse than silently dropping the block.
+  //    Repeat the block strip until stable so adjacent leftovers all clear.
+  let prev: string;
+  do {
+    prev = out;
+    out = out.replace(/\{\{\s*#[a-zA-Z][^}]*\}\}[\s\S]*?\{\{\s*\/[a-zA-Z][^}]*\}\}/g, '');
+  } while (out !== prev);
+  out = out.replace(/\{\{\s*(?:#|\/)[a-zA-Z][^}]*\}\}/g, '');
+  out = out.replace(/\{\{\s*else\s*\}\}/g, '');
+
   return out;
 }


### PR DESCRIPTION
## Summary

- Unsupported handlebars forms (helpers like `{{#if (eq …)}}`, `{{else}}`, item-scoped `{{#if item.field}}` inside `{{#each}}`) used to leave raw `{{#if …}}` / `{{/if}}` tokens visible in rendered widgets — e.g. `greenhouse-search-discovered` showed `{{#if item.company_url}}lightningai{{#unless item.company_url}}lightningai{{/unless}}{{/if}}` literally in the page
- Add a safety net at the end of `substitutePlaceholders`: drop remaining `{{#X}}…{{/X}}` block pairs (looped until stable) plus bare `{{else}}` / `{{#X}}` / `{{/X}}` tokens
- Updates the existing `(eq …)` test, which previously locked in the "render as literal" non-feature; adds a regression test for the greenhouse-style leak

This is a fail-closed safety net only. PR 2 (next) actually delivers item-scoped `{{#if item.X}}` / `{{#unless item.X}}` inside `#each` bodies so authors can write the natural form.

## Test plan

- [x] `npx vitest run packages/core/src/html-sanitizer.test.ts` — 49 tests pass
- [x] `npm test` — 1311 passing / 3 skipped (baseline 1309 + 2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)