### PR TITLE
feat(tools): surface installed LLM providers on the catalog page (PR 5/5)

### DIFF
--- a/.changeset/tools-catalog-llm-providers.md
+++ b/.changeset/tools-catalog-llm-providers.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Surface installed LLM providers on the `/tools` catalog page.
+
+A new "LLM providers" section above the user / built-in tabs lists every entry in the provider registry with its installed status (resolved from `$PATH` at request time), version string, and "used by N agents" count. Counts walk every active agent's nodes, resolve each LLM-prompt node's effective provider (`node.provider ?? agent.provider ?? 'claude'`), and tally agents (not nodes) per provider — an agent with five Claude nodes counts once.
+
+Cards are read-only — no invoke button. The intent is *discoverability*: it gives back what the deleted `claude-code` built-in tool used to provide (a visible entry on the tools page) without re-introducing a parallel call path. Providers that aren't on PATH render with a "not on PATH" badge and the install hint instead of a version.
+
+Closes the LLM-prompt unification plan (PR 5 of 5). Adding a third provider in the future remains one entry in `PROVIDERS` from PR 1 — the catalog row appears automatically.

--- a/packages/dashboard/src/lib/provider-usage.test.ts
+++ b/packages/dashboard/src/lib/provider-usage.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import type { Agent } from '@some-useful-agents/core';
+import { computeProviderUsage } from './provider-usage.js';
+
+const mkAgent = (id: string, partial: Partial<Agent>): Agent => ({
+  id,
+  name: id,
+  status: 'active',
+  source: 'local',
+  mcp: false,
+  version: 1,
+  nodes: [],
+  ...partial,
+} as Agent);
+
+describe('computeProviderUsage', () => {
+  it('returns one row per provider, even when no agents use them', () => {
+    const rows = computeProviderUsage([]);
+    const ids = rows.map((r) => r.id).sort();
+    expect(ids).toEqual(['claude', 'codex']);
+    for (const r of rows) {
+      expect(r.agentCount).toBe(0);
+      expect(typeof r.installed).toBe('boolean');
+    }
+  });
+
+  it('counts an agent under its agent-level default provider', () => {
+    const agents = [
+      mkAgent('a1', {
+        provider: 'codex',
+        nodes: [{ id: 'main', type: 'llm-prompt', prompt: 'hi' }] as Agent['nodes'],
+      }),
+    ];
+    const rows = computeProviderUsage(agents);
+    const codex = rows.find((r) => r.id === 'codex')!;
+    const claude = rows.find((r) => r.id === 'claude')!;
+    expect(codex.agentCount).toBe(1);
+    expect(claude.agentCount).toBe(0);
+  });
+
+  it('honors node-level provider override over agent default', () => {
+    const agents = [
+      mkAgent('a1', {
+        provider: 'claude',
+        nodes: [
+          { id: 'a', type: 'llm-prompt', prompt: 'x', provider: 'codex' },
+        ] as Agent['nodes'],
+      }),
+    ];
+    const rows = computeProviderUsage(agents);
+    expect(rows.find((r) => r.id === 'codex')!.agentCount).toBe(1);
+    expect(rows.find((r) => r.id === 'claude')!.agentCount).toBe(0);
+  });
+
+  it('counts an agent once per distinct provider, regardless of node count', () => {
+    const agents = [
+      mkAgent('a1', {
+        provider: 'claude',
+        nodes: [
+          { id: 'a', type: 'llm-prompt', prompt: 'x' },
+          { id: 'b', type: 'llm-prompt', prompt: 'y' },
+          { id: 'c', type: 'claude-code', prompt: 'z' },
+        ] as Agent['nodes'],
+      }),
+    ];
+    const rows = computeProviderUsage(agents);
+    expect(rows.find((r) => r.id === 'claude')!.agentCount).toBe(1);
+  });
+
+  it('counts an agent under two providers when it mixes node-level overrides', () => {
+    const agents = [
+      mkAgent('a1', {
+        provider: 'claude',
+        nodes: [
+          { id: 'a', type: 'llm-prompt', prompt: 'x' },               // → claude (default)
+          { id: 'b', type: 'llm-prompt', prompt: 'y', provider: 'codex' }, // → codex
+        ] as Agent['nodes'],
+      }),
+    ];
+    const rows = computeProviderUsage(agents);
+    expect(rows.find((r) => r.id === 'claude')!.agentCount).toBe(1);
+    expect(rows.find((r) => r.id === 'codex')!.agentCount).toBe(1);
+  });
+
+  it('accepts the legacy claude-code node type as an LLM-prompt node', () => {
+    const agents = [
+      mkAgent('a1', { nodes: [{ id: 'main', type: 'claude-code', prompt: 'hi' }] as Agent['nodes'] }),
+    ];
+    expect(computeProviderUsage(agents).find((r) => r.id === 'claude')!.agentCount).toBe(1);
+  });
+
+  it('ignores non-LLM node types', () => {
+    const agents = [
+      mkAgent('a1', { nodes: [{ id: 'main', type: 'shell', command: 'echo hi' }] as Agent['nodes'] }),
+    ];
+    for (const r of computeProviderUsage(agents)) {
+      expect(r.agentCount).toBe(0);
+    }
+  });
+});

--- a/packages/dashboard/src/lib/provider-usage.ts
+++ b/packages/dashboard/src/lib/provider-usage.ts
@@ -1,0 +1,57 @@
+import { PROVIDERS, PROVIDER_IDS, detectLlms, type Agent, type LlmProvider } from '@some-useful-agents/core';
+
+/**
+ * One row in the "LLM Providers" section of the tools page. Derived from
+ * `detectLlms()` + a walk of every active agent's nodes. The intent is
+ * read-only discoverability: which CLIs are on PATH, how many agents
+ * actually use each one, and what to do if a provider is missing.
+ */
+export interface ProviderUsageRow {
+  id: LlmProvider;
+  displayName: string;
+  binary: string;
+  installed: boolean;
+  version?: string;
+  /** Number of agents that have at least one LLM-prompt node resolving to this provider. */
+  agentCount: number;
+}
+
+/** True when the node runs an LLM prompt. Matches `isLlmPromptType` in core. */
+function isLlmPromptNode(type: string | undefined): boolean {
+  return type === 'llm-prompt' || type === 'claude-code';
+}
+
+/**
+ * Walk the agent list and compute per-provider usage. Provider resolution:
+ * `node.provider ?? agent.provider ?? 'claude'` (the same default the
+ * dispatcher uses). An agent is counted once per distinct provider it
+ * uses, regardless of how many LLM-prompt nodes it has.
+ */
+export function computeProviderUsage(agents: Agent[]): ProviderUsageRow[] {
+  const availability = detectLlms();
+  const counts: Record<LlmProvider, number> = { claude: 0, codex: 0 };
+
+  for (const agent of agents) {
+    const agentDefault = (agent.provider ?? 'claude') as LlmProvider;
+    const seen = new Set<LlmProvider>();
+    for (const node of agent.nodes ?? []) {
+      if (!isLlmPromptNode(node.type)) continue;
+      const effective = (node.provider ?? agentDefault) as LlmProvider;
+      if (effective in counts) seen.add(effective);
+    }
+    for (const id of seen) counts[id] += 1;
+  }
+
+  return PROVIDER_IDS.map((id) => {
+    const def = PROVIDERS[id];
+    const av = availability[id];
+    return {
+      id,
+      displayName: def.displayName,
+      binary: def.binary,
+      installed: av.installed,
+      version: av.version,
+      agentCount: counts[id],
+    };
+  });
+}

--- a/packages/dashboard/src/routes/tools.ts
+++ b/packages/dashboard/src/routes/tools.ts
@@ -8,6 +8,7 @@ import {
   type McpServerConfig,
 } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
+import { computeProviderUsage } from '../lib/provider-usage.js';
 import { renderToolsList } from '../views/tools-list.js';
 import { renderToolDetail } from '../views/tool-detail.js';
 import {
@@ -36,7 +37,18 @@ toolsRouter.get('/tools', (req: Request, res: Response) => {
   const tab = req.query.tab === 'builtin' ? 'builtin' : 'user';
   const limit = Math.min(100, Math.max(1, parseInt(String(req.query.limit), 10) || 12));
   const offset = Math.max(0, parseInt(String(req.query.offset), 10) || 0);
-  res.type('html').send(renderToolsList({ builtins, userTools, filter: { q, type }, tab, limit, offset }));
+
+  // LLM providers section: derived view of which CLIs are on PATH and
+  // how many agents use each one. Not invocable — pure discoverability.
+  let providerUsage: ReturnType<typeof computeProviderUsage> = [];
+  try {
+    providerUsage = computeProviderUsage(ctx.agentStore.listAgents());
+  } catch {
+    // Agent store unavailable — show providers without usage counts.
+    providerUsage = computeProviderUsage([]);
+  }
+
+  res.type('html').send(renderToolsList({ builtins, userTools, filter: { q, type }, tab, limit, offset, providerUsage }));
 });
 
 toolsRouter.get('/tools/mcp/import', (_req: Request, res: Response) => {

--- a/packages/dashboard/src/views/tools-list.ts
+++ b/packages/dashboard/src/views/tools-list.ts
@@ -1,4 +1,5 @@
 import type { ToolDefinition } from '@some-useful-agents/core';
+import type { ProviderUsageRow } from '../lib/provider-usage.js';
 import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
@@ -12,6 +13,7 @@ export function renderToolsList(args: {
   tab?: Tab;
   limit?: number;
   offset?: number;
+  providerUsage?: ProviderUsageRow[];
 }): string {
   const f = args.filter ?? {};
   const limit = args.limit ?? 12;
@@ -91,6 +93,8 @@ export function renderToolsList(args: {
       cta: html`<a href="/tools/mcp/import" class="btn btn--sm">Import from MCP server</a>`,
     })}
 
+    ${renderProvidersSection(args.providerUsage ?? [])}
+
     ${tabStrip}
     ${filterBar}
 
@@ -106,6 +110,42 @@ export function renderToolsList(args: {
   `;
 
   return render(layout({ title: 'Tools', activeNav: 'tools' }, body));
+}
+
+function renderProvidersSection(rows: ProviderUsageRow[]): SafeHtml {
+  if (rows.length === 0) return html``;
+
+  const cards = rows.map((r) => {
+    const statusBadge = r.installed
+      ? html`<span class="badge badge--ok">installed</span>`
+      : html`<span class="badge badge--muted">not on PATH</span>`;
+    const usage = r.agentCount === 0
+      ? html`<span class="dim">used by 0 agents</span>`
+      : html`<a href="/agents?provider=${r.id}" class="dim">used by ${String(r.agentCount)} agent${r.agentCount === 1 ? '' : 's'}</a>`;
+    const versionLine = r.installed && r.version
+      ? html`<p class="dim text-xs mb-0">${r.version}</p>`
+      : html`<p class="dim text-xs mb-0">Install <code>${r.binary}</code> on PATH to enable this provider.</p>`;
+    return html`
+      <article class="agent-card" style="opacity: ${r.installed ? '1' : '0.7'};">
+        <div class="agent-card__header">
+          <h3 class="agent-card__title">${r.displayName}</h3>
+          ${statusBadge}
+        </div>
+        <p class="dim text-xs" style="margin: var(--space-1) 0 var(--space-2);"><code>${r.binary}</code> &middot; ${usage}</p>
+        ${versionLine}
+      </article>
+    `;
+  });
+
+  return html`
+    <section class="mb-4">
+      <h2 style="font-size: var(--font-size-md); margin: 0 0 var(--space-2);">LLM providers</h2>
+      <p class="dim text-xs mb-3">Detected at startup from <code>$PATH</code>. To use a provider, set <code>provider:</code> on an <code>llm-prompt</code> node (or at the agent level).</p>
+      <div class="agent-grid">
+        ${cards as unknown as SafeHtml[]}
+      </div>
+    </section>
+  `;
 }
 
 function renderToolCard(t: ToolDefinition): SafeHtml {


### PR DESCRIPTION
## Summary

A new **LLM providers** section above the user / built-in tabs on `/tools` lists every entry in the `PROVIDERS` registry (introduced in PR 1) with:

- Installed status badge (resolved from `$PATH` at request time)
- Version string when installed; install hint when not
- "Used by N agents" count — walks active agents, resolves each LLM-prompt node's effective provider (`node.provider ?? agent.provider ?? 'claude'`), tallies **agents** (not nodes) per provider. An agent with five Claude nodes counts once.

Cards are **read-only** — no invoke button. The intent is discoverability: it gives back what the deleted `claude-code` built-in tool used to provide (a visible entry on the tools page) without re-introducing a parallel call path.

This closes the LLM-prompt unification plan at `~/.claude/plans/llm-prompt-unification.md`. Adding a third provider remains one entry in `PROVIDERS` from PR 1 — the catalog row appears automatically.

## Test plan

- [x] `npm test` — **1438 passing + 3 skipped** (was 1431; +7 from new `provider-usage.test.ts`)
- [x] Clean rebuild succeeds
- [x] Unit tests cover: empty agent list, agent-level default, node-level override, multi-node-same-provider de-dup, mixed providers in one agent, legacy `claude-code` type recognition, ignore non-LLM nodes
- [ ] Manual: visit `/tools` with at least one `provider: claude` agent → "Claude Code" card shows count ≥ 1
- [ ] Manual: visit `/tools` with `codex` not on PATH → "Codex" card shows "not on PATH" + install hint

## Series summary (PR 1–5)

| PR | What |
|---|---|
| [#294](https://github.com/gregmeyer/some-useful-agents/pull/294) | `PROVIDERS` registry — single source of truth |
| [#295](https://github.com/gregmeyer/some-useful-agents/pull/295) | `type: llm-prompt` as canonical; `claude-code` legacy alias |
| [#296](https://github.com/gregmeyer/some-useful-agents/pull/296) | Migrate 11 example agents + docs + ADR-0023 |
| [#297](https://github.com/gregmeyer/some-useful-agents/pull/297) | Delete the relic `claude-code` built-in tool; picker uses `llm-prompt` sentinel |
| **this** | Surface providers on the tools catalog (derived, not invocable) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)