### PR TITLE
feat(layout): computeLayoutSuggestions() heuristic helper (PR 3/4)

### DIFF
--- a/.changeset/layout-suggestions-helper.md
+++ b/.changeset/layout-suggestions-helper.md
@@ -1,0 +1,20 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Add `computeLayoutSuggestions()` helper for the Pulse "Improve layout" wizard.
+
+Pure heuristic — no LLM. Takes agent metadata + the current layout JSON and returns up to 5 suggestion pills for the modal's pill row. Three dynamic (state-derived) pills come first when triggered:
+
+- **Surface failing agents** — when one or more agents have `successRate < 0.5` and have run in the last 30 days.
+- **Group ungrouped agents** — when two or more agents aren't in any container.
+- **Hide stale agents** — when one or more agents haven't run in 30+ days.
+- **Combine monitoring agents** — when two or more agents match `monitor|health|uptime|watch|alert|status|ping|check` in their id or title.
+
+Dynamic pills are capped at 3 (ordered by signal strength); static fillers (Group by topic, Rank by reliability, Surface daily-run, Pin top 5 reliable) fill the remaining slots up to a 5-pill cap. Each pill has a short `label` for the chip and a longer `prompt` that fills the FOCUS textarea on click — dynamic pills include the affected agent ids inline so the downstream layout-planner can act directly.
+
+Routes and modal UI come in the next PR; this commit is unit-test-only.

--- a/packages/dashboard/src/lib/layout-suggestions.test.ts
+++ b/packages/dashboard/src/lib/layout-suggestions.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeLayoutSuggestions,
+  type LayoutSuggestionAgent,
+  type CurrentLayout,
+} from './layout-suggestions.js';
+
+const NOW = new Date('2026-06-01T12:00:00Z').getTime();
+const DAY = 24 * 60 * 60 * 1000;
+const isoDaysAgo = (d: number) => new Date(NOW - d * DAY).toISOString();
+
+function agent(partial: Partial<LayoutSuggestionAgent> & { id: string }): LayoutSuggestionAgent {
+  return partial;
+}
+
+describe('computeLayoutSuggestions', () => {
+  describe('static fillers', () => {
+    it('returns the four static pills when there are no agents', () => {
+      const out = computeLayoutSuggestions([], null, NOW);
+      expect(out.length).toBe(4);
+      expect(out.every((s) => s.dynamic === false)).toBe(true);
+      const ids = out.map((s) => s.id);
+      expect(ids).toEqual(['group-by-topic', 'rank-by-reliability', 'surface-daily', 'pin-most-reliable']);
+    });
+
+    it('returns static pills when no dynamic conditions trigger', () => {
+      const agents = [
+        agent({ id: 'a1', title: 'Agent 1', lastRunAt: isoDaysAgo(1), successRate: 1.0, runCount30d: 30 }),
+      ];
+      const layout: CurrentLayout = { containers: [{ label: 'All', tiles: ['a1'] }] };
+      const out = computeLayoutSuggestions(agents, layout, NOW);
+      expect(out.every((s) => s.dynamic === false)).toBe(true);
+      expect(out.length).toBe(4);
+    });
+  });
+
+  describe('failing-agents pill', () => {
+    it('emits when at least one agent has successRate < 0.5 and has run recently', () => {
+      const agents = [
+        agent({ id: 'flaky', successRate: 0.2, runCount30d: 10 }),
+        agent({ id: 'fine', successRate: 0.95, runCount30d: 10 }),
+      ];
+      const out = computeLayoutSuggestions(agents, null, NOW);
+      const pill = out.find((s) => s.id === 'surface-failing');
+      expect(pill).toBeDefined();
+      expect(pill!.dynamic).toBe(true);
+      expect(pill!.label).toContain('1 failing');
+      expect(pill!.prompt).toContain('flaky');
+      expect(pill!.prompt).not.toContain('fine');
+    });
+
+    it('does not emit when successRate is undefined (no run history)', () => {
+      const agents = [agent({ id: 'never-run' })];
+      const out = computeLayoutSuggestions(agents, null, NOW);
+      expect(out.find((s) => s.id === 'surface-failing')).toBeUndefined();
+    });
+
+    it('does not emit when runCount30d is 0 even with low successRate', () => {
+      const agents = [agent({ id: 'old', successRate: 0, runCount30d: 0 })];
+      const out = computeLayoutSuggestions(agents, null, NOW);
+      expect(out.find((s) => s.id === 'surface-failing')).toBeUndefined();
+    });
+  });
+
+  describe('ungrouped-agents pill', () => {
+    it('emits when 2+ agents are not in any container', () => {
+      const agents = [
+        agent({ id: 'a1', successRate: 1, runCount30d: 1 }),
+        agent({ id: 'a2', successRate: 1, runCount30d: 1 }),
+        agent({ id: 'a3', successRate: 1, runCount30d: 1 }),
+      ];
+      const layout: CurrentLayout = { containers: [{ label: 'Some', tiles: ['a3'] }] };
+      const out = computeLayoutSuggestions(agents, layout, NOW);
+      const pill = out.find((s) => s.id === 'group-ungrouped');
+      expect(pill).toBeDefined();
+      expect(pill!.label).toContain('2 ungrouped');
+      expect(pill!.prompt).toContain('a1');
+      expect(pill!.prompt).toContain('a2');
+      expect(pill!.prompt).not.toContain('a3');
+    });
+
+    it('does not emit when only 1 agent is ungrouped', () => {
+      const agents = [
+        agent({ id: 'a1', successRate: 1, runCount30d: 1 }),
+        agent({ id: 'a2', successRate: 1, runCount30d: 1 }),
+      ];
+      const layout: CurrentLayout = { containers: [{ label: 'Some', tiles: ['a2'] }] };
+      const out = computeLayoutSuggestions(agents, layout, NOW);
+      expect(out.find((s) => s.id === 'group-ungrouped')).toBeUndefined();
+    });
+
+    it('treats null layout as everything ungrouped', () => {
+      const agents = [
+        agent({ id: 'a1', successRate: 1, runCount30d: 1 }),
+        agent({ id: 'a2', successRate: 1, runCount30d: 1 }),
+      ];
+      const out = computeLayoutSuggestions(agents, null, NOW);
+      expect(out.find((s) => s.id === 'group-ungrouped')).toBeDefined();
+    });
+  });
+
+  describe('stale-agents pill', () => {
+    it('emits for agents that have not run in 30+ days', () => {
+      const agents = [
+        agent({ id: 'fresh', lastRunAt: isoDaysAgo(1) }),
+        agent({ id: 'old', lastRunAt: isoDaysAgo(45) }),
+      ];
+      const out = computeLayoutSuggestions(agents, null, NOW);
+      const pill = out.find((s) => s.id === 'collapse-stale');
+      expect(pill).toBeDefined();
+      expect(pill!.prompt).toContain('old');
+      expect(pill!.prompt).not.toContain('fresh');
+    });
+
+    it('does not count never-run agents as stale (no lastRunAt)', () => {
+      const agents = [agent({ id: 'never' })];
+      const out = computeLayoutSuggestions(agents, null, NOW);
+      expect(out.find((s) => s.id === 'collapse-stale')).toBeUndefined();
+    });
+
+    it('agents at exactly 30 days are not yet stale (strict greater-than)', () => {
+      const agents = [agent({ id: 'edge', lastRunAt: isoDaysAgo(30) })];
+      const out = computeLayoutSuggestions(agents, null, NOW);
+      expect(out.find((s) => s.id === 'collapse-stale')).toBeUndefined();
+    });
+  });
+
+  describe('monitoring-cluster pill', () => {
+    it('emits when 2+ agents look like monitoring tools (id or title)', () => {
+      const agents = [
+        agent({ id: 'api-monitor' }),
+        agent({ id: 'system-health' }),
+        agent({ id: 'daily-joke' }),
+      ];
+      const out = computeLayoutSuggestions(agents, null, NOW);
+      const pill = out.find((s) => s.id === 'cluster-monitoring');
+      expect(pill).toBeDefined();
+      expect(pill!.prompt).toContain('api-monitor');
+      expect(pill!.prompt).toContain('system-health');
+      expect(pill!.prompt).not.toContain('daily-joke');
+    });
+
+    it('matches by title when id is opaque', () => {
+      const agents = [
+        agent({ id: 'a1', title: 'API Monitor' }),
+        agent({ id: 'a2', title: 'System Health' }),
+      ];
+      const out = computeLayoutSuggestions(agents, null, NOW);
+      expect(out.find((s) => s.id === 'cluster-monitoring')).toBeDefined();
+    });
+
+    it('does not emit when only 1 monitoring-like agent exists', () => {
+      const agents = [
+        agent({ id: 'api-monitor' }),
+        agent({ id: 'daily-joke' }),
+      ];
+      const out = computeLayoutSuggestions(agents, null, NOW);
+      expect(out.find((s) => s.id === 'cluster-monitoring')).toBeUndefined();
+    });
+  });
+
+  describe('ordering + caps', () => {
+    it('returns at most 5 pills total', () => {
+      // Trigger all 4 dynamic + plenty of static available.
+      const agents = [
+        agent({ id: 'flaky', successRate: 0.1, runCount30d: 10 }),
+        agent({ id: 'lonely-1' }),
+        agent({ id: 'lonely-2' }),
+        agent({ id: 'stale-1', lastRunAt: isoDaysAgo(40) }),
+        agent({ id: 'api-monitor-a' }),
+        agent({ id: 'api-monitor-b' }),
+      ];
+      const out = computeLayoutSuggestions(agents, null, NOW);
+      expect(out.length).toBeLessThanOrEqual(5);
+    });
+
+    it('places dynamic pills before static fillers', () => {
+      const agents = [
+        agent({ id: 'flaky', successRate: 0.1, runCount30d: 10 }),
+      ];
+      const out = computeLayoutSuggestions(agents, null, NOW);
+      expect(out[0].dynamic).toBe(true);
+      expect(out[0].id).toBe('surface-failing');
+    });
+
+    it('caps dynamic pills at 3 (with 4 triggered, the 4th drops)', () => {
+      const agents = [
+        agent({ id: 'flaky', successRate: 0.1, runCount30d: 10 }),
+        agent({ id: 'lonely-1' }),
+        agent({ id: 'lonely-2' }),
+        agent({ id: 'stale-1', lastRunAt: isoDaysAgo(40) }),
+        agent({ id: 'api-monitor-a' }),
+        agent({ id: 'api-monitor-b' }),
+      ];
+      const out = computeLayoutSuggestions(agents, null, NOW);
+      const dynamic = out.filter((s) => s.dynamic);
+      expect(dynamic.length).toBe(3);
+    });
+
+    it('each pill has stable id, label, and non-empty prompt', () => {
+      const agents = [agent({ id: 'flaky', successRate: 0.1, runCount30d: 10 })];
+      const out = computeLayoutSuggestions(agents, null, NOW);
+      for (const s of out) {
+        expect(s.id).toBeTruthy();
+        expect(s.label).toBeTruthy();
+        expect(s.prompt.length).toBeGreaterThan(10);
+        expect(typeof s.dynamic).toBe('boolean');
+      }
+    });
+
+    it('id list truncates with "and N more" suffix when more than 6 ids', () => {
+      const agents = Array.from({ length: 8 }, (_, i) => agent({ id: `lonely-${i}` }));
+      const out = computeLayoutSuggestions(agents, null, NOW);
+      const pill = out.find((s) => s.id === 'group-ungrouped');
+      expect(pill).toBeDefined();
+      expect(pill!.prompt).toMatch(/and \d+ more/);
+    });
+  });
+});

--- a/packages/dashboard/src/lib/layout-suggestions.ts
+++ b/packages/dashboard/src/lib/layout-suggestions.ts
@@ -1,0 +1,190 @@
+/**
+ * Suggestion pills for the "Improve layout" wizard on `/pulse`.
+ *
+ * Pure heuristic — no LLM, no DB queries. Called by the modal-init
+ * route with already-gathered agent metadata + the current layout JSON.
+ *
+ * Each pill carries a short `label` (for the chip) and a longer `prompt`
+ * that fills the FOCUS textarea when the user clicks it. Dynamic pills
+ * include the actual affected agent ids inline in the prompt so the
+ * downstream layout-planner can act on them directly.
+ *
+ * Output is ordered dynamic-first (state-specific = more useful), then
+ * static fillers. Capped at 5 to keep the pill row scannable.
+ */
+
+export interface LayoutSuggestionAgent {
+  id: string;
+  title?: string;
+  /** ISO timestamp of the most recent run; null/undefined when never run. */
+  lastRunAt?: string | null;
+  /** 0-1 fraction over recent runs; null/undefined when no run history. */
+  successRate?: number | null;
+  /** Count of runs in the last 30 days. */
+  runCount30d?: number | null;
+}
+
+export interface CurrentLayout {
+  containers?: Array<{ label: string; tiles: string[] }>;
+}
+
+export interface LayoutSuggestion {
+  /** Stable identifier — UI uses it to toggle the active-pill class. */
+  id: string;
+  /** Short text rendered inside the pill chip. */
+  label: string;
+  /**
+   * Longer prompt that fills the FOCUS textarea when the pill is clicked.
+   * For dynamic pills, names the affected agent ids inline so the
+   * downstream layout-planner can act directly.
+   */
+  prompt: string;
+  /** True when state-derived (computed from agent/layout state); false for static defaults. */
+  dynamic: boolean;
+}
+
+const STALE_THRESHOLD_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+const FAIL_RATE_THRESHOLD = 0.5;
+const MAX_SUGGESTIONS = 5;
+const MAX_DYNAMIC = 3;
+
+/** Heuristic match for "this looks like a monitoring agent." */
+const MONITORING_RE = /\b(monitor|monitoring|health|uptime|watch|alert|status|ping|check)\b/i;
+
+/** Compact a list of ids for inclusion in a prompt string. */
+function formatIds(ids: string[]): string {
+  if (ids.length <= 6) return ids.join(', ');
+  return `${ids.slice(0, 5).join(', ')} (and ${ids.length - 5} more)`;
+}
+
+/** True when this agent's id is referenced by any container in the layout. */
+function isInLayout(agentId: string, layout: CurrentLayout | null): boolean {
+  if (!layout?.containers) return false;
+  return layout.containers.some((c) => c.tiles.includes(agentId));
+}
+
+/** True when the agent hasn't run in 30+ days (or has lastRunAt but it's old). */
+function isStale(agent: LayoutSuggestionAgent, now: number): boolean {
+  if (!agent.lastRunAt) return false; // never-run is handled separately
+  const ts = new Date(agent.lastRunAt).getTime();
+  if (!Number.isFinite(ts)) return false;
+  return now - ts > STALE_THRESHOLD_MS;
+}
+
+/** True when the agent has run AND its success rate is below threshold. */
+function isFailing(agent: LayoutSuggestionAgent): boolean {
+  if (agent.successRate === undefined || agent.successRate === null) return false;
+  if (!(agent.runCount30d && agent.runCount30d > 0)) return false;
+  return agent.successRate < FAIL_RATE_THRESHOLD;
+}
+
+/** True when the agent's id or title looks like a monitoring tool. */
+function looksLikeMonitoring(agent: LayoutSuggestionAgent): boolean {
+  if (MONITORING_RE.test(agent.id)) return true;
+  if (agent.title && MONITORING_RE.test(agent.title)) return true;
+  return false;
+}
+
+/** Compute the dynamic (state-derived) suggestions. Up to MAX_DYNAMIC entries, ordered by signal strength. */
+function computeDynamicSuggestions(
+  agents: LayoutSuggestionAgent[],
+  layout: CurrentLayout | null,
+  now: number,
+): LayoutSuggestion[] {
+  const out: LayoutSuggestion[] = [];
+
+  // 1. Failing agents — highest signal, surface first.
+  const failing = agents.filter(isFailing);
+  if (failing.length >= 1) {
+    const ids = failing.map((a) => a.id);
+    out.push({
+      id: 'surface-failing',
+      label: `Surface ${failing.length} failing agent${failing.length === 1 ? '' : 's'}`,
+      prompt: `Surface the ${failing.length} agent${failing.length === 1 ? '' : 's'} that ${failing.length === 1 ? 'has' : 'have'} been failing recently (${formatIds(ids)}). Place them in a "Needs attention" container at the top.`,
+      dynamic: true,
+    });
+  }
+
+  // 2. Agents not yet in any container.
+  const ungrouped = agents.filter((a) => !isInLayout(a.id, layout));
+  if (ungrouped.length >= 2) {
+    const ids = ungrouped.map((a) => a.id);
+    out.push({
+      id: 'group-ungrouped',
+      label: `Group ${ungrouped.length} ungrouped agent${ungrouped.length === 1 ? '' : 's'}`,
+      prompt: `Group these agents that aren't yet in a container into one or more topic-based containers: ${formatIds(ids)}.`,
+      dynamic: true,
+    });
+  }
+
+  // 3. Stale agents (haven't run in 30+ days).
+  const stale = agents.filter((a) => isStale(a, now));
+  if (stale.length >= 1) {
+    const ids = stale.map((a) => a.id);
+    out.push({
+      id: 'collapse-stale',
+      label: `Hide ${stale.length} stale agent${stale.length === 1 ? '' : 's'}`,
+      prompt: `These ${stale.length} agent${stale.length === 1 ? '' : 's'} haven't run in 30+ days (${formatIds(ids)}). Hide or collapse them into a low-priority container at the bottom.`,
+      dynamic: true,
+    });
+  }
+
+  // 4. Monitoring cluster.
+  const monitoring = agents.filter(looksLikeMonitoring);
+  if (monitoring.length >= 2) {
+    const ids = monitoring.map((a) => a.id);
+    out.push({
+      id: 'cluster-monitoring',
+      label: `Combine ${monitoring.length} monitoring agents`,
+      prompt: `Combine these monitoring/health-check agents into a single "Monitoring" container: ${formatIds(ids)}.`,
+      dynamic: true,
+    });
+  }
+
+  return out.slice(0, MAX_DYNAMIC);
+}
+
+/** Always-on default suggestions. Order matters — first entries fill in if dynamic pills are scarce. */
+const STATIC_SUGGESTIONS: LayoutSuggestion[] = [
+  {
+    id: 'group-by-topic',
+    label: 'Group by topic',
+    prompt: 'Group similar agents into topic-based containers (Monitoring, Daily news, Personal, etc.).',
+    dynamic: false,
+  },
+  {
+    id: 'rank-by-reliability',
+    label: 'Rank by reliability',
+    prompt: 'Rank agents by recent success rate. Surface the most reliable ones first; collapse or hide unreliable ones.',
+    dynamic: false,
+  },
+  {
+    id: 'surface-daily',
+    label: 'Surface daily-run agents',
+    prompt: 'Surface the agents I run daily at the top of the layout. Collapse or hide the rest.',
+    dynamic: false,
+  },
+  {
+    id: 'pin-most-reliable',
+    label: 'Pin top 5 reliable',
+    prompt: 'Pin my 5 most reliable agents (highest recent success rate) to the top of the layout.',
+    dynamic: false,
+  },
+];
+
+/**
+ * Compute up to MAX_SUGGESTIONS pills for the modal. Dynamic pills first
+ * (capped at MAX_DYNAMIC); static fillers fill the remaining slots.
+ *
+ * @param now Override the wall clock — primarily for tests. Defaults to Date.now().
+ */
+export function computeLayoutSuggestions(
+  agents: LayoutSuggestionAgent[],
+  layout: CurrentLayout | null,
+  now: number = Date.now(),
+): LayoutSuggestion[] {
+  const dynamic = computeDynamicSuggestions(agents, layout, now);
+  const remaining = MAX_SUGGESTIONS - dynamic.length;
+  const fillers = STATIC_SUGGESTIONS.slice(0, Math.max(0, remaining));
+  return [...dynamic, ...fillers];
+}


### PR DESCRIPTION
## Summary

Pure-function helper for the suggestion-pill row in the upcoming "Improve layout" modal on Pulse. No LLM — all heuristic. Lives at \`packages/dashboard/src/lib/layout-suggestions.ts\`.

Inputs: agent metadata array (id, title, lastRunAt, successRate, runCount30d) + current \`sua-pulse-layout\` JSON (or null).

Output: up to 5 \`LayoutSuggestion\` entries with \`{ id, label, prompt, dynamic }\`. Dynamic pills first (signal-strength order, capped at 3), then static fillers up to the cap.

## Dynamic pills

| Pill | Trigger |
|---|---|
| Surface failing agents | ≥1 agent with \`successRate < 0.5\` AND \`runCount30d > 0\` |
| Group ungrouped agents | ≥2 agents not referenced in any container |
| Hide stale agents | ≥1 agent whose \`lastRunAt\` > 30 days ago (strict) |
| Combine monitoring agents | ≥2 agents matching \`monitor\|health\|uptime\|watch\|alert\|status\|ping\|check\` in id or title |

Each dynamic prompt includes the affected agent ids inline (truncated with "and N more" when > 6) so the downstream layout-planner can act on them directly.

## Static fillers

\`Group by topic\`, \`Rank by reliability\`, \`Surface daily-run agents\`, \`Pin top 5 reliable\`. Always-on baselines that work even with no agent state.

## Test plan

- [x] \`npm test\` — **1479 passing + 3 skipped** (was 1460; +19 from new \`layout-suggestions.test.ts\`)
- [x] Clean rebuild succeeds
- [x] Tests cover: empty input, each dynamic trigger independently, boundary conditions (exactly-30-days = not stale; \`runCount30d = 0\` even with low successRate = not failing), ordering (dynamic before static), the 5-pill total cap, the 3-pill dynamic cap, and the "and N more" truncation on long id lists

Part 3 of 4 in the layout-improvement plan at \`~/.claude/plans/how-would-you-improve-joyful-wadler.md\`. PR 4 wires routes + the modal UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)