### PR TITLE
feat(widget): edit all 6 control types + actions inline in Output Widget editor

### DIFF
--- a/.changeset/editor-controls-ui.md
+++ b/.changeset/editor-controls-ui.md
@@ -1,0 +1,20 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Output Widget editor: edit all 6 `controls` types inline (sort / filter / paginate / replay / field-toggle / view-switch).
+
+Phase 2 of the editor-UI-for-table-things work after #288 (columns editor). A new collapsible Controls section between Fields and Interactive renders one bordered row per control with the type-select up top and per-type inputs below. The active type's inputs show; the rest are hidden but still SSR'd so toggling the type select via JS just swaps visibility (no rebuilds).
+
+- **sort** / **filter** / **paginate**: array name + columns (csv) + per-type knobs (default `col asc`, placeholder, pageSize). Pair with `type: table` fields by sharing the array name.
+- **replay**: optional label + optional inputs subset (csv). Re-runs the agent inline. The auto-synthesised replay from interactive mode still applies when none is declared.
+- **field-toggle**: label + toggleable fields (csv) + default (shown / hidden).
+- **view-switch**: label + views JSON (rarest type — nested `[{id, fields[]}]` edited as JSON in a textarea for now) + default view id.
+
+The editor now posts a hidden `widget_controls_edited=1` sentinel so the server can distinguish "user deleted all controls" (honour deletion) from "non-editor caller silent on controls" (keep #287's prev-version preservation). Empty / half-built control rows skip silently instead of failing schema validation. Malformed view-switch JSON drops just that row.
+
+Tests cover all 6 types parsing, the empty-edit sentinel path, the non-editor preservation path, and the malformed-JSON skip.

--- a/.changeset/editor-controls-ui.md
+++ b/.changeset/editor-controls-ui.md
@@ -6,7 +6,7 @@
 "@some-useful-agents/dashboard": minor
 ---
 
-Output Widget editor: edit all 6 `controls` types inline (sort / filter / paginate / replay / field-toggle / view-switch).
+Output Widget editor: edit all 6 `controls` types inline (sort / filter / paginate / replay / field-toggle / view-switch) plus the `actions` array.
 
 Phase 2 of the editor-UI-for-table-things work after #288 (columns editor). A new collapsible Controls section between Fields and Interactive renders one bordered row per control with the type-select up top and per-type inputs below. The active type's inputs show; the rest are hidden but still SSR'd so toggling the type select via JS just swaps visibility (no rebuilds).
 
@@ -15,6 +15,10 @@ Phase 2 of the editor-UI-for-table-things work after #288 (columns editor). A ne
 - **field-toggle**: label + toggleable fields (csv) + default (shown / hidden).
 - **view-switch**: label + views JSON (rarest type — nested `[{id, fields[]}]` edited as JSON in a textarea for now) + default view id.
 
-The editor now posts a hidden `widget_controls_edited=1` sentinel so the server can distinguish "user deleted all controls" (honour deletion) from "non-editor caller silent on controls" (keep #287's prev-version preservation). Empty / half-built control rows skip silently instead of failing schema validation. Malformed view-switch JSON drops just that row.
+Also adds an Actions editor (POST buttons used by `diff-apply` widgets) with `id` / `label` / `endpoint` / optional `payloadField` inputs per row. Method is locked to POST per the schema.
 
-Tests cover all 6 types parsing, the empty-edit sentinel path, the non-editor preservation path, and the malformed-JSON skip.
+The editor now posts hidden `widget_controls_edited=1` and `widget_actions_edited=1` sentinels so the server can distinguish "user deleted all controls/actions" (honour deletion) from "non-editor caller silent" (keep #287's prev-version preservation). Empty / half-built control or action rows skip silently instead of failing schema validation. Malformed view-switch JSON drops just that row.
+
+After this PR the editor handles fields + columns + controls + actions end-to-end — no remaining YAML-only widget shapes.
+
+Tests cover all 6 control types parsing, the empty-edit sentinel path, the non-editor preservation path, malformed-JSON skip, plus action create / skip-on-missing-required / empty-edit / non-editor preservation.

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -2635,6 +2635,191 @@ describe('Output widget editor UI', () => {
     expect(saved?.outputWidget?.fields?.[0]?.columns).toEqual([{ name: 'a' }, { name: 'c' }]);
   });
 
+  it('POST /output-widget/update saves all 6 control types posted from the editor', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'ow-ctl-all', name: 'ow-ctl-all', status: 'active', source: 'local', mcp: false,
+      inputs: { Q: { type: 'string' } },
+      nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
+    }, 'cli');
+
+    const res = await request(app).post('/agents/ow-ctl-all/output-widget/update')
+      .type('form').send({
+        action: 'save',
+        widgetType: 'dashboard',
+        widget_controls_edited: '1',
+        fieldName_0: 'matches', fieldType_0: 'table',
+        columnName_0_0: 'company',
+        fieldName_1: 'detail', fieldType_1: 'text',
+        // sort
+        controlType_0: 'sort',
+        controlLabel_0_sort: 'Sort by',
+        controlField_0_sort: 'matches',
+        controlColumns_0_sort: 'company, title',
+        controlDefault_0_sort: 'company asc',
+        // filter
+        controlType_1: 'filter',
+        controlField_1_filter: 'matches',
+        controlColumns_1_filter: 'company',
+        controlPlaceholder_1: 'Find a match…',
+        // paginate
+        controlType_2: 'paginate',
+        controlField_2_paginate: 'matches',
+        controlPageSize_2: '25',
+        // replay
+        controlType_3: 'replay',
+        controlLabel_3_replay: 'Re-run',
+        controlInputs_3: 'Q',
+        // field-toggle
+        controlType_4: 'field-toggle',
+        controlLabel_4_field_toggle: 'Show',
+        // (note: the form name uses a hyphen; tests must match. The
+        // editor JS reads the type string, so use the exact key.)
+        ['controlLabel_4_field-toggle']: 'Show',
+        controlFields_4: 'detail',
+        ['controlDefault_4_field-toggle']: 'hidden',
+        // view-switch
+        controlType_5: 'view-switch',
+        ['controlLabel_5_view-switch']: 'Units',
+        controlViews_5: JSON.stringify([
+          { id: 'metric', fields: ['matches'] },
+          { id: 'imperial', fields: ['detail'] },
+        ]),
+        ['controlDefault_5_view-switch']: 'metric',
+      })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    expect(res.status).toBe(303);
+    const saved = agentStore.getAgent('ow-ctl-all');
+    const controls = saved?.outputWidget?.controls ?? [];
+    expect(controls).toHaveLength(6);
+    expect(controls[0]).toMatchObject({ type: 'sort', label: 'Sort by', field: 'matches', columns: ['company', 'title'], default: 'company asc' });
+    expect(controls[1]).toMatchObject({ type: 'filter', field: 'matches', columns: ['company'], placeholder: 'Find a match…' });
+    expect(controls[2]).toMatchObject({ type: 'paginate', field: 'matches', pageSize: 25 });
+    expect(controls[3]).toMatchObject({ type: 'replay', label: 'Re-run', inputs: ['Q'] });
+    expect(controls[4]).toMatchObject({ type: 'field-toggle', label: 'Show', fields: ['detail'], default: 'hidden' });
+    expect(controls[5]).toMatchObject({ type: 'view-switch', label: 'Units', default: 'metric' });
+    expect((controls[5] as { views: Array<{ id: string }> }).views.map((v) => v.id)).toEqual(['metric', 'imperial']);
+  });
+
+  it('POST /output-widget/update skips a control row whose required-by-type fields are missing', async () => {
+    // sort needs both field AND columns — a row with only the type
+    // dropdown set (e.g. user clicked "+ Add control" then Save without
+    // filling it in) should be silently dropped, not saved as a broken
+    // control that fails schema validation.
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'ow-ctl-skip', name: 'ow-ctl-skip', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
+    }, 'cli');
+
+    const res = await request(app).post('/agents/ow-ctl-skip/output-widget/update')
+      .type('form').send({
+        action: 'save',
+        widgetType: 'dashboard',
+        widget_controls_edited: '1',
+        fieldName_0: 'rows', fieldType_0: 'text',
+        controlType_0: 'sort',
+        // no field / no columns — should be dropped silently
+      })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    expect(res.status).toBe(303);
+    const saved = agentStore.getAgent('ow-ctl-skip');
+    expect(saved?.outputWidget?.controls ?? []).toHaveLength(0);
+  });
+
+  it('POST /output-widget/update honours an explicit "delete all controls" via the editor sentinel', async () => {
+    // Without the sentinel, the prev-version fallback would silently
+    // re-add the controls after the user emptied the list. Verify the
+    // editor's `widget_controls_edited=1` hidden input distinguishes
+    // "user emptied" from "non-editor caller silent on controls".
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'ow-ctl-empty', name: 'ow-ctl-empty', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
+      outputWidget: {
+        type: 'dashboard',
+        fields: [{ name: 'rows', type: 'text' }],
+        controls: [{ type: 'sort', field: 'rows', columns: ['name'] }],
+      },
+    }, 'cli');
+
+    const res = await request(app).post('/agents/ow-ctl-empty/output-widget/update')
+      .type('form').send({
+        action: 'save',
+        widgetType: 'dashboard',
+        widget_controls_edited: '1',
+        fieldName_0: 'rows', fieldType_0: 'text',
+        // No controlType_N posted — user deleted them all in the UI.
+      })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    expect(res.status).toBe(303);
+    const saved = agentStore.getAgent('ow-ctl-empty');
+    expect(saved?.outputWidget?.controls ?? []).toHaveLength(0);
+  });
+
+  it('POST /output-widget/update without the editor sentinel preserves controls (non-editor caller)', async () => {
+    // CLI/MCP/custom POSTs don't know about the editor's hidden input.
+    // They should still benefit from the #287 prev-version preservation
+    // so a CLI save that's silent on controls doesn't wipe them.
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'ow-ctl-cli', name: 'ow-ctl-cli', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
+      outputWidget: {
+        type: 'dashboard',
+        fields: [{ name: 'rows', type: 'text' }],
+        controls: [{ type: 'sort', field: 'rows', columns: ['name'] }],
+      },
+    }, 'cli');
+
+    const res = await request(app).post('/agents/ow-ctl-cli/output-widget/update')
+      .type('form').send({
+        action: 'save',
+        widgetType: 'dashboard',
+        // No widget_controls_edited sentinel + no controlType_N — non-editor caller.
+        fieldName_0: 'rows', fieldType_0: 'text',
+      })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    expect(res.status).toBe(303);
+    const saved = agentStore.getAgent('ow-ctl-cli');
+    expect(saved?.outputWidget?.controls).toHaveLength(1);
+    expect(saved?.outputWidget?.controls?.[0]).toMatchObject({ type: 'sort' });
+  });
+
+  it('POST /output-widget/update drops a view-switch row with malformed views JSON', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'ow-ctl-badjson', name: 'ow-ctl-badjson', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
+    }, 'cli');
+
+    const res = await request(app).post('/agents/ow-ctl-badjson/output-widget/update')
+      .type('form').send({
+        action: 'save',
+        widgetType: 'dashboard',
+        widget_controls_edited: '1',
+        fieldName_0: 'rows', fieldType_0: 'text',
+        controlType_0: 'view-switch',
+        ['controlLabel_0_view-switch']: 'Units',
+        controlViews_0: '[{not valid json',
+        ['controlDefault_0_view-switch']: 'metric',
+      })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    expect(res.status).toBe(303);
+    const saved = agentStore.getAgent('ow-ctl-badjson');
+    expect(saved?.outputWidget?.controls ?? []).toHaveLength(0);
+  });
+
   it('POST /output-widget/generate returns 400 with no prompt', async () => {
     const app = await makeApp();
     agentStore.createAgent({

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -2820,6 +2820,119 @@ describe('Output widget editor UI', () => {
     expect(saved?.outputWidget?.controls ?? []).toHaveLength(0);
   });
 
+  it('POST /output-widget/update saves actions posted from the editor', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'ow-act-create', name: 'ow-act-create', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
+    }, 'cli');
+
+    const res = await request(app).post('/agents/ow-act-create/output-widget/update')
+      .type('form').send({
+        action: 'save',
+        widgetType: 'diff-apply',
+        widget_actions_edited: '1',
+        fieldName_0: 'classification', fieldType_0: 'badge',
+        fieldName_1: 'yaml', fieldType_1: 'code',
+        actionId_0: 'apply',
+        actionLabel_0: 'Apply patch',
+        actionEndpoint_0: '/agents/{agentId}/diff/apply',
+        actionPayloadField_0: 'yaml',
+      })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    expect(res.status).toBe(303);
+    const saved = agentStore.getAgent('ow-act-create');
+    expect(saved?.outputWidget?.actions).toHaveLength(1);
+    expect(saved?.outputWidget?.actions?.[0]).toEqual({
+      id: 'apply',
+      label: 'Apply patch',
+      method: 'POST',
+      endpoint: '/agents/{agentId}/diff/apply',
+      payloadField: 'yaml',
+    });
+  });
+
+  it('POST /output-widget/update skips action rows missing required fields', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'ow-act-skip', name: 'ow-act-skip', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
+    }, 'cli');
+
+    const res = await request(app).post('/agents/ow-act-skip/output-widget/update')
+      .type('form').send({
+        action: 'save',
+        widgetType: 'diff-apply',
+        widget_actions_edited: '1',
+        fieldName_0: 'classification', fieldType_0: 'badge',
+        // Half-built — has id but no label / endpoint
+        actionId_0: 'apply',
+      })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    expect(res.status).toBe(303);
+    const saved = agentStore.getAgent('ow-act-skip');
+    expect(saved?.outputWidget?.actions ?? []).toHaveLength(0);
+  });
+
+  it('POST /output-widget/update honours an empty-actions edit via sentinel', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'ow-act-empty', name: 'ow-act-empty', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
+      outputWidget: {
+        type: 'diff-apply',
+        fields: [{ name: 'classification', type: 'badge' }],
+        actions: [{ id: 'apply', label: 'Apply', method: 'POST', endpoint: '/x' }],
+      },
+    }, 'cli');
+
+    const res = await request(app).post('/agents/ow-act-empty/output-widget/update')
+      .type('form').send({
+        action: 'save',
+        widgetType: 'diff-apply',
+        widget_actions_edited: '1',
+        fieldName_0: 'classification', fieldType_0: 'badge',
+        // No actionId_N posted — user deleted all actions in the UI.
+      })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    expect(res.status).toBe(303);
+    const saved = agentStore.getAgent('ow-act-empty');
+    expect(saved?.outputWidget?.actions ?? []).toHaveLength(0);
+  });
+
+  it('POST /output-widget/update without the actions sentinel preserves actions (non-editor caller)', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'ow-act-cli', name: 'ow-act-cli', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
+      outputWidget: {
+        type: 'diff-apply',
+        fields: [{ name: 'classification', type: 'badge' }],
+        actions: [{ id: 'apply', label: 'Apply', method: 'POST', endpoint: '/x' }],
+      },
+    }, 'cli');
+
+    const res = await request(app).post('/agents/ow-act-cli/output-widget/update')
+      .type('form').send({
+        action: 'save',
+        widgetType: 'diff-apply',
+        // No widget_actions_edited sentinel + no action rows — non-editor caller
+        fieldName_0: 'classification', fieldType_0: 'badge',
+      })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    expect(res.status).toBe(303);
+    const saved = agentStore.getAgent('ow-act-cli');
+    expect(saved?.outputWidget?.actions).toHaveLength(1);
+  });
+
   it('POST /output-widget/generate returns 400 with no prompt', async () => {
     const app = await makeApp();
     agentStore.createAgent({

--- a/packages/dashboard/src/routes/agent-inputs.ts
+++ b/packages/dashboard/src/routes/agent-inputs.ts
@@ -1,5 +1,5 @@
 import { Router, type Request, type Response } from 'express';
-import type { AgentInputSpec, OutputWidgetSchema, OutputWidgetType, WidgetFieldType, NotifyConfig } from '@some-useful-agents/core';
+import type { AgentInputSpec, OutputWidgetSchema, OutputWidgetType, WidgetFieldType, WidgetControl, NotifyConfig } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 import { mergeNewInput, parseEnumValues } from './agent-nodes.js';
 import { renderOutputWidget } from '../views/output-widgets.js';
@@ -192,6 +192,93 @@ const VALID_WIDGET_TYPES = new Set<string>(['dashboard', 'key-value', 'diff-appl
 const VALID_FIELD_TYPES = new Set<string>(['text', 'code', 'badge', 'action', 'metric', 'stat', 'preview', 'table']);
 const VALID_COLUMN_FORMATS = new Set<string>(['text', 'link']);
 
+const VALID_CONTROL_TYPES = new Set<string>(['sort', 'filter', 'paginate', 'replay', 'field-toggle', 'view-switch']);
+
+/**
+ * Pull a comma-separated list of bare tokens, dropping blanks. Used for
+ * sort.columns / filter.columns / replay.inputs / field-toggle.fields
+ * — all "csv of identifiers" inputs that share the same trim/split shape.
+ */
+function csv(raw: unknown): string[] {
+  if (typeof raw !== 'string') return [];
+  return raw.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+/**
+ * Pull control rows posted by the editor. Each row is a discriminated
+ * union — the form carries all per-type inputs (only the active one is
+ * visible in the UI) and this parser picks the matching sibling inputs
+ * based on `controlType_N`. Inputs for other types are ignored.
+ *
+ * Skips rows whose required-by-type fields are missing (e.g. sort
+ * without a field name) instead of returning a half-built control —
+ * the schema validator would reject those at save time anyway, but a
+ * silent skip lets a half-edited new row coexist with valid ones.
+ *
+ * view-switch's nested `views: [{id, fields[]}]` is parsed as JSON; an
+ * invalid JSON string skips the row.
+ */
+function parseControlsFromBody(body: Record<string, unknown>): WidgetControl[] {
+  const out: WidgetControl[] = [];
+  for (let i = 0; i < 50; i++) {
+    const rawType = body[`controlType_${i}`];
+    if (typeof rawType !== 'string' || !VALID_CONTROL_TYPES.has(rawType)) continue;
+    const type = rawType as 'sort' | 'filter' | 'paginate' | 'replay' | 'field-toggle' | 'view-switch';
+    const labelRaw = body[`controlLabel_${i}_${type}`];
+    const label = typeof labelRaw === 'string' && labelRaw.trim() ? labelRaw.trim() : undefined;
+
+    if (type === 'sort') {
+      const field = typeof body[`controlField_${i}_sort`] === 'string' ? (body[`controlField_${i}_sort`] as string).trim() : '';
+      const columns = csv(body[`controlColumns_${i}_sort`]);
+      const def = typeof body[`controlDefault_${i}_sort`] === 'string' ? (body[`controlDefault_${i}_sort`] as string).trim() : '';
+      if (!field || columns.length === 0) continue;
+      out.push({
+        type, field, columns,
+        ...(label ? { label } : {}),
+        ...(def ? { default: def } : {}),
+      });
+    } else if (type === 'filter') {
+      const field = typeof body[`controlField_${i}_filter`] === 'string' ? (body[`controlField_${i}_filter`] as string).trim() : '';
+      const columns = csv(body[`controlColumns_${i}_filter`]);
+      const placeholder = typeof body[`controlPlaceholder_${i}`] === 'string' ? (body[`controlPlaceholder_${i}`] as string).trim() : '';
+      if (!field || columns.length === 0) continue;
+      out.push({
+        type, field, columns,
+        ...(label ? { label } : {}),
+        ...(placeholder ? { placeholder } : {}),
+      });
+    } else if (type === 'paginate') {
+      const field = typeof body[`controlField_${i}_paginate`] === 'string' ? (body[`controlField_${i}_paginate`] as string).trim() : '';
+      const sizeRaw = body[`controlPageSize_${i}`];
+      const pageSize = typeof sizeRaw === 'string' ? parseInt(sizeRaw, 10) : (typeof sizeRaw === 'number' ? sizeRaw : NaN);
+      if (!field || !Number.isFinite(pageSize) || pageSize < 1) continue;
+      out.push({ type, field, pageSize });
+    } else if (type === 'replay') {
+      const inputs = csv(body[`controlInputs_${i}`]);
+      out.push({
+        type,
+        ...(label ? { label } : {}),
+        ...(inputs.length > 0 ? { inputs } : {}),
+      });
+    } else if (type === 'field-toggle') {
+      const fields = csv(body[`controlFields_${i}`]);
+      const def = body[`controlDefault_${i}_field-toggle`];
+      const defStr = def === 'shown' || def === 'hidden' ? def : 'shown';
+      if (fields.length === 0 || !label) continue; // label is required by schema
+      out.push({ type, label, fields, default: defStr });
+    } else if (type === 'view-switch') {
+      const rawJson = body[`controlViews_${i}`];
+      const defView = typeof body[`controlDefault_${i}_view-switch`] === 'string' ? (body[`controlDefault_${i}_view-switch`] as string).trim() : '';
+      if (typeof rawJson !== 'string' || !rawJson.trim() || !label || !defView) continue;
+      let views: unknown;
+      try { views = JSON.parse(rawJson); } catch { continue; }
+      if (!Array.isArray(views)) continue;
+      out.push({ type, label, views, default: defView });
+    }
+  }
+  return out;
+}
+
 /**
  * Pull column rows posted by the editor's table-field sub-table.
  * Form names follow `columnName_<fieldIdx>_<colIdx>` (plus Label / Format
@@ -322,13 +409,22 @@ agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res:
   const replayLabel = typeof body.widget_replay_label === 'string' && body.widget_replay_label.trim()
     ? body.widget_replay_label.trim() : undefined;
 
-  // Carry over schema shapes the editor form doesn't surface, but only
-  // when staying on the same widget type — a type change implies "start
-  // over", so `actions` (diff-apply only) and `controls` (per-type
-  // semantics) shouldn't survive a switch.
+  // Parse controls from the form (editor now has UI for all 6 types).
+  // The editor injects `widget_controls_edited=1` so the server can
+  // distinguish "form is silent on controls" (non-editor caller — fall
+  // back to prev) from "user explicitly emptied the list" (editor —
+  // honour the deletion). Without the sentinel, deleting the last
+  // control via the UI would silently re-add the prev controls.
+  // `actions` is still YAML-only to edit, preserved via the prev-version
+  // pattern from #287 (same-type only).
+  const parsedControls = parseControlsFromBody(body);
   const sameType = agent.outputWidget?.type === widgetType;
   const prevControls = sameType ? agent.outputWidget?.controls : undefined;
   const prevActions = sameType ? agent.outputWidget?.actions : undefined;
+  const controlsEdited = body.widget_controls_edited === '1';
+  const controls = parsedControls.length > 0
+    ? parsedControls
+    : controlsEdited ? [] : prevControls;
 
   let outputWidget: OutputWidgetSchema;
   if (widgetType === 'ai-template') {
@@ -348,7 +444,7 @@ agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res:
       ...(interactive && runInputs ? { runInputs } : {}),
       ...(interactive && askLabel ? { askLabel } : {}),
       ...(interactive && replayLabel ? { replayLabel } : {}),
-      ...(prevControls?.length ? { controls: prevControls } : {}),
+      ...(controls?.length ? { controls } : {}),
       ...(prevActions?.length ? { actions: prevActions } : {}),
     };
   } else {
@@ -381,7 +477,7 @@ agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res:
       ...(interactive && runInputs ? { runInputs } : {}),
       ...(interactive && askLabel ? { askLabel } : {}),
       ...(interactive && replayLabel ? { replayLabel } : {}),
-      ...(prevControls?.length ? { controls: prevControls } : {}),
+      ...(controls?.length ? { controls } : {}),
       ...(prevActions?.length ? { actions: prevActions } : {}),
     };
   }

--- a/packages/dashboard/src/routes/agent-inputs.ts
+++ b/packages/dashboard/src/routes/agent-inputs.ts
@@ -1,5 +1,5 @@
 import { Router, type Request, type Response } from 'express';
-import type { AgentInputSpec, OutputWidgetSchema, OutputWidgetType, WidgetFieldType, WidgetControl, NotifyConfig } from '@some-useful-agents/core';
+import type { AgentInputSpec, OutputWidgetSchema, OutputWidgetType, WidgetFieldType, WidgetControl, WidgetAction, NotifyConfig } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 import { mergeNewInput, parseEnumValues } from './agent-nodes.js';
 import { renderOutputWidget } from '../views/output-widgets.js';
@@ -280,6 +280,33 @@ function parseControlsFromBody(body: Record<string, unknown>): WidgetControl[] {
 }
 
 /**
+ * Pull action rows posted by the editor. Each action is a POST button
+ * (schema locks `method` to POST). Rows missing required fields
+ * (`id`, `label`, `endpoint`) skip silently so half-built rows don't
+ * fail the schema validator at save time.
+ */
+function parseActionsFromBody(body: Record<string, unknown>): WidgetAction[] {
+  const out: WidgetAction[] = [];
+  for (let i = 0; i < 50; i++) {
+    const id = body[`actionId_${i}`];
+    const label = body[`actionLabel_${i}`];
+    const endpoint = body[`actionEndpoint_${i}`];
+    const payloadField = body[`actionPayloadField_${i}`];
+    if (typeof id !== 'string' || !id.trim()) continue;
+    if (typeof label !== 'string' || !label.trim()) continue;
+    if (typeof endpoint !== 'string' || !endpoint.trim()) continue;
+    out.push({
+      id: id.trim(),
+      label: label.trim(),
+      method: 'POST',
+      endpoint: endpoint.trim(),
+      ...(typeof payloadField === 'string' && payloadField.trim() ? { payloadField: payloadField.trim() } : {}),
+    });
+  }
+  return out;
+}
+
+/**
  * Pull column rows posted by the editor's table-field sub-table.
  * Form names follow `columnName_<fieldIdx>_<colIdx>` (plus Label / Format
  * / Href / Text). Walks 0..49 colIdx and skips gaps so removing a column
@@ -418,13 +445,18 @@ agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res:
   // `actions` is still YAML-only to edit, preserved via the prev-version
   // pattern from #287 (same-type only).
   const parsedControls = parseControlsFromBody(body);
+  const parsedActions = parseActionsFromBody(body);
   const sameType = agent.outputWidget?.type === widgetType;
   const prevControls = sameType ? agent.outputWidget?.controls : undefined;
   const prevActions = sameType ? agent.outputWidget?.actions : undefined;
   const controlsEdited = body.widget_controls_edited === '1';
+  const actionsEdited = body.widget_actions_edited === '1';
   const controls = parsedControls.length > 0
     ? parsedControls
     : controlsEdited ? [] : prevControls;
+  const actions = parsedActions.length > 0
+    ? parsedActions
+    : actionsEdited ? [] : prevActions;
 
   let outputWidget: OutputWidgetSchema;
   if (widgetType === 'ai-template') {
@@ -445,7 +477,7 @@ agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res:
       ...(interactive && askLabel ? { askLabel } : {}),
       ...(interactive && replayLabel ? { replayLabel } : {}),
       ...(controls?.length ? { controls } : {}),
-      ...(prevActions?.length ? { actions: prevActions } : {}),
+      ...(actions?.length ? { actions } : {}),
     };
   } else {
     // Typed widgets (dashboard / key-value / diff-apply / raw) are
@@ -478,7 +510,7 @@ agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res:
       ...(interactive && askLabel ? { askLabel } : {}),
       ...(interactive && replayLabel ? { replayLabel } : {}),
       ...(controls?.length ? { controls } : {}),
-      ...(prevActions?.length ? { actions: prevActions } : {}),
+      ...(actions?.length ? { actions } : {}),
     };
   }
 

--- a/packages/dashboard/src/views/agent-detail-helpers.ts
+++ b/packages/dashboard/src/views/agent-detail-helpers.ts
@@ -174,6 +174,68 @@ function escapeAttr(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
+const CONTROL_TYPES = ['sort', 'filter', 'paginate', 'replay', 'field-toggle', 'view-switch'] as const;
+type ControlType = typeof CONTROL_TYPES[number];
+
+/**
+ * Render one editable control row. Carries all per-type input groups in
+ * the DOM so JS only has to toggle visibility on type change — no
+ * rebuilds. Each input is namespaced by `_<idx>` so the server can scan
+ * `controlType_0`..`controlType_49` and pull the matching siblings.
+ *
+ * View-switch's nested `views: [{id, fields[]}]` is edited as JSON in a
+ * single textarea (rarest control type; nested editing would be a UI
+ * project of its own). Server validates the JSON before save.
+ */
+function renderControlRow(idx: number, control?: { type?: string; label?: string; field?: string; columns?: string[]; default?: string; placeholder?: string; pageSize?: number; inputs?: string[]; fields?: string[]; views?: Array<{ id: string; fields: string[] }> }): string {
+  const c = control ?? {};
+  const currentType = (typeof c.type === 'string' && (CONTROL_TYPES as readonly string[]).includes(c.type)) ? c.type as ControlType : 'sort';
+  const csv = (arr?: string[]) => Array.isArray(arr) ? arr.join(', ') : '';
+  const typeOpts = CONTROL_TYPES.map((t) => `<option value="${t}"${t === currentType ? ' selected' : ''}>${t}</option>`).join('');
+  const viewsJson = Array.isArray(c.views) ? JSON.stringify(c.views, null, 2) : '';
+  const show = (t: ControlType) => `display: ${t === currentType ? 'flex' : 'none'};`;
+  const ROW = 'display: flex; gap: var(--space-2); flex-wrap: wrap; align-items: flex-end;';
+  const LBL = 'display: flex; flex-direction: column; gap: 2px; font-size: var(--font-size-xs); color: var(--color-text-muted);';
+  return `
+    <div data-control-row data-control-idx="${idx}" style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--space-2); margin-bottom: var(--space-2); background: var(--color-surface);">
+      <div style="display: flex; gap: var(--space-2); align-items: center; margin-bottom: var(--space-2);">
+        <select name="controlType_${idx}" data-control-type style="${COL_INPUT}">${typeOpts}</select>
+        <button type="button" class="btn btn--ghost btn--sm ow-remove-control" style="margin-left: auto; padding: 2px 6px; font-size: var(--font-size-xs); color: var(--color-err);">×</button>
+      </div>
+      <div data-control-inputs="sort" style="${ROW} ${show('sort')}">
+        <label style="${LBL}">Label <input type="text" name="controlLabel_${idx}_sort" value="${escapeAttr(c.label ?? '')}" placeholder="Sort" style="${COL_INPUT} width: 10rem;"></label>
+        <label style="${LBL}">Array field <input type="text" name="controlField_${idx}_sort" value="${escapeAttr(c.field ?? '')}" placeholder="matches" style="${COL_INPUT} font-family: var(--font-mono); width: 10rem;"></label>
+        <label style="${LBL}">Sortable columns (csv) <input type="text" name="controlColumns_${idx}_sort" value="${escapeAttr(csv(c.columns))}" placeholder="company, title, cost" style="${COL_INPUT} width: 16rem;"></label>
+        <label style="${LBL}">Default (col [asc|desc]) <input type="text" name="controlDefault_${idx}_sort" value="${escapeAttr(c.default ?? '')}" placeholder="cost desc" style="${COL_INPUT} width: 10rem;"></label>
+      </div>
+      <div data-control-inputs="filter" style="${ROW} ${show('filter')}">
+        <label style="${LBL}">Label <input type="text" name="controlLabel_${idx}_filter" value="${escapeAttr(c.label ?? '')}" placeholder="Filter" style="${COL_INPUT} width: 10rem;"></label>
+        <label style="${LBL}">Array field <input type="text" name="controlField_${idx}_filter" value="${escapeAttr(c.field ?? '')}" placeholder="matches" style="${COL_INPUT} font-family: var(--font-mono); width: 10rem;"></label>
+        <label style="${LBL}">Filterable columns (csv) <input type="text" name="controlColumns_${idx}_filter" value="${escapeAttr(csv(c.columns))}" placeholder="company, title" style="${COL_INPUT} width: 16rem;"></label>
+        <label style="${LBL}">Placeholder <input type="text" name="controlPlaceholder_${idx}" value="${escapeAttr(c.placeholder ?? '')}" placeholder="Filter…" style="${COL_INPUT} width: 12rem;"></label>
+      </div>
+      <div data-control-inputs="paginate" style="${ROW} ${show('paginate')}">
+        <label style="${LBL}">Array field <input type="text" name="controlField_${idx}_paginate" value="${escapeAttr(c.field ?? '')}" placeholder="matches" style="${COL_INPUT} font-family: var(--font-mono); width: 10rem;"></label>
+        <label style="${LBL}">Page size <input type="number" min="1" max="1000" name="controlPageSize_${idx}" value="${escapeAttr(c.pageSize != null ? String(c.pageSize) : '25')}" style="${COL_INPUT} width: 6rem;"></label>
+      </div>
+      <div data-control-inputs="replay" style="${ROW} ${show('replay')}">
+        <label style="${LBL}">Label <input type="text" name="controlLabel_${idx}_replay" value="${escapeAttr(c.label ?? '')}" placeholder="Re-run" style="${COL_INPUT} width: 10rem;"></label>
+        <label style="${LBL}">Inputs to expose (csv, blank = all) <input type="text" name="controlInputs_${idx}" value="${escapeAttr(csv(c.inputs))}" placeholder="JOB_QUERY, TOPIC" style="${COL_INPUT} width: 20rem;"></label>
+      </div>
+      <div data-control-inputs="field-toggle" style="${ROW} ${show('field-toggle')}">
+        <label style="${LBL}">Label <input type="text" name="controlLabel_${idx}_field-toggle" value="${escapeAttr(c.label ?? '')}" placeholder="Show" style="${COL_INPUT} width: 10rem;"></label>
+        <label style="${LBL}">Toggleable fields (csv) <input type="text" name="controlFields_${idx}" value="${escapeAttr(csv(c.fields))}" placeholder="uv, sunrise, sunset" style="${COL_INPUT} width: 16rem;"></label>
+        <label style="${LBL}">Default <select name="controlDefault_${idx}_field-toggle" style="${COL_INPUT}"><option value="shown"${c.default === 'shown' ? ' selected' : ''}>shown</option><option value="hidden"${c.default === 'hidden' ? ' selected' : ''}>hidden</option></select></label>
+      </div>
+      <div data-control-inputs="view-switch" style="${ROW} ${show('view-switch')}">
+        <label style="${LBL} flex: 1; min-width: 100%;">Label <input type="text" name="controlLabel_${idx}_view-switch" value="${escapeAttr(c.label ?? '')}" placeholder="Units" style="${COL_INPUT} width: 10rem;"></label>
+        <label style="${LBL} flex: 1; min-width: 100%;">Views (JSON: <code>[{id, fields:[...]}]</code>) <textarea name="controlViews_${idx}" rows="4" style="${COL_INPUT} font-family: var(--font-mono); width: 100%;">${escapeAttr(viewsJson)}</textarea></label>
+        <label style="${LBL}">Default view id <input type="text" name="controlDefault_${idx}_view-switch" value="${escapeAttr(c.default ?? '')}" placeholder="metric" style="${COL_INPUT} width: 10rem;"></label>
+      </div>
+    </div>
+  `;
+}
+
 export function renderOutputWidgetEditor(agent: Agent): SafeHtml {
   const widget = agent.outputWidget;
   const currentType: OutputWidgetType = widget?.type ?? 'raw';
@@ -304,6 +366,25 @@ export function renderOutputWidgetEditor(agent: Agent): SafeHtml {
         <p class="dim" style="font-size: var(--font-size-xs); margin: 0;">
           Reference output values via <code>{{outputs.NAME}}</code> or <code>{{result}}</code>. Sanitized to a tag/attribute allowlist before save.
         </p>
+      </div>
+
+      <input type="hidden" name="widget_controls_edited" value="1">
+      <div id="ow-controls-block" style="margin-bottom: var(--space-3);">
+        <details ${widget?.controls?.length ? 'open' : ''} style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--space-2);">
+          <summary style="cursor: pointer; font-size: var(--font-size-xs); font-weight: var(--weight-semibold);">
+            Controls
+            <span class="dim" style="font-weight: var(--weight-regular); margin-left: var(--space-2);">
+              ${widget?.controls?.length ? `${String(widget.controls.length)} declared` : 'none — add sort / filter / paginate / replay / field-toggle / view-switch'}
+            </span>
+          </summary>
+          <p class="dim" style="font-size: var(--font-size-xs); margin: var(--space-2) 0;">
+            Rendered above the widget body. URL-driven (no client JS), so refresh resets to default. Sort / filter / paginate target a top-level array; replay re-runs the agent; field-toggle / view-switch toggle declared fields.
+          </p>
+          <div id="ow-controls-list">
+            ${unsafeHtml((widget?.controls ?? []).map((c, i) => renderControlRow(i, c as Parameters<typeof renderControlRow>[1])).join(''))}
+          </div>
+          <button type="button" class="btn btn--ghost btn--sm" id="ow-add-control" style="font-size: var(--font-size-xs);">+ Add control</button>
+        </details>
       </div>
 
       <div id="ow-interactive-block" style="margin-bottom: var(--space-3); padding: var(--space-3); border: 1px solid var(--color-border); border-radius: var(--radius-sm);">
@@ -622,6 +703,96 @@ export function renderOutputWidgetEditor(agent: Agent): SafeHtml {
       exampleSel.addEventListener('change', function () {
         if (this.value) { loadExample(this.value); this.value = ''; }
       });
+
+      // ── Controls editor wiring ────────────────────────────────────────
+      var controlsList = document.getElementById('ow-controls-list');
+      var addControlBtn = document.getElementById('ow-add-control');
+      var nextControlIdx = controlsList ? controlsList.querySelectorAll('[data-control-row]').length : 0;
+      var CONTROL_TYPES = ['sort', 'filter', 'paginate', 'replay', 'field-toggle', 'view-switch'];
+
+      function controlRowHtml(idx) {
+        // Bare scaffold for new rows; matches the SSR template above but
+        // with empty values. Default type = sort (paired with table fields,
+        // the most common pairing for new controls today).
+        var typeOpts = CONTROL_TYPES.map(function (t) {
+          return '<option value="' + t + '"' + (t === 'sort' ? ' selected' : '') + '>' + t + '</option>';
+        }).join('');
+        var ROW = 'display:flex;gap:var(--space-2);flex-wrap:wrap;align-items:flex-end;';
+        var LBL = 'display:flex;flex-direction:column;gap:2px;font-size:var(--font-size-xs);color:var(--color-text-muted);';
+        function block(t, body) {
+          return '<div data-control-inputs="' + t + '" style="' + ROW + 'display:' + (t === 'sort' ? 'flex' : 'none') + ';">' + body + '</div>';
+        }
+        function input(n, ph, extra) {
+          return '<input type="text" name="' + n + '" placeholder="' + ph + '" style="' + COL_INPUT_STYLE + (extra || '') + '">';
+        }
+        return '<div data-control-row data-control-idx="' + idx + '" style="border:1px solid var(--color-border);border-radius:var(--radius-sm);padding:var(--space-2);margin-bottom:var(--space-2);background:var(--color-surface);">' +
+          '<div style="display:flex;gap:var(--space-2);align-items:center;margin-bottom:var(--space-2);">' +
+            '<select name="controlType_' + idx + '" data-control-type style="' + COL_INPUT_STYLE + '">' + typeOpts + '</select>' +
+            '<button type="button" class="btn btn--ghost btn--sm ow-remove-control" style="margin-left:auto;padding:2px 6px;font-size:var(--font-size-xs);color:var(--color-err);">\\u00D7</button>' +
+          '</div>' +
+          block('sort',
+            '<label style="' + LBL + '">Label ' + input('controlLabel_' + idx + '_sort', 'Sort', 'width:10rem;') + '</label>' +
+            '<label style="' + LBL + '">Array field ' + input('controlField_' + idx + '_sort', 'matches', 'font-family:var(--font-mono);width:10rem;') + '</label>' +
+            '<label style="' + LBL + '">Sortable columns (csv) ' + input('controlColumns_' + idx + '_sort', 'company, title', 'width:16rem;') + '</label>' +
+            '<label style="' + LBL + '">Default (col [asc|desc]) ' + input('controlDefault_' + idx + '_sort', 'cost desc', 'width:10rem;') + '</label>'
+          ) +
+          block('filter',
+            '<label style="' + LBL + '">Label ' + input('controlLabel_' + idx + '_filter', 'Filter', 'width:10rem;') + '</label>' +
+            '<label style="' + LBL + '">Array field ' + input('controlField_' + idx + '_filter', 'matches', 'font-family:var(--font-mono);width:10rem;') + '</label>' +
+            '<label style="' + LBL + '">Filterable columns (csv) ' + input('controlColumns_' + idx + '_filter', 'company, title', 'width:16rem;') + '</label>' +
+            '<label style="' + LBL + '">Placeholder ' + input('controlPlaceholder_' + idx, 'Filter\\u2026', 'width:12rem;') + '</label>'
+          ) +
+          block('paginate',
+            '<label style="' + LBL + '">Array field ' + input('controlField_' + idx + '_paginate', 'matches', 'font-family:var(--font-mono);width:10rem;') + '</label>' +
+            '<label style="' + LBL + '">Page size <input type="number" min="1" max="1000" name="controlPageSize_' + idx + '" value="25" style="' + COL_INPUT_STYLE + 'width:6rem;"></label></label>'
+          ) +
+          block('replay',
+            '<label style="' + LBL + '">Label ' + input('controlLabel_' + idx + '_replay', 'Re-run', 'width:10rem;') + '</label>' +
+            '<label style="' + LBL + '">Inputs to expose (csv, blank = all) ' + input('controlInputs_' + idx, 'JOB_QUERY, TOPIC', 'width:20rem;') + '</label>'
+          ) +
+          block('field-toggle',
+            '<label style="' + LBL + '">Label ' + input('controlLabel_' + idx + '_field-toggle', 'Show', 'width:10rem;') + '</label>' +
+            '<label style="' + LBL + '">Toggleable fields (csv) ' + input('controlFields_' + idx, 'uv, sunrise', 'width:16rem;') + '</label>' +
+            '<label style="' + LBL + '">Default <select name="controlDefault_' + idx + '_field-toggle" style="' + COL_INPUT_STYLE + '"><option value="shown">shown</option><option value="hidden">hidden</option></select></label>'
+          ) +
+          block('view-switch',
+            '<label style="' + LBL + 'flex:1;min-width:100%;">Label ' + input('controlLabel_' + idx + '_view-switch', 'Units', 'width:10rem;') + '</label>' +
+            '<label style="' + LBL + 'flex:1;min-width:100%;">Views (JSON) <textarea name="controlViews_' + idx + '" rows="4" style="' + COL_INPUT_STYLE + 'font-family:var(--font-mono);width:100%;"></textarea></label>' +
+            '<label style="' + LBL + '">Default view id ' + input('controlDefault_' + idx + '_view-switch', 'metric', 'width:10rem;') + '</label>'
+          ) +
+        '</div>';
+      }
+
+      function setControlInputsVisibility(row, type) {
+        var blocks = row.querySelectorAll('[data-control-inputs]');
+        for (var i = 0; i < blocks.length; i++) {
+          blocks[i].style.display = blocks[i].getAttribute('data-control-inputs') === type ? 'flex' : 'none';
+        }
+      }
+
+      if (addControlBtn && controlsList) {
+        addControlBtn.addEventListener('click', function () {
+          var wrap = document.createElement('div');
+          wrap.innerHTML = controlRowHtml(nextControlIdx++);
+          controlsList.appendChild(wrap.firstElementChild);
+          refreshPreview();
+        });
+        controlsList.addEventListener('click', function (e) {
+          if (e.target && e.target.classList && e.target.classList.contains('ow-remove-control')) {
+            var row = e.target.closest('[data-control-row]');
+            if (row) { row.parentNode.removeChild(row); refreshPreview(); }
+          }
+        });
+        controlsList.addEventListener('change', function (e) {
+          var t = e.target;
+          if (t && t.tagName === 'SELECT' && t.hasAttribute('data-control-type')) {
+            var row = t.closest('[data-control-row]');
+            if (row) setControlInputsVisibility(row, t.value);
+          }
+          refreshPreview();
+        });
+        controlsList.addEventListener('input', refreshPreview);
+      }
 
       // ai-template generate button
       var aiGenBtn = document.getElementById('ow-ai-generate');

--- a/packages/dashboard/src/views/agent-detail-helpers.ts
+++ b/packages/dashboard/src/views/agent-detail-helpers.ts
@@ -178,6 +178,25 @@ const CONTROL_TYPES = ['sort', 'filter', 'paginate', 'replay', 'field-toggle', '
 type ControlType = typeof CONTROL_TYPES[number];
 
 /**
+ * Render one editable action row (POST button on diff-apply widgets).
+ * Schema requires `id`, `label`, `endpoint`; `payloadField` is optional
+ * (names a declared field whose value gets sent as the POST body).
+ * `method` is locked to POST per the schema — not exposed in the UI.
+ */
+function renderActionRow(idx: number, action?: { id?: string; label?: string; endpoint?: string; payloadField?: string }): string {
+  const a = action ?? {};
+  return `
+    <tr data-action-row data-action-idx="${idx}">
+      <td><input type="text" name="actionId_${idx}" value="${escapeAttr(a.id ?? '')}" placeholder="apply" style="${COL_INPUT} font-family: var(--font-mono); width: 100%;"></td>
+      <td><input type="text" name="actionLabel_${idx}" value="${escapeAttr(a.label ?? '')}" placeholder="Apply" style="${COL_INPUT} width: 100%;"></td>
+      <td><input type="text" name="actionEndpoint_${idx}" value="${escapeAttr(a.endpoint ?? '')}" placeholder="/agents/{agentId}/apply" style="${COL_INPUT} font-family: var(--font-mono); width: 100%;"></td>
+      <td><input type="text" name="actionPayloadField_${idx}" value="${escapeAttr(a.payloadField ?? '')}" placeholder="yaml" style="${COL_INPUT} font-family: var(--font-mono); width: 100%;"></td>
+      <td><button type="button" class="btn btn--ghost btn--sm ow-remove-action" style="padding: 2px 6px; font-size: var(--font-size-xs); color: var(--color-err);">×</button></td>
+    </tr>
+  `;
+}
+
+/**
  * Render one editable control row. Carries all per-type input groups in
  * the DOM so JS only has to toggle visibility on type change — no
  * rebuilds. Each input is namespaced by `_<idx>` so the server can scan
@@ -384,6 +403,34 @@ export function renderOutputWidgetEditor(agent: Agent): SafeHtml {
             ${unsafeHtml((widget?.controls ?? []).map((c, i) => renderControlRow(i, c as Parameters<typeof renderControlRow>[1])).join(''))}
           </div>
           <button type="button" class="btn btn--ghost btn--sm" id="ow-add-control" style="font-size: var(--font-size-xs);">+ Add control</button>
+        </details>
+      </div>
+
+      <input type="hidden" name="widget_actions_edited" value="1">
+      <div id="ow-actions-block" style="margin-bottom: var(--space-3);">
+        <details ${widget?.actions?.length ? 'open' : ''} style="border: 1px solid var(--color-border); border-radius: var(--radius-sm); padding: var(--space-2);">
+          <summary style="cursor: pointer; font-size: var(--font-size-xs); font-weight: var(--weight-semibold);">
+            Actions
+            <span class="dim" style="font-weight: var(--weight-regular); margin-left: var(--space-2);">
+              ${widget?.actions?.length ? `${String(widget.actions.length)} declared` : 'none — POST buttons used by diff-apply widgets'}
+            </span>
+          </summary>
+          <p class="dim" style="font-size: var(--font-size-xs); margin: var(--space-2) 0;">
+            POST buttons rendered with the widget. <code>endpoint</code> may include <code>{agentId}</code>, which is substituted at render time. <code>payloadField</code> names a declared widget field whose value is sent as the request body. Method is always POST.
+          </p>
+          <table class="table" style="font-size: var(--font-size-xs); margin: 0;">
+            <thead><tr>
+              <th style="width: 8rem;">Id</th>
+              <th style="width: 8rem;">Label</th>
+              <th>Endpoint</th>
+              <th style="width: 9rem;" title="Optional: declared widget field whose value gets POSTed">Payload field</th>
+              <th></th>
+            </tr></thead>
+            <tbody id="ow-actions-list">
+              ${unsafeHtml((widget?.actions ?? []).map((a, i) => renderActionRow(i, a)).join(''))}
+            </tbody>
+          </table>
+          <button type="button" class="btn btn--ghost btn--sm" id="ow-add-action" style="font-size: var(--font-size-xs); margin-top: var(--space-2);">+ Add action</button>
         </details>
       </div>
 
@@ -792,6 +839,37 @@ export function renderOutputWidgetEditor(agent: Agent): SafeHtml {
           refreshPreview();
         });
         controlsList.addEventListener('input', refreshPreview);
+      }
+
+      // ── Actions editor wiring ─────────────────────────────────────────
+      var actionsList = document.getElementById('ow-actions-list');
+      var addActionBtn = document.getElementById('ow-add-action');
+      var nextActionIdx = actionsList ? actionsList.querySelectorAll('[data-action-row]').length : 0;
+
+      function actionRowHtml(idx) {
+        return '<tr data-action-row data-action-idx="' + idx + '">' +
+          '<td><input type="text" name="actionId_' + idx + '" placeholder="apply" style="' + COL_INPUT_STYLE + 'font-family:var(--font-mono);width:100%;"></td>' +
+          '<td><input type="text" name="actionLabel_' + idx + '" placeholder="Apply" style="' + COL_INPUT_STYLE + 'width:100%;"></td>' +
+          '<td><input type="text" name="actionEndpoint_' + idx + '" placeholder="/agents/{agentId}/apply" style="' + COL_INPUT_STYLE + 'font-family:var(--font-mono);width:100%;"></td>' +
+          '<td><input type="text" name="actionPayloadField_' + idx + '" placeholder="yaml" style="' + COL_INPUT_STYLE + 'font-family:var(--font-mono);width:100%;"></td>' +
+          '<td><button type="button" class="btn btn--ghost btn--sm ow-remove-action" style="padding:2px 6px;font-size:var(--font-size-xs);color:var(--color-err);">\\u00D7</button></td>' +
+        '</tr>';
+      }
+
+      if (addActionBtn && actionsList) {
+        addActionBtn.addEventListener('click', function () {
+          var wrap = document.createElement('tbody');
+          wrap.innerHTML = actionRowHtml(nextActionIdx++);
+          actionsList.appendChild(wrap.firstElementChild);
+          refreshPreview();
+        });
+        actionsList.addEventListener('click', function (e) {
+          if (e.target && e.target.classList && e.target.classList.contains('ow-remove-action')) {
+            var tr = e.target.closest('tr[data-action-row]');
+            if (tr) { tr.parentNode.removeChild(tr); refreshPreview(); }
+          }
+        });
+        actionsList.addEventListener('input', refreshPreview);
       }
 
       // ai-template generate button


### PR DESCRIPTION
## Summary

Phase 2 of editor-UI-for-table-things after #288 (columns editor). Adds a collapsible **Controls** section between Fields and Interactive with editable rows for **all 6** control types, plus a follow-up **Actions** section (POST buttons used by `diff-apply` widgets).

**After this PR: fields + columns + controls + actions are all editable in the dashboard. No YAML-only widget shapes remain.**

## Controls editor

Per-row UI: type select up top + per-type input row below. Each row carries all 6 per-type input groups in the DOM with only the active type visible — toggling the type select just swaps visibility via CSS, no rebuilds. Each input is namespaced `controlX_<idx>_<type>` so the server picks the matching siblings for the chosen type and ignores the others.

- **sort** — label · array field · sortable columns (csv) · default (`col [asc|desc]`)
- **filter** — label · array field · filterable columns (csv) · placeholder
- **paginate** — array field · page size
- **replay** — label · inputs subset (csv, blank = all)
- **field-toggle** — label · toggleable fields (csv) · default (shown/hidden)
- **view-switch** — label · views JSON (rarest type; nested `[{id, fields[]}]` edited as JSON in a textarea) · default view id

## Actions editor

Simple table of `id` / `label` / `endpoint` / optional `payloadField` inputs. Method is locked to POST per the schema. Used by `diff-apply` widgets to render action buttons.

## Subtleties

- Server skips half-built control/action rows silently instead of saving broken shapes that fail schema validation.
- Malformed view-switch JSON drops just that row.
- Editor injects hidden `widget_controls_edited=1` / `widget_actions_edited=1` sentinels so the server can distinguish "user deleted all" (honour deletion) from "non-editor caller silent" (preserve via #287). Without them, deleting the last control / action via the UI would silently re-add it from the previous version.

## Out of scope (deferred)

- Nested per-view editing for `view-switch` (JSON textarea suffices for the rarest control type; structured UI is a future polish).

## Test plan

- [x] 9 new tests in `dashboard.test.ts`: all-6-control-types round-trip, half-built control rows dropped, controls sentinel honours empty-list delete, controls non-editor preservation, malformed view-switch JSON drops only that row, action create round-trip, half-built action skipped, actions sentinel honours empty-list delete, actions non-editor preservation
- [x] `npx vitest run packages/dashboard/src/dashboard.test.ts -t output-widget` — all 23 pass
- [x] `npm test` — 1347 passing / 3 skipped (1338 baseline + 9 new)
- [ ] After merge: open greenhouse-search-discovered output widget → Controls section open with 4 declared rows (replay/sort/filter/paginate). Add/edit/remove rows, click Save, refresh — controls survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)