### PR TITLE
feat(widget): first-class `table` field type for dashboard widgets

### DIFF
--- a/.changeset/table-field-type.md
+++ b/.changeset/table-field-type.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+First-class `table` field type for `dashboard` widgets — declare columns inline instead of writing `<table>` markup in an ai-template.
+
+A `table` field reads a top-level JSON array from the run output and renders a row-per-item HTML table over it. Columns are declared as `[{ name, label?, format?, href?, text? }]`; `format: link` columns wrap the cell in `<a href>` driven by `href` (per-row JSON key holding the URL) and `text` (per-row key OR literal label fallback like `"Apply →"`). Empty / missing arrays still render the header row plus a "No rows" caption so the column structure stays visible.
+
+Sort / filter / paginate `WidgetControl`s attach by sharing the field's `name` — same grammar and per-field URL state (`?ws_<field>=`, `?wf_<field>=`, `?wp_<field>=`) as ai-template widgets. Discovery catalog updated with the new field type, schema, and a complete example. Editor preview synthesises three sample rows so authors can see the column layout immediately.

--- a/packages/core/src/discovery-catalog.test.ts
+++ b/packages/core/src/discovery-catalog.test.ts
@@ -173,13 +173,13 @@ describe('buildDiscoveryCatalog', () => {
     expect(catalog).toMatch(/USE WHEN.*view-switch|view-switch.*USE WHEN/is);
   });
 
-  it('stays under 12500 chars with typical data (4000 → 11000 over time; +500 for v3 composition hints in AVAILABLE AGENTS)', () => {
+  it('stays under 14000 chars with typical data (4000 → 11000 over time; +500 for v3 composition hints; +1500 for table field type docs)', () => {
     const catalog = buildDiscoveryCatalog({
       agents: MOCK_AGENTS,
       tools: [],
       templateRegistry: MOCK_REGISTRY,
     });
-    expect(catalog.length).toBeLessThan(12500);
+    expect(catalog.length).toBeLessThan(14000);
   });
 
   it('handles empty agents gracefully', () => {

--- a/packages/core/src/discovery-catalog.ts
+++ b/packages/core/src/discovery-catalog.ts
@@ -62,7 +62,7 @@ UPSTREAM DATA FLOW:
 const OUTPUT_WIDGETS = `
 ## OUTPUT WIDGET TYPES (outputWidget: in agent YAML)
 Use when the agent produces structured JSON. The widget renders on the agent detail page.
-- dashboard: Hero metric + stats grid. Field types: metric (big number), stat (compact label+value), badge (pill), text.
+- dashboard: Hero metric + stats grid, plus row-per-item tables. Field types: metric (big number), stat (compact label+value), badge (pill), text, table (over a top-level array).
 - key-value: Labeled pairs as definition list. Field types: text, code, badge.
 - diff-apply: Review/analysis with actions. Field types: text, code, badge. Supports actions (buttons that POST).
 - raw: Sectioned fallback for mixed content. Field types: text, code, preview.
@@ -71,8 +71,9 @@ Use when the agent produces structured JSON. The widget renders on the agent det
 CRITICAL — OUTPUT WIDGET FIELD SCHEMA:
 Each entry in outputWidget.fields has EXACTLY these keys:
   name: string    ← THE JSON KEY TO LOOK UP in the agent's final-node JSON output
-  type: string    ← one of: text | code | badge | action | metric | stat | preview
+  type: string    ← one of: text | code | badge | action | metric | stat | preview | table
   label: string   ← OPTIONAL human-readable display label (defaults to name)
+  columns: list   ← REQUIRED only when type=table. See TABLE FIELDS below.
 DO NOT use \`source:\`, \`path:\`, \`from:\`, or \`key:\` — these are silently dropped and the widget renders empty.
 Example for a final node that emits {"file":"x.md","count":5}:
   fields:
@@ -82,6 +83,33 @@ Example for a final node that emits {"file":"x.md","count":5}:
     - name: count      # reads outputs.count → renders "5"
       type: metric
       label: Stories
+
+TABLE FIELDS (dashboard widgets only):
+A \`table\` field renders an HTML table over a top-level JSON array. Use this
+INSTEAD of writing \`<table>\` markup in an ai-template when your data is a
+simple list of objects with the same keys. Sort/filter/paginate controls
+attach by sharing the field's \`name\` — no extra wiring needed.
+
+  fields:
+    - name: matches            # reads outputs.matches (must be an array)
+      type: table
+      label: Job matches       # optional caption above the table
+      columns:
+        - { name: company, label: Company }
+        - { name: title,   label: Title }
+        - { name: url,     label: Apply, format: link, href: url, text: "Apply →" }
+  controls:
+    - { type: sort,     field: matches, columns: [company, title] }
+    - { type: filter,   field: matches, columns: [company, title] }
+    - { type: paginate, field: matches, pageSize: 20 }
+
+Column formats:
+  - (default text): escaped cell value from row[name].
+  - format: link: wraps the cell in <a href>. \`href\` names the per-row key
+    holding the URL (e.g. href: url reads row.url). \`text\` either names a
+    per-row key for the displayed text OR is a literal string fallback
+    when no row carries that key (e.g. text: "Apply →" always renders that
+    label). Cells with a missing/empty href fall back to plain text.
 
 ## WIDGET CONTROLS (outputWidget.controls — interactive UI on the rendered widget)
 Make widgets feel alive. Three control types render as a row above the widget body. State lives in URL query params (no client JS); refresh = default state. NOT supported on ai-template widgets except for "replay".

--- a/packages/core/src/output-widget-schema.test.ts
+++ b/packages/core/src/output-widget-schema.test.ts
@@ -268,3 +268,82 @@ describe('agent YAML round-trip preserves controls', () => {
     });
   });
 });
+
+describe('outputWidgetSchema — table field type', () => {
+  it('accepts a minimal table field with text-only columns', () => {
+    const r = outputWidgetSchema.safeParse({
+      type: 'dashboard',
+      fields: [{
+        name: 'rows', type: 'table',
+        columns: [{ name: 'company' }, { name: 'title' }],
+      }],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts a table field with a format=link column', () => {
+    const r = outputWidgetSchema.safeParse({
+      type: 'dashboard',
+      fields: [{
+        name: 'matches', type: 'table',
+        columns: [
+          { name: 'company', label: 'Company' },
+          { name: 'url', format: 'link', href: 'url', text: 'Apply →' },
+        ],
+      }],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects a table field with no columns', () => {
+    const r = outputWidgetSchema.safeParse({
+      type: 'dashboard',
+      fields: [{ name: 'rows', type: 'table' }],
+    });
+    expect(r.success).toBe(false);
+    expect(JSON.stringify(r)).toContain('columns');
+  });
+
+  it('rejects format=link without an href', () => {
+    const r = outputWidgetSchema.safeParse({
+      type: 'dashboard',
+      fields: [{
+        name: 'rows', type: 'table',
+        columns: [{ name: 'url', format: 'link' }],
+      }],
+    });
+    expect(r.success).toBe(false);
+    expect(JSON.stringify(r)).toContain('href');
+  });
+
+  it('rejects href/text on a non-link column', () => {
+    const r = outputWidgetSchema.safeParse({
+      type: 'dashboard',
+      fields: [{
+        name: 'rows', type: 'table',
+        columns: [{ name: 'company', href: 'url' }],
+      }],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects table on non-dashboard widgets', () => {
+    const r = outputWidgetSchema.safeParse({
+      type: 'key-value',
+      fields: [{
+        name: 'rows', type: 'table',
+        columns: [{ name: 'a' }],
+      }],
+    });
+    expect(r.success).toBe(false);
+    expect(JSON.stringify(r)).toContain('table fields are only supported on dashboard');
+  });
+
+  it('rejects columns on non-table fields', () => {
+    const r = outputWidgetSchema.safeParse({
+      type: 'dashboard',
+      fields: [{ name: 'count', type: 'metric', columns: [{ name: 'x' }] }],
+    });
+    expect(r.success).toBe(false);
+  });
+});

--- a/packages/core/src/output-widget-schema.ts
+++ b/packages/core/src/output-widget-schema.ts
@@ -4,10 +4,52 @@
 
 import { z } from 'zod';
 
+export const tableColumnSchema = z.object({
+  name: z.string().min(1),
+  label: z.string().optional(),
+  format: z.enum(['text', 'link']).optional(),
+  /** For format=link: the per-row JSON key holding the URL. */
+  href: z.string().min(1).optional(),
+  /** For format=link: per-row key for the displayed text, OR a literal string
+   *  fallback (when no row has a matching key). */
+  text: z.string().min(1).optional(),
+});
+
 export const widgetFieldSchema = z.object({
   name: z.string().min(1),
   label: z.string().optional(),
-  type: z.enum(['text', 'code', 'badge', 'action', 'metric', 'stat', 'preview']),
+  type: z.enum(['text', 'code', 'badge', 'action', 'metric', 'stat', 'preview', 'table']),
+  columns: z.array(tableColumnSchema).min(1, 'table.columns must list at least one column.').optional(),
+}).superRefine((field, ctx) => {
+  if (field.type === 'table') {
+    if (!field.columns || field.columns.length === 0) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['columns'], message: 'table fields require `columns` (at least one).' });
+      return;
+    }
+    for (let i = 0; i < field.columns.length; i++) {
+      const col = field.columns[i];
+      if (col.format === 'link' && !col.href) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['columns', i, 'href'],
+          message: `column "${col.name}" has format=link but no \`href\` — name the per-row JSON key holding the URL.`,
+        });
+      }
+      if (col.format !== 'link' && (col.href || col.text)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['columns', i, 'format'],
+          message: `column "${col.name}" sets \`href\`/\`text\` but format is not "link".`,
+        });
+      }
+    }
+  } else if (field.columns) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['columns'],
+      message: '`columns` is only valid on `type: table` fields.',
+    });
+  }
 });
 
 export const widgetActionSchema = z.object({
@@ -127,6 +169,21 @@ export const outputWidgetSchema = z.object({
   } else {
     if (!Array.isArray(schema.fields) || schema.fields.length === 0) {
       ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['fields'], message: 'Non-ai widgets need at least one field.' });
+    }
+  }
+
+  // `table` fields only render on `dashboard` widgets — other typed widgets
+  // (key-value/raw/diff-apply) use a scalar-per-field layout that doesn't
+  // know how to surface array data, and ai-template widgets render via the
+  // template so a typed `table` field would be meaningless.
+  for (let i = 0; i < (schema.fields?.length ?? 0); i++) {
+    const f = schema.fields![i];
+    if (f.type === 'table' && schema.type !== 'dashboard') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['fields', i, 'type'],
+        message: `table fields are only supported on dashboard widgets (this widget is type "${schema.type}").`,
+      });
     }
   }
 

--- a/packages/core/src/output-widget-types.ts
+++ b/packages/core/src/output-widget-types.ts
@@ -7,16 +7,39 @@
 /** Field type determines rendering: text is plain, code gets monospace+scroll,
  *  badge gets a colored pill, action renders a button, metric renders a big number,
  *  stat renders a compact label+value pair in a grid, preview renders a file
- *  in a sandboxed iframe via the /output-file route. */
-export type WidgetFieldType = 'text' | 'code' | 'badge' | 'action' | 'metric' | 'stat' | 'preview';
+ *  in a sandboxed iframe via the /output-file route, table renders a row-per-
+ *  item table over a top-level array. */
+export type WidgetFieldType = 'text' | 'code' | 'badge' | 'action' | 'metric' | 'stat' | 'preview' | 'table';
+
+/** Cell render mode within a `table` field column. `text` (default) escapes the
+ *  value as plain text; `link` wraps the cell in an `<a>` using `href` (a row-
+ *  key name resolved per-row) and `text` (a row-key name OR a literal string)
+ *  to drive what's shown. */
+export type TableColumnFormat = 'text' | 'link';
+
+/** One column in a `table` field. `name` is the per-row JSON key whose value
+ *  drives the cell. `format` picks the cell render; for `link`, `href` names a
+ *  per-row key holding the URL, and optional `text` either names a per-row key
+ *  for the displayed text or — when no such key exists on the row — falls back
+ *  to a literal string (e.g. `"Open"`). */
+export interface TableColumn {
+  name: string;
+  label?: string;
+  format?: TableColumnFormat;
+  href?: string;
+  text?: string;
+}
 
 export interface WidgetField {
-  /** Key in the structured output to extract this field from. */
+  /** Key in the structured output to extract this field from. For `table`
+   *  fields, this is the name of the top-level array (e.g. `matches`). */
   name: string;
   /** Display label. Defaults to `name` if omitted. */
   label?: string;
   /** How to render the field value. */
   type: WidgetFieldType;
+  /** Required when `type` is `table`. One entry per column, in display order. */
+  columns?: TableColumn[];
 }
 
 export interface WidgetAction {

--- a/packages/dashboard/src/views/agent-detail-helpers.ts
+++ b/packages/dashboard/src/views/agent-detail-helpers.ts
@@ -132,7 +132,7 @@ export function renderVariablesEditor(agent: Agent): SafeHtml {
 // ── Output widget editor ────────────────────────────────────────────────
 
 const WIDGET_TYPES: OutputWidgetType[] = ['dashboard', 'key-value', 'diff-apply', 'raw', 'ai-template'];
-const FIELD_TYPES: WidgetFieldType[] = ['text', 'code', 'badge', 'metric', 'stat', 'preview', 'action'];
+const FIELD_TYPES: WidgetFieldType[] = ['text', 'code', 'badge', 'metric', 'stat', 'preview', 'action', 'table'];
 
 function widgetTypeSelect(current: string): string {
   const opts = WIDGET_TYPES.map((t) =>

--- a/packages/dashboard/src/views/output-widget-help.ts
+++ b/packages/dashboard/src/views/output-widget-help.ts
@@ -10,7 +10,7 @@
 import type { OutputWidgetSchema } from '@some-useful-agents/core';
 
 export type WidgetType = 'raw' | 'key-value' | 'diff-apply' | 'dashboard' | 'ai-template';
-export type FieldType = 'text' | 'code' | 'badge' | 'action' | 'metric' | 'stat' | 'preview';
+export type FieldType = 'text' | 'code' | 'badge' | 'action' | 'metric' | 'stat' | 'preview' | 'table';
 
 export interface WidgetTypeInfo {
   name: WidgetType;
@@ -58,7 +58,7 @@ export const WIDGET_TYPES: Record<WidgetType, WidgetTypeInfo> = {
     displayName: 'Dashboard',
     description: 'Hero metrics up top, compact stats below, text sections underneath.',
     layoutHint: '┌────┐ ┌────┐\n│ 42 │ │ 12 │\n└────┘ └────┘\n  stat  stat\nBody text…',
-    compatibleFields: ['text', 'code', 'badge', 'metric', 'stat', 'preview'],
+    compatibleFields: ['text', 'code', 'badge', 'metric', 'stat', 'preview', 'table'],
     helperCopy: 'Use metric for headline numbers (rendered large) and stat for the compact row below. Any text/code/badge fields render beneath in order. Best for run scorecards and KPI summaries.',
   },
   'ai-template': {
@@ -113,6 +113,11 @@ export const FIELD_TYPES: Record<FieldType, FieldTypeInfo> = {
     name: 'preview',
     description: 'Value must be a file path. Renders HTML in an iframe or images inline.',
     validIn: ['raw', 'dashboard'],
+  },
+  table: {
+    name: 'table',
+    description: 'Row-per-item table over a top-level array. Declare `columns` inline. Pairs with sort/filter/paginate controls.',
+    validIn: ['dashboard'],
   },
 };
 
@@ -192,7 +197,7 @@ export function synthPreviewOutput(fields: Array<{ name: string; type: FieldType
   return JSON.stringify(payload, null, 2);
 }
 
-function sampleValueFor(type: FieldType, name: string): string | number {
+function sampleValueFor(type: FieldType, name: string): string | number | unknown[] {
   switch (type) {
     case 'metric':
     case 'stat':
@@ -205,6 +210,15 @@ function sampleValueFor(type: FieldType, name: string): string | number {
       return '/sample/preview.html';
     case 'action':
       return 'Run';
+    case 'table':
+      // Three plausible rows so the preview renders the column layout +
+      // an example of how `format: link` cells light up when href/text
+      // columns are present on the row.
+      return [
+        { name: 'Alpha', count: 12, url: 'https://example.com/a' },
+        { name: 'Bravo', count: 7, url: 'https://example.com/b' },
+        { name: 'Charlie', count: 3, url: '' },
+      ];
     case 'text':
     default:
       return `Sample ${name} value. This is what your tile will show when the agent emits a real value.`;

--- a/packages/dashboard/src/views/output-widgets.test.ts
+++ b/packages/dashboard/src/views/output-widgets.test.ts
@@ -354,3 +354,116 @@ describe('renderOutputWidget — sort / filter / paginate controls', () => {
     expect(rowsFromHtml(out)).toEqual(['c', 'b', 'a']);
   });
 });
+
+describe('renderOutputWidget — table field type (dashboard)', () => {
+  const matches = [
+    { company: 'Remotecom', title: 'Senior PM', team: 'Product', url: 'https://x/remote' },
+    { company: 'Clickhouse', title: 'Senior PM - Cloud', team: 'Product', url: 'https://x/click' },
+    { company: 'Gitlab', title: 'Senior PM, Scale', team: 'Platforms', url: '' },
+  ];
+  const output = JSON.stringify({ headline: '3 matches', matches });
+
+  const baseSchema = {
+    type: 'dashboard' as const,
+    fields: [
+      { name: 'headline', type: 'metric' as const, label: 'Headline' },
+      {
+        name: 'matches',
+        type: 'table' as const,
+        label: 'Job matches',
+        columns: [
+          { name: 'company', label: 'Company' },
+          { name: 'title', label: 'Title' },
+          { name: 'team', label: 'Team' },
+          { name: 'url', label: 'Apply', format: 'link' as const, href: 'url', text: 'Apply →' },
+        ],
+      },
+    ],
+  };
+
+  function bodyTexts(html: string): string[] {
+    // Pull tbody-only cells so we don't pick up the column headers.
+    const tbody = /<tbody>([\s\S]*?)<\/tbody>/.exec(html);
+    if (!tbody) return [];
+    return [...tbody[1].matchAll(/<td[^>]*>([\s\S]*?)<\/td>/g)].map((m) => m[1].trim());
+  }
+
+  it('renders a row per item with column-driven cells', () => {
+    const out = String(renderOutputWidget(baseSchema, output, 'a') ?? '');
+    expect(out).toContain('<th'); // header row present
+    expect(out).toContain('>Company<');
+    expect(out).toContain('>Title<');
+    // Per-row cells: company / title / team are escaped text, last column is a link.
+    const cells = bodyTexts(out);
+    expect(cells.slice(0, 4)).toEqual([
+      'Remotecom', 'Senior PM', 'Product',
+      '<a href="https://x/remote" target="_blank" rel="noopener">Apply →</a>',
+    ]);
+  });
+
+  it('renders the literal link text when no row carries the named text key', () => {
+    // `text: "Apply →"` is a literal because no row has an "Apply →" key.
+    const out = String(renderOutputWidget(baseSchema, output, 'a') ?? '');
+    expect(out).toContain('>Apply →</a>');
+  });
+
+  it('uses a per-row key for link text when the row supplies it', () => {
+    const schema = {
+      type: 'dashboard' as const,
+      fields: [{
+        name: 'rows', type: 'table' as const, columns: [
+          { name: 'name', format: 'link' as const, href: 'url', text: 'name' },
+        ],
+      }],
+    };
+    const out = String(renderOutputWidget(schema, JSON.stringify({
+      rows: [{ name: 'Acme', url: 'https://acme/' }],
+    }), 'a') ?? '');
+    expect(out).toContain('<a href="https://acme/" target="_blank" rel="noopener">Acme</a>');
+  });
+
+  it('falls back to plain text when href is missing on a row', () => {
+    const out = String(renderOutputWidget(baseSchema, output, 'a') ?? '');
+    // Row 3 has url: '' — the last cell should be plain "Apply →" without an <a>.
+    expect(out).toMatch(/Gitlab[\s\S]*?Senior PM, Scale[\s\S]*?Platforms[\s\S]*?<td[^>]*>Apply →<\/td>/);
+  });
+
+  it('renders header row + empty-state caption when the array is missing or empty', () => {
+    const out = String(renderOutputWidget(baseSchema, '{"headline":"none"}', 'a') ?? '');
+    expect(out).toContain('>Company<'); // header still visible
+    expect(out).toContain('No rows.');
+  });
+
+  it('shares sort/filter/paginate controls with the field by name', () => {
+    const schema = {
+      ...baseSchema,
+      controls: [
+        { type: 'sort' as const, field: 'matches', columns: ['company', 'title'], default: 'company asc' },
+        { type: 'filter' as const, field: 'matches', columns: ['company'] },
+      ],
+    };
+    const sorted = String(renderOutputWidget(schema, output, 'a', {}) ?? '');
+    const cells = bodyTexts(sorted);
+    // First column of each row should now be sorted: Clickhouse, Gitlab, Remotecom.
+    expect([cells[0], cells[4], cells[8]]).toEqual(['Clickhouse', 'Gitlab', 'Remotecom']);
+
+    const filtered = String(renderOutputWidget(schema, output, 'a', {
+      filter: new Map([['matches', 'gitlab']]),
+    }) ?? '');
+    const fcells = bodyTexts(filtered);
+    expect(fcells[0]).toBe('Gitlab');
+    // Only one row in the filtered set.
+    expect(fcells.length / 4).toBe(1);
+  });
+
+  it('escapes raw HTML in cell values', () => {
+    const out = String(renderOutputWidget({
+      type: 'dashboard' as const,
+      fields: [{
+        name: 'rows', type: 'table' as const, columns: [{ name: 'name' }],
+      }],
+    }, JSON.stringify({ rows: [{ name: '<script>alert(1)</script>' }] }), 'a') ?? '');
+    expect(out).not.toContain('<script>alert');
+    expect(out).toContain('&lt;script&gt;');
+  });
+});

--- a/packages/dashboard/src/views/output-widgets.ts
+++ b/packages/dashboard/src/views/output-widgets.ts
@@ -447,9 +447,30 @@ export function renderOutputWidget(
     case 'raw':
       body = renderRaw(filtered, fields);
       break;
-    case 'dashboard':
-      body = renderDashboard(filtered, fields);
+    case 'dashboard': {
+      // Dashboards may declare `type: table` fields backed by top-level
+      // arrays in the parsed JSON. Build the array map once, then run the
+      // existing sort/filter/paginate engine over it so table fields share
+      // the same controls grammar (and per-field URL state) as ai-template
+      // widgets. Fields without a matching array render nothing — the
+      // table-rendering branch handles that.
+      const arraysForTable: Record<string, unknown> = {};
+      const tableFields = (filtered.fields ?? []).filter((f) => f.type === 'table');
+      if (tableFields.length > 0) {
+        const parsed = parseJsonFromOutput(output);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          for (const f of tableFields) {
+            const v = (parsed as Record<string, unknown>)[f.name];
+            if (Array.isArray(v)) arraysForTable[f.name] = v;
+          }
+        }
+        if (controlState) {
+          arrayMeta = applyControlsToArrayData(arraysForTable, filtered, controlState);
+        }
+      }
+      body = renderDashboard(filtered, fields, arraysForTable);
       break;
+    }
     case 'ai-template': {
       const r = renderAiTemplate(filtered, output, fields, controlState);
       body = r.body;
@@ -1076,16 +1097,30 @@ function renderRaw(
 function renderDashboard(
   schema: OutputWidgetSchema,
   fields: Record<string, string | undefined>,
+  /** Top-level arrays for `table` fields, already filtered/sorted/paged by
+   *  `applyControlsToArrayData`. Keyed by the field's `name`. Absent / non-
+   *  array entries render as an empty-state caption under the column header. */
+  arrays: Record<string, unknown> = {},
 ): SafeHtml {
   const heroes: SafeHtml[] = [];
   const badges: SafeHtml[] = [];
   const stats: SafeHtml[] = [];
   const texts: SafeHtml[] = [];
+  const tables: SafeHtml[] = [];
 
   for (const f of schema.fields ?? []) {
+    const label = f.label ?? f.name;
+
+    // `table` reads from the arrays map, not the fields map — top-level
+    // array data is structured (objects per row), so it bypasses the
+    // scalar field extractor.
+    if (f.type === 'table') {
+      tables.push(renderTableField(f, arrays[f.name]));
+      continue;
+    }
+
     const value = fields[f.name];
     if (value === undefined) continue;
-    const label = f.label ?? f.name;
 
     if (f.type === 'metric') {
       heroes.push(html`
@@ -1123,8 +1158,12 @@ function renderDashboard(
   // Combine heroes + badges into one top row so badges sit alongside metrics
   const topRow = [...heroes, ...badges];
 
+  // Tables expand to fill width — drop the 480px cap when any are present
+  // so columns have room to breathe.
+  const widthCap = tables.length > 0 ? '' : 'max-width: 480px;';
+
   return html`
-    <div class="output-widget output-widget--dashboard" style="display: flex; flex-direction: column; gap: var(--space-3); max-width: 480px;">
+    <div class="output-widget output-widget--dashboard" style="display: flex; flex-direction: column; gap: var(--space-3); ${unsafeHtml(widthCap)}">
       ${topRow.length > 0 ? html`
         <div style="display: flex; gap: var(--space-4); justify-content: center; align-items: flex-start; padding: var(--space-2) 0; flex-wrap: wrap;">
           ${topRow as unknown as SafeHtml[]}
@@ -1140,6 +1179,63 @@ function renderDashboard(
           ${texts as unknown as SafeHtml[]}
         </div>
       ` : html``}
+      ${tables.length > 0 ? html`
+        <div style="display: flex; flex-direction: column; gap: var(--space-4);">
+          ${tables as unknown as SafeHtml[]}
+        </div>
+      ` : html``}
     </div>
+  `;
+}
+
+/**
+ * Render a `type: table` field as an HTML table. `value` is the (possibly
+ * filtered/sorted/paged) array for this field; non-array / empty values
+ * render the header row + a "No rows" caption so the column structure stays
+ * visible. Cells are escaped text by default; `format: "link"` columns wrap
+ * the cell value in an `<a href>` driven by the per-row key named in `href`,
+ * with display text drawn from `text` (also a per-row key, or — if no row
+ * has that key — a literal string fallback like "Open").
+ */
+function renderTableField(field: WidgetField, value: unknown): SafeHtml {
+  const label = field.label ?? field.name;
+  const cols = field.columns ?? [];
+  const rows = Array.isArray(value) ? value : [];
+
+  const headerCells = cols.map((c) => html`
+    <th style="text-align: left; padding: var(--space-2); border-bottom: 2px solid var(--color-border); font-size: var(--font-size-xs); text-transform: uppercase; letter-spacing: 0.05em; color: var(--color-text-muted);">${c.label ?? c.name}</th>
+  `);
+
+  const bodyRows = rows.map((rawRow) => {
+    const row = (rawRow && typeof rawRow === 'object' ? rawRow : {}) as Record<string, unknown>;
+    const cells = cols.map((c) => {
+      const raw = row[c.name];
+      const cellText = raw == null ? '' : String(raw);
+      if (c.format === 'link') {
+        const href = c.href ? row[c.href] : undefined;
+        // `text` is per-row key when one exists on the row; otherwise treat
+        // as a literal label (so `text: "Open"` works without every row
+        // needing an `open` field).
+        const textRaw = c.text && c.text in row ? row[c.text] : c.text;
+        const display = (textRaw == null || textRaw === '') ? cellText : String(textRaw);
+        if (href != null && href !== '') {
+          return html`<td style="padding: var(--space-2); border-bottom: 1px solid var(--color-border); font-size: var(--font-size-sm);"><a href="${String(href)}" target="_blank" rel="noopener">${display}</a></td>`;
+        }
+        return html`<td style="padding: var(--space-2); border-bottom: 1px solid var(--color-border); font-size: var(--font-size-sm);">${display}</td>`;
+      }
+      return html`<td style="padding: var(--space-2); border-bottom: 1px solid var(--color-border); font-size: var(--font-size-sm);">${cellText}</td>`;
+    });
+    return html`<tr>${cells as unknown as SafeHtml[]}</tr>`;
+  });
+
+  return html`
+    <section class="output-widget__table" data-field="${field.name}">
+      ${field.label ? html`<h4 style="margin: 0 0 var(--space-2); font-size: var(--font-size-sm); color: var(--color-text-muted);">${label}</h4>` : html``}
+      <table style="width: 100%; border-collapse: collapse;">
+        <thead><tr>${headerCells as unknown as SafeHtml[]}</tr></thead>
+        <tbody>${bodyRows as unknown as SafeHtml[]}</tbody>
+      </table>
+      ${rows.length === 0 ? html`<p class="dim" style="font-size: var(--font-size-xs); margin: var(--space-2) 0 0;">No rows.</p>` : html``}
+    </section>
   `;
 }


### PR DESCRIPTION
## Summary

Adds a `type: table` field for `dashboard` widgets — authors declare columns inline instead of writing `<table>` markup in an ai-template. Reads a top-level JSON array, renders a row per item, escapes cells by default, and supports `format: link` columns wired to per-row URL keys.

```yaml
outputWidget:
  type: dashboard
  fields:
    - name: matches            # reads outputs.matches
      type: table
      label: Job matches
      columns:
        - { name: company, label: Company }
        - { name: title,   label: Title }
        - { name: url,     label: Apply, format: link, href: url, text: "Apply →" }
  controls:
    - { type: sort,     field: matches, columns: [company, title] }
    - { type: filter,   field: matches, columns: [company, title] }
    - { type: paginate, field: matches, pageSize: 20 }
```

- `format: text` (default) — escapes the per-row cell value.
- `format: link` — wraps the cell in `<a href>`. `href` names the per-row JSON key holding the URL; `text` is either a per-row key OR a literal label fallback (e.g. `"Apply →"`). Missing/empty `href` falls back to plain text.
- Empty/missing arrays still render the header row + a "No rows" caption so column structure stays visible.
- Sort / filter / paginate `WidgetControl`s attach by sharing the field's `name` — same per-field URL state (`?ws_<field>=`, `?wf_<field>=`, `?wp_<field>=`) as ai-template widgets.
- Editor preview synthesises three sample rows so authors see the layout immediately.
- Cross-validation: `table` fields are only valid on `dashboard` widgets; `columns` is rejected on non-table fields; `format: link` without `href` is rejected; non-link columns with `href`/`text` are rejected.

## Test plan

- [x] `npx vitest run packages/core/src/output-widget-schema.test.ts packages/dashboard/src/views/output-widgets.test.ts` — 59 tests pass (7 new schema + 7 new render)
- [x] `npm test` — 1330 passing / 3 skipped (1316 baseline + 14 new). Test-data flake on first run is the documented pre-existing race; clean on second run.
- [x] Rendered the table inline against the real greenhouse-search-discovered run JSON locally — 3 rows with `Apply →` links, sort chips, filter input, and replay button all render.
- [ ] After merge: hard-refresh `http://127.0.0.1:3000/agents/greenhouse-search-discovered` (current production agent still uses ai-template; can be migrated in a follow-up).

## Trade-offs

- **MVP column formats**: shipped `text` + `link`. `badge` / `code` / `number` formats deliberately deferred — easy to add later when an agent needs them.
- **No file split**: `packages/dashboard/src/views/output-widgets.ts` is now ~1010 LOC. A no-feature split can follow if the file becomes obnoxious to navigate.
- **Catalog size cap bumped 12500 → 14000**: added ~1500 chars of table-field docs to help the planner LLM author tables correctly without a round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)