### PR TITLE
feat(dashboard): expose per-node LLM options on add-node + edit-node forms

### DIFF
--- a/.changeset/llm-prompt-options-ui.md
+++ b/.changeset/llm-prompt-options-ui.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Expose per-node LLM options (provider, model, maxTurns, allowedTools) on the add-node and edit-node forms.
+
+The schema has always honored these fields, but the dashboard only exposed `provider` (and only on the edit-node page). Authors who wanted to allowlist tools the LLM could invoke (Read, Write, Edit, web-search, MCP tools) or override the model had to drop to YAML. The deleted `claude-code` built-in tool used to surface them via its `toolInputs` schema; PR #297 inadvertently took that affordance with it.
+
+A new `renderLlmOptions()` helper sits alongside the Prompt textarea on both forms, inside the same `data-node-field="llm-prompt"` container so the existing tool-picker show/hide logic catches it. A matching `parseLlmOptions()` reads the form body and persists fields on the node. Empty fields are omitted (no spurious `model: ''` in YAML).

--- a/packages/dashboard/src/routes/agent-nodes.ts
+++ b/packages/dashboard/src/routes/agent-nodes.ts
@@ -18,6 +18,7 @@ import { renderAgentYaml } from '../views/agent-detail-v2.js';
 import { getContext } from '../context.js';
 import { renderAgentAddNode, type AddNodeFormValues } from '../views/agent-add-node.js';
 import { renderAgentEditNode, type EditNodeFormValues } from '../views/agent-edit-node.js';
+import { parseLlmOptions } from '../views/llm-options.js';
 import { autoFixYaml } from './run-now-build.js';
 
 export const agentNodesRouter: Router = Router();
@@ -67,6 +68,10 @@ agentNodesRouter.post('/agents/:name/add-node', (req: Request, res: Response) =>
     command: typeof body.command === 'string' ? body.command : undefined,
     prompt: typeof body.prompt === 'string' ? body.prompt : undefined,
     dependsOn,
+    provider: typeof body.provider === 'string' ? body.provider : undefined,
+    model: typeof body.model === 'string' ? body.model : undefined,
+    maxTurns: typeof body.maxTurns === 'string' ? body.maxTurns : undefined,
+    allowedTools: typeof body.allowedTools === 'string' ? body.allowedTools : undefined,
   };
 
   // Validate.
@@ -133,10 +138,20 @@ agentNodesRouter.post('/agents/:name/add-node', (req: Request, res: Response) =>
       },
       ...(dependsOn.length > 0 ? { dependsOn } : {}),
     };
+  } else if (nodeType === 'shell') {
+    newNode = { id: values.id!, type: 'shell' as const, command: values.command!, ...(dependsOn.length > 0 ? { dependsOn } : {}) };
   } else {
-    newNode = nodeType === 'shell'
-      ? { id: values.id!, type: 'shell' as const, command: values.command!, ...(dependsOn.length > 0 ? { dependsOn } : {}) }
-      : { id: values.id!, type: 'llm-prompt' as const, prompt: values.prompt!, ...(dependsOn.length > 0 ? { dependsOn } : {}) };
+    const llm = parseLlmOptions(body);
+    newNode = {
+      id: values.id!,
+      type: 'llm-prompt' as const,
+      prompt: values.prompt!,
+      ...(dependsOn.length > 0 ? { dependsOn } : {}),
+      ...(llm.provider ? { provider: llm.provider } : {}),
+      ...(llm.model ? { model: llm.model } : {}),
+      ...(llm.maxTurns ? { maxTurns: llm.maxTurns } : {}),
+      ...(llm.allowedTools ? { allowedTools: llm.allowedTools } : {}),
+    };
   }
 
   try {
@@ -199,6 +214,10 @@ agentNodesRouter.post('/agents/:name/nodes/:nodeId/edit', (req: Request, res: Re
     command: typeof body.command === 'string' ? body.command : undefined,
     prompt: typeof body.prompt === 'string' ? body.prompt : undefined,
     dependsOn,
+    provider: typeof body.provider === 'string' ? body.provider : undefined,
+    model: typeof body.model === 'string' ? body.model : undefined,
+    maxTurns: typeof body.maxTurns === 'string' ? body.maxTurns : undefined,
+    allowedTools: typeof body.allowedTools === 'string' ? body.allowedTools : undefined,
   };
 
   // Every declared dependency must be a node that's not the current
@@ -239,16 +258,34 @@ agentNodesRouter.post('/agents/:name/nodes/:nodeId/edit', (req: Request, res: Re
   }
 
   // Build the updated node. Preserve any fields we don't let the form
-  // edit (inputs, secrets, env, envAllowlist, allowedTools, model,
-  // maxTurns, timeout, redactSecrets, position) — those come back in
-  // a follow-up when the inspector can render them.
-  const provider = typeof body.provider === 'string' && ['claude', 'codex'].includes(body.provider)
-    ? body.provider as 'claude' | 'codex'
-    : undefined;
+  // edit (inputs, secrets, env, envAllowlist, timeout, redactSecrets,
+  // position) — those come back in a follow-up when the inspector can
+  // render them.
+  const llm = parseLlmOptions(body);
 
   const updatedNode = values.type === 'shell'
-    ? { ...node, type: 'shell' as const, command: values.command!, prompt: undefined, provider: undefined, ...(dependsOn.length > 0 ? { dependsOn } : { dependsOn: undefined }) }
-    : { ...node, type: 'llm-prompt' as const, prompt: values.prompt!, command: undefined, ...(provider ? { provider } : {}), ...(dependsOn.length > 0 ? { dependsOn } : { dependsOn: undefined }) };
+    ? {
+        ...node,
+        type: 'shell' as const,
+        command: values.command!,
+        prompt: undefined,
+        provider: undefined,
+        model: undefined,
+        maxTurns: undefined,
+        allowedTools: undefined,
+        ...(dependsOn.length > 0 ? { dependsOn } : { dependsOn: undefined }),
+      }
+    : {
+        ...node,
+        type: 'llm-prompt' as const,
+        prompt: values.prompt!,
+        command: undefined,
+        provider: llm.provider,
+        model: llm.model,
+        maxTurns: llm.maxTurns,
+        allowedTools: llm.allowedTools,
+        ...(dependsOn.length > 0 ? { dependsOn } : { dependsOn: undefined }),
+      };
 
   const updatedNodes = agent.nodes.map((n) => n.id === nodeId ? updatedNode : n);
 

--- a/packages/dashboard/src/views/agent-add-node.ts
+++ b/packages/dashboard/src/views/agent-add-node.ts
@@ -4,6 +4,7 @@ import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
 import { computePaletteSuggestions, renderPalettePayload } from './template-palette.js';
 import { renderToolPicker, renderToolInputsSection, getAvailableTools } from './tool-picker.js';
+import { renderLlmOptions } from './llm-options.js';
 import { NODE_PATTERNS } from './node-patterns.js';
 
 function availableVariablesPanel(agent: Agent): SafeHtml {
@@ -57,6 +58,10 @@ export interface AddNodeFormValues {
   command?: string;
   prompt?: string;
   dependsOn?: string[];
+  provider?: string;
+  model?: string;
+  maxTurns?: number | string;
+  allowedTools?: string[] | string;
 }
 
 export function renderAgentAddNode(args: {
@@ -169,6 +174,12 @@ export function renderAgentAddNode(args: {
               data-palette-source="palette-add-node">${v.prompt ?? ''}</textarea>
             <span class="form-field__hint">Type <code>{{</code> for available template refs.</span>
           </div>
+          ${renderLlmOptions({
+            provider: v.provider,
+            model: v.model,
+            maxTurns: v.maxTurns,
+            allowedTools: v.allowedTools,
+          })}
         </div>
       </fieldset>
 

--- a/packages/dashboard/src/views/agent-edit-node.ts
+++ b/packages/dashboard/src/views/agent-edit-node.ts
@@ -5,12 +5,17 @@ import { pageHeader } from './page-header.js';
 import { computePaletteSuggestions, renderPalettePayload } from './template-palette.js';
 import { renderToolPicker, renderToolInputsSection, getAvailableTools } from './tool-picker.js';
 import { renderControlFlowSection, isControlFlowNode } from './controlflow-edit.js';
+import { renderLlmOptions } from './llm-options.js';
 
 export interface EditNodeFormValues {
   type?: string;
   command?: string;
   prompt?: string;
   dependsOn?: string[];
+  provider?: string;
+  model?: string;
+  maxTurns?: number | string;
+  allowedTools?: string[] | string;
 }
 
 export function renderAgentEditNode(args: {
@@ -73,16 +78,6 @@ export function renderAgentEditNode(args: {
           ${renderToolInputsSection(node.tool ?? ((v.type === 'claude-code' || v.type === 'llm-prompt') ? 'llm-prompt' : 'shell-exec'), allTools, node.toolInputs as Record<string, unknown> | undefined)}
         `}
 
-      ${node.type === 'claude-code' || node.type === 'llm-prompt' || v.type === 'claude-code' || v.type === 'llm-prompt' ? html`
-        <fieldset class="fieldset">
-          <legend class="fieldset__legend">LLM Provider</legend>
-          <select name="provider" class="form-field__input" style="width: auto;">
-            <option value="claude" ${node.provider !== 'codex' ? 'selected' : ''}>Claude</option>
-            <option value="codex" ${node.provider === 'codex' ? 'selected' : ''}>Codex</option>
-          </select>
-          <span class="dim text-xs" style="margin-left: var(--space-2);">Which LLM CLI to use for this node.</span>
-        </fieldset>
-      ` : html``}
 
       <fieldset class="fieldset">
         <legend class="fieldset__legend">Depends on</legend>
@@ -117,6 +112,12 @@ export function renderAgentEditNode(args: {
               data-palette-source="palette-edit-node">${v.prompt ?? ''}</textarea>
             <span class="form-field__hint">Type <code>{{</code> for available template refs.</span>
           </div>
+          ${renderLlmOptions({
+            provider: submitted?.provider ?? node.provider,
+            model: submitted?.model ?? node.model,
+            maxTurns: submitted?.maxTurns ?? node.maxTurns,
+            allowedTools: submitted?.allowedTools ?? node.allowedTools,
+          })}
         </div>
       </fieldset>
 

--- a/packages/dashboard/src/views/llm-options.test.ts
+++ b/packages/dashboard/src/views/llm-options.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { parseLlmOptions } from './llm-options.js';
+
+describe('parseLlmOptions', () => {
+  it('returns an empty object for an empty body', () => {
+    expect(parseLlmOptions({})).toEqual({});
+  });
+
+  it('accepts known providers, rejects others', () => {
+    expect(parseLlmOptions({ provider: 'claude' })).toEqual({ provider: 'claude' });
+    expect(parseLlmOptions({ provider: 'codex' })).toEqual({ provider: 'codex' });
+    expect(parseLlmOptions({ provider: 'gemini' })).toEqual({});
+    expect(parseLlmOptions({ provider: '' })).toEqual({});
+  });
+
+  it('trims model, omits when empty', () => {
+    expect(parseLlmOptions({ model: '  claude-opus-4-7  ' })).toEqual({ model: 'claude-opus-4-7' });
+    expect(parseLlmOptions({ model: '   ' })).toEqual({});
+    expect(parseLlmOptions({ model: '' })).toEqual({});
+  });
+
+  it('parses maxTurns as a positive integer', () => {
+    expect(parseLlmOptions({ maxTurns: '5' })).toEqual({ maxTurns: 5 });
+    expect(parseLlmOptions({ maxTurns: '0' })).toEqual({});
+    expect(parseLlmOptions({ maxTurns: '-1' })).toEqual({});
+    expect(parseLlmOptions({ maxTurns: 'abc' })).toEqual({});
+    expect(parseLlmOptions({ maxTurns: '' })).toEqual({});
+  });
+
+  it('splits allowedTools on commas and whitespace', () => {
+    expect(parseLlmOptions({ allowedTools: 'Read, Write, Edit' })).toEqual({ allowedTools: ['Read', 'Write', 'Edit'] });
+    expect(parseLlmOptions({ allowedTools: 'Read Write Edit' })).toEqual({ allowedTools: ['Read', 'Write', 'Edit'] });
+    expect(parseLlmOptions({ allowedTools: 'Read,Write,  ,Edit' })).toEqual({ allowedTools: ['Read', 'Write', 'Edit'] });
+    expect(parseLlmOptions({ allowedTools: '   ' })).toEqual({});
+    expect(parseLlmOptions({ allowedTools: '' })).toEqual({});
+  });
+
+  it('combines all four fields', () => {
+    const body = {
+      provider: 'codex',
+      model: 'gpt-5',
+      maxTurns: '10',
+      allowedTools: 'Read, web-search',
+    };
+    expect(parseLlmOptions(body)).toEqual({
+      provider: 'codex',
+      model: 'gpt-5',
+      maxTurns: 10,
+      allowedTools: ['Read', 'web-search'],
+    });
+  });
+});

--- a/packages/dashboard/src/views/llm-options.ts
+++ b/packages/dashboard/src/views/llm-options.ts
@@ -1,0 +1,96 @@
+import { html, type SafeHtml } from './html.js';
+
+/**
+ * Per-node LLM options for `type: llm-prompt` nodes — provider, model,
+ * maxTurns, allowedTools. Rendered as a block of form-fields meant to
+ * sit alongside the Prompt textarea inside the same `data-node-field`
+ * container, so the existing tool-picker show/hide logic catches them.
+ *
+ * Values may come from a parsed node (numbers / arrays) or from a
+ * re-rendered submitted form (strings); both shapes are normalised.
+ */
+export interface LlmOptionsValues {
+  provider?: string;
+  model?: string;
+  maxTurns?: number | string;
+  allowedTools?: string[] | string;
+}
+
+export function renderLlmOptions(values: LlmOptionsValues = {}): SafeHtml {
+  const provider = values.provider === 'codex' ? 'codex' : 'claude';
+  const model = typeof values.model === 'string' ? values.model : '';
+  const maxTurns =
+    typeof values.maxTurns === 'number' ? String(values.maxTurns)
+    : typeof values.maxTurns === 'string' ? values.maxTurns
+    : '';
+  const allowedTools =
+    Array.isArray(values.allowedTools) ? values.allowedTools.join(', ')
+    : typeof values.allowedTools === 'string' ? values.allowedTools
+    : '';
+
+  return html`
+    <div class="form-field">
+      <strong>Provider</strong>
+      <select name="provider" class="form-field__input" style="width: auto;">
+        <option value="claude" ${provider !== 'codex' ? 'selected' : ''}>Claude</option>
+        <option value="codex" ${provider === 'codex' ? 'selected' : ''}>Codex</option>
+      </select>
+      <span class="form-field__hint">Which LLM CLI runs the prompt. Inherits from the agent if unset.</span>
+    </div>
+
+    <div class="form-field">
+      <strong>Model <span class="dim text-xs">(optional)</span></strong>
+      <input type="text" name="model" value="${model}" placeholder="e.g. claude-opus-4-7"
+        class="form-field__input">
+      <span class="form-field__hint">Override the default model for this node. Provider-specific.</span>
+    </div>
+
+    <div class="form-field">
+      <strong>Max turns <span class="dim text-xs">(optional)</span></strong>
+      <input type="number" name="maxTurns" value="${maxTurns}" min="1" placeholder="5"
+        class="form-field__input" style="width: 8rem;">
+      <span class="form-field__hint">Cap on tool-use turns inside the prompt. Default 5.</span>
+    </div>
+
+    <div class="form-field">
+      <strong>Allowed tools <span class="dim text-xs">(optional)</span></strong>
+      <input type="text" name="allowedTools" value="${allowedTools}"
+        placeholder="Read, Write, Edit, web-search" class="form-field__input">
+      <span class="form-field__hint">Comma-separated allowlist of tools the LLM may invoke. Leave empty to use the provider's defaults.</span>
+    </div>
+  `;
+}
+
+export interface ParsedLlmOptions {
+  provider?: 'claude' | 'codex';
+  model?: string;
+  maxTurns?: number;
+  allowedTools?: string[];
+}
+
+/** Parse LLM-options form fields out of a request body. Empty fields are omitted. */
+export function parseLlmOptions(body: Record<string, unknown>): ParsedLlmOptions {
+  const result: ParsedLlmOptions = {};
+
+  if (typeof body.provider === 'string' && (body.provider === 'claude' || body.provider === 'codex')) {
+    result.provider = body.provider;
+  }
+
+  if (typeof body.model === 'string' && body.model.trim()) {
+    result.model = body.model.trim();
+  }
+
+  if (typeof body.maxTurns === 'string' && body.maxTurns.trim()) {
+    const n = parseInt(body.maxTurns, 10);
+    if (Number.isFinite(n) && n > 0) result.maxTurns = n;
+  } else if (typeof body.maxTurns === 'number' && body.maxTurns > 0) {
+    result.maxTurns = body.maxTurns;
+  }
+
+  if (typeof body.allowedTools === 'string' && body.allowedTools.trim()) {
+    const tools = body.allowedTools.split(/[,\s]+/).map((s) => s.trim()).filter(Boolean);
+    if (tools.length > 0) result.allowedTools = tools;
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

`llm-prompt` nodes have four schema-supported fields the dashboard didn't expose: `provider`, `model`, `maxTurns`, `allowedTools`. Only `provider` was rendered, and only on the edit-node page. Authors who wanted to allowlist tools the LLM could invoke (Read, Write, Edit, web-search, MCP tools) or override the model had to drop to YAML.

The deleted `claude-code` built-in tool used to surface these via its `toolInputs` schema; PR #297 inadvertently took that affordance with it. This PR adds them back as proper node-level fields.

- **New helper** `packages/dashboard/src/views/llm-options.ts` exports `renderLlmOptions(values)` + `parseLlmOptions(body)`. Empty fields are omitted on persist so YAML stays clean.
- **Both forms** (add-node + edit-node) now render the four options inside the existing `data-node-field="llm-prompt"` container, so the tool-picker's show/hide logic catches them automatically — they appear only when the LLM Prompt node type is selected.
- **Route handlers** read all four fields via `parseLlmOptions()` and persist them on the node alongside `prompt:`.

## Test plan

- [x] `npm test` — **1444 passing + 3 skipped** (+6 from new `llm-options.test.ts`)
- [x] Clean rebuild succeeds
- [x] Parser unit tests cover: empty body, provider allowlist, model trim, maxTurns int parsing (rejects negative / non-numeric), allowedTools comma + whitespace splitting, all-four combo
- [ ] Manual: visit `/agents/:id/add-node`, pick LLM Prompt → see Provider / Model / Max turns / Allowed tools fields. Fill them in. Save. Confirm the YAML has all four fields.
- [ ] Manual: visit `/agents/:id/nodes/:nodeId/edit` on an existing node with `allowedTools: [Read, Write]` set in YAML → form pre-populates them as "Read, Write". Save without changes. YAML still has them. Save with changes. YAML reflects changes.
- [ ] Manual: clear all four fields in the edit form, save → YAML drops the keys entirely (no `model: ''`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)