### PR TITLE
feat(dashboard): expose LLM options on /agents/new + tighten radio copy

### DIFF
--- a/.changeset/agents-new-llm-options.md
+++ b/.changeset/agents-new-llm-options.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Surface Advanced LLM options on `/agents/new` and tighten the radio copy.
+
+PR #300 added per-node LLM options (`provider`, `model`, `maxTurns`, `allowedTools`) to the add-node and edit-node forms but missed the initial-create page. This release fills the gap. The four fields sit under a collapsed `<details>` block ("Advanced LLM options") so the common case — a quick prompt, no extras — stays terse, but power users can set allowedTools / model / maxTurns at create time without round-tripping through an edit page.
+
+Radio copy on `/agents/new` tightened from *"runs an LLM prompt — you have Claude Code and Codex installed"* to *"runs an LLM prompt (Claude Code, Codex installed)"*. The em-dash sandwich was redundant.

--- a/packages/dashboard/src/routes/agents/new.ts
+++ b/packages/dashboard/src/routes/agents/new.ts
@@ -2,6 +2,7 @@ import { Router, type Request, type Response } from 'express';
 import { detectLlms, PROVIDERS, PROVIDER_IDS } from '@some-useful-agents/core';
 import { getContext } from '../../context.js';
 import { renderAgentNew, type AgentNewFormValues } from '../../views/agent-new.js';
+import { parseLlmOptions } from '../../views/llm-options.js';
 
 const AGENT_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
 
@@ -39,6 +40,10 @@ agentNewRouter.post('/agents/new', (req: Request, res: Response) => {
     type: (body.type === 'llm-prompt' || body.type === 'claude-code') ? 'llm-prompt' : 'shell',
     command: typeof body.command === 'string' ? body.command : undefined,
     prompt: typeof body.prompt === 'string' ? body.prompt : undefined,
+    provider: typeof body.provider === 'string' ? body.provider : undefined,
+    model: typeof body.model === 'string' ? body.model : undefined,
+    maxTurns: typeof body.maxTurns === 'string' ? body.maxTurns : undefined,
+    allowedTools: typeof body.allowedTools === 'string' ? body.allowedTools : undefined,
   };
 
   // Validate in order of what the user typed top-to-bottom so the error
@@ -79,6 +84,8 @@ agentNewRouter.post('/agents/new', (req: Request, res: Response) => {
     return;
   }
 
+  const llm = values.type === 'llm-prompt' ? parseLlmOptions(body) : {};
+
   try {
     ctx.agentStore.createAgent(
       {
@@ -91,7 +98,15 @@ agentNewRouter.post('/agents/new', (req: Request, res: Response) => {
         nodes: [
           values.type === 'shell'
             ? { id: 'main', type: 'shell', command: values.command! }
-            : { id: 'main', type: 'llm-prompt', prompt: values.prompt! },
+            : {
+                id: 'main',
+                type: 'llm-prompt',
+                prompt: values.prompt!,
+                ...(llm.provider ? { provider: llm.provider } : {}),
+                ...(llm.model ? { model: llm.model } : {}),
+                ...(llm.maxTurns ? { maxTurns: llm.maxTurns } : {}),
+                ...(llm.allowedTools ? { allowedTools: llm.allowedTools } : {}),
+              },
         ],
       },
       'dashboard',

--- a/packages/dashboard/src/views/agent-new.ts
+++ b/packages/dashboard/src/views/agent-new.ts
@@ -1,6 +1,7 @@
 import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
+import { renderLlmOptions } from './llm-options.js';
 
 export interface AgentNewFormValues {
   id?: string;
@@ -9,13 +10,15 @@ export interface AgentNewFormValues {
   type?: 'shell' | 'llm-prompt';
   command?: string;
   prompt?: string;
+  provider?: string;
+  model?: string;
+  maxTurns?: number | string;
+  allowedTools?: string[] | string;
 }
 
 function formatInstalled(providers: string[]): string {
-  if (providers.length === 0) return 'no LLM CLIs detected on PATH';
-  if (providers.length === 1) return `you have ${providers[0]} installed`;
-  if (providers.length === 2) return `you have ${providers[0]} and ${providers[1]} installed`;
-  return `you have ${providers.slice(0, -1).join(', ')}, and ${providers[providers.length - 1]} installed`;
+  if (providers.length === 0) return 'no LLM CLIs on PATH';
+  return `${providers.join(', ')} installed`;
 }
 
 export function renderAgentNew(args: {
@@ -66,7 +69,7 @@ export function renderAgentNew(args: {
         </label>
         <label class="radio-option">
           <input type="radio" name="type" value="llm-prompt" ${isClaude ? 'checked' : ''}>
-          <span><strong>LLM Prompt</strong> <span class="dim">\u2014 runs an LLM prompt \u2014 ${installedSuffix}</span></span>
+          <span><strong>LLM Prompt</strong> <span class="dim">\u2014 runs an LLM prompt (${installedSuffix})</span></span>
         </label>
       </fieldset>
 
@@ -75,10 +78,22 @@ export function renderAgentNew(args: {
         <textarea name="command" rows="4" placeholder="echo hello" class="form-field__textarea">${v.command ?? ''}</textarea>
       </div>
 
-      <div class="form-field mb-4">
+      <div class="form-field">
         <strong>Prompt <span class="dim text-xs">(llm-prompt agents only)</span></strong>
         <textarea name="prompt" rows="4" placeholder="Summarise the attached text." class="form-field__textarea">${v.prompt ?? ''}</textarea>
       </div>
+
+      <details class="mb-4" ${(v.provider || v.model || v.maxTurns || v.allowedTools) ? 'open' : ''}>
+        <summary class="dim text-xs" style="cursor: pointer; padding: var(--space-2) 0;">Advanced LLM options <span class="dim">(llm-prompt agents only)</span></summary>
+        <div style="padding-top: var(--space-2);">
+          ${renderLlmOptions({
+            provider: v.provider,
+            model: v.model,
+            maxTurns: v.maxTurns,
+            allowedTools: v.allowedTools,
+          })}
+        </div>
+      </details>
 
       <div class="flex-end">
         <a class="btn" href="/agents">Cancel</a>


### PR DESCRIPTION
## Summary

Two small UX fixes for `/agents/new`:

1. **Advanced LLM options** (provider, model, maxTurns, allowedTools) now appear under a collapsed \`<details>\` block on the initial-create page. Common case stays terse; power users can set everything at create time without round-tripping through an edit page. PR #300 had added these to add-node and edit-node but missed this form.
2. **Radio copy tightened** from *"runs an LLM prompt — you have Claude Code and Codex installed"* to *"runs an LLM prompt (Claude Code, Codex installed)"*. The em-dash sandwich was redundant.

The \`<details>\` block defaults to closed on a fresh form; if the user re-submits with an error and one of the LLM fields is populated, it stays open so they can see what they typed.

## Test plan

- [x] \`npm test\` — **1444 passing + 3 skipped** (no test changes; the existing dashboard test for /agents/new doesn't assert the radio copy)
- [x] Clean rebuild succeeds
- [ ] Manual: visit /agents/new, pick LLM Prompt, expand "Advanced LLM options", fill allowedTools=\`Read, Write\`. Save. \`sua agent audit <id>\` should show \`allowedTools: [Read, Write]\` on the node.
- [ ] Manual: leave all advanced fields empty → YAML has no \`provider:\` / \`model:\` / \`maxTurns:\` / \`allowedTools:\` keys.
- [ ] Manual: submit an invalid form (e.g. duplicate id) with allowedTools filled in → form re-renders with the details block already expanded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)