### PR TITLE
fix(widget): editor Save preserves columns / controls / actions

### DIFF
--- a/.changeset/widget-editor-preserves-columns-controls.md
+++ b/.changeset/widget-editor-preserves-columns-controls.md
@@ -1,0 +1,16 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Output Widget editor's Save no longer wipes `columns:` on table fields, `controls:`, or `actions:` — schema shapes the form doesn't yet surface are now carried forward from the previous version.
+
+The dashboard's Output Widget editor only has form fields for `name` / `label` / `type` per field plus the interactive-mode flags. Save used to rebuild `outputWidget` from scratch using only those inputs, silently dropping anything else — so any author who set up `controls:` / `actions:` via the YAML editor, or used the new `type: table` field (which requires `columns:`), would lose them on the next Save click. Preservation rules:
+
+- Per-field `columns:` carry forward when the field name AND type are both unchanged from the previous version. Switching a field's type away from `table` strips its `columns` (the new type can't use them).
+- Top-level `controls:` and `actions:` carry forward when the widget type is unchanged. A type switch implies "start over" — controls target arrays the new widget may not surface.
+
+Also adds `table` to the editor's `VALID_FIELD_TYPES` set (was missed in #286), so the type dropdown's `table` option actually saves through instead of being silently coerced to `text`.

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -2367,6 +2367,159 @@ describe('Output widget editor UI', () => {
     expect(saved?.outputWidget?.prompt).toBe('show the headline');
   });
 
+  it('POST /output-widget/update preserves columns on a table field across saves', async () => {
+    // Regression: the editor form has fields for name/label/type but no UI
+    // for `columns` yet. A naive Save would rebuild the schema and drop
+    // columns — wiping authored YAML on every click. Preserve them when
+    // the previous version had columns and the type stays `table`.
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'ow-table-preserve',
+      name: 'ow-table-preserve',
+      status: 'active',
+      source: 'local',
+      mcp: false,
+      nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
+      outputWidget: {
+        type: 'dashboard',
+        fields: [
+          { name: 'headline', type: 'text', label: 'Summary' },
+          {
+            name: 'matches', type: 'table', label: 'Matches',
+            columns: [
+              { name: 'company', label: 'Company' },
+              { name: 'url', label: 'Apply', format: 'link', href: 'url', text: 'Apply →' },
+            ],
+          },
+        ],
+      },
+    }, 'cli');
+
+    const res = await request(app).post('/agents/ow-table-preserve/output-widget/update')
+      .type('form').send({
+        action: 'save',
+        widgetType: 'dashboard',
+        fieldName_0: 'headline', fieldType_0: 'text', fieldLabel_0: 'Summary',
+        fieldName_1: 'matches', fieldType_1: 'table', fieldLabel_1: 'Matches',
+      })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    expect(res.status).toBe(303);
+    const saved = agentStore.getAgent('ow-table-preserve');
+    const matchField = saved?.outputWidget?.fields?.find((f) => f.name === 'matches');
+    expect(matchField?.type).toBe('table');
+    expect(matchField?.columns).toHaveLength(2);
+    expect(matchField?.columns?.[1]).toMatchObject({ name: 'url', format: 'link', href: 'url', text: 'Apply →' });
+  });
+
+  it('POST /output-widget/update preserves top-level controls across saves', async () => {
+    // Same shape of regression for `controls:` — the editor form doesn't
+    // surface them, so a Save would drop sort/filter/paginate/replay/etc.
+    // Only preserved when the widget type is unchanged (a type switch
+    // implies "start over").
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'ow-controls-preserve',
+      name: 'ow-controls-preserve',
+      status: 'active',
+      source: 'local',
+      mcp: false,
+      nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
+      outputWidget: {
+        type: 'dashboard',
+        fields: [{ name: 'rows', type: 'text' }],
+        controls: [
+          { type: 'sort', field: 'rows', columns: ['name'], default: 'name asc' },
+          { type: 'replay', label: 'Re-run' },
+        ],
+      },
+    }, 'cli');
+
+    const res = await request(app).post('/agents/ow-controls-preserve/output-widget/update')
+      .type('form').send({
+        action: 'save',
+        widgetType: 'dashboard',
+        fieldName_0: 'rows', fieldType_0: 'text',
+      })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    expect(res.status).toBe(303);
+    const saved = agentStore.getAgent('ow-controls-preserve');
+    expect(saved?.outputWidget?.controls).toHaveLength(2);
+    expect(saved?.outputWidget?.controls?.[0]).toMatchObject({ type: 'sort', field: 'rows' });
+    expect(saved?.outputWidget?.controls?.[1]).toMatchObject({ type: 'replay' });
+  });
+
+  it('POST /output-widget/update drops controls when the widget type changes', async () => {
+    // Type switch = "start over". sort/filter/paginate target arrays that
+    // the new widget type may not surface, so carrying them forward would
+    // produce broken control rows.
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'ow-controls-typeswitch',
+      name: 'ow-controls-typeswitch',
+      status: 'active',
+      source: 'local',
+      mcp: false,
+      nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
+      outputWidget: {
+        type: 'dashboard',
+        fields: [{ name: 'rows', type: 'text' }],
+        controls: [{ type: 'sort', field: 'rows', columns: ['name'] }],
+      },
+    }, 'cli');
+
+    const res = await request(app).post('/agents/ow-controls-typeswitch/output-widget/update')
+      .type('form').send({
+        action: 'save',
+        widgetType: 'key-value',
+        fieldName_0: 'rows', fieldType_0: 'text',
+      })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    expect(res.status).toBe(303);
+    const saved = agentStore.getAgent('ow-controls-typeswitch');
+    expect(saved?.outputWidget?.type).toBe('key-value');
+    expect(saved?.outputWidget?.controls ?? []).toHaveLength(0);
+  });
+
+  it('POST /output-widget/update strips columns when the field type changes away from table', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'ow-table-typeswitch',
+      name: 'ow-table-typeswitch',
+      status: 'active',
+      source: 'local',
+      mcp: false,
+      nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
+      outputWidget: {
+        type: 'dashboard',
+        fields: [{
+          name: 'rows', type: 'table',
+          columns: [{ name: 'a' }, { name: 'b' }],
+        }],
+      },
+    }, 'cli');
+
+    const res = await request(app).post('/agents/ow-table-typeswitch/output-widget/update')
+      .type('form').send({
+        action: 'save',
+        widgetType: 'dashboard',
+        fieldName_0: 'rows', fieldType_0: 'text',
+      })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    expect(res.status).toBe(303);
+    const saved = agentStore.getAgent('ow-table-typeswitch');
+    const field = saved?.outputWidget?.fields?.[0];
+    expect(field?.type).toBe('text');
+    expect(field?.columns).toBeUndefined();
+  });
+
   it('POST /output-widget/generate returns 400 with no prompt', async () => {
     const app = await makeApp();
     agentStore.createAgent({

--- a/packages/dashboard/src/routes/agent-inputs.ts
+++ b/packages/dashboard/src/routes/agent-inputs.ts
@@ -189,7 +189,7 @@ agentInputsRouter.get('/agents/:name/output-widget', (req: Request, res: Respons
 // ── Output widget update ────────────────────────────────────────────────
 
 const VALID_WIDGET_TYPES = new Set<string>(['dashboard', 'key-value', 'diff-apply', 'raw', 'ai-template']);
-const VALID_FIELD_TYPES = new Set<string>(['text', 'code', 'badge', 'action', 'metric', 'stat', 'preview']);
+const VALID_FIELD_TYPES = new Set<string>(['text', 'code', 'badge', 'action', 'metric', 'stat', 'preview', 'table']);
 
 agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
@@ -229,6 +229,15 @@ agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res:
   }
 
   // Collect fields from the form (fieldName_0, fieldLabel_0, fieldType_0, etc.).
+  // For richer field shapes the editor form doesn't yet know about (e.g. a
+  // `table` field's `columns`), copy them over from the previous version of
+  // the same-named field so a Save here doesn't wipe author-edited YAML.
+  // Pre-existing limitation: this means renaming a field via the editor
+  // loses its columns — acceptable for now since the editor doesn't expose
+  // a rename flow and columns are author-edited via YAML.
+  const prevFieldsByName = new Map<string, NonNullable<OutputWidgetSchema['fields']>[number]>();
+  for (const f of agent.outputWidget?.fields ?? []) prevFieldsByName.set(f.name, f);
+
   const fields: NonNullable<OutputWidgetSchema['fields']> = [];
   for (let i = 0; i < 50; i++) {
     const fieldName = body[`fieldName_${i}`];
@@ -236,10 +245,16 @@ agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res:
     const fieldType = body[`fieldType_${i}`];
     if (typeof fieldName !== 'string' || !fieldName.trim()) continue;
     const ft = typeof fieldType === 'string' && VALID_FIELD_TYPES.has(fieldType) ? fieldType : 'text';
+    const name = fieldName.trim();
+    const prev = prevFieldsByName.get(name);
     fields.push({
-      name: fieldName.trim(),
+      name,
       ...(typeof fieldLabel === 'string' && fieldLabel.trim() ? { label: fieldLabel.trim() } : {}),
       type: ft as WidgetFieldType,
+      // Carry `columns` forward when the type still wants them (only `table`
+      // today). Stripped on type changes so e.g. switching table → text
+      // doesn't smuggle a stale `columns` array into a field that can't use it.
+      ...(ft === 'table' && prev?.type === 'table' && prev.columns ? { columns: prev.columns } : {}),
     });
   }
 
@@ -257,6 +272,14 @@ agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res:
     ? body.widget_ask_label.trim() : undefined;
   const replayLabel = typeof body.widget_replay_label === 'string' && body.widget_replay_label.trim()
     ? body.widget_replay_label.trim() : undefined;
+
+  // Carry over schema shapes the editor form doesn't surface, but only
+  // when staying on the same widget type — a type change implies "start
+  // over", so `actions` (diff-apply only) and `controls` (per-type
+  // semantics) shouldn't survive a switch.
+  const sameType = agent.outputWidget?.type === widgetType;
+  const prevControls = sameType ? agent.outputWidget?.controls : undefined;
+  const prevActions = sameType ? agent.outputWidget?.actions : undefined;
 
   let outputWidget: OutputWidgetSchema;
   if (widgetType === 'ai-template') {
@@ -276,6 +299,8 @@ agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res:
       ...(interactive && runInputs ? { runInputs } : {}),
       ...(interactive && askLabel ? { askLabel } : {}),
       ...(interactive && replayLabel ? { replayLabel } : {}),
+      ...(prevControls?.length ? { controls: prevControls } : {}),
+      ...(prevActions?.length ? { actions: prevActions } : {}),
     };
   } else {
     // Typed widgets (dashboard / key-value / diff-apply / raw) are
@@ -307,6 +332,8 @@ agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res:
       ...(interactive && runInputs ? { runInputs } : {}),
       ...(interactive && askLabel ? { askLabel } : {}),
       ...(interactive && replayLabel ? { replayLabel } : {}),
+      ...(prevControls?.length ? { controls: prevControls } : {}),
+      ...(prevActions?.length ? { actions: prevActions } : {}),
     };
   }
 


### PR DESCRIPTION
## Summary

- The Output Widget editor's Save handler rebuilt `outputWidget` from scratch using only `fieldName_N` / `fieldLabel_N` / `fieldType_N` form inputs plus the interactive-mode flags. Anything else got silently dropped.
- That dropped: per-field `columns:` (so `type: table` fields broke on every Save), top-level `controls:` (sort/filter/paginate/replay), and top-level `actions:` (diff-apply buttons).
- PR #286 made it user-visible because the new `type: table` field hard-requires `columns:`. I hit it dogfooding the greenhouse-search-discovered migration — saved a `type: table` widget via the YAML route, then a single Save click in the widget editor wiped it back to `type: text` with no columns.
- Also adds `table` to `VALID_FIELD_TYPES` (missed in #286) so the dropdown's `table` option actually saves through instead of being silently coerced to `text`.

## Preservation rules

- **Per-field `columns:`** carry forward when the field's name AND type are both unchanged. Switching a field's type away from `table` strips its columns (the new type can't use them).
- **Top-level `controls:` and `actions:`** carry forward when the widget type is unchanged. A type switch implies "start over" — controls target arrays the new widget may not surface.

Out of scope: building UI to edit columns / controls inside the editor. Anyone who needs to modify them today still uses the YAML editor. This PR just makes sure the editor stops *destroying* them.

## Test plan

- [x] 4 new tests in `dashboard.test.ts` covering: columns preserved on table-field Save, controls preserved on same-type Save, controls dropped on type switch, columns dropped on field-type change away from table
- [x] `npx vitest run packages/dashboard/src/dashboard.test.ts -t output-widget` — all 10 pass
- [x] `npm test` — 1333 passing / 3 skipped (1330 baseline + 4 new − 1 unrelated mcp-servers order-dependent flake that passes in isolation)
- [ ] After merge: restart daemon, then click Save on the greenhouse-search-discovered output widget → confirm `matches` field still has `type: table` + columns and `controls` array survives

🤖 Generated with [Claude Code](https://claude.com/claude-code)