### PR TITLE
feat(layout): add layout-planner agent + prompt-example regression test (PR 2/4)

### DIFF
--- a/.changeset/layout-planner-agent.md
+++ b/.changeset/layout-planner-agent.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Add the `layout-planner` agent.
+
+Single-node `type: llm-prompt` agent at `agents/examples/layout-planner.yaml` that reads `CURRENT_LAYOUT` + `AGENT_METADATA` + an optional `FOCUS` statement and emits a structured `LayoutPlan` JSON (introduced in the previous PR) wrapped in `<plan>...</plan>` tags. The prompt teaches the LLM the ranking rules (FOCUS-first, then a recency × reliability × frequency combination), the container grouping rules (1–6 containers, unique labels, each tile in exactly one container), and when to emit clarifying questions (FOCUS empty → ask about ranking heuristic).
+
+The route handler + UI come in a later PR; this commit is the agent and a regression test that locks the prompt's embedded `<plan>` example to the schema. Editing the prompt's example out of sync with the schema fails the test.

--- a/agents/examples/layout-planner.yaml
+++ b/agents/examples/layout-planner.yaml
@@ -1,0 +1,184 @@
+# Layout Planner — picks top agents and proposes a Pulse container layout.
+#
+# The Pulse "Improve layout" wizard sends current localStorage layout +
+# per-agent metadata (signal.size, signal.title, run frequency, success
+# rate, last-run timestamp) + optional FOCUS text. The planner returns
+# a structured LayoutPlan JSON with:
+#   - summary: one-line description of the proposal
+#   - topAgents: ranked list with rationales + suggestedSize hints
+#   - containers: proposed grouping (label + tiles) for sua-pulse-layout
+#   - questions: post-plan clarifying questions when FOCUS is vague
+#
+# The wizard renders the plan, lets the user answer questions to refine
+# (re-runs with appended context), then applies — the apply step writes
+# the proposed containers to localStorage and reloads the Pulse view.
+
+id: layout-planner
+name: Layout Planner
+description: >
+  Picks the most-important agents from your installed catalog and proposes
+  a grouped Pulse layout. Reads current layout + agent run history + an
+  optional focus statement; emits a structured LayoutPlan JSON that the
+  wizard renders and applies. Run via "Improve layout" on /pulse.
+status: active
+source: examples
+
+inputs:
+  CURRENT_LAYOUT:
+    type: string
+    required: false
+    default: ""
+    description: >
+      Current sua-pulse-layout JSON from the user's localStorage, e.g.
+      {"containers":[{"id":"default","label":"Default","tiles":["a","b"]}]}.
+      Empty string means no custom layout yet (default ordering).
+  AGENT_METADATA:
+    type: string
+    required: true
+    description: >
+      JSON array of every visible agent with metadata used for ranking:
+      [{ "id", "title", "size"?, "lastRunAt"?, "successRate"?, "runCount30d"? }].
+      Injected at request time by the route handler.
+  FOCUS:
+    type: string
+    required: false
+    default: ""
+    description: >
+      Optional user focus statement. Examples: "I care about API monitors",
+      "group by topic", "surface my failing agents". Blank is fine — the
+      planner will ask a clarifying question about the ranking heuristic.
+
+nodes:
+  - id: plan
+    type: llm-prompt
+    prompt: |
+      You are the Pulse layout planner for the sua agent platform.
+
+      Read the user's installed agents + current layout + optional focus,
+      then emit a structured LayoutPlan JSON describing how to rearrange
+      the Pulse page.
+
+      ════════════════════════════════════════════════════════════════
+      WHAT YOU RECEIVE
+      ════════════════════════════════════════════════════════════════
+
+      FOCUS:
+      {{inputs.FOCUS}}
+
+      CURRENT_LAYOUT (JSON, may be empty string):
+      {{inputs.CURRENT_LAYOUT}}
+
+      AGENT_METADATA (JSON array, one row per visible agent):
+      {{inputs.AGENT_METADATA}}
+
+      Each AGENT_METADATA row may have:
+      - id: lowercase-with-dashes
+      - title: human-readable signal.title
+      - size: signal.size hint (1x1 / 2x1 / 1x2 / 2x2) — optional
+      - lastRunAt: ISO timestamp of the most recent run — optional
+      - successRate: 0-1 fraction over recent runs — optional
+      - runCount30d: count of runs in the last 30 days — optional
+
+      ════════════════════════════════════════════════════════════════
+      WHAT YOU DO
+      ════════════════════════════════════════════════════════════════
+
+      STEP 1 — RANK. Pick the agents that should be most prominent on
+      Pulse. Use these signals (FOCUS overrides everything else):
+      - If FOCUS names a topic ("API monitors", "weather"), match agent
+        titles + ids to it and rank those first.
+      - Otherwise, rank by a combination of recency + reliability +
+        frequency. Agents that have never run or haven't run in 30+ days
+        rank lower.
+      - Emit at most 10 topAgents. Each MUST have a one-line `rationale`
+        explaining why it's there ("daily run, 98% success" / "matches
+        FOCUS=API monitors" / "user-pinned in current layout"). The
+        rationale is rendered next to the agent in the UI — keep it
+        concise and concrete.
+      - `suggestedSize` is optional. Default to the agent's existing
+        size if set; otherwise pick a size that fits the content:
+        - "metric" / "status" templates → 1x1
+        - "text-headline" / "comparison" → 2x1
+        - "table" / "story" / "widget" → 2x2
+
+      STEP 2 — GROUP into containers. The layout JSON the wizard writes
+      to localStorage looks like:
+        {"containers":[{"label":"...","tiles":["agent-id-1","agent-id-2"]}]}
+      Rules:
+      - 1 to 6 containers. Fewer is better. Don't make a container per
+        agent.
+      - Container labels are short, human-readable nouns ("Monitoring",
+        "Daily news", "Personal projects"). Capitalize.
+      - Each tile (agent id) belongs to EXACTLY ONE container. Tiles
+        appearing in two containers is an error.
+      - Container labels must be unique (case-insensitive).
+      - Every agent in topAgents SHOULD be assigned to a container. You
+        MAY also include lower-ranked agents in containers without
+        promoting them to topAgents (e.g. a "Misc" container at the
+        bottom catches everything else).
+      - Honor CURRENT_LAYOUT's container structure when it's clearly
+        intentional. If the user already has a "Monitoring" container,
+        keep it; don't rename to "Health" for no reason.
+
+      STEP 3 — ASK clarifying questions when FOCUS is ambiguous. Use
+      `questions[]` for ambiguities the user must resolve before commit.
+      Examples:
+      - FOCUS is empty AND there's no clear ranking signal → ask "Rank
+        by what — most recently run / most reliable / most frequent / I
+        will pin manually?" Include the options array for select-style
+        rendering.
+      - FOCUS mentions a topic that matches multiple distinct groups →
+        ask "Did you mean A or B?"
+      - Two-thirds of agents have never run → ask "Should I hide agents
+        that have never run from the layout?"
+      Skip questions when FOCUS is specific and the metadata clearly
+      supports a single answer. Empty `questions: []` is fine.
+
+      STEP 4 — emit the plan. Wrap the JSON in <plan>…</plan> tags.
+      Output ONLY the <plan> block. No explanation before or after.
+
+      ════════════════════════════════════════════════════════════════
+      OUTPUT FORMAT — exact shape
+      ════════════════════════════════════════════════════════════════
+
+      <plan>
+      {
+        "summary": "Grouped 12 agents into 3 containers: Monitoring, Daily news, Misc. Topped by api-monitor and hn-top-3.",
+        "topAgents": [
+          { "id": "api-monitor", "rationale": "runs every 5 minutes, 100% success last 30d", "suggestedSize": "2x1" },
+          { "id": "hn-top-3", "rationale": "matches FOCUS=news, ran successfully today", "suggestedSize": "2x2" }
+        ],
+        "containers": [
+          { "label": "Monitoring", "tiles": ["api-monitor", "system-health"] },
+          { "label": "Daily news", "tiles": ["hn-top-3", "weather-forecast"] },
+          { "label": "Misc", "tiles": ["daily-joke", "cat-video-finder"] }
+        ],
+        "questions": [
+          {
+            "text": "Rank by what?",
+            "suggestedAnswer": "recency",
+            "options": ["recency", "reliability", "frequency", "I'll pin manually"]
+          }
+        ]
+      }
+      </plan>
+
+      ════════════════════════════════════════════════════════════════
+      VALIDATION RULES (failing these means the plan is rejected)
+      ════════════════════════════════════════════════════════════════
+
+      - `summary` is required and non-empty.
+      - `topAgents` has at least one entry. Each has id (lowercase-with-
+        dashes-or-underscores) and a non-empty rationale.
+      - `containers` has at least one entry. Each has a non-empty label
+        and at least one tile.
+      - No tile appears in two containers.
+      - No two container labels are the same (case-insensitive).
+      - No two topAgents share an id.
+      - `suggestedSize` if set must be one of "1x1", "2x1", "1x2", "2x2".
+      - `questions[]` may be empty. When set, each entry has non-empty
+        `text`; `suggestedAnswer` and `options` are optional.
+
+      Output ONLY the <plan>…</plan> block. No explanation before or after.
+    maxTurns: 3
+    timeout: 180

--- a/packages/core/src/layout-planner.test.ts
+++ b/packages/core/src/layout-planner.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parseAgent } from './agent-yaml.js';
+import { layoutPlanSchema } from './layout-plan-schema.js';
+
+/**
+ * Find the embedded `<plan>{...}</plan>` JSON example in the prompt
+ * text. Unlike `extractPlanJson` (which matches any <plan> block —
+ * including the prose mention "Wrap the JSON in <plan>…</plan> tags"),
+ * this regex requires a `{` immediately after the opening tag so it
+ * only matches a real JSON example.
+ */
+function extractPlanExample(promptText: string): string | null {
+  const m = /<plan>\s*(\{[\s\S]*?\})\s*<\/plan>/i.exec(promptText);
+  return m ? m[1] : null;
+}
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..', '..');
+const LAYOUT_PLANNER_PATH = join(REPO_ROOT, 'agents', 'examples', 'layout-planner.yaml');
+
+describe('layout-planner.yaml', () => {
+  const yamlText = readFileSync(LAYOUT_PLANNER_PATH, 'utf-8');
+
+  it('parses cleanly through the v2 agent schema', () => {
+    const agent = parseAgent(yamlText);
+    expect(agent.id).toBe('layout-planner');
+    expect(agent.source).toBe('examples');
+    expect(agent.nodes).toHaveLength(1);
+    expect(agent.nodes[0].type).toBe('llm-prompt');
+  });
+
+  it('declares the inputs the route handler will inject', () => {
+    const agent = parseAgent(yamlText);
+    const inputs = agent.inputs ?? {};
+    expect(inputs).toHaveProperty('CURRENT_LAYOUT');
+    expect(inputs).toHaveProperty('AGENT_METADATA');
+    expect(inputs).toHaveProperty('FOCUS');
+    expect(inputs.AGENT_METADATA.required).toBe(true);
+  });
+
+  it("embeds an example <plan> block in the prompt that validates against layoutPlanSchema", () => {
+    const agent = parseAgent(yamlText);
+    const prompt = agent.nodes[0].prompt ?? '';
+    const planJson = extractPlanExample(prompt);
+    expect(planJson, 'no <plan>{...}</plan> JSON example found in the prompt').not.toBeNull();
+
+    const parsed = JSON.parse(planJson!);
+    const r = layoutPlanSchema.safeParse(parsed);
+    if (!r.success) {
+      // Surface the issues so a contributor editing the prompt sees
+      // exactly which schema rule they broke.
+      console.log('layout-planner prompt example failed schema validation:', r.error.issues);
+    }
+    expect(r.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Single-node \`type: llm-prompt\` agent at \`agents/examples/layout-planner.yaml\` that drives the upcoming "Improve layout" wizard on Pulse.

Reads three inputs:
- \`CURRENT_LAYOUT\` — current \`sua-pulse-layout\` JSON from localStorage (may be empty)
- \`AGENT_METADATA\` — JSON array with per-agent id / title / size / lastRunAt / successRate / runCount30d
- \`FOCUS\` — optional user focus statement

Emits a \`<plan>{...}</plan>\` block matching \`LayoutPlan\` (introduced in #305): summary, ranked topAgents with rationales + suggestedSize, 1–6 containers grouping tiles, optional clarifying questions.

Prompt encodes:
- **Ranking:** FOCUS-first, then recency × reliability × frequency combo. Cap at 10 topAgents. Every entry needs a one-line rationale.
- **Grouping:** 1–6 containers max, unique case-insensitive labels, each tile in exactly one container. Honor existing CURRENT_LAYOUT structure when it's clearly intentional.
- **Questions:** ask about the ranking heuristic when FOCUS is empty; skip questions when FOCUS is specific.

## Regression test

A companion test loads \`layout-planner.yaml\` from disk, validates it parses through the v2 agent schema, and asserts the embedded \`<plan>{...}</plan>\` JSON example in the prompt validates against \`layoutPlanSchema\`. So if a contributor edits the example out of sync with the schema, the test fails immediately with the specific zod issue.

(Note: the test uses a custom regex that matches \`<plan>\` followed by \`{\` — \`extractPlanJson\` from \`build-plan-schema.ts\` was too eager and matched the prose mention "wrap in <plan>…</plan> tags" first.)

## Part of

LLM-planner-driven dashboard layout improvements. Part 2 of 4 in the plan at \`~/.claude/plans/how-would-you-improve-joyful-wadler.md\`. PR 3 adds the static + dynamic suggestion-pill helper; PR 4 wires the routes and the modal UI.

## Test plan

- [x] \`npm test\` — **1460 passing + 3 skipped** (was 1457; +3 from new test file)
- [x] Clean rebuild succeeds
- [x] \`parseAgent\` + \`layoutPlanSchema.safeParse\` round-trip on the prompt example passes
- [ ] Manual (after PR 4 lands): submit a real goal and confirm the LLM emits a plan that passes the same validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)