### PR TITLE
refactor(planner): extract critic-retry into PlannerLoopRunner (PR 1/4)

### DIFF
--- a/.changeset/planner-loop-scaffold.md
+++ b/.changeset/planner-loop-scaffold.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Planner refactor PR 1 — extract the inline critic-retry from run-now-build into a `PlannerLoopRunner` class with named phases (observe / evaluate / reflect / compose / done / failed). Behaviour-equivalent.
+
+The extract → parse → schema-validate → autofix → critic → maybe-retry sequence used to live inline at run-now-build.ts:820-950. It's now in `packages/core/src/planner-loop/{types,primitives,runner}.ts`. Each primitive is a small TS function; the runner orchestrates them and emits a uniform `LoopStepRecord` per phase so PR 2 can drop a smoke-run eval next to the critic and PR 3 can add cross-run memory without churning the dashboard route.
+
+No user-visible change. Tests cover the 9 distinct paths through the runner (no plan, JSON parse fail, schema invalid, fallback to nodeExecResult, critic pass, critic fail with retry, critic fail with budget exhausted, retry-spawn-fails, autofix invocation). First of a planned 4-PR sequence (see plan).

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -163,6 +163,20 @@ export {
   type PlanCriticContext,
 } from './build-plan-critic.js';
 export {
+  PlannerLoopRunner,
+  type PlannerLoopRunnerDeps,
+  autofixPlanYamls,
+  evaluatePlan,
+  observePlan,
+  reflectOnEval,
+  type ObserveResult,
+  type ObserveStatus,
+  type ReflectDecision,
+  type LoopOutcome,
+  type LoopPhase,
+  type LoopStepRecord,
+} from './planner-loop/index.js';
+export {
   policyDocumentSchema,
   policyRuleSchema,
   loadPolicyDocument,

--- a/packages/core/src/planner-loop/index.ts
+++ b/packages/core/src/planner-loop/index.ts
@@ -1,0 +1,12 @@
+export { PlannerLoopRunner, type PlannerLoopRunnerDeps } from './runner.js';
+export {
+  autofixPlanYamls,
+  evaluatePlan,
+  observePlan,
+  reflectOnEval,
+  step,
+  type ObserveResult,
+  type ObserveStatus,
+  type ReflectDecision,
+} from './primitives.js';
+export type { LoopOutcome, LoopPhase, LoopStepRecord } from './types.js';

--- a/packages/core/src/planner-loop/primitives.ts
+++ b/packages/core/src/planner-loop/primitives.ts
@@ -1,0 +1,116 @@
+import { buildPlanSchema, critiquePlan, extractPlanJson, type BuildPlan, type PlanCriticError } from '../index.js';
+import type { LoopPhase, LoopStepRecord } from './types.js';
+
+/**
+ * Result of the `observe` primitive: take the raw planner-run output and
+ * try to land on a validated `BuildPlan`. Reports a telemetry-friendly
+ * status string so the caller (and PR 2's step log) can record the right
+ * shape without re-walking the result.
+ */
+export type ObserveStatus = 'ok' | 'no-json' | 'json-parse-error' | 'schema-invalid';
+
+export interface ObserveResult {
+  status: ObserveStatus;
+  /** Populated only when status === 'ok'. */
+  plan?: BuildPlan;
+  /** Raw parsed JSON (before schema validation) — surfaced on schema-invalid so the UI can show what came back. */
+  rawPlan?: unknown;
+  /** Human-readable error for failure surfaces. */
+  errorMessage?: string;
+  /** Count of zod issues (only meaningful on schema-invalid). */
+  validationErrors: number;
+}
+
+/**
+ * `observe` — extract + parse + schema-validate the planner's raw output.
+ *
+ * Mirrors the inline extract/parse/validate sequence in run-now-build.ts so
+ * the loop runner can stay as the only caller after PR 1 lands. Does NOT
+ * autofix YAML — the runner does that as a separate step so the autofix
+ * count is independently observable for telemetry.
+ *
+ * `nodeExecResult` lets the caller fall back to the plan-node's per-node
+ * output when the run's top-level result doesn't carry `<plan>…</plan>`
+ * (matches the existing fallback at run-now-build.ts:828-830).
+ */
+export function observePlan(args: { runResult: string; nodeExecResult?: string }): ObserveResult {
+  let resultText = args.runResult;
+  if (!resultText.includes('<plan>') && args.nodeExecResult) {
+    resultText = args.nodeExecResult;
+  }
+  const planText = extractPlanJson(resultText);
+  if (!planText) {
+    return { status: 'no-json', errorMessage: 'Planner did not produce a <plan>…</plan> block.', validationErrors: 0 };
+  }
+  let parsed: unknown;
+  try { parsed = JSON.parse(planText); }
+  catch (e) {
+    return { status: 'json-parse-error', errorMessage: `Plan JSON parse failed: ${(e as Error).message}`, validationErrors: 0 };
+  }
+  const result = buildPlanSchema.safeParse(parsed);
+  if (!result.success) {
+    const issues = result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+    return {
+      status: 'schema-invalid',
+      rawPlan: parsed,
+      errorMessage: `Plan validation failed: ${issues}`,
+      validationErrors: result.error.issues.length,
+    };
+  }
+  return { status: 'ok', plan: result.data, validationErrors: 0 };
+}
+
+/**
+ * Walk `plan.newAgents`, apply `autoFixYaml` to each, return the cleaned
+ * plan and a count of how many YAMLs were actually modified.
+ *
+ * `autoFixYaml` lives in the dashboard package (next to the route that
+ * uses it), so the runner takes it as a constructor dependency rather
+ * than importing it here.
+ */
+export function autofixPlanYamls(plan: BuildPlan, autoFixYaml: (yaml: string) => string): { plan: BuildPlan; autofixCount: number } {
+  let autofixCount = 0;
+  const cleanedNewAgents = plan.newAgents.map((a) => {
+    const fixed = autoFixYaml(a.yaml);
+    if (fixed !== a.yaml) autofixCount++;
+    return { ...a, yaml: fixed };
+  });
+  return { plan: { ...plan, newAgents: cleanedNewAgents }, autofixCount };
+}
+
+/**
+ * `evaluate` — run the critic against the validated plan. Trivial wrapper
+ * today; PR 2 also runs `planSmokeRun` here and merges both error lists.
+ */
+export function evaluatePlan(plan: BuildPlan, existingAgentIds: Set<string>): { ok: boolean; errors: PlanCriticError[] } {
+  return critiquePlan(plan, { existingAgentIds });
+}
+
+/**
+ * `reflect` — decide what to do next given an eval result and the attempt
+ * count. No retry-spawning here; the runner does the I/O. This stays a
+ * pure function so it's trivial to unit-test the decision rules.
+ */
+export type ReflectDecision = { kind: 'done' } | { kind: 'retry'; reason: string };
+
+export function reflectOnEval(args: {
+  criticOk: boolean;
+  attemptsSoFar: number;
+  maxRetries: number;
+}): ReflectDecision {
+  if (args.criticOk) return { kind: 'done' };
+  if (args.attemptsSoFar > args.maxRetries) return { kind: 'done' }; // out of retries, fall through to "done with criticWarning"
+  return { kind: 'retry', reason: 'critic failed and retry budget remains' };
+}
+
+/** Convenience: build a `LoopStepRecord` with `at` filled in. */
+export function step(args: {
+  phase: LoopPhase;
+  primitive: string;
+  runId: string;
+  ok: boolean;
+  summary: string;
+  tookMs: number;
+}): LoopStepRecord {
+  return { ...args, at: new Date().toISOString() };
+}

--- a/packages/core/src/planner-loop/runner.test.ts
+++ b/packages/core/src/planner-loop/runner.test.ts
@@ -14,6 +14,7 @@ const TRIVIAL_PLAN: BuildPlan = {
   survey: { matchedAgents: [], missingFor: [], existingDashboards: [] },
   newAgents: [{ id: 'noop', purpose: 'noop', yaml: 'id: noop\nname: noop\nnodes:\n  - id: a\n    type: shell\n    command: echo\n' }],
   questions: [],
+  dashboard: null,
 };
 
 function wrapInPlan(plan: BuildPlan): string {

--- a/packages/core/src/planner-loop/runner.test.ts
+++ b/packages/core/src/planner-loop/runner.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { BuildPlan } from '../build-plan-schema.js';
+import type { PlannerTelemetryStore } from '../planner-telemetry-store.js';
+import { PlannerLoopRunner } from './runner.js';
+
+/**
+ * A minimal valid BuildPlan that the critic will accept (no newAgents,
+ * no dashboard → trivially valid). Used by tests that focus on the
+ * loop's plumbing rather than critic behaviour.
+ */
+const TRIVIAL_PLAN: BuildPlan = {
+  intent: 'agent',
+  summary: 'trivial',
+  survey: { matchedAgents: [], missingFor: [], existingDashboards: [] },
+  newAgents: [{ id: 'noop', purpose: 'noop', yaml: 'id: noop\nname: noop\nnodes:\n  - id: a\n    type: shell\n    command: echo\n' }],
+  questions: [],
+};
+
+function wrapInPlan(plan: BuildPlan): string {
+  return `<plan>${JSON.stringify(plan)}</plan>`;
+}
+
+/** Stub telemetry store — records calls so tests can assert side effects. */
+function stubTelemetry(): PlannerTelemetryStore & {
+  calls: { extract: unknown[]; retrySpawn: unknown[]; incrementAttempts: string[]; resolve: string[] };
+} {
+  const calls = { extract: [] as unknown[], retrySpawn: [] as unknown[], incrementAttempts: [] as string[], resolve: [] as string[] };
+  const planAttempts = new Map<string, number>();
+  return {
+    calls,
+    recordExtract: (args: unknown) => { calls.extract.push(args); },
+    recordRetrySpawn: (originalRunId: string, retryRunId: string) => { calls.retrySpawn.push({ originalRunId, retryRunId }); },
+    incrementAttempts: (runId: string) => {
+      calls.incrementAttempts.push(runId);
+      planAttempts.set(runId, (planAttempts.get(runId) ?? 1) + 1);
+    },
+    resolveOriginalRunId: (runId: string) => { calls.resolve.push(runId); return runId; },
+    get: (runId: string) => ({
+      runId, planAttempts: planAttempts.get(runId) ?? 1, goal: 'fake goal', intent: null, createdAt: new Date().toISOString(),
+      planExtractStatus: 'pending', planValidationErrors: 0, planAutofixCount: 0,
+      timeToPlanMs: null, timeToCommitMs: null, committedAt: null,
+    }),
+  } as unknown as PlannerTelemetryStore & typeof calls extends { calls: infer C } ? { calls: C } : never;
+}
+
+describe('PlannerLoopRunner', () => {
+  function makeRunner(overrides: Partial<{
+    kickoff: ReturnType<typeof vi.fn>;
+    autofix: ReturnType<typeof vi.fn>;
+    existingIds: Set<string>;
+    telemetry: ReturnType<typeof stubTelemetry>;
+    maxRetries: number;
+  }> = {}) {
+    const telemetry = overrides.telemetry ?? stubTelemetry();
+    const kickoff = overrides.kickoff ?? vi.fn(async () => 'retry-run-123');
+    const autofix = overrides.autofix ?? vi.fn((yaml: string) => yaml);
+    const runner = new PlannerLoopRunner({
+      telemetryStore: telemetry,
+      kickoffPlannerRun: kickoff,
+      autoFixYaml: autofix,
+      loadExistingAgentIds: () => overrides.existingIds ?? new Set<string>(),
+      maxRetries: overrides.maxRetries ?? 2,
+    });
+    return { runner, telemetry, kickoff, autofix };
+  }
+
+  it('returns failed when no <plan> block is present', async () => {
+    const { runner, telemetry } = makeRunner();
+    const out = await runner.advance({ runId: 'r1', runResult: 'no plan here', planMs: 100 });
+    expect(out.kind).toBe('failed');
+    if (out.kind === 'failed') {
+      expect(out.error).toContain('<plan>');
+      // observe step recorded as failed
+      expect(out.steps[0]).toMatchObject({ phase: 'observe', primitive: 'observePlan', ok: false });
+    }
+    expect(telemetry.calls.extract).toHaveLength(1);
+    expect(telemetry.calls.extract[0]).toMatchObject({ runId: 'r1', status: 'no-json' });
+  });
+
+  it('returns failed with rawPlan when JSON parses but schema fails', async () => {
+    const { runner, telemetry } = makeRunner();
+    const bogus = '<plan>{"intent": "not-a-real-intent"}</plan>';
+    const out = await runner.advance({ runId: 'r2', runResult: bogus, planMs: 50 });
+    expect(out.kind).toBe('failed');
+    if (out.kind === 'failed') {
+      expect(out.error).toContain('Plan validation failed');
+      expect(out.rawPlan).toEqual({ intent: 'not-a-real-intent' });
+    }
+    expect(telemetry.calls.extract[0]).toMatchObject({ runId: 'r2', status: 'schema-invalid' });
+  });
+
+  it('returns failed when JSON parse fails inside the <plan> block', async () => {
+    const { runner, telemetry } = makeRunner();
+    const broken = '<plan>{not json}</plan>';
+    const out = await runner.advance({ runId: 'r3', runResult: broken, planMs: 10 });
+    expect(out.kind).toBe('failed');
+    if (out.kind === 'failed') expect(out.error).toContain('parse failed');
+    // recordExtract conflates JSON-parse-error with no-json (mirrors pre-refactor behaviour)
+    expect(telemetry.calls.extract[0]).toMatchObject({ runId: 'r3', status: 'no-json' });
+  });
+
+  it('falls back to nodeExecResult when the run result lacks <plan>', async () => {
+    const { runner } = makeRunner({ existingIds: new Set(['noop']) });
+    const out = await runner.advance({
+      runId: 'r4',
+      runResult: 'no plan here',
+      nodeExecResult: wrapInPlan(TRIVIAL_PLAN),
+      planMs: 5,
+    });
+    expect(out.kind).toBe('done');
+  });
+
+  it('returns done when critic passes on the first attempt', async () => {
+    const { runner, telemetry } = makeRunner({ existingIds: new Set(['noop']) });
+    const out = await runner.advance({
+      runId: 'r5',
+      runResult: wrapInPlan(TRIVIAL_PLAN),
+      planMs: 200,
+    });
+    expect(out.kind).toBe('done');
+    if (out.kind === 'done') {
+      expect(out.criticErrors).toBeUndefined();
+      expect(out.criticWarning).toBeUndefined();
+      const phases = out.steps.map((s) => s.phase);
+      expect(phases).toEqual(['observe', 'observe', 'evaluate', 'reflect']);
+    }
+    expect(telemetry.calls.extract[0]).toMatchObject({ status: 'ok', validationErrors: 0 });
+  });
+
+  it('spawns a retry when critic fails and attempts remain', async () => {
+    // Use a plan that the critic WILL reject — newAgent.yaml that won't parse.
+    const badPlan: BuildPlan = {
+      ...TRIVIAL_PLAN,
+      newAgents: [{ id: 'broken', purpose: 'broken', yaml: '!!!not valid yaml at all' }],
+    };
+    const kickoff = vi.fn(async () => 'retry-run-abc');
+    const { runner, telemetry } = makeRunner({ kickoff });
+    const out = await runner.advance({
+      runId: 'r6',
+      runResult: wrapInPlan(badPlan),
+      planMs: 100,
+    });
+    expect(out.kind).toBe('retrying');
+    if (out.kind === 'retrying') {
+      expect(out.retryRunId).toBe('retry-run-abc');
+      expect(out.attempt).toBe(2);
+      expect(out.criticErrors.length).toBeGreaterThan(0);
+      expect(out.phase).toContain('attempt 2');
+    }
+    expect(kickoff).toHaveBeenCalledOnce();
+    expect(telemetry.calls.incrementAttempts).toEqual(['r6']);
+    expect(telemetry.calls.retrySpawn).toEqual([{ originalRunId: 'r6', retryRunId: 'retry-run-abc' }]);
+  });
+
+  it('returns done with criticWarning when retry budget is exhausted', async () => {
+    const badPlan: BuildPlan = {
+      ...TRIVIAL_PLAN,
+      newAgents: [{ id: 'broken', purpose: 'broken', yaml: '!!!not valid yaml at all' }],
+    };
+    // Telemetry that reports planAttempts already at maxRetries+1 (i.e. 3, when maxRetries=2)
+    const tele = stubTelemetry();
+    tele.incrementAttempts('r7'); // 2
+    tele.incrementAttempts('r7'); // 3
+    const { runner, telemetry } = makeRunner({ telemetry: tele });
+    const out = await runner.advance({ runId: 'r7', runResult: wrapInPlan(badPlan), planMs: 1 });
+    expect(out.kind).toBe('done');
+    if (out.kind === 'done') {
+      expect(out.criticErrors!.length).toBeGreaterThan(0);
+      expect(out.criticWarning).toContain('could not produce a clean plan');
+    }
+    // No retry attempted
+    expect(telemetry.calls.retrySpawn).toEqual([]);
+  });
+
+  it('returns done with a "retry-could-not-start" warning when kickoff returns null', async () => {
+    const badPlan: BuildPlan = {
+      ...TRIVIAL_PLAN,
+      newAgents: [{ id: 'broken', purpose: 'broken', yaml: '!!!not valid yaml at all' }],
+    };
+    const kickoff = vi.fn(async () => null);
+    const { runner } = makeRunner({ kickoff });
+    const out = await runner.advance({ runId: 'r8', runResult: wrapInPlan(badPlan), planMs: 1 });
+    expect(out.kind).toBe('done');
+    if (out.kind === 'done') {
+      expect(out.criticWarning).toContain('retry could not be started');
+      expect(out.criticErrors!.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('runs autoFixYaml on every newAgent and records the modification count', async () => {
+    const autofix = vi.fn((yaml: string) => `${yaml}\n# autofixed`);
+    const { runner } = makeRunner({ autofix, existingIds: new Set(['noop']) });
+    const out = await runner.advance({
+      runId: 'r9',
+      runResult: wrapInPlan(TRIVIAL_PLAN),
+      planMs: 1,
+    });
+    expect(autofix).toHaveBeenCalledOnce();
+    expect(out.kind).toBe('done');
+    if (out.kind === 'done') {
+      expect(out.plan.newAgents[0].yaml).toContain('# autofixed');
+      const autofixStep = out.steps.find((s) => s.primitive === 'autofixPlanYamls');
+      expect(autofixStep?.summary).toContain('1 of 1');
+    }
+  });
+});

--- a/packages/core/src/planner-loop/runner.ts
+++ b/packages/core/src/planner-loop/runner.ts
@@ -1,0 +1,196 @@
+import { formatCriticFeedback } from '../build-plan-critic.js';
+import type { BuildPlan } from '../build-plan-schema.js';
+import type { PlannerTelemetryStore } from '../planner-telemetry-store.js';
+import { autofixPlanYamls, evaluatePlan, observePlan, reflectOnEval, step } from './primitives.js';
+import type { LoopOutcome, LoopStepRecord } from './types.js';
+
+/**
+ * Drives one *post-run* iteration of the planner loop. The HTTP wizard
+ * polls the planner run, and once it completes, calls `advance(...)` to
+ * (a) observe what came back, (b) evaluate it, (c) reflect on whether to
+ * retry, and (d) optionally spawn the retry. The "loop" plays out across
+ * multiple HTTP polls — each advance() is one trip through the state
+ * machine, not a synchronous until-done loop.
+ *
+ * Behaviour-equivalent to the inline block at run-now-build.ts:820-950
+ * before this refactor. PRs 2-4 will extend this with smoke-run eval,
+ * cross-run memory, and shared types with the generated-agent loop.
+ */
+export interface PlannerLoopRunnerDeps {
+  /** Look up the root telemetry row (aliased-runId → root) to count attempts. */
+  telemetryStore: PlannerTelemetryStore | undefined;
+  /** Spawn a fresh planner run; returns the new runId or null on failure. */
+  kickoffPlannerRun: (args: { goal: string; criticFeedback: string }) => Promise<string | null>;
+  /** Apply the dashboard's YAML autofixer to a single newAgent YAML. */
+  autoFixYaml: (yaml: string) => string;
+  /** Snapshot of agent-ids the catalog knows about, for critic cross-ref checks. */
+  loadExistingAgentIds: () => Set<string>;
+  /** Max *additional* retries after the initial attempt. Default 2 (total 3 tries). */
+  maxRetries?: number;
+}
+
+export class PlannerLoopRunner {
+  private readonly deps: Required<Pick<PlannerLoopRunnerDeps, 'telemetryStore' | 'kickoffPlannerRun' | 'autoFixYaml' | 'loadExistingAgentIds' | 'maxRetries'>>;
+
+  constructor(deps: PlannerLoopRunnerDeps) {
+    this.deps = {
+      telemetryStore: deps.telemetryStore,
+      kickoffPlannerRun: deps.kickoffPlannerRun,
+      autoFixYaml: deps.autoFixYaml,
+      loadExistingAgentIds: deps.loadExistingAgentIds,
+      maxRetries: deps.maxRetries ?? 2,
+    };
+  }
+
+  /**
+   * Drive one iteration. Given a completed planner run, decide what's next.
+   *
+   * `planMs` is the planner run's wall-clock duration, threaded through
+   * for telemetry. The caller already computed it from
+   * run.completedAt − run.startedAt.
+   */
+  async advance(input: {
+    runId: string;
+    runResult: string;
+    nodeExecResult?: string;
+    planMs: number;
+  }): Promise<LoopOutcome> {
+    const steps: LoopStepRecord[] = [];
+
+    // ── observe ──────────────────────────────────────────────────────
+    const obsStart = Date.now();
+    const obs = observePlan({ runResult: input.runResult, nodeExecResult: input.nodeExecResult });
+    steps.push(step({
+      phase: 'observe',
+      primitive: 'observePlan',
+      runId: input.runId,
+      ok: obs.status === 'ok',
+      summary: obs.status === 'ok' ? `plan extracted (intent=${obs.plan!.intent})` : `extract failed: ${obs.status}`,
+      tookMs: Date.now() - obsStart,
+    }));
+
+    if (obs.status !== 'ok') {
+      // Mirror existing telemetry shape: schema-invalid records validationErrors,
+      // the other two record 'no-json' (the legacy code conflated json-parse-error with no-json).
+      try {
+        this.deps.telemetryStore?.recordExtract({
+          runId: input.runId,
+          status: obs.status === 'schema-invalid' ? 'schema-invalid' : 'no-json',
+          autofixCount: 0,
+          validationErrors: obs.validationErrors,
+          timeToPlanMs: input.planMs,
+        });
+      } catch { /* swallow */ }
+      return { kind: 'failed', error: obs.errorMessage!, rawPlan: obs.rawPlan, steps };
+    }
+
+    // ── observe (continued): autofix YAMLs ──────────────────────────
+    const fixStart = Date.now();
+    const { plan, autofixCount } = autofixPlanYamls(obs.plan!, this.deps.autoFixYaml);
+    steps.push(step({
+      phase: 'observe',
+      primitive: 'autofixPlanYamls',
+      runId: input.runId,
+      ok: true,
+      summary: `${autofixCount} of ${plan.newAgents.length} newAgent yaml(s) modified by autofix`,
+      tookMs: Date.now() - fixStart,
+    }));
+
+    // ── evaluate ─────────────────────────────────────────────────────
+    const evalStart = Date.now();
+    const critic = evaluatePlan(plan, this.deps.loadExistingAgentIds());
+    steps.push(step({
+      phase: 'evaluate',
+      primitive: 'critiquePlan',
+      runId: input.runId,
+      ok: critic.ok,
+      summary: critic.ok ? 'critic passed' : `critic flagged ${critic.errors.length} issue(s)`,
+      tookMs: Date.now() - evalStart,
+    }));
+
+    // ── reflect (decide) ─────────────────────────────────────────────
+    const rootRunId = this.deps.telemetryStore?.resolveOriginalRunId(input.runId) ?? input.runId;
+    const rootRow = this.deps.telemetryStore?.get(rootRunId) ?? null;
+    const attemptsSoFar = rootRow?.planAttempts ?? 1;
+    const decision = reflectOnEval({ criticOk: critic.ok, attemptsSoFar, maxRetries: this.deps.maxRetries });
+    steps.push(step({
+      phase: 'reflect',
+      primitive: 'reflectOnEval',
+      runId: input.runId,
+      ok: true,
+      summary: decision.kind === 'retry'
+        ? `retry (attempt ${attemptsSoFar + 1} of ${this.deps.maxRetries + 1})`
+        : critic.ok ? 'done — critic passed' : `done — out of retries (${attemptsSoFar} attempts)`,
+      tookMs: 0,
+    }));
+
+    // ── compose (spawn retry if reflect said retry) ──────────────────
+    if (decision.kind === 'retry') {
+      try { this.deps.telemetryStore?.incrementAttempts(input.runId); } catch { /* swallow */ }
+      const goal = rootRow?.goal ?? '';
+      const feedback = formatCriticFeedback(critic.errors);
+      const composeStart = Date.now();
+      const retryRunId = await this.deps.kickoffPlannerRun({ goal, criticFeedback: feedback });
+      steps.push(step({
+        phase: 'compose',
+        primitive: 'kickoffPlannerRun',
+        runId: input.runId,
+        ok: !!retryRunId,
+        summary: retryRunId ? `spawned retry runId=${retryRunId.slice(0, 8)}` : 'retry spawn failed',
+        tookMs: Date.now() - composeStart,
+      }));
+      if (retryRunId && this.deps.telemetryStore) {
+        try { this.deps.telemetryStore.recordRetrySpawn(rootRunId, retryRunId); } catch { /* swallow */ }
+      }
+      // Record THIS attempt's extract telemetry as ok (schema accepted; only critic rejected).
+      this.recordExtractOk(input.runId, autofixCount, critic.errors.length, input.planMs, plan);
+
+      if (!retryRunId) {
+        // Couldn't spawn a retry — surface what we have with the critic errors.
+        return {
+          kind: 'done',
+          plan,
+          criticErrors: critic.errors,
+          criticWarning: 'Plan has unresolved structural issues; retry could not be started. You can commit anyway or dismiss.',
+          steps,
+        };
+      }
+      return {
+        kind: 'retrying',
+        retryRunId,
+        attempt: attemptsSoFar + 1,
+        criticErrors: critic.errors,
+        phase: `Refining plan (attempt ${attemptsSoFar + 1})...`,
+        steps,
+      };
+    }
+
+    // ── done (critic passed, or retries exhausted) ───────────────────
+    this.recordExtractOk(input.runId, autofixCount, critic.ok ? 0 : critic.errors.length, input.planMs, plan);
+
+    if (critic.ok) {
+      return { kind: 'done', plan, steps };
+    }
+    return {
+      kind: 'done',
+      plan,
+      criticErrors: critic.errors,
+      criticWarning: `Planner could not produce a clean plan after ${attemptsSoFar} attempts. Review the issues below and either fix the YAML inline or commit anyway.`,
+      steps,
+    };
+  }
+
+  private recordExtractOk(runId: string, autofixCount: number, validationErrors: number, planMs: number, plan: BuildPlan): void {
+    try {
+      this.deps.telemetryStore?.recordExtract({
+        runId,
+        status: 'ok',
+        autofixCount,
+        validationErrors,
+        timeToPlanMs: planMs,
+        intent: plan.intent,
+      });
+    } catch { /* swallow */ }
+  }
+
+}

--- a/packages/core/src/planner-loop/types.ts
+++ b/packages/core/src/planner-loop/types.ts
@@ -1,0 +1,57 @@
+import type { BuildPlan, PlanCriticError } from '../index.js';
+
+/**
+ * Phases of the planner loop, matching the refactor principles
+ * (understand → compose → observe → evaluate → reflect → done|failed).
+ * PR 1 wires compose/observe/evaluate/reflect/done/failed; `understand`
+ * lights up in PR 3 when cross-run memory retrieval is added.
+ */
+export type LoopPhase = 'understand' | 'compose' | 'observe' | 'evaluate' | 'reflect' | 'done' | 'failed';
+
+/**
+ * One row in the loop's step log. The shape is uniform across primitives so
+ * a per-run "graph of what was done" can be reconstructed from a single
+ * append-only table (added as a SQLite store in PR 2). PR 1 just collects
+ * the records on the outcome — no persistence yet.
+ */
+export interface LoopStepRecord {
+  phase: LoopPhase;
+  /** Name of the primitive that produced this step (e.g. "observe", "critique"). */
+  primitive: string;
+  /** The planner run-id this step ran against. For retries the new (retry) runId. */
+  runId: string;
+  ok: boolean;
+  /** One-line summary, ≤ ~200 chars. */
+  summary: string;
+  tookMs: number;
+  /** ISO timestamp. */
+  at: string;
+}
+
+/**
+ * The terminal output of one `runner.advance()` call. Maps 1:1 to the JSON
+ * response the wizard polls for. Naming mirrors the existing status strings
+ * (done / retrying / failed) so the dashboard route is a straight passthrough.
+ */
+export type LoopOutcome =
+  | {
+      kind: 'done';
+      plan: BuildPlan;
+      criticErrors?: PlanCriticError[];
+      criticWarning?: string;
+      steps: LoopStepRecord[];
+    }
+  | {
+      kind: 'failed';
+      error: string;
+      rawPlan?: unknown;
+      steps: LoopStepRecord[];
+    }
+  | {
+      kind: 'retrying';
+      retryRunId: string;
+      attempt: number;
+      criticErrors: PlanCriticError[];
+      phase: string;
+      steps: LoopStepRecord[];
+    };

--- a/packages/dashboard/src/routes/run-now-build.ts
+++ b/packages/dashboard/src/routes/run-now-build.ts
@@ -13,9 +13,7 @@ import {
   parseAgent,
   buildDiscoveryCatalog,
   buildPlanSchema,
-  extractPlanJson,
-  critiquePlan,
-  formatCriticFeedback,
+  PlannerLoopRunner,
   type BuildPlan,
   type PlanCriticError,
   type RunStatus,
@@ -818,134 +816,56 @@ buildRouter.get('/agents/build/:runId', async (req: Request, res: Response) => {
   const ranPlanner = run.agentName === PLANNER_AGENT_ID;
 
   if (ranPlanner) {
-    // Telemetry timing — measure from the run's startedAt to its completedAt.
+    // The extract → autofix → critic → maybe-retry sequence used to live
+    // inline here. It's now driven by PlannerLoopRunner (in core) so the
+    // phases are named (observe / evaluate / reflect / compose), the step
+    // log is uniform, and PR 2 can drop a smoke-run eval next to the
+    // critic without churning the dashboard route. Behaviour is
+    // byte-equivalent to the pre-refactor block.
     const planMs = run.completedAt && run.startedAt
       ? new Date(run.completedAt).getTime() - new Date(run.startedAt).getTime()
       : 0;
-    // Extract + validate the plan JSON.
-    let resultText = run.result;
-    if (!resultText.includes('<plan>')) {
-      const execs = ctx.runStore.listNodeExecutions(runId);
-      const planExec = execs.find((e) => e.nodeId === 'plan' && e.status === 'completed');
-      if (planExec?.result) resultText = planExec.result;
-    }
-    const planText = extractPlanJson(resultText);
-    if (!planText) {
-      try { ctx.plannerTelemetryStore?.recordExtract({ runId, status: 'no-json', autofixCount: 0, timeToPlanMs: planMs }); } catch { /* swallow */ }
-      res.json({ ok: true, status: 'failed', error: 'Planner did not produce a <plan>…</plan> block.' });
-      return;
-    }
-    let parsed: unknown;
-    try { parsed = JSON.parse(planText); }
-    catch (e) {
-      try { ctx.plannerTelemetryStore?.recordExtract({ runId, status: 'no-json', autofixCount: 0, timeToPlanMs: planMs }); } catch { /* swallow */ }
-      res.json({ ok: true, status: 'failed', error: `Plan JSON parse failed: ${(e as Error).message}` });
-      return;
-    }
-    const result = buildPlanSchema.safeParse(parsed);
-    if (!result.success) {
-      const issues = result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
-      try { ctx.plannerTelemetryStore?.recordExtract({ runId, status: 'schema-invalid', autofixCount: 0, validationErrors: result.error.issues.length, timeToPlanMs: planMs }); } catch { /* swallow */ }
-      res.json({ ok: true, status: 'failed', error: `Plan validation failed: ${issues}`, rawPlan: parsed });
-      return;
-    }
+    const execs = ctx.runStore.listNodeExecutions(runId);
+    const planExec = execs.find((e) => e.nodeId === 'plan' && e.status === 'completed');
 
-    // Apply autoFixYaml to each newAgent's YAML so we surface a clean
-    // form to the user (mirrors what /create did before). Count how many
-    // YAMLs were actually modified by autoFix so /metrics/planner can
-    // surface "how often did the planner generate clean YAML on its own".
-    let autofixCount = 0;
-    const cleanedNewAgents = result.data.newAgents.map((a) => {
-      const fixed = autoFixYaml(a.yaml);
-      if (fixed !== a.yaml) autofixCount++;
-      return { ...a, yaml: fixed };
+    const loopRunner = new PlannerLoopRunner({
+      telemetryStore: ctx.plannerTelemetryStore,
+      kickoffPlannerRun: ({ goal, criticFeedback }) => kickoffPlannerRun({ ctx, goal, criticFeedback }),
+      autoFixYaml,
+      loadExistingAgentIds: () => loadExistingAgentIds(ctx),
+      maxRetries: MAX_CRITIC_RETRIES,
     });
-    const plan: BuildPlan = { ...result.data, newAgents: cleanedNewAgents };
 
-    // Critic loop: structurally validate the plan against catalog reality
-    // (newAgent YAMLs parse, cross-refs resolve, dashboard refs land, etc.).
-    // On failure, retry up to MAX_CRITIC_RETRIES times by spawning a fresh
-    // planner run with the critic feedback appended to the goal.
-    const critic = critiquePlan(plan, { existingAgentIds: loadExistingAgentIds(ctx) });
+    const outcome = await loopRunner.advance({
+      runId,
+      runResult: run.result,
+      nodeExecResult: planExec?.result,
+      planMs,
+    });
 
-    // The runId we got polled with may be a retry alias; resolve to root
-    // for telemetry + attempt-counting, and look the goal up there.
-    const rootRunId = ctx.plannerTelemetryStore?.resolveOriginalRunId(runId) ?? runId;
-    const rootRow = ctx.plannerTelemetryStore?.get(rootRunId) ?? null;
-    const attemptsSoFar = rootRow?.planAttempts ?? 1;
-
-    if (!critic.ok && attemptsSoFar <= MAX_CRITIC_RETRIES) {
-      // Spawn a retry with the critic feedback. Increment attempts on the
-      // root telemetry row so the next pass can stop after MAX retries.
-      try { ctx.plannerTelemetryStore?.incrementAttempts(runId); } catch { /* swallow */ }
-      const goal = rootRow?.goal ?? '';
-      const feedback = formatCriticFeedback(critic.errors);
-      const retryRunId = await kickoffPlannerRun({ ctx, goal, criticFeedback: feedback });
-      if (retryRunId && ctx.plannerTelemetryStore) {
-        try { ctx.plannerTelemetryStore.recordRetrySpawn(rootRunId, retryRunId); } catch { /* swallow */ }
-      }
-      // Telemetry: stamp this attempt's extract status as schema-valid (the
-      // schema accepted it; only the critic rejected). Record validation
-      // errors as the critic-error count so the metrics page reflects them.
-      try {
-        ctx.plannerTelemetryStore?.recordExtract({
-          runId,
-          status: 'ok',
-          autofixCount,
-          validationErrors: critic.errors.length,
-          timeToPlanMs: planMs,
-          intent: plan.intent,
-        });
-      } catch { /* swallow */ }
-
-      if (!retryRunId) {
-        // Couldn't spawn a retry — surface what we have with the critic errors.
-        res.json({
-          ok: true,
-          status: 'done',
-          plan,
-          criticErrors: critic.errors,
-          criticWarning: 'Plan has unresolved structural issues; retry could not be started. You can commit anyway or dismiss.',
-        });
-        return;
-      }
-
+    if (outcome.kind === 'failed') {
+      res.json({ ok: true, status: 'failed', error: outcome.error, ...(outcome.rawPlan !== undefined ? { rawPlan: outcome.rawPlan } : {}) });
+      return;
+    }
+    if (outcome.kind === 'retrying') {
       res.json({
         ok: true,
         status: 'retrying',
-        runId: retryRunId,
-        attempt: attemptsSoFar + 1,
-        criticErrors: critic.errors,
-        phase: `Refining plan (attempt ${attemptsSoFar + 1})...`,
+        runId: outcome.retryRunId,
+        attempt: outcome.attempt,
+        criticErrors: outcome.criticErrors,
+        phase: outcome.phase,
       });
       return;
     }
-
-    // Either critic passed, or we've exhausted retries — return the plan.
-    // When the critic is still failing, surface its errors so the wizard
-    // can show "Continue anyway" with eyes-open consent.
-    try {
-      ctx.plannerTelemetryStore?.recordExtract({
-        runId,
-        status: 'ok',
-        autofixCount,
-        validationErrors: critic.ok ? 0 : critic.errors.length,
-        timeToPlanMs: planMs,
-        intent: plan.intent,
-      });
-    } catch { /* swallow */ }
-
-    if (critic.ok) {
-      res.json({ ok: true, status: 'done', plan });
-    } else {
-      res.json({
-        ok: true,
-        status: 'done',
-        plan,
-        criticErrors: critic.errors,
-        criticWarning: `Planner could not produce a clean plan after ${attemptsSoFar} attempts. Review the issues below and either fix the YAML inline or commit anyway.`,
-      });
-    }
+    // 'done'
+    res.json({
+      ok: true,
+      status: 'done',
+      plan: outcome.plan,
+      ...(outcome.criticErrors ? { criticErrors: outcome.criticErrors } : {}),
+      ...(outcome.criticWarning ? { criticWarning: outcome.criticWarning } : {}),
+    });
     return;
   }
 


### PR DESCRIPTION
## Summary

**PR 1 of a 4-PR planner refactor** ([plan](.claude/plans/i-need-to-refactor-peaceful-salamander.md) saved locally). Behaviour-equivalent scaffold — no user-visible change. Sets up the structure so PR 2-4 can plug in the new loop principles.

The inline extract → parse → schema-validate → autofix → critic → maybe-retry sequence at [run-now-build.ts:820-950](packages/dashboard/src/routes/run-now-build.ts#L820-L950) (~130 LOC of nested branches) now lives in `packages/core/src/planner-loop/` with named phases (observe / evaluate / reflect / compose / done / failed) and emits a uniform `LoopStepRecord` per primitive invocation.

### Files

```
packages/core/src/planner-loop/types.ts       — LoopPhase, LoopStepRecord, LoopOutcome
packages/core/src/planner-loop/primitives.ts  — observePlan, autofixPlanYamls, evaluatePlan, reflectOnEval, step
packages/core/src/planner-loop/runner.ts      — PlannerLoopRunner class
packages/core/src/planner-loop/index.ts       — barrel
packages/core/src/planner-loop/runner.test.ts — 9 tests
packages/dashboard/src/routes/run-now-build.ts — inline block → loopRunner.advance call
```

### What's preserved byte-for-byte

- 3-attempt cap (now `maxRetries` constructor option, default 2).
- All telemetry side effects (`recordExtract` / `incrementAttempts` / `recordRetrySpawn` / `resolveOriginalRunId`).
- The fallback to per-node plan output when the run's top-level result lacks `<plan>`.
- Critic feedback formatting via `formatCriticFeedback`.
- `done` / `retrying` / `failed` JSON response shapes (with `criticErrors` / `criticWarning` / `rawPlan` where applicable).

### What's set up for PR 2+

- `LoopStepRecord` shape exists but isn't persisted yet (PR 2 adds the SQLite step log).
- `observe / evaluate / reflect / compose` phases are explicit, so PR 2's smoke-run eval lands inside `evaluate` and PR 3's memory retrieval lands inside a new `understand` phase without churning the dashboard route.
- `understand` phase is in the enum but not yet emitted — lights up in PR 3.

## Sequence

- **PR 1 (this)**: scaffold, no behaviour change.
- **PR 2**: `planSmokeRun` eval (dry-run-validate each newAgent YAML) + step-log SQLite store + 2 new telemetry columns.
- **PR 3**: cross-run planner memory (read prior successful plans for similar goals; inject as `<priorPlans>` examples).
- **PR 4**: `AgentLoopRunner` for generated agents with author-declared `successCriteria` + agent-memory table.

## Test plan

- [x] `npx vitest run packages/core/src/planner-loop/runner.test.ts` — 9 tests pass (no-plan / JSON parse fail / schema invalid / fallback to nodeExecResult / critic pass / critic fail with retry / retry exhausted / retry-spawn-fails / autofix invocation)
- [x] `npm test` — 1356 passing / 3 skipped (1347 baseline + 9 new)
- [ ] After merge: trigger a real build via the dashboard wizard with a known goal; confirm same plan output, same telemetry rows, same retry behaviour on critic failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)