### PR TITLE
feat(cli): sua agent audit falls back to the project DB

### DIFF
--- a/.changeset/cli-audit-db-fallback.md
+++ b/.changeset/cli-audit-db-fallback.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+`sua agent audit` now falls back to the project DB when no on-disk YAML matches.
+
+Agents created via the dashboard's Build-from-Goal flow live in the project SQLite store, not in `agents/local/*.yaml`. Previously running `sua agent audit <id>` against them printed "not found". This release adds a DB lookup as the second-pass resolver: if `loadAgents()` doesn't find the id on disk, the CLI opens the project DB read-only, fetches the agent, and prints its canonical YAML via `exportAgent()` with a banner noting the storage location.
+
+Side effect: v2-only on-disk YAMLs (which `loadAgents` didn't surface because that loader is v1-shaped) now audit successfully too via the same path. The on-disk v1 audit path is unchanged for v1 agents.

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -1,8 +1,48 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
-import { loadAgents } from '@some-useful-agents/core';
-import { loadConfig, getAgentDirs } from '../config.js';
+import { DatabaseSync } from 'node:sqlite';
+import { existsSync } from 'node:fs';
+import { AgentStore, exportAgent, loadAgents } from '@some-useful-agents/core';
+import { loadConfig, getAgentDirs, getDbPath } from '../config.js';
 import * as ui from '../ui.js';
+
+/**
+ * Look up a v2 agent in the project DB and print its canonical YAML.
+ * Used as a fallback when the agent isn't present in any on-disk
+ * `agents/*` directory — e.g. agents created via the dashboard's
+ * Build-from-Goal flow, which writes to the DB but not to disk.
+ */
+function tryAuditFromDb(name: string): boolean {
+  const config = loadConfig();
+  const dbPath = getDbPath(config);
+  if (!existsSync(dbPath)) return false;
+
+  let db: DatabaseSync;
+  try {
+    db = new DatabaseSync(dbPath, { readOnly: true });
+  } catch {
+    return false;
+  }
+
+  let agent;
+  try {
+    const store = AgentStore.fromHandle(db);
+    agent = store.getAgent(name);
+  } finally {
+    db.close();
+  }
+
+  if (!agent) return false;
+
+  const sourceLabel = agent.source ?? 'local';
+  const headerColor = sourceLabel === 'community' ? chalk.red.bold : chalk.cyan.bold;
+  console.log('');
+  console.log(headerColor(`Agent: ${agent.id}  [source=${sourceLabel}, storage=db]`));
+  console.log(ui.dim('  (loaded from project DB. Use `sua agent export` to write a YAML file.)'));
+  console.log('');
+  console.log(exportAgent(agent));
+  return true;
+}
 
 /**
  * Read-only inspection of an agent. Prints the full resolved YAML including
@@ -19,6 +59,9 @@ export const auditCommand = new Command('audit')
 
     const agent = agents.get(name);
     if (!agent) {
+      // No on-disk YAML matched. Try the DB — dashboard-created agents
+      // live there only.
+      if (tryAuditFromDb(name)) return;
       ui.fail(`Agent "${name}" not found.`);
       console.error(ui.dim('Run "sua agent list" or "sua agent list --catalog" to see options.'));
       process.exit(1);


### PR DESCRIPTION
## Summary

Dashboard-created agents (Build from Goal, /agents/new, etc.) live in the project SQLite store at \`data/runs.db\`, not in \`agents/local/*.yaml\`. \`sua agent audit <id>\` previously failed with "not found" against them because the CLI only looked at on-disk YAML.

This PR adds a DB fallback: if \`loadAgents()\` returns no match, open the DB read-only via \`AgentStore.fromHandle()\`, fetch the agent, and print its canonical YAML via \`exportAgent()\` with a banner showing \`storage=db\`. On-disk v1 audit path is unchanged for v1 agents.

## Why we're not auto-syncing DB ↔ disk

Discussed in the conversation that led to this PR: writing dashboard-created agents to disk on commit creates a two-writer problem (DB vs hand-edited YAML), forces a choice about where versioning + status live, and breaks down for non-repo deployments. Reading from the DB on miss is the lower-risk direction.

A future companion PR can add \`sua agent export <id> > path.yaml\` for explicit one-way disk writes when an author wants to commit a dashboard-created agent to git.

## Test plan

- [x] \`npm test\` — **1444 passing + 3 skipped** (no test changes; behavior is additive)
- [x] Clean rebuild succeeds
- [x] Manual: \`sua agent audit hn-top-3\` (a dashboard-created agent) → prints canonical YAML with \`storage=db\` banner
- [x] Manual: \`sua agent audit nonexistent\` → unchanged "not found" exit 1
- [x] Manual: \`sua agent audit hello\` (seeded example, v2) → prints via DB path

🤖 Generated with [Claude Code](https://claude.com/claude-code)