### PR TITLE
feat(widget): edit table-field columns inline in Output Widget editor

### DIFF
--- a/.changeset/editor-columns-ui.md
+++ b/.changeset/editor-columns-ui.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Output Widget editor: edit `table` field columns inline (no more YAML-only round-trip).
+
+Each `type: table` field now expands a sub-table with one row per column (Column key / Label / Format / Href key / Text key-or-literal / delete). The Format dropdown toggles between `text` and `link`; switching a field's type to `table` seeds an empty column row so the schema validator doesn't immediately reject. Removing a column doesn't reshuffle indices — the parser skips gaps. `href`/`text` are only saved when format=link (schema would reject them on text columns).
+
+The previous-version preservation from #287 still kicks in when the form posts no columns for an existing table field (so non-dashboard callers — CLI/MCP/custom integrations — don't get destroyed), but form-posted columns now win whenever they're present, which is what makes the editor actually editable.
+
+Controls (`sort` / `filter` / `paginate` / `replay`) and `actions` are still YAML-only to edit; those get their own follow-up. They're still preserved across saves per #287.

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -2520,6 +2520,121 @@ describe('Output widget editor UI', () => {
     expect(field?.columns).toBeUndefined();
   });
 
+  it('POST /output-widget/update saves columns posted from the editor form', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'ow-col-create', name: 'ow-col-create', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
+    }, 'cli');
+
+    const res = await request(app).post('/agents/ow-col-create/output-widget/update')
+      .type('form').send({
+        action: 'save',
+        widgetType: 'dashboard',
+        fieldName_0: 'matches', fieldType_0: 'table', fieldLabel_0: 'Matches',
+        columnName_0_0: 'company', columnLabel_0_0: 'Company',
+        columnFormat_0_0: 'text',
+        columnName_0_1: 'url', columnLabel_0_1: 'Apply',
+        columnFormat_0_1: 'link', columnHref_0_1: 'url', columnText_0_1: 'Apply →',
+      })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    expect(res.status).toBe(303);
+    const saved = agentStore.getAgent('ow-col-create');
+    const field = saved?.outputWidget?.fields?.[0];
+    expect(field?.type).toBe('table');
+    expect(field?.columns).toHaveLength(2);
+    expect(field?.columns?.[0]).toEqual({ name: 'company', label: 'Company' });
+    expect(field?.columns?.[1]).toEqual({ name: 'url', label: 'Apply', format: 'link', href: 'url', text: 'Apply →' });
+  });
+
+  it('POST /output-widget/update strips href/text from non-link columns', async () => {
+    // Schema validator would reject href/text on a non-link column; the
+    // parser drops them server-side so the user can switch format=link →
+    // text without having to first clear the href input.
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'ow-col-strip', name: 'ow-col-strip', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
+    }, 'cli');
+
+    const res = await request(app).post('/agents/ow-col-strip/output-widget/update')
+      .type('form').send({
+        action: 'save',
+        widgetType: 'dashboard',
+        fieldName_0: 'rows', fieldType_0: 'table',
+        columnName_0_0: 'name',
+        columnFormat_0_0: 'text', columnHref_0_0: 'leftover_href', columnText_0_0: 'leftover_text',
+      })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    expect(res.status).toBe(303);
+    const saved = agentStore.getAgent('ow-col-strip');
+    const col = saved?.outputWidget?.fields?.[0]?.columns?.[0];
+    expect(col).toEqual({ name: 'name' }); // no format/href/text
+  });
+
+  it('POST /output-widget/update column-edit overrides the prev-version fallback', async () => {
+    // #287 carries previous columns forward when the form is silent.
+    // Verify the form-posted columns WIN when both are present (i.e. the
+    // editor actually edits, not just preserves).
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'ow-col-override', name: 'ow-col-override', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
+      outputWidget: {
+        type: 'dashboard',
+        fields: [{
+          name: 'rows', type: 'table',
+          columns: [{ name: 'OLD_COL' }, { name: 'OLD_COL_2' }],
+        }],
+      },
+    }, 'cli');
+
+    const res = await request(app).post('/agents/ow-col-override/output-widget/update')
+      .type('form').send({
+        action: 'save',
+        widgetType: 'dashboard',
+        fieldName_0: 'rows', fieldType_0: 'table',
+        columnName_0_0: 'NEW_COL',
+      })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    expect(res.status).toBe(303);
+    const saved = agentStore.getAgent('ow-col-override');
+    expect(saved?.outputWidget?.fields?.[0]?.columns).toEqual([{ name: 'NEW_COL' }]);
+  });
+
+  it('POST /output-widget/update tolerates gaps in column indices', async () => {
+    // Removing a column in the UI doesn't reshuffle indices — the row
+    // just disappears. Make sure the parser skips missing indices and
+    // returns a clean array.
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'ow-col-gaps', name: 'ow-col-gaps', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
+    }, 'cli');
+
+    const res = await request(app).post('/agents/ow-col-gaps/output-widget/update')
+      .type('form').send({
+        action: 'save',
+        widgetType: 'dashboard',
+        fieldName_0: 'rows', fieldType_0: 'table',
+        columnName_0_0: 'a',
+        // gap at index 1 — author removed it via UI
+        columnName_0_2: 'c',
+      })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    expect(res.status).toBe(303);
+    const saved = agentStore.getAgent('ow-col-gaps');
+    expect(saved?.outputWidget?.fields?.[0]?.columns).toEqual([{ name: 'a' }, { name: 'c' }]);
+  });
+
   it('POST /output-widget/generate returns 400 with no prompt', async () => {
     const app = await makeApp();
     agentStore.createAgent({

--- a/packages/dashboard/src/routes/agent-inputs.ts
+++ b/packages/dashboard/src/routes/agent-inputs.ts
@@ -190,6 +190,41 @@ agentInputsRouter.get('/agents/:name/output-widget', (req: Request, res: Respons
 
 const VALID_WIDGET_TYPES = new Set<string>(['dashboard', 'key-value', 'diff-apply', 'raw', 'ai-template']);
 const VALID_FIELD_TYPES = new Set<string>(['text', 'code', 'badge', 'action', 'metric', 'stat', 'preview', 'table']);
+const VALID_COLUMN_FORMATS = new Set<string>(['text', 'link']);
+
+/**
+ * Pull column rows posted by the editor's table-field sub-table.
+ * Form names follow `columnName_<fieldIdx>_<colIdx>` (plus Label / Format
+ * / Href / Text). Walks 0..49 colIdx and skips gaps so removing a column
+ * via the UI (which doesn't reshuffle indices) still parses cleanly.
+ *
+ * `href` / `text` only carry through when `format === 'link'` — the
+ * schema validator rejects them on non-link columns and we'd otherwise
+ * smuggle stale form values into a failed save.
+ */
+function parseColumnsFromBody(body: Record<string, unknown>, fieldIdx: number): Array<{
+  name: string; label?: string; format?: 'text' | 'link'; href?: string; text?: string;
+}> {
+  const cols: Array<{ name: string; label?: string; format?: 'text' | 'link'; href?: string; text?: string }> = [];
+  for (let j = 0; j < 50; j++) {
+    const name = body[`columnName_${fieldIdx}_${j}`];
+    if (typeof name !== 'string' || !name.trim()) continue;
+    const label = body[`columnLabel_${fieldIdx}_${j}`];
+    const rawFormat = body[`columnFormat_${fieldIdx}_${j}`];
+    const format = typeof rawFormat === 'string' && VALID_COLUMN_FORMATS.has(rawFormat) ? (rawFormat as 'text' | 'link') : 'text';
+    const href = body[`columnHref_${fieldIdx}_${j}`];
+    const text = body[`columnText_${fieldIdx}_${j}`];
+    cols.push({
+      name: name.trim(),
+      ...(typeof label === 'string' && label.trim() ? { label: label.trim() } : {}),
+      // Omit format when it's the default to keep the saved schema concise.
+      ...(format !== 'text' ? { format } : {}),
+      ...(format === 'link' && typeof href === 'string' && href.trim() ? { href: href.trim() } : {}),
+      ...(format === 'link' && typeof text === 'string' && text.trim() ? { text: text.trim() } : {}),
+    });
+  }
+  return cols;
+}
 
 agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
@@ -247,14 +282,28 @@ agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res:
     const ft = typeof fieldType === 'string' && VALID_FIELD_TYPES.has(fieldType) ? fieldType : 'text';
     const name = fieldName.trim();
     const prev = prevFieldsByName.get(name);
+
+    // For table fields: read columns from the form. The editor now has
+    // editable column sub-rows (`columnName_<fieldIdx>_<colIdx>` etc).
+    // Fall back to the previous version's columns ONLY when the form
+    // carried no columns AND the field name+type are unchanged — keeps
+    // the no-UI-change save flow non-destructive for callers that don't
+    // yet post column inputs (CLI/MCP, custom integrations).
+    let columns: NonNullable<NonNullable<OutputWidgetSchema['fields']>[number]['columns']> | undefined;
+    if (ft === 'table') {
+      const parsed = parseColumnsFromBody(body, i);
+      if (parsed.length > 0) {
+        columns = parsed;
+      } else if (prev?.type === 'table' && prev.columns) {
+        columns = prev.columns;
+      }
+    }
+
     fields.push({
       name,
       ...(typeof fieldLabel === 'string' && fieldLabel.trim() ? { label: fieldLabel.trim() } : {}),
       type: ft as WidgetFieldType,
-      // Carry `columns` forward when the type still wants them (only `table`
-      // today). Stripped on type changes so e.g. switching table → text
-      // doesn't smuggle a stale `columns` array into a field that can't use it.
-      ...(ft === 'table' && prev?.type === 'table' && prev.columns ? { columns: prev.columns } : {}),
+      ...(columns ? { columns } : {}),
     });
   }
 
@@ -407,10 +456,12 @@ agentInputsRouter.post('/agents/:name/output-widget/preview', (req: Request, res
     const fieldType = body[`fieldType_${i}`];
     if (typeof fieldName !== 'string' || !fieldName.trim()) continue;
     const ft = typeof fieldType === 'string' && VALID_FIELD_TYPES.has(fieldType) ? fieldType : 'text';
+    const columns = ft === 'table' ? parseColumnsFromBody(body, i) : [];
     fields.push({
       name: fieldName.trim(),
       ...(typeof fieldLabel === 'string' && fieldLabel.trim() ? { label: fieldLabel.trim() } : {}),
       type: ft as WidgetFieldType,
+      ...(columns.length > 0 ? { columns } : {}),
     });
   }
 

--- a/packages/dashboard/src/views/agent-detail-helpers.ts
+++ b/packages/dashboard/src/views/agent-detail-helpers.ts
@@ -148,6 +148,32 @@ function fieldTypeSelect(name: string, current: string): string {
   return `<select name="${name}" style="padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs);">${opts}</select>`;
 }
 
+const COL_INPUT = 'padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs);';
+
+/** One column row inside a table-field's columns sub-table. */
+function renderColumnRow(fieldIdx: number, colIdx: number, col?: { name?: string; label?: string; format?: string; href?: string; text?: string }): string {
+  const name = col?.name ?? '';
+  const label = col?.label ?? '';
+  const format = col?.format ?? 'text';
+  const href = col?.href ?? '';
+  const text = col?.text ?? '';
+  const formatOpts = ['text', 'link'].map((f) => `<option value="${f}"${f === format ? ' selected' : ''}>${f}</option>`).join('');
+  return `
+    <tr data-column-row data-field-idx="${fieldIdx}" data-col-idx="${colIdx}">
+      <td><input type="text" name="columnName_${fieldIdx}_${colIdx}" value="${escapeAttr(name)}" placeholder="key" style="${COL_INPUT} font-family: var(--font-mono); width: 100%;"></td>
+      <td><input type="text" name="columnLabel_${fieldIdx}_${colIdx}" value="${escapeAttr(label)}" placeholder="${escapeAttr(name)}" style="${COL_INPUT} width: 100%;"></td>
+      <td><select name="columnFormat_${fieldIdx}_${colIdx}" style="${COL_INPUT}">${formatOpts}</select></td>
+      <td><input type="text" name="columnHref_${fieldIdx}_${colIdx}" value="${escapeAttr(href)}" placeholder="url_key" style="${COL_INPUT} font-family: var(--font-mono); width: 100%;"></td>
+      <td><input type="text" name="columnText_${fieldIdx}_${colIdx}" value="${escapeAttr(text)}" placeholder='text_key OR "Apply →"' style="${COL_INPUT} width: 100%;"></td>
+      <td><button type="button" class="btn btn--ghost btn--sm ow-remove-column" style="padding: 2px 6px; font-size: var(--font-size-xs); color: var(--color-err);">×</button></td>
+    </tr>
+  `;
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
 export function renderOutputWidgetEditor(agent: Agent): SafeHtml {
   const widget = agent.outputWidget;
   const currentType: OutputWidgetType = widget?.type ?? 'raw';
@@ -181,15 +207,46 @@ export function renderOutputWidgetEditor(agent: Agent): SafeHtml {
     ([key, ex]) => `<option value="${key}">${ex.label} — ${ex.description}</option>`,
   ).join('');
 
-  // Field rows
-  const fieldRows = (widget?.fields ?? []).map((f, i) => unsafeHtml(`
-    <tr data-row="${i}">
-      <td><input type="text" name="fieldName_${i}" value="${f.name}" style="${FIELD} font-family: var(--font-mono); width: 8rem;"></td>
-      <td><input type="text" name="fieldLabel_${i}" value="${f.label ?? ''}" placeholder="${f.name}" style="${FIELD} width: 8rem;"></td>
-      <td>${fieldTypeSelectWithTooltip(`fieldType_${i}`, f.type, currentType)}</td>
-      <td><button type="button" class="btn btn--ghost btn--sm ow-remove-row" style="padding: 2px 6px; font-size: var(--font-size-xs); color: var(--color-err);">\u00D7</button></td>
-    </tr>
-  `));
+  // Field rows. Each field gets a second <tr> for its columns sub-table
+  // (shown only when type === 'table'). Column names follow the
+  // `columnName_<fieldIdx>_<colIdx>` convention so the server can parse
+  // them in a per-field inner loop without ordering assumptions.
+  const fieldRows = (widget?.fields ?? []).flatMap((f, i) => {
+    const cols = f.type === 'table' ? (f.columns ?? []) : [];
+    const colsRowsHtml = cols.map((c, j) => renderColumnRow(i, j, c)).join('');
+    const colsBlockVisible = f.type === 'table';
+    return [
+      unsafeHtml(`
+        <tr data-field-row data-field-idx="${i}">
+          <td><input type="text" name="fieldName_${i}" value="${f.name}" style="${FIELD} font-family: var(--font-mono); width: 8rem;"></td>
+          <td><input type="text" name="fieldLabel_${i}" value="${f.label ?? ''}" placeholder="${f.name}" style="${FIELD} width: 8rem;"></td>
+          <td>${fieldTypeSelectWithTooltip(`fieldType_${i}`, f.type, currentType)}</td>
+          <td><button type="button" class="btn btn--ghost btn--sm ow-remove-row" style="padding: 2px 6px; font-size: var(--font-size-xs); color: var(--color-err);">\u00D7</button></td>
+        </tr>
+      `),
+      unsafeHtml(`
+        <tr data-columns-row data-field-idx="${i}" style="display: ${colsBlockVisible ? 'table-row' : 'none'};">
+          <td colspan="4" style="padding: 0 0 var(--space-3) var(--space-4); background: var(--color-surface);">
+            <div style="font-size: 10px; color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em; margin: var(--space-1) 0;">Columns</div>
+            <table class="table" style="font-size: var(--font-size-xs); width: 100%; margin: 0;">
+              <thead><tr>
+                <th style="width: 7rem;">Column key</th>
+                <th style="width: 7rem;">Label</th>
+                <th style="width: 5rem;">Format</th>
+                <th style="width: 7rem;" title="Per-row JSON key holding the URL (format=link only)">Href key</th>
+                <th title="Per-row JSON key for cell text, OR a literal string fallback (format=link only)">Text key / literal</th>
+                <th></th>
+              </tr></thead>
+              <tbody data-columns-tbody data-field-idx="${i}">
+                ${colsRowsHtml}
+              </tbody>
+            </table>
+            <button type="button" class="btn btn--ghost btn--sm ow-add-column" data-field-idx="${i}" style="margin-top: var(--space-2); font-size: var(--font-size-xs);">+ Add column</button>
+          </td>
+        </tr>
+      `),
+    ];
+  });
 
   const helperCopyJson = JSON.stringify(
     Object.fromEntries(WIDGET_TYPES.map((t) => [t, WIDGET_TYPE_INFO[t].helperCopy])),
@@ -389,18 +446,94 @@ export function renderOutputWidgetEditor(agent: Agent): SafeHtml {
         }).join('');
       }
 
+      // Tracks "next column index" per field so deleted columns don't
+      // reuse names — server iterates 0..49 and skips gaps, so we just
+      // never recycle. Keyed by field idx; defaults to existing length on
+      // first lookup so server-rendered columns aren't clobbered.
+      var nextColIdx = {};
+
+      function getNextColIdx(fieldIdx) {
+        if (nextColIdx[fieldIdx] == null) {
+          var colTbody = document.querySelector('tbody[data-columns-tbody][data-field-idx="' + fieldIdx + '"]');
+          nextColIdx[fieldIdx] = colTbody ? colTbody.rows.length : 0;
+        }
+        return nextColIdx[fieldIdx]++;
+      }
+
+      var COL_INPUT_STYLE = 'padding:var(--space-1) var(--space-2);border:1px solid var(--color-border-strong);border-radius:var(--radius-sm);font-size:var(--font-size-xs);';
+
+      function columnRowHtml(fieldIdx, colIdx, data) {
+        data = data || {};
+        var format = data.format || 'text';
+        var formatOpts = ['text', 'link'].map(function (f) {
+          return '<option value="' + f + '"' + (f === format ? ' selected' : '') + '>' + f + '</option>';
+        }).join('');
+        return '<td><input type="text" name="columnName_' + fieldIdx + '_' + colIdx + '" value="' + esc(data.name || '') + '" placeholder="key" style="' + COL_INPUT_STYLE + 'font-family:var(--font-mono);width:100%;"></td>' +
+          '<td><input type="text" name="columnLabel_' + fieldIdx + '_' + colIdx + '" value="' + esc(data.label || '') + '" placeholder="Label" style="' + COL_INPUT_STYLE + 'width:100%;"></td>' +
+          '<td><select name="columnFormat_' + fieldIdx + '_' + colIdx + '" style="' + COL_INPUT_STYLE + '">' + formatOpts + '</select></td>' +
+          '<td><input type="text" name="columnHref_' + fieldIdx + '_' + colIdx + '" value="' + esc(data.href || '') + '" placeholder="url_key" style="' + COL_INPUT_STYLE + 'font-family:var(--font-mono);width:100%;"></td>' +
+          '<td><input type="text" name="columnText_' + fieldIdx + '_' + colIdx + '" value="' + esc(data.text || '') + '" placeholder=\\'text_key OR "Apply →"\\' style="' + COL_INPUT_STYLE + 'width:100%;"></td>' +
+          '<td><button type="button" class="btn btn--ghost btn--sm ow-remove-column" style="padding:2px 6px;font-size:var(--font-size-xs);color:var(--color-err);">\\u00D7</button></td>';
+      }
+
+      function appendColumnRow(fieldIdx, data) {
+        var colTbody = document.querySelector('tbody[data-columns-tbody][data-field-idx="' + fieldIdx + '"]');
+        if (!colTbody) return;
+        var colIdx = getNextColIdx(fieldIdx);
+        var tr = document.createElement('tr');
+        tr.setAttribute('data-column-row', '');
+        tr.setAttribute('data-field-idx', String(fieldIdx));
+        tr.setAttribute('data-col-idx', String(colIdx));
+        tr.innerHTML = columnRowHtml(fieldIdx, colIdx, data);
+        colTbody.appendChild(tr);
+      }
+
+      function setColumnsVisibility(fieldIdx, visible) {
+        var row = document.querySelector('tr[data-columns-row][data-field-idx="' + fieldIdx + '"]');
+        if (row) row.style.display = visible ? 'table-row' : 'none';
+        if (visible) {
+          var colTbody = document.querySelector('tbody[data-columns-tbody][data-field-idx="' + fieldIdx + '"]');
+          if (colTbody && colTbody.rows.length === 0) {
+            // table fields need at least one column to pass schema validation;
+            // seed one empty row so the author has something to fill in.
+            appendColumnRow(fieldIdx);
+          }
+        }
+      }
+
       function addRow(data) {
         data = data || {};
-        var idx = tbody.rows.length;
-        var tr = document.createElement('tr');
-        tr.setAttribute('data-row', String(idx));
+        var idx = tbody.rows.length / 2; // each field is 2 trs (field row + columns row)
         var tip = FIELD_DESCS[data.type || 'text'] || '';
-        tr.innerHTML =
+        var type = data.type || 'text';
+        var fieldTr = document.createElement('tr');
+        fieldTr.setAttribute('data-field-row', '');
+        fieldTr.setAttribute('data-field-idx', String(idx));
+        fieldTr.innerHTML =
           '<td><input type="text" name="fieldName_' + idx + '" value="' + esc(data.name || '') + '" placeholder="field_name" style="padding:var(--space-1) var(--space-2);border:1px solid var(--color-border-strong);border-radius:var(--radius-sm);font-size:var(--font-size-xs);font-family:var(--font-mono);width:8rem;"></td>' +
           '<td><input type="text" name="fieldLabel_' + idx + '" value="' + esc(data.label || '') + '" placeholder="Label" style="padding:var(--space-1) var(--space-2);border:1px solid var(--color-border-strong);border-radius:var(--radius-sm);font-size:var(--font-size-xs);width:8rem;"></td>' +
-          '<td><select name="fieldType_' + idx + '" title="' + esc(tip) + '" style="padding:var(--space-1) var(--space-2);border:1px solid var(--color-border-strong);border-radius:var(--radius-sm);font-size:var(--font-size-xs);">' + typeOptionsHtml(data.type || 'text') + '</select></td>' +
+          '<td><select name="fieldType_' + idx + '" title="' + esc(tip) + '" style="padding:var(--space-1) var(--space-2);border:1px solid var(--color-border-strong);border-radius:var(--radius-sm);font-size:var(--font-size-xs);">' + typeOptionsHtml(type) + '</select></td>' +
           '<td><button type="button" class="btn btn--ghost btn--sm ow-remove-row" style="padding:2px 6px;font-size:var(--font-size-xs);color:var(--color-err);">\\u00D7</button></td>';
-        tbody.appendChild(tr);
+        tbody.appendChild(fieldTr);
+
+        var colsTr = document.createElement('tr');
+        colsTr.setAttribute('data-columns-row', '');
+        colsTr.setAttribute('data-field-idx', String(idx));
+        colsTr.style.display = type === 'table' ? 'table-row' : 'none';
+        colsTr.innerHTML =
+          '<td colspan="4" style="padding:0 0 var(--space-3) var(--space-4);background:var(--color-surface);">' +
+            '<div style="font-size:10px;color:var(--color-text-muted);text-transform:uppercase;letter-spacing:0.05em;margin:var(--space-1) 0;">Columns</div>' +
+            '<table class="table" style="font-size:var(--font-size-xs);width:100%;margin:0;">' +
+              '<thead><tr><th style="width:7rem;">Column key</th><th style="width:7rem;">Label</th><th style="width:5rem;">Format</th><th style="width:7rem;">Href key</th><th>Text key / literal</th><th></th></tr></thead>' +
+              '<tbody data-columns-tbody data-field-idx="' + idx + '"></tbody>' +
+            '</table>' +
+            '<button type="button" class="btn btn--ghost btn--sm ow-add-column" data-field-idx="' + idx + '" style="margin-top:var(--space-2);font-size:var(--font-size-xs);">+ Add column</button>' +
+          '</td>';
+        tbody.appendChild(colsTr);
+
+        // If the row was seeded as a table field with no columns, drop in a
+        // placeholder so the row is editable immediately.
+        if (type === 'table') setColumnsVisibility(idx, true);
       }
 
       function esc(s) { return String(s).replace(/[&<>"\\']/g, function (c) { return { '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"\\'":'&#39;' }[c]; }); }
@@ -456,13 +589,36 @@ export function renderOutputWidgetEditor(agent: Agent): SafeHtml {
       });
       addBtn.addEventListener('click', function () { addRow(); refreshFieldDimming(); refreshPreview(); });
       tbody.addEventListener('click', function (e) {
-        if (e.target && e.target.classList && e.target.classList.contains('ow-remove-row')) {
-          var tr = e.target.closest('tr');
-          if (tr) { tr.parentNode.removeChild(tr); refreshPreview(); }
+        var t = e.target;
+        if (!t || !t.classList) return;
+        if (t.classList.contains('ow-remove-row')) {
+          // Field row delete: also remove the matching columns sub-row.
+          var tr = t.closest('tr[data-field-row]');
+          if (tr) {
+            var idx = tr.getAttribute('data-field-idx');
+            var colsRow = document.querySelector('tr[data-columns-row][data-field-idx="' + idx + '"]');
+            tr.parentNode.removeChild(tr);
+            if (colsRow) colsRow.parentNode.removeChild(colsRow);
+            refreshPreview();
+          }
+        } else if (t.classList.contains('ow-add-column')) {
+          appendColumnRow(parseInt(t.getAttribute('data-field-idx'), 10));
+          refreshPreview();
+        } else if (t.classList.contains('ow-remove-column')) {
+          var colTr = t.closest('tr[data-column-row]');
+          if (colTr) { colTr.parentNode.removeChild(colTr); refreshPreview(); }
         }
       });
+      tbody.addEventListener('change', function (e) {
+        var t = e.target;
+        // Type select changed → show/hide the columns sub-row beneath it.
+        if (t && t.tagName === 'SELECT' && /^fieldType_(\\d+)$/.test(t.name)) {
+          var idx = parseInt(t.name.split('_')[1], 10);
+          setColumnsVisibility(idx, t.value === 'table');
+        }
+        refreshPreview();
+      });
       tbody.addEventListener('input', refreshPreview);
-      tbody.addEventListener('change', refreshPreview);
       exampleSel.addEventListener('change', function () {
         if (this.value) { loadExample(this.value); this.value = ''; }
       });


### PR DESCRIPTION
## Summary

Phase 1 of the editor-UI-for-table-things work queued after #286/#287. Adds an editable Columns sub-table under each `type: table` field row so authors can edit columns without dropping into YAML.

- Five inputs per column: Column key / Label / Format / Href key / Text key-or-literal + delete button
- "+ Add column" button per table field
- Switching a field's type to `table` auto-seeds one empty column row (schema requires ≥1 column)
- Type-change to/from `table` shows/hides the columns sub-row
- Removing a column doesn't reshuffle indices — server parser skips gaps
- `href`/`text` stripped server-side when format != link (schema rejects them on text columns)
- Live preview reflects column edits before save (both `/update` and `/preview` share `parseColumnsFromBody`)

The `prev → new` column fallback from #287 still applies when the form posts no columns (so CLI/MCP/custom integrations that don't yet post column inputs aren't destroyed), but form-posted columns win when present — that's what makes the editor actually editable.

## What's still YAML-only

Out of scope for this PR (intentional):
- Controls editor (sort / filter / paginate / replay) — separate PR; needs different UI patterns per control type
- Actions editor (diff-apply only — narrowest audience)

Both still preserved across saves per #287.

## Test plan

- [x] 4 new tests in `dashboard.test.ts` covering: columns posted from form save through; href/text stripped on non-link columns; form-posted columns win over prev fallback; gaps in column indices tolerated
- [x] `npx vitest run packages/dashboard/src/dashboard.test.ts -t output-widget` — all 14 pass
- [x] `npm test` — 1338 passing / 3 skipped (1334 baseline + 4 new)
- [ ] After merge: open the greenhouse-search-discovered Output Widget editor → confirm the Columns sub-table renders for the `matches` field, edits round-trip through Save without dropping columns, deleting a column survives

🤖 Generated with [Claude Code](https://claude.com/claude-code)