### PR TITLE
feat(core): add LayoutPlan zod schema for layout-planner (PR 1/4)

### DIFF
--- a/.changeset/layout-plan-schema.md
+++ b/.changeset/layout-plan-schema.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Add the `LayoutPlan` zod schema for the upcoming layout-planner agent.
+
+Parallel to `BuildPlan` from `build-plan-schema.ts`. Defines the structured output the layout-planner emits in a `<plan>…</plan>` wrapper: a `summary`, a ranked `topAgents[]` with one-line rationales and optional `suggestedSize`, proposed `containers[]` (label + tiles) that mirror the `sua-pulse-layout` localStorage shape, and post-plan clarifying `questions[]`.
+
+Strict-mode validation catches the common LLM mistakes: duplicate tiles across containers, duplicate container labels (case-insensitive), duplicate topAgent ids. Loose enough that container tiles can reference any agent (not just topAgents) so lower-ranked agents can be placed without promotion.
+
+This PR is schema-only — no agent or UI yet. Part 1 of 4 in the dashboard-layout-improvement plan at `~/.claude/plans/how-would-you-improve-joyful-wadler.md`.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -157,6 +157,13 @@ export {
   type BuildPlanInput,
 } from './build-plan-schema.js';
 export {
+  layoutPlanSchema,
+  SIGNAL_SIZES,
+  type LayoutPlan,
+  type LayoutPlanInput,
+  type SignalSize,
+} from './layout-plan-schema.js';
+export {
   critiquePlan,
   formatCriticFeedback,
   type PlanCriticError,

--- a/packages/core/src/layout-plan-schema.test.ts
+++ b/packages/core/src/layout-plan-schema.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { layoutPlanSchema } from './layout-plan-schema.js';
+
+const validPlan = {
+  summary: 'Group monitoring and pin reliable agents.',
+  topAgents: [
+    { id: 'api-monitor', rationale: 'runs every 5 minutes, 100% success', suggestedSize: '2x1' as const },
+    { id: 'weather-forecast', rationale: 'user mentioned weather', suggestedSize: '1x1' as const },
+  ],
+  containers: [
+    { label: 'Monitoring', tiles: ['api-monitor'] },
+    { label: 'Personal', tiles: ['weather-forecast'] },
+  ],
+  questions: [],
+};
+
+describe('layoutPlanSchema', () => {
+  it('accepts a minimal well-formed plan', () => {
+    const r = layoutPlanSchema.safeParse(validPlan);
+    if (!r.success) console.log(r.error.issues);
+    expect(r.success).toBe(true);
+  });
+
+  it('defaults questions to an empty array when omitted', () => {
+    const { questions, ...rest } = validPlan;
+    void questions;
+    const r = layoutPlanSchema.safeParse(rest);
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.questions).toEqual([]);
+  });
+
+  it('accepts questions with options for select-style rendering', () => {
+    const r = layoutPlanSchema.safeParse({
+      ...validPlan,
+      questions: [
+        { text: 'Rank by?', suggestedAnswer: 'recency', options: ['recency', 'reliability', 'frequency'] },
+      ],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects empty topAgents', () => {
+    const r = layoutPlanSchema.safeParse({ ...validPlan, topAgents: [] });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects empty containers', () => {
+    const r = layoutPlanSchema.safeParse({ ...validPlan, containers: [] });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects a container with no tiles', () => {
+    const r = layoutPlanSchema.safeParse({
+      ...validPlan,
+      containers: [{ label: 'Empty', tiles: [] }],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects when the same tile appears in two containers', () => {
+    const r = layoutPlanSchema.safeParse({
+      ...validPlan,
+      containers: [
+        { label: 'A', tiles: ['api-monitor'] },
+        { label: 'B', tiles: ['api-monitor'] }, // duplicate
+      ],
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.message.includes('appears in containers'))).toBe(true);
+    }
+  });
+
+  it('rejects duplicate container labels (case-insensitive)', () => {
+    const r = layoutPlanSchema.safeParse({
+      ...validPlan,
+      containers: [
+        { label: 'Monitoring', tiles: ['api-monitor'] },
+        { label: 'monitoring', tiles: ['weather-forecast'] }, // collides
+      ],
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.message.includes('duplicates'))).toBe(true);
+    }
+  });
+
+  it('rejects duplicate topAgents ids', () => {
+    const r = layoutPlanSchema.safeParse({
+      ...validPlan,
+      topAgents: [
+        { id: 'api-monitor', rationale: 'a' },
+        { id: 'api-monitor', rationale: 'b' },
+      ],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects invalid suggestedSize values', () => {
+    const r = layoutPlanSchema.safeParse({
+      ...validPlan,
+      topAgents: [{ id: 'api-monitor', rationale: 'a', suggestedSize: '5x5' }],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('accepts a plan where topAgents and container tiles are disjoint', () => {
+    // The full agent metadata reaches the planner; lower-ranked agents
+    // may appear in containers without being promoted to topAgents.
+    const r = layoutPlanSchema.safeParse({
+      ...validPlan,
+      topAgents: [{ id: 'api-monitor', rationale: 'critical' }],
+      containers: [
+        { label: 'Monitoring', tiles: ['api-monitor'] },
+        { label: 'Side', tiles: ['some-other-agent'] }, // not in topAgents
+      ],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects malformed agent ids', () => {
+    const r = layoutPlanSchema.safeParse({
+      ...validPlan,
+      topAgents: [{ id: 'Api Monitor!', rationale: 'a' }],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('requires a non-empty summary', () => {
+    const r = layoutPlanSchema.safeParse({ ...validPlan, summary: '' });
+    expect(r.success).toBe(false);
+  });
+});

--- a/packages/core/src/layout-plan-schema.ts
+++ b/packages/core/src/layout-plan-schema.ts
@@ -1,0 +1,121 @@
+/**
+ * Schema for the structured plan emitted by the layout-planner agent.
+ *
+ * The Pulse layout wizard sends current-state + focus → planner returns
+ * a LayoutPlan → wizard renders top agents, containers, and clarifying
+ * questions → user accepts → client writes the proposed containers to
+ * localStorage (`sua-pulse-layout`).
+ *
+ * Validation runs server-side after extracting the plan JSON from the
+ * planner's `<plan>…</plan>` wrapper. Loose enough to absorb LLM noise
+ * (optional fields default to []), strict enough to catch obvious
+ * structural lies (tiles referencing agents that aren't in topAgents,
+ * empty containers, etc.).
+ *
+ * Parallel to `build-plan-schema.ts`. The two planners share the same
+ * `<plan>…</plan>` wrapper convention and the same `extractPlanJson()`
+ * helper from `build-plan-schema.ts`.
+ */
+
+import { z } from 'zod';
+
+const AGENT_ID_RE = /^[a-z0-9][a-z0-9_-]*$/;
+
+export const SIGNAL_SIZES = ['1x1', '2x1', '1x2', '2x2'] as const;
+export type SignalSize = typeof SIGNAL_SIZES[number];
+
+export const layoutPlanSchema = z.object({
+  summary: z.string().min(1, 'summary is required'),
+
+  /**
+   * Ranked list of agents the planner thinks should be most prominent.
+   * Order matters — index 0 is the most important. Each entry has a
+   * one-line rationale so the UI can render "why this one".
+   */
+  topAgents: z.array(z.object({
+    id: z.string().regex(AGENT_ID_RE, 'topAgents.id must be lowercase_with_dashes_or_underscores'),
+    rationale: z.string().min(1, 'topAgents.rationale is required'),
+    suggestedSize: z.enum(SIGNAL_SIZES).optional(),
+  })).min(1, 'topAgents must have at least one entry'),
+
+  /**
+   * Proposed container layout for `sua-pulse-layout`. Each container
+   * groups one or more tiles under a label. Order matters — index 0
+   * is the topmost container.
+   */
+  containers: z.array(z.object({
+    label: z.string().min(1, 'containers.label is required'),
+    tiles: z.array(z.string().regex(AGENT_ID_RE, 'containers.tiles[] must be a valid agent id'))
+      .min(1, 'containers.tiles must have at least one entry'),
+  })).min(1, 'layout must have at least one container'),
+
+  /**
+   * Post-plan clarifying questions. Same shape as build-planner's
+   * questions[]. The UI renders them with optional answer textareas;
+   * answered questions are appended to the FOCUS context and the
+   * planner is re-run.
+   */
+  questions: z.array(z.object({
+    text: z.string().min(1),
+    suggestedAnswer: z.string().optional(),
+    /** When set, render as a select instead of a free-form textarea. */
+    options: z.array(z.string().min(1)).optional(),
+  })).default([]),
+}).superRefine((plan, ctx) => {
+  // Tiles must reference agents declared in topAgents OR be marked as
+  // additional context (full agent metadata reaches the planner; the
+  // planner may include lower-ranked agents in containers without
+  // promoting them to topAgents). So we don't enforce containment here.
+  // What we DO enforce: no tile appears in two containers (a tile
+  // belongs to exactly one container, matching the localStorage shape).
+  const seenTiles = new Map<string, number>();
+  plan.containers.forEach((c, cIdx) => {
+    c.tiles.forEach((tile, tIdx) => {
+      const prev = seenTiles.get(tile);
+      if (prev !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['containers', cIdx, 'tiles', tIdx],
+          message: `tile "${tile}" appears in containers[${prev}] and containers[${cIdx}] — each tile belongs to exactly one container`,
+        });
+      } else {
+        seenTiles.set(tile, cIdx);
+      }
+    });
+  });
+
+  // Container labels must be unique — duplicates would collide in
+  // localStorage container ids derived from the label.
+  const seenLabels = new Map<string, number>();
+  plan.containers.forEach((c, cIdx) => {
+    const key = c.label.toLowerCase().trim();
+    const prev = seenLabels.get(key);
+    if (prev !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['containers', cIdx, 'label'],
+        message: `container label "${c.label}" duplicates containers[${prev}].label (case-insensitive)`,
+      });
+    } else {
+      seenLabels.set(key, cIdx);
+    }
+  });
+
+  // topAgents ids must be unique.
+  const seenAgents = new Map<string, number>();
+  plan.topAgents.forEach((a, aIdx) => {
+    const prev = seenAgents.get(a.id);
+    if (prev !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['topAgents', aIdx, 'id'],
+        message: `topAgents[${aIdx}].id "${a.id}" duplicates topAgents[${prev}].id`,
+      });
+    } else {
+      seenAgents.set(a.id, aIdx);
+    }
+  });
+});
+
+export type LayoutPlanInput = z.input<typeof layoutPlanSchema>;
+export type LayoutPlan = z.output<typeof layoutPlanSchema>;


### PR DESCRIPTION
## Summary

Parallel to \`BuildPlan\` from \`build-plan-schema.ts\`. Defines the structured output the upcoming layout-planner agent will emit in a \`<plan>…</plan>\` wrapper:

- \`summary\` — one-line description
- \`topAgents[]\` — ranked list with id + rationale + optional \`suggestedSize\` (1x1 / 2x1 / 1x2 / 2x2)
- \`containers[]\` — label + tiles, mirrors the \`sua-pulse-layout\` localStorage JSON shape
- \`questions[]\` — post-plan clarifying questions (same shape as build-planner's)

Strict-mode validation catches the LLM mistakes worth gating:
- Same tile in two containers
- Duplicate container labels (case-insensitive)
- Duplicate topAgent ids

Loose enough that container tiles can reference any agent in the input metadata (not just \`topAgents\`) so lower-ranked agents can be placed without promotion.

Schema-only — no agent or UI in this PR. Part 1 of 4 in the dashboard-layout-improvement plan at \`~/.claude/plans/how-would-you-improve-joyful-wadler.md\`.

## Test plan

- [x] \`npm test\` — **1457 passing + 3 skipped** (was 1444; +13 from new \`layout-plan-schema.test.ts\`)
- [x] Clean rebuild succeeds
- [x] Unit tests cover: minimal valid plan, optional-question defaulting, select-style options, empty-topAgents reject, empty-containers reject, empty-tiles reject, duplicate-tile-across-containers reject, duplicate-label reject, duplicate-id reject, bad-suggestedSize reject, disjoint-topAgents-vs-containers accept, malformed-id reject, empty-summary reject

🤖 Generated with [Claude Code](https://claude.com/claude-code)