### PR TITLE
feat(llm): provider registry as single source of truth (PR 1/5)

### DIFF
--- a/.changeset/llm-provider-registry.md
+++ b/.changeset/llm-provider-registry.md
@@ -1,0 +1,11 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Single source of truth for LLM provider metadata.
+
+Adds `PROVIDERS` registry + `ProviderDef` type in `@some-useful-agents/core`, with one entry per supported CLI (display name, binary, version argv, prompt argv). `detectLlms()` and `invokeLlm()` now iterate the registry instead of hard-coding two branches. The dashboard's "New Agent" form reads provider display names from the same registry, and its TYPE radio is relabeled "LLM Prompt — runs an LLM prompt — you have {list} installed" so users see which CLIs are actually on PATH. Public API of `detectLlms` / `invokeLlm` is unchanged; this PR is preparation for adding more providers without a parallel call path.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export * from './cron-human.js';
 export * from './scheduler-heartbeat.js';
 export * from './scheduler-catchup.js';
 export * from './discovery-catalog.js';
+export * from './llm-providers.js';
 export * from './llm-invoker.js';
 export * from './fs-utils.js';
 export * from './mcp-token.js';

--- a/packages/core/src/llm-invoker.ts
+++ b/packages/core/src/llm-invoker.ts
@@ -1,6 +1,5 @@
 import { spawn, execSync } from 'node:child_process';
-
-export type LlmProvider = 'claude' | 'codex';
+import { PROVIDERS, PROVIDER_IDS, type LlmProvider } from './llm-providers.js';
 
 export interface LlmInvokeOptions {
   prompt: string;
@@ -26,18 +25,17 @@ export function detectLlms(): LlmAvailability {
     codex: { installed: false },
   };
 
-  try {
-    const v = execSync('claude --version', { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
-    result.claude = { installed: true, version: v };
-  } catch {
-    // not installed or not on PATH
-  }
-
-  try {
-    const v = execSync('codex --version', { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
-    result.codex = { installed: true, version: v };
-  } catch {
-    // not installed
+  for (const id of PROVIDER_IDS) {
+    const def = PROVIDERS[id];
+    try {
+      const v = execSync(
+        `${def.binary} ${def.versionArgv.join(' ')}`,
+        { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] },
+      ).trim();
+      result[id] = { installed: true, version: v };
+    } catch {
+      // not installed or not on PATH
+    }
   }
 
   return result;
@@ -45,17 +43,14 @@ export function detectLlms(): LlmAvailability {
 
 /**
  * Invoke an LLM CLI with a prompt, return its stdout.
- * Uses --print (claude) / exec -s read-only (codex).
+ * Argv shape is provider-specific (see PROVIDERS in llm-providers.ts).
  */
 export function invokeLlm(options: LlmInvokeOptions): Promise<LlmInvokeResult> {
   const { prompt, provider, timeoutMs = 60_000 } = options;
+  const def = PROVIDERS[provider];
 
   return new Promise((resolve) => {
-    const args = provider === 'claude'
-      ? ['--print', prompt]
-      : ['exec', '-s', 'read-only', prompt];
-
-    const child = spawn(provider, args, {
+    const child = spawn(def.binary, def.promptArgv(prompt), {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 

--- a/packages/core/src/llm-providers.test.ts
+++ b/packages/core/src/llm-providers.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { PROVIDERS, PROVIDER_IDS } from './llm-providers.js';
+
+describe('PROVIDERS registry', () => {
+  it('exposes both built-in providers', () => {
+    expect(PROVIDER_IDS).toContain('claude');
+    expect(PROVIDER_IDS).toContain('codex');
+  });
+
+  it('every entry has the fields the invoker reads', () => {
+    for (const id of PROVIDER_IDS) {
+      const def = PROVIDERS[id];
+      expect(def.id).toBe(id);
+      expect(typeof def.displayName).toBe('string');
+      expect(typeof def.binary).toBe('string');
+      expect(Array.isArray(def.versionArgv)).toBe(true);
+      expect(typeof def.promptArgv).toBe('function');
+    }
+  });
+
+  it('preserves the historical argv shapes (back-compat guard)', () => {
+    expect(PROVIDERS.claude.binary).toBe('claude');
+    expect(PROVIDERS.claude.promptArgv('hi')).toEqual(['--print', 'hi']);
+    expect(PROVIDERS.codex.binary).toBe('codex');
+    expect(PROVIDERS.codex.promptArgv('hi')).toEqual(['exec', '-s', 'read-only', 'hi']);
+  });
+});

--- a/packages/core/src/llm-providers.ts
+++ b/packages/core/src/llm-providers.ts
@@ -1,0 +1,41 @@
+/**
+ * Single source of truth for LLM provider metadata.
+ *
+ * Every place that needs to know about a provider (the spawner, the
+ * install-check, the dashboard's "you have X installed" hint, the tool
+ * catalog) reads from PROVIDERS. Adding a new provider is one entry
+ * here plus a `LlmProvider` union member.
+ */
+
+export type LlmProvider = 'claude' | 'codex';
+
+export interface ProviderDef {
+  id: LlmProvider;
+  /** Human-readable name for UI ("Claude Code", "Codex"). */
+  displayName: string;
+  /** Binary name resolved against PATH. */
+  binary: string;
+  /** Argv used by `detectLlms()` to probe install + version. */
+  versionArgv: readonly string[];
+  /** Build the argv for a single-prompt invocation. */
+  promptArgv: (prompt: string) => string[];
+}
+
+export const PROVIDERS: Record<LlmProvider, ProviderDef> = {
+  claude: {
+    id: 'claude',
+    displayName: 'Claude Code',
+    binary: 'claude',
+    versionArgv: ['--version'],
+    promptArgv: (prompt) => ['--print', prompt],
+  },
+  codex: {
+    id: 'codex',
+    displayName: 'Codex',
+    binary: 'codex',
+    versionArgv: ['--version'],
+    promptArgv: (prompt) => ['exec', '-s', 'read-only', prompt],
+  },
+};
+
+export const PROVIDER_IDS: readonly LlmProvider[] = Object.keys(PROVIDERS) as LlmProvider[];

--- a/packages/dashboard/src/routes/agents/new.ts
+++ b/packages/dashboard/src/routes/agents/new.ts
@@ -1,8 +1,19 @@
 import { Router, type Request, type Response } from 'express';
+import { detectLlms, PROVIDERS, PROVIDER_IDS } from '@some-useful-agents/core';
 import { getContext } from '../../context.js';
 import { renderAgentNew, type AgentNewFormValues } from '../../views/agent-new.js';
 
 const AGENT_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+let cachedProviders: string[] | null = null;
+function getInstalledProviders(): string[] {
+  if (cachedProviders) return cachedProviders;
+  const avail = detectLlms();
+  cachedProviders = PROVIDER_IDS
+    .filter((id) => avail[id].installed)
+    .map((id) => PROVIDERS[id].displayName);
+  return cachedProviders;
+}
 
 /**
  * GET  /agents/new — show the create-agent form.
@@ -14,7 +25,7 @@ const AGENT_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
 export const agentNewRouter: Router = Router();
 
 agentNewRouter.get('/agents/new', (_req: Request, res: Response) => {
-  res.type('html').send(renderAgentNew({}));
+  res.type('html').send(renderAgentNew({ installedProviders: getInstalledProviders(),}));
 });
 
 agentNewRouter.post('/agents/new', (req: Request, res: Response) => {
@@ -33,35 +44,35 @@ agentNewRouter.post('/agents/new', (req: Request, res: Response) => {
   // Validate in order of what the user typed top-to-bottom so the error
   // points at the first thing wrong rather than a buried field.
   if (!values.id || !AGENT_ID_RE.test(values.id)) {
-    res.status(400).type('html').send(renderAgentNew({
+    res.status(400).type('html').send(renderAgentNew({ installedProviders: getInstalledProviders(),
       values,
       error: 'Id must be lowercase letters, digits, or hyphens, starting with a letter or digit.',
     }));
     return;
   }
   if (!values.name) {
-    res.status(400).type('html').send(renderAgentNew({
+    res.status(400).type('html').send(renderAgentNew({ installedProviders: getInstalledProviders(),
       values,
       error: 'Name is required.',
     }));
     return;
   }
   if (ctx.agentStore.getAgent(values.id)) {
-    res.status(400).type('html').send(renderAgentNew({
+    res.status(400).type('html').send(renderAgentNew({ installedProviders: getInstalledProviders(),
       values,
       error: `An agent with id "${values.id}" already exists.`,
     }));
     return;
   }
   if (values.type === 'shell' && (!values.command || values.command.trim() === '')) {
-    res.status(400).type('html').send(renderAgentNew({
+    res.status(400).type('html').send(renderAgentNew({ installedProviders: getInstalledProviders(),
       values,
       error: 'Shell agents need a command.',
     }));
     return;
   }
   if (values.type === 'claude-code' && (!values.prompt || values.prompt.trim() === '')) {
-    res.status(400).type('html').send(renderAgentNew({
+    res.status(400).type('html').send(renderAgentNew({ installedProviders: getInstalledProviders(),
       values,
       error: 'Claude-Code agents need a prompt.',
     }));
@@ -89,7 +100,7 @@ agentNewRouter.post('/agents/new', (req: Request, res: Response) => {
     res.redirect(303, `/agents/${encodeURIComponent(values.id)}/add-node?fromCreate=1`);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    res.status(400).type('html').send(renderAgentNew({
+    res.status(400).type('html').send(renderAgentNew({ installedProviders: getInstalledProviders(),
       values,
       error: `Create failed: ${msg}`,
     }));

--- a/packages/dashboard/src/views/agent-new.ts
+++ b/packages/dashboard/src/views/agent-new.ts
@@ -11,14 +11,23 @@ export interface AgentNewFormValues {
   prompt?: string;
 }
 
+function formatInstalled(providers: string[]): string {
+  if (providers.length === 0) return 'no LLM CLIs detected on PATH';
+  if (providers.length === 1) return `you have ${providers[0]} installed`;
+  if (providers.length === 2) return `you have ${providers[0]} and ${providers[1]} installed`;
+  return `you have ${providers.slice(0, -1).join(', ')}, and ${providers[providers.length - 1]} installed`;
+}
+
 export function renderAgentNew(args: {
   values?: AgentNewFormValues;
   error?: string;
+  installedProviders?: string[];
 }): string {
   const v = args.values ?? {};
   const type = v.type ?? 'shell';
   const isShell = type === 'shell';
   const isClaude = type === 'claude-code';
+  const installedSuffix = formatInstalled(args.installedProviders ?? []);
 
   const errorBlock = args.error ? html`<div class="flash flash--error">${args.error}</div>` : html``;
 
@@ -57,7 +66,7 @@ export function renderAgentNew(args: {
         </label>
         <label class="radio-option">
           <input type="radio" name="type" value="claude-code" ${isClaude ? 'checked' : ''}>
-          <span><strong>Claude Code</strong> <span class="dim">\u2014 runs a Claude Code prompt</span></span>
+          <span><strong>LLM Prompt</strong> <span class="dim">\u2014 runs an LLM prompt \u2014 ${installedSuffix}</span></span>
         </label>
       </fieldset>
 
@@ -67,7 +76,7 @@ export function renderAgentNew(args: {
       </div>
 
       <div class="form-field mb-4">
-        <strong>Prompt <span class="dim text-xs">(claude-code agents only)</span></strong>
+        <strong>Prompt <span class="dim text-xs">(LLM Prompt agents only)</span></strong>
         <textarea name="prompt" rows="4" placeholder="Summarise the attached text." class="form-field__textarea">${v.prompt ?? ''}</textarea>
       </div>
 


### PR DESCRIPTION
## Summary

- New `packages/core/src/llm-providers.ts`: `PROVIDERS` registry + `ProviderDef` type. One entry per CLI with display name, binary, version argv, prompt argv.
- `detectLlms()` and `invokeLlm()` iterate the registry instead of hard-coding two branches. Argv shapes preserved exactly — a new test guards the back-compat contract.
- Dashboard `/agents/new` route reads provider display names from the registry. TYPE radio relabeled **"LLM Prompt — runs an LLM prompt — you have {list} installed"** so users can see which CLIs are on PATH.
- Public API of `detectLlms` / `invokeLlm` unchanged. Adding a third provider in the future is now one entry in the registry.

Part 1 of 5 in the LLM-prompt unification plan at `~/.claude/plans/llm-prompt-unification.md`. Subsequent PRs add the `llm-prompt` type alias, delete the relic `claude-code` built-in tool, migrate examples, and surface providers in the tool catalog.

## Test plan

- [x] `npm test` — **1423 passing + 3 skipped** (baseline was 1420; +3 from new `llm-providers.test.ts`)
- [x] Clean rebuild (`rm -rf packages/*/dist *.tsbuildinfo && npm run build`) succeeds
- [ ] Manual: visit `/agents/new`, confirm the radio reads "LLM Prompt — runs an LLM prompt — you have Claude Code installed" (or whatever combination is installed on the reviewer's machine)
- [ ] Manual: create a `type: claude-code` agent through the form; confirm it still runs (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)