### PR TITLE
fix(cli): preserve execute bit on dist/index.js across rebuilds

### DIFF
--- a/.changeset/cli-bin-exec-bit.md
+++ b/.changeset/cli-bin-exec-bit.md
@@ -1,0 +1,11 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Preserve the execute bit on `dist/index.js` across rebuilds so `sua` stays runnable when the package is `npm link`-ed.
+
+`tsc` emits plain files without `+x`, so a clean rebuild against a globally-linked install (`npm link @some-useful-agents/cli`) silently breaks the `sua` shim until the next `npm install`. The build script now chmods the bin file after compilation. No effect on fresh installs (npm sets the bit itself during install) or published tarballs (npm preserves it).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
     "sua": "dist/index.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && chmod +x dist/index.js",
     "clean": "rm -rf dist"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

`tsc` emits plain files without `+x`. After a clean rebuild (e.g. \`rm -rf packages/*/dist && npm run build\`) the \`sua\` binary at \`/opt/homebrew/bin/sua\` — which is an \`npm link\` symlink into the local repo — silently breaks until the next \`npm install\` restores the bit.

One-line fix: append \`chmod +x dist/index.js\` to the cli \`build\` script.

## Why this doesn't affect fresh installs

- \`npm install\` / \`npm link\` set +x on declared \`"bin":\` files automatically.
- Published tarballs preserve the bit.

The issue only bites contributors who run \`npm run build\` directly after a clean (which is the recommended pattern in CLAUDE.md / \`feedback_clean_build_before_push.md\`).

## Test plan

- [x] \`npm run build -w @some-useful-agents/cli\` → \`dist/index.js\` is \`-rwxr-xr-x\`
- [x] \`sua --version\` runs without "permission denied"

🤖 Generated with [Claude Code](https://claude.com/claude-code)