### PR TITLE
feat(agent-loop): successCriteria + AgentLoopRunner for generated agents (PR 4/4)

### DIFF
--- a/.changeset/agent-loop-success-criteria.md
+++ b/.changeset/agent-loop-success-criteria.md
@@ -1,0 +1,26 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Planner refactor PR 4 — generated agents can declare `successCriteria` and run inside an eval loop.
+
+Closes the 4-PR planner refactor. After PRs 1-3 brought the loop/eval/memory model to the planner itself, this PR extends the same shape to every agent: when an agent declares `successCriteria`, its execution is wrapped in `AgentLoopRunner`, which re-runs the DAG (up to `maxLoopIterations`) with prior-iteration eval feedback in `LOOP_FEEDBACK` until either eval passes or the budget is exhausted.
+
+**Schema additions** (both optional; absence = single-shot pass-through, no behaviour change for existing agents):
+- `successCriteria: [Criterion]` — discriminated union of `shellExitZero` / `fileExists` / `jsonPathEquals` / `regexMatch`.
+- `maxLoopIterations: 1..5` — defaults to 1 (criteria evaluated but no retry on failure). Explicit opt-in (≥2) required for retry behaviour.
+
+**Wiring**:
+- `LocalScheduler.v2Deps` accepts `agentMemoryStore`; scheduled fires go through `executeAgentLoop`.
+- Dashboard `run-mutations` route (manual retry) routes through `executeAgentLoop`.
+- CLI `sua schedule start` instantiates `AgentMemoryStore` and threads it in.
+
+**Each iteration writes one row to `agent_memory`** (root_run_id + iteration as the grouping key), capturing inputs / observations / eval status / failure list.
+
+**`LOOP_FEEDBACK`** input is automatically populated on iteration 2+; iteration 1 sees an empty string. Agents opt in by referencing `{{inputs.LOOP_FEEDBACK}}` (claude-code) or `$LOOP_FEEDBACK` (shell).
+
+30 new tests (20 eval-criteria + 3 memory-store + 7 runner). Docs added at `docs/success-criteria.md`. Total of 1420 passing across the 4-PR refactor.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -345,4 +345,6 @@ nodes:
 - [Tools](tools.md) — built-in + MCP + user-authored
 - [Templating](templating.md) — placeholder reference
 - [Output widgets](output-widgets.md) — render run output as UI
+- [Success criteria + agent loop](success-criteria.md) — author-declared eval gate, re-runs on failure
+- [Retry policy](retry.md) — transient-failure backoff (separate from success criteria)
 - [Security model](SECURITY.md) — trust rings, shell gate, env filter

--- a/docs/success-criteria.md
+++ b/docs/success-criteria.md
@@ -1,0 +1,74 @@
+# Agent success criteria + the agent loop
+
+When an agent declares `successCriteria`, the runtime wraps its execution in an **agent loop**: after each DAG run, the listed criteria are checked, and if any fail the agent re-runs (up to `maxLoopIterations`) with a `LOOP_FEEDBACK` input carrying the failure list from the previous attempt.
+
+This is **author-declared validation acceptance** — separate from the [`retry:`](retry.md) policy, which handles transient infrastructure failures like timeouts and exit-nonzero categories.
+
+## Minimal example
+
+```yaml
+id: weather-summary
+name: weather-summary
+inputs:
+  CITY:
+    type: string
+    default: Brooklyn
+nodes:
+  - id: fetch
+    type: shell
+    command: |
+      curl -fsS "https://wttr.in/$CITY?format=j1" > /tmp/wx.json && cat /tmp/wx.json
+
+successCriteria:
+  - kind: shellExitZero
+    nodeId: fetch
+  - kind: jsonPathEquals
+    nodeId: fetch
+    path: current_condition.0.temp_C
+    equals: "21"
+maxLoopIterations: 2
+```
+
+If `fetch` returns a non-zero exit OR the JSON path doesn't match the expected temperature, the agent re-runs once more before giving up.
+
+## Criterion kinds
+
+Each kind is checked without an LLM call — fast, deterministic, free.
+
+| `kind` | Required fields | Passes when |
+| --- | --- | --- |
+| `shellExitZero` | `nodeId` | target shell node completed with exit code 0 |
+| `fileExists` | `pathTemplate` | path exists on disk (supports `{{inputs.X}}` expansion) |
+| `jsonPathEquals` | `nodeId`, `path`, `equals` | target node's JSON output, dot-walked, deep-equals the value |
+| `regexMatch` | `nodeId`, `pattern` | target node's stringified output matches the regex |
+
+`jsonPathEquals` walks dotted paths including array indices: `items.0.name`, `summary.totals.passed`, etc. Returns `undefined` on miss, which won't `equals` anything except `undefined`.
+
+## `LOOP_FEEDBACK` input
+
+When `maxLoopIterations > 1` and the first iteration fails, the agent re-runs with an extra `LOOP_FEEDBACK` input containing the failure list. Agents opt in by referencing it:
+
+- **claude-code** node: `{{inputs.LOOP_FEEDBACK}}` in the prompt
+- **shell** node: `$LOOP_FEEDBACK` env var in the command
+
+Iteration 1 gets the input set to an empty string, so no template-resolution drama for agents that always reference it.
+
+## What gets persisted
+
+Each iteration writes one row to `agent_memory`:
+
+- `agent_id`, `root_run_id` (the first iteration's run id), `iteration` (1-indexed), `run_id` (this iteration's run id — equals `root_run_id` when `iteration = 1`)
+- `inputs_json` — what got passed in (truncated to 8KB)
+- `observations_json` — compact summary of per-node status + result preview (truncated)
+- `eval_status` — `passed` | `failed` | `transient-error` | `no-criteria`
+- `eval_failures_json` — full failure list when `eval_status = failed`
+
+There's no UI for this yet — query the SQLite table directly to inspect. A dashboard surface is a future polish.
+
+## When NOT to use this
+
+- **Pure observation agents** (cron jobs that fetch data and store it; no "did it work" definition beyond exit code). The `retry:` policy already covers transient infra failures.
+- **Agents whose criteria depend on real-time external state** that doesn't settle between iterations (re-running won't change the answer).
+- **Agents where iteration cost matters** (each iteration is a fresh DAG run with its own LLM/HTTP costs).
+
+When `successCriteria` is absent or empty, the runtime is a pure pass-through to the existing retry-wrapped executor — no behaviour change.

--- a/packages/cli/src/commands/schedule.ts
+++ b/packages/cli/src/commands/schedule.ts
@@ -12,6 +12,7 @@ import {
   AgentStore,
   VariablesStore,
   IntegrationsStore,
+  AgentMemoryStore,
   EncryptedFileStore,
   cronToHuman,
   getSchedulerStatus,
@@ -250,6 +251,10 @@ scheduleCommand
       try { return new IntegrationsStore(getDbPath(config)); }
       catch { return undefined; }
     })();
+    const agentMemoryStore = (() => {
+      try { return new AgentMemoryStore(getDbPath(config)); }
+      catch { return undefined; }
+    })();
     const secretsStore = (() => {
       try { return new EncryptedFileStore(getSecretsPath(config)); }
       catch { return undefined; }
@@ -265,6 +270,7 @@ scheduleCommand
         variablesStore,
         integrationsStore,
         agentStore,
+        agentMemoryStore,
         allowUntrustedShell: new Set(options.allowUntrustedShell),
         dashboardBaseUrl: getDashboardBaseUrl(config),
         dataRoot: agentStore.dataRoot,

--- a/packages/core/src/agent-loop/eval-criteria.test.ts
+++ b/packages/core/src/agent-loop/eval-criteria.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { evaluateCriteria, formatCriterionFailures } from './eval-criteria.js';
+import type { NodeExecutionRecord } from '../agent-v2-types.js';
+import type { Run } from '../types.js';
+
+const dummyRun: Run = {
+  id: 'r1',
+  agentName: 'test',
+  status: 'completed',
+  startedAt: '2026-05-18T00:00:00Z',
+  triggeredBy: 'cli',
+};
+
+const completedShell = (nodeId: string, exitCode: number, result?: string): NodeExecutionRecord => ({
+  runId: 'r1',
+  nodeId,
+  workflowVersion: 1,
+  status: 'completed',
+  startedAt: '2026-05-18T00:00:00Z',
+  completedAt: '2026-05-18T00:00:01Z',
+  exitCode,
+  result,
+});
+
+describe('evaluateCriteria — shellExitZero', () => {
+  it('passes when target node exited 0', () => {
+    const r = evaluateCriteria({
+      criteria: [{ kind: 'shellExitZero', nodeId: 'a' }],
+      run: dummyRun,
+      nodeExecutions: [completedShell('a', 0)],
+    });
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails when target node exited non-zero (with reason)', () => {
+    const r = evaluateCriteria({
+      criteria: [{ kind: 'shellExitZero', nodeId: 'a' }],
+      run: dummyRun,
+      nodeExecutions: [completedShell('a', 17)],
+    });
+    expect(r.passed).toBe(false);
+    expect(r.results[0].reason).toContain('17');
+  });
+
+  it('fails when target node did not run', () => {
+    const r = evaluateCriteria({
+      criteria: [{ kind: 'shellExitZero', nodeId: 'missing' }],
+      run: dummyRun,
+      nodeExecutions: [completedShell('a', 0)],
+    });
+    expect(r.passed).toBe(false);
+    expect(r.results[0].reason).toContain('did not run');
+  });
+
+  it('fails when target node has no exit code (claude-code node)', () => {
+    const r = evaluateCriteria({
+      criteria: [{ kind: 'shellExitZero', nodeId: 'a' }],
+      run: dummyRun,
+      nodeExecutions: [{
+        runId: 'r1', nodeId: 'a', workflowVersion: 1,
+        status: 'completed', startedAt: '2026-05-18T00:00:00Z',
+      }],
+    });
+    expect(r.passed).toBe(false);
+    expect(r.results[0].reason).toContain('no exit code');
+  });
+});
+
+describe('evaluateCriteria — fileExists', () => {
+  let dir: string;
+
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'eval-test-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('passes when the path exists', () => {
+    const p = join(dir, 'out.txt');
+    writeFileSync(p, 'hello');
+    const r = evaluateCriteria({
+      criteria: [{ kind: 'fileExists', pathTemplate: p }],
+      run: dummyRun,
+      nodeExecutions: [],
+    });
+    expect(r.passed).toBe(true);
+  });
+
+  it('expands {{inputs.X}} in the path template', () => {
+    const p = join(dir, 'expanded.txt');
+    writeFileSync(p, 'x');
+    const r = evaluateCriteria({
+      criteria: [{ kind: 'fileExists', pathTemplate: `${dir}/{{inputs.NAME}}.txt` }],
+      run: dummyRun,
+      nodeExecutions: [],
+      inputs: { NAME: 'expanded' },
+    });
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails when the path does not exist', () => {
+    const r = evaluateCriteria({
+      criteria: [{ kind: 'fileExists', pathTemplate: join(dir, 'nope.txt') }],
+      run: dummyRun,
+      nodeExecutions: [],
+    });
+    expect(r.passed).toBe(false);
+    expect(r.results[0].reason).toContain('does not exist');
+  });
+
+  it('fails when the path template expands to empty', () => {
+    const r = evaluateCriteria({
+      criteria: [{ kind: 'fileExists', pathTemplate: '{{inputs.MISSING}}' }],
+      run: dummyRun,
+      nodeExecutions: [],
+      inputs: {},
+    });
+    expect(r.passed).toBe(false);
+    expect(r.results[0].reason).toContain('empty');
+  });
+});
+
+describe('evaluateCriteria — jsonPathEquals', () => {
+  it('passes when the dotted path equals the expected value', () => {
+    const r = evaluateCriteria({
+      criteria: [{ kind: 'jsonPathEquals', nodeId: 'a', path: 'count', equals: 3 }],
+      run: dummyRun,
+      nodeExecutions: [completedShell('a', 0, JSON.stringify({ count: 3 }))],
+    });
+    expect(r.passed).toBe(true);
+  });
+
+  it('walks nested paths including array indices', () => {
+    const r = evaluateCriteria({
+      criteria: [{ kind: 'jsonPathEquals', nodeId: 'a', path: 'items.1.name', equals: 'bravo' }],
+      run: dummyRun,
+      nodeExecutions: [completedShell('a', 0, JSON.stringify({ items: [{ name: 'alpha' }, { name: 'bravo' }] }))],
+    });
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails when the value differs', () => {
+    const r = evaluateCriteria({
+      criteria: [{ kind: 'jsonPathEquals', nodeId: 'a', path: 'status', equals: 'ok' }],
+      run: dummyRun,
+      nodeExecutions: [completedShell('a', 0, JSON.stringify({ status: 'broken' }))],
+    });
+    expect(r.passed).toBe(false);
+    expect(r.results[0].reason).toContain('"broken"');
+  });
+
+  it('fails when the result is not JSON', () => {
+    const r = evaluateCriteria({
+      criteria: [{ kind: 'jsonPathEquals', nodeId: 'a', path: 'x', equals: 1 }],
+      run: dummyRun,
+      nodeExecutions: [completedShell('a', 0, 'plain text not json')],
+    });
+    expect(r.passed).toBe(false);
+    expect(r.results[0].reason).toContain('not JSON');
+  });
+
+  it('deep-equals objects and arrays', () => {
+    const r = evaluateCriteria({
+      criteria: [{ kind: 'jsonPathEquals', nodeId: 'a', path: 'arr', equals: [1, 2, 3] }],
+      run: dummyRun,
+      nodeExecutions: [completedShell('a', 0, JSON.stringify({ arr: [1, 2, 3] }))],
+    });
+    expect(r.passed).toBe(true);
+  });
+});
+
+describe('evaluateCriteria — regexMatch', () => {
+  it('passes when the result matches the pattern', () => {
+    const r = evaluateCriteria({
+      criteria: [{ kind: 'regexMatch', nodeId: 'a', pattern: 'success' }],
+      run: dummyRun,
+      nodeExecutions: [completedShell('a', 0, 'OK: success rate 99%')],
+    });
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails when the pattern doesn\'t match', () => {
+    const r = evaluateCriteria({
+      criteria: [{ kind: 'regexMatch', nodeId: 'a', pattern: '^error:' }],
+      run: dummyRun,
+      nodeExecutions: [completedShell('a', 0, 'OK: nothing happened')],
+    });
+    expect(r.passed).toBe(false);
+  });
+
+  it('fails on invalid regex with a clear reason', () => {
+    const r = evaluateCriteria({
+      criteria: [{ kind: 'regexMatch', nodeId: 'a', pattern: '(unclosed' }],
+      run: dummyRun,
+      nodeExecutions: [completedShell('a', 0, 'whatever')],
+    });
+    expect(r.passed).toBe(false);
+    expect(r.results[0].reason).toContain('invalid regex');
+  });
+});
+
+describe('evaluateCriteria — aggregate', () => {
+  it('passes only when every criterion passes', () => {
+    const r = evaluateCriteria({
+      criteria: [
+        { kind: 'shellExitZero', nodeId: 'a' },
+        { kind: 'regexMatch', nodeId: 'a', pattern: 'ok' },
+      ],
+      run: dummyRun,
+      nodeExecutions: [completedShell('a', 0, 'all ok here')],
+    });
+    expect(r.passed).toBe(true);
+  });
+
+  it('fails the aggregate when any criterion fails', () => {
+    const r = evaluateCriteria({
+      criteria: [
+        { kind: 'shellExitZero', nodeId: 'a' },
+        { kind: 'regexMatch', nodeId: 'a', pattern: 'WONT_MATCH' },
+      ],
+      run: dummyRun,
+      nodeExecutions: [completedShell('a', 0, 'all ok')],
+    });
+    expect(r.passed).toBe(false);
+    expect(r.results.filter((x) => !x.passed)).toHaveLength(1);
+  });
+});
+
+describe('formatCriterionFailures', () => {
+  it('returns empty string when nothing failed', () => {
+    expect(formatCriterionFailures([
+      { description: 'a', passed: true },
+    ])).toBe('');
+  });
+
+  it('renders each failure with its reason', () => {
+    const out = formatCriterionFailures([
+      { description: 'shellExitZero(a)', passed: false, reason: 'exit code 7' },
+      { description: 'fileExists(/tmp/out)', passed: false, reason: 'does not exist' },
+    ]);
+    expect(out).toContain('Eval feedback');
+    expect(out).toContain('shellExitZero(a): exit code 7');
+    expect(out).toContain('fileExists(/tmp/out): does not exist');
+  });
+});

--- a/packages/core/src/agent-loop/eval-criteria.ts
+++ b/packages/core/src/agent-loop/eval-criteria.ts
@@ -1,0 +1,167 @@
+/**
+ * Evaluator for agent-loop success criteria. Reads the just-completed
+ * run's per-node executions + the run's structured outputs, checks each
+ * declared criterion, returns a structured pass/fail list.
+ *
+ * Criteria are deliberately narrow: each kind is something we can
+ * answer without an LLM call. More elaborate "did the agent satisfy the
+ * spirit of this goal?" checks would need a critic-style LLM
+ * eval — deferred until we have enough usage data to know what kinds
+ * matter.
+ */
+
+import { existsSync } from 'node:fs';
+import type { AgentSuccessCriterion, NodeExecutionRecord } from '../agent-v2-types.js';
+import type { Run } from '../types.js';
+
+export interface CriterionResult {
+  /** Stringified description of the criterion that fired, for the failure list / memory. */
+  description: string;
+  passed: boolean;
+  /** When `passed === false`, a short reason for the user / next-iteration prompt. */
+  reason?: string;
+}
+
+export interface EvaluateCriteriaResult {
+  passed: boolean;
+  results: CriterionResult[];
+}
+
+export interface EvaluateCriteriaInput {
+  criteria: AgentSuccessCriterion[];
+  run: Run;
+  nodeExecutions: NodeExecutionRecord[];
+  /**
+   * Inputs supplied to the run, for `pathTemplate` expansion in
+   * `fileExists`. Optional — when absent, `{{inputs.X}}` templates
+   * resolve to empty strings.
+   */
+  inputs?: Record<string, string>;
+}
+
+export function evaluateCriteria(input: EvaluateCriteriaInput): EvaluateCriteriaResult {
+  const results: CriterionResult[] = [];
+  for (const c of input.criteria) {
+    results.push(evalOne(c, input));
+  }
+  return { passed: results.every((r) => r.passed), results };
+}
+
+function evalOne(c: AgentSuccessCriterion, input: EvaluateCriteriaInput): CriterionResult {
+  switch (c.kind) {
+    case 'shellExitZero':
+      return evalShellExitZero(c, input.nodeExecutions);
+    case 'fileExists':
+      return evalFileExists(c, input.inputs ?? {});
+    case 'jsonPathEquals':
+      return evalJsonPathEquals(c, input.nodeExecutions);
+    case 'regexMatch':
+      return evalRegexMatch(c, input.nodeExecutions);
+  }
+}
+
+function evalShellExitZero(c: Extract<AgentSuccessCriterion, { kind: 'shellExitZero' }>, execs: NodeExecutionRecord[]): CriterionResult {
+  const desc = `shellExitZero(${c.nodeId})`;
+  const exec = execs.find((e) => e.nodeId === c.nodeId);
+  if (!exec) return { description: desc, passed: false, reason: `node "${c.nodeId}" did not run` };
+  if (exec.status !== 'completed') return { description: desc, passed: false, reason: `node status was "${exec.status}", not "completed"` };
+  if (exec.exitCode === null || exec.exitCode === undefined) {
+    return { description: desc, passed: false, reason: 'node has no exit code (not a shell node?)' };
+  }
+  return exec.exitCode === 0
+    ? { description: desc, passed: true }
+    : { description: desc, passed: false, reason: `exit code ${exec.exitCode}` };
+}
+
+function evalFileExists(c: Extract<AgentSuccessCriterion, { kind: 'fileExists' }>, inputs: Record<string, unknown>): CriterionResult {
+  // Minimal template expansion: {{inputs.X}} → inputs[X] stringified.
+  // The full template grammar lives in node-templates.ts but is overkill
+  // here — criteria are author-edited, so trust them to write simple paths.
+  const resolved = c.pathTemplate.replace(/\{\{\s*inputs\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g, (_, name: string) => {
+    const v = inputs[name];
+    return v == null ? '' : String(v);
+  });
+  const desc = `fileExists(${c.pathTemplate})`;
+  if (resolved.length === 0) return { description: desc, passed: false, reason: 'path template expanded to empty string' };
+  return existsSync(resolved)
+    ? { description: desc, passed: true }
+    : { description: desc, passed: false, reason: `path "${resolved}" does not exist` };
+}
+
+function evalJsonPathEquals(c: Extract<AgentSuccessCriterion, { kind: 'jsonPathEquals' }>, execs: NodeExecutionRecord[]): CriterionResult {
+  const desc = `jsonPathEquals(${c.nodeId}, ${c.path}, ${JSON.stringify(c.equals)})`;
+  const exec = execs.find((e) => e.nodeId === c.nodeId);
+  if (!exec) return { description: desc, passed: false, reason: `node "${c.nodeId}" did not run` };
+  if (!exec.result) return { description: desc, passed: false, reason: `node "${c.nodeId}" produced no result` };
+  let parsed: unknown;
+  try { parsed = JSON.parse(exec.result); }
+  catch { return { description: desc, passed: false, reason: `node "${c.nodeId}" result is not JSON` }; }
+  const actual = walkJsonPath(parsed, c.path);
+  return deepEqual(actual, c.equals)
+    ? { description: desc, passed: true }
+    : { description: desc, passed: false, reason: `expected ${JSON.stringify(c.equals)} at ${c.path}, got ${JSON.stringify(actual)}` };
+}
+
+function evalRegexMatch(c: Extract<AgentSuccessCriterion, { kind: 'regexMatch' }>, execs: NodeExecutionRecord[]): CriterionResult {
+  const desc = `regexMatch(${c.nodeId}, /${c.pattern}/)`;
+  const exec = execs.find((e) => e.nodeId === c.nodeId);
+  if (!exec) return { description: desc, passed: false, reason: `node "${c.nodeId}" did not run` };
+  if (!exec.result) return { description: desc, passed: false, reason: `node "${c.nodeId}" produced no result` };
+  let re: RegExp;
+  try { re = new RegExp(c.pattern); }
+  catch (e) { return { description: desc, passed: false, reason: `invalid regex: ${(e as Error).message}` }; }
+  return re.test(exec.result)
+    ? { description: desc, passed: true }
+    : { description: desc, passed: false, reason: 'regex did not match' };
+}
+
+/** Walk a dotted path through a parsed JSON value. `a.b.0.c` works. Returns undefined on miss. */
+function walkJsonPath(root: unknown, path: string): unknown {
+  let cur: unknown = root;
+  for (const part of path.split('.')) {
+    if (cur === null || cur === undefined) return undefined;
+    if (typeof cur !== 'object') return undefined;
+    if (Array.isArray(cur)) {
+      const idx = Number(part);
+      if (!Number.isInteger(idx) || idx < 0 || idx >= cur.length) return undefined;
+      cur = cur[idx];
+    } else {
+      cur = (cur as Record<string, unknown>)[part];
+    }
+  }
+  return cur;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null || a === undefined || b === undefined) return false;
+  if (typeof a !== typeof b) return false;
+  if (typeof a !== 'object') return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (Array.isArray(a)) {
+    const aa = a as unknown[], bb = b as unknown[];
+    if (aa.length !== bb.length) return false;
+    return aa.every((x, i) => deepEqual(x, bb[i]));
+  }
+  const aKeys = Object.keys(a as object).sort();
+  const bKeys = Object.keys(b as object).sort();
+  if (aKeys.length !== bKeys.length) return false;
+  if (!aKeys.every((k, i) => k === bKeys[i])) return false;
+  const ao = a as Record<string, unknown>, bo = b as Record<string, unknown>;
+  return aKeys.every((k) => deepEqual(ao[k], bo[k]));
+}
+
+/**
+ * Render the failed-criteria list as feedback the next iteration can
+ * read. Format mirrors `formatCriticFeedback` from the planner side so
+ * the visual convention is consistent across both loop runners.
+ */
+export function formatCriterionFailures(results: CriterionResult[]): string {
+  const failed = results.filter((r) => !r.passed);
+  if (failed.length === 0) return '';
+  const lines: string[] = ['Eval feedback from the previous iteration (fix every item below before re-running):'];
+  for (const r of failed) {
+    lines.push(`- ${r.description}: ${r.reason ?? 'failed'}`);
+  }
+  return lines.join('\n');
+}

--- a/packages/core/src/agent-loop/index.ts
+++ b/packages/core/src/agent-loop/index.ts
@@ -1,0 +1,3 @@
+export { executeAgentLoop, type AgentLoopRunnerDeps, type AgentLoopHooks } from './runner.js';
+export { evaluateCriteria, formatCriterionFailures, type CriterionResult, type EvaluateCriteriaResult, type EvaluateCriteriaInput } from './eval-criteria.js';
+export { AgentMemoryStore, type AgentMemoryRow, type AgentMemoryEvalStatus } from './memory-store.js';

--- a/packages/core/src/agent-loop/memory-store.test.ts
+++ b/packages/core/src/agent-loop/memory-store.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { AgentMemoryStore } from './memory-store.js';
+
+describe('AgentMemoryStore', () => {
+  let dir: string;
+  let store: AgentMemoryStore;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'amem-test-'));
+    store = new AgentMemoryStore(join(dir, 'agent.db'));
+  });
+
+  afterEach(() => {
+    store.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('round-trips an iteration row', () => {
+    store.recordIteration({
+      agentId: 'agent-a',
+      rootRunId: 'root-1',
+      iteration: 1,
+      runId: 'root-1',
+      inputsJson: JSON.stringify({ X: 'hi' }),
+      observationsJson: JSON.stringify({ a: { status: 'completed' } }),
+      evalStatus: 'failed',
+      evalFailuresJson: JSON.stringify([{ description: 'x', passed: false }]),
+    });
+    const rows = store.listForRoot('agent-a', 'root-1');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      agentId: 'agent-a',
+      rootRunId: 'root-1',
+      iteration: 1,
+      runId: 'root-1',
+      evalStatus: 'failed',
+    });
+  });
+
+  it('orders iterations ascending and groups by root', () => {
+    store.recordIteration({ agentId: 'a', rootRunId: 'r1', iteration: 2, runId: 'r1b', inputsJson: null, observationsJson: null, evalStatus: 'failed', evalFailuresJson: null });
+    store.recordIteration({ agentId: 'a', rootRunId: 'r1', iteration: 1, runId: 'r1', inputsJson: null, observationsJson: null, evalStatus: 'failed', evalFailuresJson: null });
+    store.recordIteration({ agentId: 'a', rootRunId: 'r1', iteration: 3, runId: 'r1c', inputsJson: null, observationsJson: null, evalStatus: 'passed', evalFailuresJson: null });
+    store.recordIteration({ agentId: 'a', rootRunId: 'r2', iteration: 1, runId: 'r2', inputsJson: null, observationsJson: null, evalStatus: 'passed', evalFailuresJson: null });
+
+    const root1 = store.listForRoot('a', 'r1');
+    expect(root1.map((r) => r.iteration)).toEqual([1, 2, 3]);
+    expect(store.listForRoot('a', 'r2')).toHaveLength(1);
+  });
+
+  it('upserts (replaces) on the (agent_id, root_run_id, iteration) PK', () => {
+    store.recordIteration({ agentId: 'a', rootRunId: 'r', iteration: 1, runId: 'r', inputsJson: null, observationsJson: null, evalStatus: 'failed', evalFailuresJson: null });
+    store.recordIteration({ agentId: 'a', rootRunId: 'r', iteration: 1, runId: 'r', inputsJson: null, observationsJson: null, evalStatus: 'passed', evalFailuresJson: null });
+    const rows = store.listForRoot('a', 'r');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].evalStatus).toBe('passed');
+  });
+});

--- a/packages/core/src/agent-loop/memory-store.ts
+++ b/packages/core/src/agent-loop/memory-store.ts
@@ -1,0 +1,106 @@
+/**
+ * Per-agent iteration log: one row per loop iteration, grouped by the
+ * first iteration's run id. Lets a later iteration reach back to "what
+ * did the previous attempt produce + which criteria failed" and lets the
+ * dashboard show "this run was iteration 2 of 3" once a UI is wired.
+ *
+ * MVP: write-only from `AgentLoopRunner`. Reads come in a future PR
+ * when we expose them in the dashboard / planner-side analytics.
+ */
+
+import { DatabaseSync } from 'node:sqlite';
+
+export type AgentMemoryEvalStatus = 'passed' | 'failed' | 'no-criteria' | 'transient-error';
+
+export interface AgentMemoryRow {
+  agentId: string;
+  rootRunId: string;
+  iteration: number;
+  runId: string;
+  inputsJson: string | null;
+  observationsJson: string | null;
+  evalStatus: AgentMemoryEvalStatus;
+  evalFailuresJson: string | null;
+  createdAt: string;
+}
+
+export class AgentMemoryStore {
+  private db: DatabaseSync;
+  private readonly ownsConnection: boolean;
+
+  constructor(dbPath: string) {
+    this.db = new DatabaseSync(dbPath);
+    this.ownsConnection = true;
+    this.ensureSchema();
+  }
+
+  static fromHandle(db: DatabaseSync): AgentMemoryStore {
+    const store = Object.create(AgentMemoryStore.prototype) as AgentMemoryStore;
+    (store as unknown as { db: DatabaseSync }).db = db;
+    (store as unknown as { ownsConnection: boolean }).ownsConnection = false;
+    store.ensureSchema();
+    return store;
+  }
+
+  private ensureSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS agent_memory (
+        agent_id TEXT NOT NULL,
+        root_run_id TEXT NOT NULL,
+        iteration INTEGER NOT NULL,
+        run_id TEXT NOT NULL,
+        inputs_json TEXT,
+        observations_json TEXT,
+        eval_status TEXT NOT NULL,
+        eval_failures_json TEXT,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (agent_id, root_run_id, iteration)
+      )
+    `);
+    this.db.exec(`CREATE INDEX IF NOT EXISTS idx_am_agent_time ON agent_memory(agent_id, created_at DESC)`);
+  }
+
+  recordIteration(row: Omit<AgentMemoryRow, 'createdAt'>): void {
+    this.db.prepare(`
+      INSERT OR REPLACE INTO agent_memory (
+        agent_id, root_run_id, iteration, run_id,
+        inputs_json, observations_json, eval_status, eval_failures_json, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+    `).run(
+      row.agentId,
+      row.rootRunId,
+      row.iteration,
+      row.runId,
+      row.inputsJson,
+      row.observationsJson,
+      row.evalStatus,
+      row.evalFailuresJson,
+    );
+  }
+
+  /** All iterations for one root run, ordered by iteration ASC. Used by tests + future UI surfaces. */
+  listForRoot(agentId: string, rootRunId: string): AgentMemoryRow[] {
+    const rows = this.db.prepare(`
+      SELECT agent_id, root_run_id, iteration, run_id,
+             inputs_json, observations_json, eval_status, eval_failures_json, created_at
+      FROM agent_memory WHERE agent_id = ? AND root_run_id = ? ORDER BY iteration ASC
+    `).all(agentId, rootRunId) as Array<Record<string, unknown>>;
+    return rows.map(this.rowToMemory);
+  }
+
+  close(): void {
+    if (this.ownsConnection) this.db.close();
+  }
+
+  private rowToMemory = (r: Record<string, unknown>): AgentMemoryRow => ({
+    agentId: r.agent_id as string,
+    rootRunId: r.root_run_id as string,
+    iteration: r.iteration as number,
+    runId: r.run_id as string,
+    inputsJson: (r.inputs_json as string | null) ?? null,
+    observationsJson: (r.observations_json as string | null) ?? null,
+    evalStatus: r.eval_status as AgentMemoryEvalStatus,
+    evalFailuresJson: (r.eval_failures_json as string | null) ?? null,
+    createdAt: r.created_at as string,
+  });
+}

--- a/packages/core/src/agent-loop/runner.test.ts
+++ b/packages/core/src/agent-loop/runner.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { executeAgentLoop } from './runner.js';
+import { AgentMemoryStore } from './memory-store.js';
+import type { Agent } from '../agent-v2-types.js';
+import type { Run } from '../types.js';
+import type { DagExecutorDeps } from '../dag-executor.js';
+
+// Mock `executeAgentWithRetry` so tests don't spin up a real DAG executor.
+vi.mock('../retry.js', async (orig) => {
+  const real = await orig<typeof import('../retry.js')>();
+  return {
+    ...real,
+    executeAgentWithRetry: vi.fn(),
+  };
+});
+
+import { executeAgentWithRetry } from '../retry.js';
+
+const baseAgent: Agent = {
+  id: 'test-agent',
+  name: 'test',
+  status: 'active',
+  source: 'local',
+  version: 1,
+  nodes: [{ id: 'a', type: 'shell', command: 'echo' }],
+};
+
+function makeRun(id: string, status: Run['status'] = 'completed'): Run {
+  return {
+    id, agentName: 'test-agent', status,
+    startedAt: '2026-05-18T00:00:00Z',
+    triggeredBy: 'cli',
+  };
+}
+
+/**
+ * Build a deps stub. Only `runStore.listNodeExecutions` is used by the
+ * runner; the mocked executeAgentWithRetry doesn't touch the rest.
+ */
+function stubDeps(execs: Record<string, Array<{ nodeId: string; status: string; exitCode?: number; result?: string }>>): DagExecutorDeps {
+  return {
+    runStore: {
+      listNodeExecutions: (runId: string) => execs[runId] ?? [],
+    },
+  } as unknown as DagExecutorDeps;
+}
+
+describe('executeAgentLoop', () => {
+  let tmpDir: string;
+  let memory: AgentMemoryStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'agentloop-test-'));
+    memory = new AgentMemoryStore(join(tmpDir, 'mem.db'));
+    vi.mocked(executeAgentWithRetry).mockReset();
+  });
+
+  afterEach(() => {
+    memory.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('is a pure pass-through when the agent declares no successCriteria', async () => {
+    vi.mocked(executeAgentWithRetry).mockResolvedValueOnce(makeRun('r1'));
+    const result = await executeAgentLoop(baseAgent, { triggeredBy: 'cli' }, stubDeps({}));
+    expect(result.id).toBe('r1');
+    expect(executeAgentWithRetry).toHaveBeenCalledOnce();
+  });
+
+  it('runs once + returns when criteria pass on the first iteration', async () => {
+    vi.mocked(executeAgentWithRetry).mockResolvedValueOnce(makeRun('r1'));
+    const agent: Agent = {
+      ...baseAgent,
+      successCriteria: [{ kind: 'shellExitZero', nodeId: 'a' }],
+      maxLoopIterations: 3,
+    };
+    const deps = stubDeps({ r1: [{ nodeId: 'a', status: 'completed', exitCode: 0 }] });
+    const result = await executeAgentLoop(agent, { triggeredBy: 'cli' }, deps, { memoryStore: memory });
+    expect(result.id).toBe('r1');
+    expect(executeAgentWithRetry).toHaveBeenCalledOnce();
+    const mem = memory.listForRoot('test-agent', 'r1');
+    expect(mem).toHaveLength(1);
+    expect(mem[0]).toMatchObject({ iteration: 1, evalStatus: 'passed' });
+  });
+
+  it('re-runs up to maxLoopIterations when criteria fail, recording each iteration', async () => {
+    vi.mocked(executeAgentWithRetry)
+      .mockResolvedValueOnce(makeRun('r1'))
+      .mockResolvedValueOnce(makeRun('r2'))
+      .mockResolvedValueOnce(makeRun('r3'));
+    const agent: Agent = {
+      ...baseAgent,
+      successCriteria: [{ kind: 'shellExitZero', nodeId: 'a' }],
+      maxLoopIterations: 3,
+    };
+    const deps = stubDeps({
+      r1: [{ nodeId: 'a', status: 'completed', exitCode: 1 }],
+      r2: [{ nodeId: 'a', status: 'completed', exitCode: 1 }],
+      r3: [{ nodeId: 'a', status: 'completed', exitCode: 1 }],
+    });
+    const result = await executeAgentLoop(agent, { triggeredBy: 'cli' }, deps, { memoryStore: memory });
+    expect(result.id).toBe('r3'); // last iteration's run
+    expect(executeAgentWithRetry).toHaveBeenCalledTimes(3);
+    const mem = memory.listForRoot('test-agent', 'r1');
+    expect(mem.map((m) => m.iteration)).toEqual([1, 2, 3]);
+    expect(mem.every((m) => m.evalStatus === 'failed')).toBe(true);
+  });
+
+  it('stops early when an iteration passes', async () => {
+    vi.mocked(executeAgentWithRetry)
+      .mockResolvedValueOnce(makeRun('r1'))
+      .mockResolvedValueOnce(makeRun('r2'));
+    const agent: Agent = {
+      ...baseAgent,
+      successCriteria: [{ kind: 'shellExitZero', nodeId: 'a' }],
+      maxLoopIterations: 5,
+    };
+    const deps = stubDeps({
+      r1: [{ nodeId: 'a', status: 'completed', exitCode: 1 }],
+      r2: [{ nodeId: 'a', status: 'completed', exitCode: 0 }],
+    });
+    const result = await executeAgentLoop(agent, { triggeredBy: 'cli' }, deps, { memoryStore: memory });
+    expect(result.id).toBe('r2');
+    expect(executeAgentWithRetry).toHaveBeenCalledTimes(2);
+    const mem = memory.listForRoot('test-agent', 'r1');
+    expect(mem.map((m) => m.evalStatus)).toEqual(['failed', 'passed']);
+  });
+
+  it('aborts after a transient failure without re-iterating', async () => {
+    vi.mocked(executeAgentWithRetry).mockResolvedValueOnce(makeRun('r1', 'failed'));
+    const agent: Agent = {
+      ...baseAgent,
+      successCriteria: [{ kind: 'shellExitZero', nodeId: 'a' }],
+      maxLoopIterations: 3,
+    };
+    const result = await executeAgentLoop(agent, { triggeredBy: 'cli' }, stubDeps({}), { memoryStore: memory });
+    expect(result.status).toBe('failed');
+    expect(executeAgentWithRetry).toHaveBeenCalledOnce();
+    const mem = memory.listForRoot('test-agent', 'r1');
+    expect(mem[0].evalStatus).toBe('transient-error');
+  });
+
+  it('injects LOOP_FEEDBACK on iteration 2+ but not on the first', async () => {
+    vi.mocked(executeAgentWithRetry)
+      .mockResolvedValueOnce(makeRun('r1'))
+      .mockResolvedValueOnce(makeRun('r2'));
+    const agent: Agent = {
+      ...baseAgent,
+      successCriteria: [{ kind: 'shellExitZero', nodeId: 'a' }],
+      maxLoopIterations: 2,
+    };
+    const deps = stubDeps({
+      r1: [{ nodeId: 'a', status: 'completed', exitCode: 1 }],
+      r2: [{ nodeId: 'a', status: 'completed', exitCode: 0 }],
+    });
+    await executeAgentLoop(agent, { triggeredBy: 'cli', inputs: { Q: 'hi' } }, deps);
+
+    const calls = vi.mocked(executeAgentWithRetry).mock.calls;
+    expect(calls[0][1].inputs?.LOOP_FEEDBACK).toBe(''); // first iteration: empty
+    expect(calls[1][1].inputs?.LOOP_FEEDBACK).toContain('Eval feedback');
+    expect(calls[1][1].inputs?.LOOP_FEEDBACK).toContain('shellExitZero(a)');
+    expect(calls[1][1].inputs?.Q).toBe('hi'); // user inputs preserved
+  });
+
+  it('fires onEvalRetry hook before each retry iteration', async () => {
+    vi.mocked(executeAgentWithRetry)
+      .mockResolvedValueOnce(makeRun('r1'))
+      .mockResolvedValueOnce(makeRun('r2'));
+    const agent: Agent = {
+      ...baseAgent,
+      successCriteria: [{ kind: 'shellExitZero', nodeId: 'a' }],
+      maxLoopIterations: 2,
+    };
+    const deps = stubDeps({
+      r1: [{ nodeId: 'a', status: 'completed', exitCode: 1 }],
+      r2: [{ nodeId: 'a', status: 'completed', exitCode: 0 }],
+    });
+    const onEvalRetry = vi.fn();
+    await executeAgentLoop(agent, { triggeredBy: 'cli' }, deps, {}, { onEvalRetry });
+    expect(onEvalRetry).toHaveBeenCalledOnce();
+    expect(onEvalRetry).toHaveBeenCalledWith(2, expect.any(Array));
+  });
+});

--- a/packages/core/src/agent-loop/runner.ts
+++ b/packages/core/src/agent-loop/runner.ts
@@ -1,0 +1,167 @@
+/**
+ * Agent-loop runner. Wraps `executeAgentWithRetry` with an
+ * author-declared evaluation loop: after each DAG execution, check the
+ * agent's `successCriteria`; if any fail and `maxLoopIterations` allows,
+ * re-run with the failure list injected as `{{loop.feedback}}` (or
+ * `$LOOP_FEEDBACK` for shell nodes — see node-env / node-templates).
+ *
+ * When the agent declares no `successCriteria`, the runner is a pure
+ * pass-through to `executeAgentWithRetry` — no behaviour change for
+ * existing agents.
+ */
+
+import type { Agent } from '../agent-v2-types.js';
+import type { DagExecuteOptions, DagExecutorDeps } from '../dag-executor.js';
+import type { Run } from '../types.js';
+import { executeAgentWithRetry, type ExecuteAgentWithRetryHooks } from '../retry.js';
+import { evaluateCriteria, formatCriterionFailures, type CriterionResult } from './eval-criteria.js';
+import type { AgentMemoryStore, AgentMemoryEvalStatus } from './memory-store.js';
+
+export interface AgentLoopHooks extends ExecuteAgentWithRetryHooks {
+  /**
+   * Fires when an iteration's eval failed and another iteration is about
+   * to start. Mirrors `executeAgentWithRetry`'s `onRetry` shape for symmetry.
+   */
+  onEvalRetry?: (nextIteration: number, failures: CriterionResult[]) => void;
+}
+
+export interface AgentLoopRunnerDeps {
+  /**
+   * Optional. When supplied, each iteration writes one row recording
+   * inputs / observations / eval status. Booting without it means the
+   * loop still runs, just without persistent observability.
+   */
+  memoryStore?: AgentMemoryStore;
+}
+
+/**
+ * Run an agent through the eval loop. Returns the LAST iteration's run
+ * (pass or fail), so callers see the same shape they got from
+ * `executeAgentWithRetry`. Iterations are separate Run rows in the run
+ * store; the loop links them via `agent_memory.root_run_id`.
+ *
+ * The loop terminates when:
+ *  - eval passes;
+ *  - eval fails but `maxLoopIterations` is hit;
+ *  - the underlying run fails transiently (the inner `executeAgentWithRetry`
+ *    already exhausted its retry budget — re-running here wouldn't help);
+ *  - `options.signal` is aborted.
+ */
+export async function executeAgentLoop(
+  agent: Agent,
+  options: DagExecuteOptions,
+  deps: DagExecutorDeps,
+  loopDeps: AgentLoopRunnerDeps = {},
+  hooks: AgentLoopHooks = {},
+): Promise<Run> {
+  const maxIterations = Math.max(1, agent.maxLoopIterations ?? 1);
+  const criteria = agent.successCriteria ?? [];
+
+  // No criteria → single-shot pass-through. Preserves byte-equivalent
+  // behaviour for every existing agent.
+  if (criteria.length === 0) {
+    return executeAgentWithRetry(agent, options, deps, hooks);
+  }
+
+  let rootRunId: string | null = null;
+  let lastRun: Run | null = null;
+  let lastFailures: CriterionResult[] = [];
+
+  for (let iteration = 1; iteration <= maxIterations; iteration++) {
+    if (iteration > 1) {
+      hooks.onEvalRetry?.(iteration, lastFailures);
+    }
+
+    // Inject the prior iteration's eval feedback as an extra input. Agents
+    // opt in by referencing `{{inputs.LOOP_FEEDBACK}}` in their prompts
+    // (claude-code) or `$LOOP_FEEDBACK` in their commands (shell). On
+    // iteration 1 it's blank.
+    const iterInputs: Record<string, string> = {
+      ...(options.inputs ?? {}),
+      LOOP_FEEDBACK: iteration > 1 ? formatCriterionFailures(lastFailures) : '',
+    };
+
+    const iterOptions: DagExecuteOptions = { ...options, inputs: iterInputs };
+
+    const run = await executeAgentWithRetry(agent, iterOptions, deps, hooks);
+    lastRun = run;
+    if (rootRunId === null) rootRunId = run.id;
+
+    // Transient failure (the inner retry wrapper already exhausted its
+    // budget). Re-running the eval loop wouldn't help — abort and surface
+    // the failed run.
+    if (run.status === 'failed') {
+      recordIteration(loopDeps.memoryStore, agent.id, rootRunId, iteration, run.id, iterInputs, null, 'transient-error', null);
+      return run;
+    }
+
+    // Eval against the just-completed run's per-node executions.
+    const nodeExecutions = deps.runStore.listNodeExecutions(run.id);
+    const evalResult = evaluateCriteria({ criteria, run, nodeExecutions, inputs: iterInputs });
+    const status: AgentMemoryEvalStatus = evalResult.passed ? 'passed' : 'failed';
+    recordIteration(
+      loopDeps.memoryStore,
+      agent.id,
+      rootRunId,
+      iteration,
+      run.id,
+      iterInputs,
+      summariseObservations(nodeExecutions),
+      status,
+      evalResult.passed ? null : evalResult.results.filter((r) => !r.passed),
+    );
+
+    if (evalResult.passed) return run;
+
+    lastFailures = evalResult.results.filter((r) => !r.passed);
+    if (options.signal?.aborted) return run;
+  }
+
+  // Loop budget exhausted with eval still failing. Surface the last run
+  // — callers can inspect `agent_memory` to see what each iteration
+  // produced, plus the per-iteration failure lists.
+  return lastRun!;
+}
+
+function recordIteration(
+  store: AgentMemoryStore | undefined,
+  agentId: string,
+  rootRunId: string,
+  iteration: number,
+  runId: string,
+  inputs: Record<string, unknown>,
+  observations: unknown,
+  evalStatus: AgentMemoryEvalStatus,
+  failures: CriterionResult[] | null,
+): void {
+  if (!store) return;
+  try {
+    store.recordIteration({
+      agentId,
+      rootRunId,
+      iteration,
+      runId,
+      inputsJson: JSON.stringify(inputs).slice(0, 8192),
+      observationsJson: observations != null ? JSON.stringify(observations).slice(0, 8192) : null,
+      evalStatus,
+      evalFailuresJson: failures ? JSON.stringify(failures).slice(0, 8192) : null,
+    });
+  } catch { /* swallow — memory is best-effort observability */ }
+}
+
+/**
+ * Compact summary of node outputs used by `agent_memory.observations_json`.
+ * Drops large fields (truncated) so memory rows stay manageable; reference
+ * the runs table for the full output.
+ */
+function summariseObservations(execs: Array<{ nodeId: string; status: string; result?: string; exitCode?: number }>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const e of execs) {
+    out[e.nodeId] = {
+      status: e.status,
+      ...(e.exitCode !== undefined ? { exitCode: e.exitCode } : {}),
+      ...(e.result ? { resultPreview: e.result.slice(0, 240) } : {}),
+    };
+  }
+  return out;
+}

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -327,6 +327,34 @@ export const agentV2Schema = z.object({
     ])).optional(),
   }).optional(),
 
+  /**
+   * Agent-loop success criteria (PR 4 of the planner refactor). When
+   * supplied, the agent runs inside an `AgentLoopRunner` that evaluates
+   * these criteria after each DAG execution and re-runs with reflection
+   * feedback when any fail. Absent / empty array = single-shot pass-through
+   * (no behaviour change for existing agents).
+   *
+   * Criterion kinds:
+   *  - `shellExitZero`: target shell node must have exited 0.
+   *  - `fileExists`: a path (template-expanded) must exist on disk.
+   *  - `jsonPathEquals`: target node's JSON output, dot-pathed, equals value.
+   *  - `regexMatch`: target node's stringified output matches the regex.
+   */
+  successCriteria: z.array(z.discriminatedUnion('kind', [
+    z.object({ kind: z.literal('shellExitZero'), nodeId: z.string().min(1) }),
+    z.object({ kind: z.literal('fileExists'), pathTemplate: z.string().min(1) }),
+    z.object({ kind: z.literal('jsonPathEquals'), nodeId: z.string().min(1), path: z.string().min(1), equals: z.unknown() }),
+    z.object({ kind: z.literal('regexMatch'), nodeId: z.string().min(1), pattern: z.string().min(1) }),
+  ])).optional(),
+
+  /**
+   * Cap on agent-loop iterations when `successCriteria` is supplied.
+   * 1 = single-shot (criteria still evaluated; no retry on failure).
+   * Defaults to 1 so adding `successCriteria` without `maxLoopIterations`
+   * is observe-only — explicit opt-in required for retry behaviour.
+   */
+  maxLoopIterations: z.number().int().min(1).max(5).optional(),
+
   author: z.string().optional(),
   tags: z.array(z.string()).optional(),
 }).superRefine((data, ctx) => {

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -373,10 +373,37 @@ export interface Agent {
    */
   retry?: RetryPolicy;
 
+  /**
+   * Agent-loop success criteria (PR 4 of the planner refactor). When
+   * supplied, the agent runs inside `AgentLoopRunner` — after each DAG
+   * execution the runner evaluates these and re-runs (up to
+   * `maxLoopIterations`) when any fail. Author-declared validation
+   * acceptance, separate from the `retry:` transient-failure policy.
+   */
+  successCriteria?: AgentSuccessCriterion[];
+
+  /**
+   * Cap on agent-loop iterations when `successCriteria` is supplied.
+   * 1 = single-shot (criteria still evaluated; no retry on failure).
+   * Defaults to 1 — explicit opt-in (≥2) required for retry behaviour.
+   */
+  maxLoopIterations?: number;
+
   // Metadata
   author?: string;
   tags?: string[];
 }
+
+/**
+ * Discriminated union of supported success-criterion shapes. Kept narrow
+ * for the MVP — each kind is something the executor or filesystem can
+ * answer without a separate LLM call.
+ */
+export type AgentSuccessCriterion =
+  | { kind: 'shellExitZero'; nodeId: string }
+  | { kind: 'fileExists'; pathTemplate: string }
+  | { kind: 'jsonPathEquals'; nodeId: string; path: string; equals: unknown }
+  | { kind: 'regexMatch'; nodeId: string; pattern: string };
 
 // -- Pulse signal --
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -192,6 +192,19 @@ export {
   type LoopStepRecord,
 } from './planner-loop/index.js';
 export {
+  executeAgentLoop,
+  type AgentLoopRunnerDeps,
+  type AgentLoopHooks,
+  evaluateCriteria,
+  formatCriterionFailures,
+  type CriterionResult,
+  type EvaluateCriteriaResult,
+  type EvaluateCriteriaInput,
+  AgentMemoryStore,
+  type AgentMemoryRow,
+  type AgentMemoryEvalStatus,
+} from './agent-loop/index.js';
+export {
   policyDocumentSchema,
   policyRuleSchema,
   loadPolicyDocument,

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -15,7 +15,8 @@ import type { VariablesStore } from './variables-store.js';
 import type { IntegrationsStore } from './integrations-store.js';
 import type { AgentStore } from './agent-store.js';
 import type { ToolStore } from './tool-store.js';
-import { executeAgentWithRetry } from './retry.js';
+import { executeAgentLoop } from './agent-loop/runner.js';
+import type { AgentMemoryStore } from './agent-loop/memory-store.js';
 
 export interface ScheduledAgentEntry {
   agent: AgentDefinition;
@@ -45,6 +46,13 @@ export interface V2SchedulerDeps {
   dashboardBaseUrl?: string;
   /** Same semantics as DagExecutorDeps.dataRoot. */
   dataRoot?: string;
+  /**
+   * Agent-loop memory store (PR 4 of the planner refactor). Threaded
+   * through so per-iteration observations + eval status get persisted
+   * when an agent declares `successCriteria`. Optional — without it the
+   * agent loop still runs, just silently.
+   */
+  agentMemoryStore?: AgentMemoryStore;
 }
 
 export interface LocalSchedulerOptions {
@@ -295,10 +303,12 @@ export class LocalScheduler {
     }
 
     this.inFlight.add(key);
-    // executeAgentWithRetry resolves only after the agent finishes (or
-    // its retry budget is exhausted). Run it without awaiting here so a
-    // long agent doesn't block the cron tick — fire-and-track instead.
-    executeAgentWithRetry(
+    // executeAgentLoop wraps executeAgentWithRetry with the agent-loop
+    // eval gate (PR 4 of the planner refactor). When the agent declares
+    // no `successCriteria` it's a pure pass-through — byte-equivalent to
+    // the prior executeAgentWithRetry call. When criteria are declared,
+    // each iteration's pass/fail + observations land in agent_memory.
+    executeAgentLoop(
       agent,
       { triggeredBy: 'schedule', inputs: this.inputs },
       {
@@ -312,6 +322,7 @@ export class LocalScheduler {
         dashboardBaseUrl: this.v2Deps.dashboardBaseUrl,
         dataRoot: this.v2Deps.dataRoot,
       },
+      { memoryStore: this.v2Deps.agentMemoryStore },
     ).then(
       (run) => {
         this.onFire?.(agent, run.id);

--- a/packages/dashboard/src/context.ts
+++ b/packages/dashboard/src/context.ts
@@ -1,4 +1,4 @@
-import type { LocalProvider, RunStore, SecretsStore, AgentDefinition, AgentStore, ToolStore, VariablesStore, PacksStore, DashboardsStore, IntegrationsStore, PlannerTelemetryStore, PlannerLoopStepLogStore, PlannerMemoryStore } from '@some-useful-agents/core';
+import type { LocalProvider, RunStore, SecretsStore, AgentDefinition, AgentStore, ToolStore, VariablesStore, PacksStore, DashboardsStore, IntegrationsStore, PlannerTelemetryStore, PlannerLoopStepLogStore, PlannerMemoryStore, AgentMemoryStore } from '@some-useful-agents/core';
 import type { SecretsSession } from './secrets-session.js';
 
 /**
@@ -110,6 +110,12 @@ export interface DashboardContext {
    * prior plans).
    */
   plannerMemoryStore?: PlannerMemoryStore;
+  /**
+   * Per-iteration log for agents that declare `successCriteria` (PR 4 of
+   * the planner refactor). Written by `AgentLoopRunner` after each
+   * iteration. Optional — agent loop runs without it, just doesn't persist.
+   */
+  agentMemoryStore?: AgentMemoryStore;
   /**
    * Active DAG runs with their AbortControllers. Used by POST /runs/:id/cancel
    * to signal cancellation to the executor. Entries are added when a run starts

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -12,6 +12,7 @@ import {
   PlannerTelemetryStore,
   PlannerLoopStepLogStore,
   PlannerMemoryStore,
+  AgentMemoryStore,
   loadBuiltinPacks,
   defaultBuiltinPacksDir,
   VariablesStore,
@@ -348,6 +349,15 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     // Non-fatal: planner just doesn't see prior plans.
   }
 
+  // Per-iteration agent memory (PR 4). Written by AgentLoopRunner when
+  // an agent declares successCriteria. Non-fatal if unavailable.
+  let agentMemoryStore: AgentMemoryStore | undefined;
+  try {
+    agentMemoryStore = new AgentMemoryStore(opts.dbPath);
+  } catch {
+    // Non-fatal: agent loop still runs, just doesn't persist iterations.
+  }
+
   const ctx: DashboardContext = {
     token,
     allowlist: buildLoopbackAllowlist(opts.port),
@@ -371,6 +381,7 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     plannerTelemetryStore,
     plannerLoopStepLogStore,
     plannerMemoryStore,
+    agentMemoryStore,
     allowUntrustedShell: opts.allowUntrustedShell ?? new Set(),
     activeRuns: new Map(),
     dataDir: dirname(opts.dbPath),

--- a/packages/dashboard/src/routes/run-mutations.ts
+++ b/packages/dashboard/src/routes/run-mutations.ts
@@ -1,5 +1,5 @@
 import { Router, type Request, type Response } from 'express';
-import { executeAgentDag, executeAgentWithRetry, extractPriorAgentInputs, topologicalSort, type RunStatus } from '@some-useful-agents/core';
+import { executeAgentDag, executeAgentLoop, extractPriorAgentInputs, topologicalSort, type RunStatus } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 
 export const runMutationsRouter: Router = Router();
@@ -265,7 +265,7 @@ runMutationsRouter.post('/runs/:id/retry', async (req: Request, res: Response) =
   const nextAttempt = maxAttempt + 1;
 
   const abortController = new AbortController();
-  const runPromise = executeAgentWithRetry(
+  const runPromise = executeAgentLoop(
     agent,
     {
       triggeredBy: 'dashboard',
@@ -284,6 +284,7 @@ runMutationsRouter.post('/runs/:id/retry', async (req: Request, res: Response) =
       dashboardBaseUrl: ctx.dashboardBaseUrl,
       dataRoot: ctx.agentStore.dataRoot,
     },
+    { memoryStore: ctx.agentMemoryStore },
   );
 
   // Track for cancel.


### PR DESCRIPTION
## Summary

**Closes the 4-PR planner refactor.** After PRs #290 (loop scaffold), #291 (smoke eval + step log), and #292 (cross-run memory) brought the loop/eval/memory model to the planner itself, this PR extends the same model to **every agent the planner builds** — and every existing agent — via an opt-in `successCriteria` field.

### Schema additions (both optional)

```yaml
successCriteria:
  - kind: shellExitZero
    nodeId: fetch
  - kind: jsonPathEquals
    nodeId: fetch
    path: current_condition.0.temp_C
    equals: "21"
maxLoopIterations: 3
```

Criterion kinds:
- `shellExitZero` (nodeId)
- `fileExists` (pathTemplate, with `{{inputs.X}}` expansion)
- `jsonPathEquals` (nodeId, dotted path including array indices, deep-equal value)
- `regexMatch` (nodeId, pattern)

`maxLoopIterations` defaults to 1 — explicit opt-in (≥2) required for retry behaviour. Absent `successCriteria` = pure pass-through, zero behaviour change for existing agents.

### Behaviour

- `AgentLoopRunner` wraps `executeAgentWithRetry`. Each iteration runs the DAG; the per-node executions are evaluated against `successCriteria`. If anything fails, the next iteration receives a `LOOP_FEEDBACK` input populated with the failure list, formatted similarly to the planner's critic feedback.
- Loop terminates on: eval pass · budget exhaustion · transient run failure (inner retry budget already exhausted) · abort signal.
- One Run row per iteration (separate `run_id`), grouped via `agent_memory.root_run_id`.
- Agents opt in to feedback by referencing `{{inputs.LOOP_FEEDBACK}}` (claude-code) or `$LOOP_FEEDBACK` (shell). Iteration 1 sees an empty string.

### Wiring

All entry points that previously called `executeAgentWithRetry` now go through `executeAgentLoop`:
- `LocalScheduler` (scheduled fires)
- Dashboard `run-mutations` (manual retry)
- CLI `sua schedule start`

Each instantiates an `AgentMemoryStore` and threads it via deps.

### What's persisted (per iteration)

`agent_memory(agent_id, root_run_id, iteration)` PRIMARY KEY, plus:
- `run_id`, `inputs_json`, `observations_json` (compact summary), `eval_status` (`passed` / `failed` / `transient-error` / `no-criteria`), `eval_failures_json`, `created_at`

No dashboard UI for it yet — query SQLite directly. Future polish.

## Files

```
packages/core/src/agent-loop/{eval-criteria,memory-store,runner}.ts + .test.ts + index.ts
packages/core/src/agent-v2-{schema,types}.ts                            — successCriteria + maxLoopIterations
packages/core/src/{scheduler,index}.ts                                  — exports + scheduler wiring
packages/dashboard/src/{context,index}.ts                               — context slot + instantiation
packages/dashboard/src/routes/run-mutations.ts                          — manual retry path
packages/cli/src/commands/schedule.ts                                   — CLI scheduler instantiation
docs/{success-criteria.md (new), agents.md}                             — author reference + cross-link
```

## Test plan

- [x] `npx vitest run packages/core/src/agent-loop/` — 30 new tests pass (20 eval-criteria + 3 memory-store + 7 runner)
- [x] Clean rebuild via `rm -rf packages/*/dist *.tsbuildinfo && npm run build` (matches CI)
- [x] `npm test` — 1420 passing / 3 skipped (1390 baseline + 30 new)
- [ ] After merge: add `successCriteria` to one existing agent, deliberately break it, confirm loop retries + records iterations in agent_memory + populates LOOP_FEEDBACK
- [ ] Confirm agents without `successCriteria` still execute exactly once (no regression for the existing fleet)

## Refactor wrap-up

- ✅ PR 1 (#290): planner loop scaffold
- ✅ PR 2 (#291): smoke eval + step log
- ✅ PR 3 (#292): cross-run memory
- ✅ PR 4 (this): generated agents inherit the loop/eval/memory shape

What's NOT in scope (explicitly deferred from the plan):
- `ask` primitive (human-in-the-loop pause mid-loop)
- `promote` primitive (skill promotion — user wants data first)
- Cross-run reads of agent_memory (PR 4 only stores; reads come when there's a UI surface to consume them)
- Embedding-based similarity for `planner_memory` (Jaccard is fine until N grows)
- Dashboard UI for step log + agent_memory inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)