### PR TITLE
fix(build-planner): teach the planner that signal.title is required

### DIFF
--- a/agents/examples/build-planner.yaml
+++ b/agents/examples/build-planner.yaml
@@ -103,6 +103,9 @@ nodes:
       - DO NOT propose modifying any existing agent. (The user does that via /agents/<id>/yaml.)
       - Each new agent's YAML should include both signal: and outputWidget: blocks so dashboard
         tiles render correctly.
+      - **signal.title is REQUIRED** when the signal block is present. It's a literal short string
+        used as the chrome label on the Pulse tile (e.g. "HN Top Stories", "Daily Joke"). Omitting
+        it causes schema validation to fail with "signal.title: Required".
       - **When the agent declares an `outputWidget`, set `signal.template: widget`.** Pulse tile
         rendering is dispatched by `signal.template`, NOT `outputWidget.type` — so an agent with
         `outputWidget: { type: ai-template, template: <rich HTML> }` and `signal.template:


### PR DESCRIPTION
## Summary

Build from Goal was failing intermittently with:

\`\`\`
newAgents[0] (id="hn-top3") YAML failed to parse:
Agent schema validation failed: signal.title: Required
\`\`\`

Even after 3 critic-retry attempts. The planner kept emitting an incomplete \`signal:\` block because the prompt told it to "include both signal: and outputWidget: blocks" without saying \`signal.title\` is required when the block is present.

Adds one bullet to the "Crucial constraints" list naming the field and showing example titles.

## Why this isn't a changeset-required PR

Per \`CLAUDE.md\`: PRs that touch only \`agents/\` skip the changeset. This only edits \`agents/examples/build-planner.yaml\`.

## Test plan

- [ ] Manual: submit a Build from Goal request like "Show me the top 3 HN stories" → planner emits agent with \`signal.title\` set → schema validates → commit succeeds first try (no critic retry)
- [ ] Manual: re-run an earlier failing prompt — should now produce a clean plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)