### PR TITLE
fix(dashboard): make Advanced LLM options summary visually prominent

### DIFF
--- a/.changeset/advanced-llm-options-styling.md
+++ b/.changeset/advanced-llm-options-styling.md
@@ -1,0 +1,11 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Make the Advanced LLM options disclosure on `/agents/new` visually prominent.
+
+PR #301 added the disclosure but styled it `dim text-xs`, which made it nearly invisible to anyone scanning the form. Now it renders as a bordered card with a semibold summary, an inline secondary hint listing the four fields it expands, and a divider above the expanded content.

--- a/packages/dashboard/src/views/agent-new.ts
+++ b/packages/dashboard/src/views/agent-new.ts
@@ -83,9 +83,12 @@ export function renderAgentNew(args: {
         <textarea name="prompt" rows="4" placeholder="Summarise the attached text." class="form-field__textarea">${v.prompt ?? ''}</textarea>
       </div>
 
-      <details class="mb-4" ${(v.provider || v.model || v.maxTurns || v.allowedTools) ? 'open' : ''}>
-        <summary class="dim text-xs" style="cursor: pointer; padding: var(--space-2) 0;">Advanced LLM options <span class="dim">(llm-prompt agents only)</span></summary>
-        <div style="padding-top: var(--space-2);">
+      <details class="card mb-4" style="padding: var(--space-3) var(--space-4); border: 1px solid var(--color-border); border-radius: var(--radius-sm);" ${(v.provider || v.model || v.maxTurns || v.allowedTools) ? 'open' : ''}>
+        <summary style="cursor: pointer; font-weight: var(--weight-semibold); padding: var(--space-1) 0;">
+          Advanced LLM options
+          <span class="dim text-xs" style="font-weight: var(--weight-normal); margin-left: var(--space-2);">provider, model, max turns, allowed tools — llm-prompt only</span>
+        </summary>
+        <div style="padding-top: var(--space-3); margin-top: var(--space-2); border-top: 1px solid var(--color-border);">
           ${renderLlmOptions({
             provider: v.provider,
             model: v.model,


### PR DESCRIPTION
## Summary

PR #301 added an "Advanced LLM options" disclosure on \`/agents/new\` but styled the \`<summary>\` as \`dim text-xs\` — nearly invisible to anyone scanning the form.

This PR renders the disclosure as a bordered card with:
- Semibold summary label
- Inline secondary hint listing the four fields it expands ("provider, model, max turns, allowed tools — llm-prompt only")
- Divider above the expanded content

Still defaults to collapsed so the common case stays terse; auto-opens when any field is pre-populated (e.g. on form re-render after an error).

## Test plan

- [x] Clean rebuild succeeds
- [ ] Manual: visit /agents/new — the "Advanced LLM options" disclosure is clearly visible as a section, not hidden in dim micro-text
- [ ] Manual: click to expand — fields render below a divider line
- [ ] Manual: submit invalid form with allowedTools filled in — disclosure opens automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)