### PR TITLE
fix(template): run #each before outer #if outputs.X (greenhouse-search-discovered empty-table regression)

### DIFF
--- a/.changeset/template-pass-order.md
+++ b/.changeset/template-pass-order.md
@@ -1,0 +1,11 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Fix ai-template renderer truncating tables when `{{#if outputs.X}}` wraps an `{{#each}}` whose body contains item-scoped `{{#if item.X}}…{{/if}}`.
+
+Outer `{{#if outputs.X}}` was processed first with a non-greedy body match, so it terminated at the FIRST `{{/if}}` — the inner item-scoped closer — truncating the wrapped table after the first cell and dropping every row. Reorder the passes so `{{#each}}` runs before outer `#if`/`#unless`: per-iteration rewriting consumes item-scoped `{{/if}}` tokens first, leaving the outer block with a balanced body. The wrapping pattern is the natural LLM-authored form (`{{#if outputs.X}}…table…{{/if}}{{#unless outputs.X}}…empty…{{/unless}}`) and now renders correctly. Regression caught by the greenhouse-search-discovered widget showing zero table rows.

--- a/packages/core/src/html-sanitizer.test.ts
+++ b/packages/core/src/html-sanitizer.test.ts
@@ -368,6 +368,29 @@ describe('substitutePlaceholders', () => {
     });
   });
 
+  // ── Wrapping #if outputs.X around an #each with item-scoped #if ────────
+  describe('outer #if outputs.X wrapping an #each with item-scoped conditionals', () => {
+    it('renders all rows when outer #if wraps an #each whose body contains {{#if item.X}}…{{/if}}', () => {
+      // Regression: greenhouse-search-discovered widget rendered zero
+      // rows. The outer {{#if outputs.matches}} was processed first with a
+      // non-greedy body match, which terminated at the FIRST {{/if}} —
+      // the INNER item-scoped closer — truncating the table after the
+      // first <td>. Fix: run #each before outer #if so per-iteration
+      // rewriting consumes item-scoped {{/if}} tokens first.
+      const t = `{{#if outputs.matches}}<table>{{#each outputs.matches as item}}<tr><td>{{#if item.url}}<a href="{{item.url}}">{{item.name}}</a>{{/if}}{{#unless item.url}}{{item.name}}{{/unless}}</td></tr>{{/each}}</table>{{/if}}{{#unless outputs.matches}}<p>empty</p>{{/unless}}`;
+      const out = substitutePlaceholders(t, {
+        outputs: { matches: [{ name: 'A', url: '/a' }, { name: 'B', url: '' }] },
+      });
+      expect(out).toBe('<table><tr><td><a href="/a">A</a></td></tr><tr><td>B</td></tr></table>');
+    });
+
+    it('falls through to the #unless branch when the array is empty', () => {
+      const t = `{{#if outputs.matches}}<table>{{#each outputs.matches as item}}<tr><td>{{item.name}}</td></tr>{{/each}}</table>{{/if}}{{#unless outputs.matches}}<p>empty</p>{{/unless}}`;
+      expect(substitutePlaceholders(t, { outputs: { matches: [] } })).toBe('<p>empty</p>');
+      expect(substitutePlaceholders(t, { outputs: {} })).toBe('<p>empty</p>');
+    });
+  });
+
   // ── Safety net: leftover handlebars block tokens ──────────────────────
   describe('leftover block-token stripping', () => {
     it('drops bare {{else}} and other stray handlebars tokens', () => {

--- a/packages/core/src/html-sanitizer.ts
+++ b/packages/core/src/html-sanitizer.ts
@@ -344,21 +344,16 @@ export function substitutePlaceholders(
     return true;
   };
 
-  // 0. #if / #unless blocks first — drop or keep the body based on
-  //    truthiness, before any inner #each / placeholder substitution so we
-  //    don't waste work on a branch we're going to discard.
-  let out = template.replace(
-    /\{\{\s*#if\s+outputs\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}([\s\S]*?)\{\{\s*\/if\s*\}\}/g,
-    (_, name: string, body: string) => (isTruthy(values.outputs?.[name]) ? body : ''),
-  );
-  out = out.replace(
-    /\{\{\s*#unless\s+outputs\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}([\s\S]*?)\{\{\s*\/unless\s*\}\}/g,
-    (_, name: string, body: string) => (isTruthy(values.outputs?.[name]) ? '' : body),
-  );
-
-  // 1. Each blocks — non-greedy body match means an inner #each would
+  // 0. Each blocks first — must run BEFORE outer #if/#unless outputs.X.
+  //    All block regexes use non-greedy body matches, and an outer
+  //    {{#if outputs.X}}…{{/if}} that wraps an {{#each}} body with
+  //    item-scoped {{#if item.X}}…{{/if}} inside would otherwise have its
+  //    outer body truncated at the FIRST {{/if}} — the inner one —
+  //    nuking the table. Running #each first consumes those inner
+  //    closers (per-iteration) so the outer #if sees a balanced body.
+  //    Non-greedy each body match also means a nested #each would
   //    confuse the parser; that's by design (no nested loops).
-  out = out.replace(
+  let out = template.replace(
     /\{\{\s*#each\s+outputs\.([a-zA-Z_][a-zA-Z0-9_]*)\s+as\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}([\s\S]*?)\{\{\s*\/each\s*\}\}/g,
     (_, name: string, itemName: string, body: string) => {
       const arr = values.outputs?.[name];
@@ -403,6 +398,23 @@ export function substitutePlaceholders(
       }).join('');
     },
   );
+
+  // 1b. Outer #if / #unless on outputs.X — runs AFTER #each so any
+  //     item-scoped {{/if}} / {{/unless}} inside an each body has already
+  //     been consumed and won't be mistaken for the outer block's closer.
+  //     Repeated until stable so multiple sibling blocks all process.
+  let blockPrev: string;
+  do {
+    blockPrev = out;
+    out = out.replace(
+      /\{\{\s*#if\s+outputs\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}([\s\S]*?)\{\{\s*\/if\s*\}\}/g,
+      (_, name: string, body: string) => (isTruthy(values.outputs?.[name]) ? body : ''),
+    );
+    out = out.replace(
+      /\{\{\s*#unless\s+outputs\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}([\s\S]*?)\{\{\s*\/unless\s*\}\}/g,
+      (_, name: string, body: string) => (isTruthy(values.outputs?.[name]) ? '' : body),
+    );
+  } while (out !== blockPrev);
 
   // 2. Triple-brace unescaped — must run before double-brace so the regex
   //    doesn't match the inner double braces of `{{{x}}}`.


### PR DESCRIPTION
## Summary

- Greenhouse-search-discovered widget rendered **zero rows** despite the JSON having 3 matches. Cause: outer `{{#if outputs.matches}}` was processed first with a non-greedy body match, terminating at the FIRST `{{/if}}` — the **inner item-scoped closer** from `{{#if item.company_url}}…{{/if}}`. That truncated the table after the first cell and orphaned the `{{#each}}`; the safety net then dropped the orphan, killing every row.
- Regression introduced when #284 added item-scoped `{{#if item.X}}` inside `{{#each}}` bodies — before that, `{{/if}}` only ever appeared at the outer level.
- Fix: reorder passes so `{{#each}}` runs **before** outer `#if`/`#unless` on `outputs.X`. Per-iteration rewriting consumes item-scoped `{{/if}}` tokens first, leaving the outer block with a balanced body.
- Also loops the outer `#if`/`#unless` pair until stable so sibling wrapper blocks across multiple iterations all resolve.

The `{{#if outputs.matches}}…table…{{/if}}{{#unless outputs.matches}}…empty…{{/unless}}` wrapping pattern is the natural LLM-authored form and now renders correctly.

## Test plan

- [x] `npx vitest run packages/core/src/html-sanitizer.test.ts` — 54 tests pass (2 new for the wrapping pattern)
- [x] `npm test` — 1316 passing / 3 skipped (was 1314 + 2 new)
- [x] Re-rendered the actual greenhouse-search-discovered template against the run 7bbee171 JSON locally — all 3 rows render with `Apply →` links
- [ ] After merge: rebuild dashboard, restart daemon, hard-refresh `http://127.0.0.1:3000/agents/greenhouse-search-discovered`

🤖 Generated with [Claude Code](https://claude.com/claude-code)