### PR TITLE
feat(pulse): Improve layout wizard — routes + modal + button (PR 4/4)

### DIFF
--- a/.changeset/improve-layout-routes-and-ui.md
+++ b/.changeset/improve-layout-routes-and-ui.md
@@ -1,0 +1,26 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Wire the "Improve layout" wizard on `/pulse` — routes + modal UI + button.
+
+A new ✨ Improve layout button sits next to Edit layout on the Pulse page. Clicking it opens a modal that:
+
+1. Fetches state-derived suggestion pills (from PR #307's `computeLayoutSuggestions`) plus pre-computed agent metadata.
+2. Renders pills above a free-form FOCUS textarea — clicking a pill prefills the textarea so the user can edit before submitting.
+3. Submits to the new `layout-planner` agent (from PR #306), polls the run, then renders the structured `LayoutPlan` (from PR #305) inline: top agents with rationales, proposed containers, and optional clarifying questions.
+4. Lets the user answer questions to refine the plan ("Update plan" re-runs with appended context), or click **Apply layout** to write the proposed containers to `localStorage` and reload `/pulse`.
+
+Four new endpoints under `/pulse/layout-plan/`:
+- `POST /suggestions` — pills + agent metadata for the modal.
+- `POST /` — kicks off the layout-planner agent with `focus`, `currentLayout`, optional `agentMetadata`. Returns `{ runId }`.
+- `GET /:runId` — polls the run; extracts `<plan>{...}</plan>`, validates against `layoutPlanSchema`, returns the typed plan or validation errors.
+- `POST /commit` — telemetry no-op for parity with `/agents/build/commit`. Reserved for future server-side layout persistence.
+
+No critic-retry loop in v1 (PlannerLoopRunner is build-plan-shaped); if the planner emits invalid YAML the modal shows validation issues and the user re-submits.
+
+Closes the dashboard-layout-improvement plan at `~/.claude/plans/how-would-you-improve-joyful-wadler.md` (PR 4 of 4).

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -51,6 +51,7 @@ import { settingsMcpRouter } from './routes/settings-mcp.js';
 import { helpRouter } from './routes/help.js';
 import { versionsRouter } from './routes/versions.js';
 import { pulseRouter } from './routes/pulse.js';
+import { pulseLayoutPlanRouter } from './routes/pulse-layout-plan.js';
 import { packsRouter } from './routes/packs.js';
 import { dashboardsRouter } from './routes/dashboards.js';
 import { dashboardsEditRouter } from './routes/dashboards-edit.js';
@@ -243,6 +244,7 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   app.use(toolsRouter);
   app.use(nodesRouter);
   app.use(pulseRouter);
+  app.use(pulseLayoutPlanRouter);
   app.use(packsRouter);
   app.use(dashboardsEditRouter);
   app.use(dashboardsRouter);

--- a/packages/dashboard/src/routes/pulse-layout-plan.ts
+++ b/packages/dashboard/src/routes/pulse-layout-plan.ts
@@ -1,0 +1,318 @@
+/**
+ * Routes for the Pulse "Improve layout" wizard.
+ *
+ *   POST /pulse/layout-plan/suggestions  — fetch pills + agent metadata
+ *   POST /pulse/layout-plan              — kick off the layout-planner agent
+ *   GET  /pulse/layout-plan/:runId       — poll a planner run
+ *   POST /pulse/layout-plan/commit       — telemetry no-op (parity with /agents/build/commit)
+ *
+ * Mirrors the build-from-goal route shape but skips the critic-retry loop
+ * (PlannerLoopRunner is tightly coupled to BuildPlan; layout uses a
+ * simpler validate-once flow). Memory injection and retries are deferred
+ * to a follow-on PR.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import {
+  executeAgentDag,
+  extractPlanJson,
+  layoutPlanSchema,
+  parseAgent,
+  type Agent,
+  type LayoutPlan,
+  type RunStatus,
+} from '@some-useful-agents/core';
+import { getContext } from '../context.js';
+import {
+  computeLayoutSuggestions,
+  type CurrentLayout,
+  type LayoutSuggestionAgent,
+} from '../lib/layout-suggestions.js';
+
+export const pulseLayoutPlanRouter: Router = Router();
+
+const LAYOUT_PLANNER_AGENT_ID = 'layout-planner';
+const STALE_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+/**
+ * True when the agent should be considered by the layout planner.
+ * Excludes archived/draft agents and any explicitly hidden from Pulse.
+ */
+function isVisibleOnPulse(agent: Agent): boolean {
+  if (agent.status === 'archived' || agent.status === 'draft') return false;
+  if (agent.pulseVisible === false) return false;
+  if (agent.signal?.hidden === true) return false;
+  return true;
+}
+
+/**
+ * Walk the run history once and roll up per-agent stats: lastRunAt,
+ * successRate (over the last 30 days), runCount30d. Avoids N+1 queries
+ * for typical installs.
+ */
+function gatherAgentMetadata(ctx: ReturnType<typeof getContext>, now: number): LayoutSuggestionAgent[] {
+  const agents = ctx.agentStore.listAgents().filter(isVisibleOnPulse);
+  // Pull the recent run window once.
+  let recent: Array<{ agentName: string; status: string; startedAt: string }> = [];
+  try {
+    const { rows } = ctx.runStore.queryRuns({ limit: 500, offset: 0 });
+    recent = rows.map((r) => ({ agentName: r.agentName, status: r.status, startedAt: r.startedAt }));
+  } catch {
+    /* run store unavailable — emit metadata with no run history */
+  }
+
+  const byAgent = new Map<string, { last?: number; successes: number; total: number }>();
+  for (const r of recent) {
+    const ts = new Date(r.startedAt).getTime();
+    if (!Number.isFinite(ts)) continue;
+    if (now - ts > STALE_WINDOW_MS) continue;
+    const cell = byAgent.get(r.agentName) ?? { last: undefined, successes: 0, total: 0 };
+    if (cell.last === undefined || ts > cell.last) cell.last = ts;
+    cell.total += 1;
+    if (r.status === 'completed') cell.successes += 1;
+    byAgent.set(r.agentName, cell);
+  }
+
+  // lastRunAt all-time (not just 30d). Pull a thin global-last lookup so
+  // agents that haven't run in 30+ days still show *when* they last ran.
+  let allTimeLast = new Map<string, number>();
+  try {
+    const { rows } = ctx.runStore.queryRuns({ limit: 1000, offset: 0 });
+    for (const r of rows) {
+      const ts = new Date(r.startedAt).getTime();
+      if (!Number.isFinite(ts)) continue;
+      const prev = allTimeLast.get(r.agentName);
+      if (prev === undefined || ts > prev) allTimeLast.set(r.agentName, ts);
+    }
+  } catch {
+    /* run store unavailable */
+  }
+
+  return agents.map((a) => {
+    const cell = byAgent.get(a.id);
+    const allTime = allTimeLast.get(a.id);
+    const lastTs = cell?.last ?? allTime;
+    const out: LayoutSuggestionAgent = {
+      id: a.id,
+      title: a.signal?.title,
+    };
+    if (lastTs !== undefined) out.lastRunAt = new Date(lastTs).toISOString();
+    if (cell && cell.total > 0) {
+      out.successRate = cell.successes / cell.total;
+      out.runCount30d = cell.total;
+    } else {
+      out.runCount30d = 0;
+    }
+    return out;
+  });
+}
+
+function parseCurrentLayout(body: Record<string, unknown>): CurrentLayout | null {
+  const raw = body.currentLayout;
+  if (typeof raw === 'string' && raw.trim()) {
+    try { return JSON.parse(raw) as CurrentLayout; } catch { return null; }
+  }
+  if (raw && typeof raw === 'object') return raw as CurrentLayout;
+  return null;
+}
+
+/**
+ * Spawn a single layout-planner agent run and return its run-id.
+ * Returns null when the planner agent file can't be loaded.
+ */
+async function kickoffLayoutPlannerRun(args: {
+  ctx: ReturnType<typeof getContext>;
+  focus: string;
+  currentLayoutJson: string;
+  agentMetadataJson: string;
+}): Promise<string | null> {
+  const { ctx, focus, currentLayoutJson, agentMetadataJson } = args;
+
+  let planner: ReturnType<typeof ctx.agentStore.getAgent> = null;
+  try {
+    const yamlPath = join(resolve('agents/examples'), `${LAYOUT_PLANNER_AGENT_ID}.yaml`);
+    const yamlText = readFileSync(yamlPath, 'utf-8');
+    const parsed = parseAgent(yamlText);
+    ctx.agentStore.upsertAgent(parsed, 'import', 'Auto-imported for layout planner');
+    planner = ctx.agentStore.getAgent(LAYOUT_PLANNER_AGENT_ID);
+  } catch { /* fall through */ }
+  if (!planner) return null;
+
+  const runPromise = executeAgentDag(
+    planner,
+    {
+      triggeredBy: 'dashboard',
+      inputs: {
+        FOCUS: focus,
+        CURRENT_LAYOUT: currentLayoutJson,
+        AGENT_METADATA: agentMetadataJson,
+      },
+    },
+    {
+      runStore: ctx.runStore,
+      secretsStore: ctx.secretsStore,
+      variablesStore: ctx.variablesStore,
+      dataRoot: ctx.agentStore.dataRoot,
+    },
+  );
+
+  // Race the run-record creation; we only need its id, not its result.
+  await Promise.race([runPromise, new Promise((r) => setTimeout(r, 200))]);
+  const { rows } = ctx.runStore.queryRuns({
+    agentName: LAYOUT_PLANNER_AGENT_ID,
+    statuses: ['running', 'completed', 'failed'] as RunStatus[],
+    limit: 1,
+    offset: 0,
+  });
+  if (rows.length > 0) return rows[0].id;
+  try {
+    const run = await runPromise;
+    return run.id;
+  } catch {
+    return null;
+  }
+}
+
+// ── Routes ─────────────────────────────────────────────────────────────
+
+/**
+ * POST /pulse/layout-plan/suggestions — pill row for the modal.
+ * Body: { currentLayout?: string | object }
+ * Returns: { ok, suggestions, agentMetadata }
+ *
+ * `agentMetadata` is also returned so the client can pass it back on the
+ * subsequent /pulse/layout-plan POST without the server re-walking the
+ * run history. Saves one DB pass per modal open.
+ */
+pulseLayoutPlanRouter.post('/pulse/layout-plan/suggestions', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const now = Date.now();
+
+  const agentMetadata = gatherAgentMetadata(ctx, now);
+  const currentLayout = parseCurrentLayout(body);
+  const suggestions = computeLayoutSuggestions(agentMetadata, currentLayout, now);
+
+  res.json({ ok: true, suggestions, agentMetadata });
+});
+
+/**
+ * POST /pulse/layout-plan — kick off the layout-planner agent.
+ * Body: { focus?: string, currentLayout?: string | object, agentMetadata?: LayoutSuggestionAgent[] }
+ * Returns: { ok, runId } or { ok: false, error }
+ *
+ * If agentMetadata is omitted, the route re-gathers it server-side. Most
+ * clients will pass the value they got from /suggestions to avoid the
+ * second DB pass.
+ */
+pulseLayoutPlanRouter.post('/pulse/layout-plan', async (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const focus = typeof body.focus === 'string' ? body.focus.trim() : '';
+  const currentLayout = parseCurrentLayout(body);
+
+  let agentMetadata: LayoutSuggestionAgent[];
+  if (Array.isArray(body.agentMetadata)) {
+    agentMetadata = body.agentMetadata as LayoutSuggestionAgent[];
+  } else {
+    agentMetadata = gatherAgentMetadata(ctx, Date.now());
+  }
+
+  if (agentMetadata.length === 0) {
+    res.json({ ok: false, error: 'No visible agents on Pulse — nothing to lay out. Create an agent first.' });
+    return;
+  }
+
+  const runId = await kickoffLayoutPlannerRun({
+    ctx,
+    focus,
+    currentLayoutJson: JSON.stringify(currentLayout ?? {}),
+    agentMetadataJson: JSON.stringify(agentMetadata),
+  });
+  if (!runId) {
+    res.json({
+      ok: false,
+      error: 'Layout planner agent not found. Ensure layout-planner.yaml exists in agents/examples/.',
+    });
+    return;
+  }
+  res.json({ ok: true, runId });
+});
+
+/**
+ * GET /pulse/layout-plan/:runId — poll a planner run.
+ * Returns one of:
+ *   { ok, status: 'running', phase? }
+ *   { ok, status: 'done', plan: LayoutPlan }
+ *   { ok, status: 'failed', error, rawResult? }
+ */
+pulseLayoutPlanRouter.get('/pulse/layout-plan/:runId', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const runId = Array.isArray(req.params.runId) ? req.params.runId[0] : req.params.runId;
+
+  const run = ctx.runStore.getRun(runId);
+  if (!run) {
+    res.json({ ok: false, status: 'not_found' });
+    return;
+  }
+
+  if (run.status === 'running' || run.status === 'pending') {
+    const execs = ctx.runStore.listNodeExecutions(runId);
+    const running = execs.find((e) => e.status === 'running');
+    const phase = running?.nodeId === 'plan' ? 'Designing layout...' : 'Starting...';
+    res.json({ ok: true, status: 'running', phase });
+    return;
+  }
+
+  if (run.status !== 'completed' || !run.result) {
+    res.json({ ok: true, status: 'failed', error: run.error ?? `Layout planner failed (${run.status}).` });
+    return;
+  }
+
+  // Extract <plan>{...}</plan> and validate. extractPlanJson handles the
+  // canonical wrapper, JSON code fences, and bare JSON blobs.
+  const planJson = extractPlanJson(run.result);
+  if (!planJson) {
+    res.json({ ok: true, status: 'failed', error: 'Planner did not produce a <plan>...</plan> block.', rawResult: run.result });
+    return;
+  }
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(planJson);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    res.json({ ok: true, status: 'failed', error: `Plan JSON did not parse: ${msg}`, rawResult: planJson });
+    return;
+  }
+
+  const validated = layoutPlanSchema.safeParse(parsedJson);
+  if (!validated.success) {
+    const issues = validated.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
+    res.json({
+      ok: true,
+      status: 'failed',
+      error: 'Layout plan failed schema validation.',
+      validationErrors: issues,
+      rawResult: planJson,
+    });
+    return;
+  }
+
+  const plan: LayoutPlan = validated.data;
+  res.json({ ok: true, status: 'done', plan });
+});
+
+/**
+ * POST /pulse/layout-plan/commit — telemetry no-op. The real "commit"
+ * happens client-side when the user clicks Apply (writes to localStorage).
+ * Endpoint exists so a future PR can add server-side layout persistence
+ * without changing the client contract.
+ */
+pulseLayoutPlanRouter.post('/pulse/layout-plan/commit', (_req: Request, res: Response) => {
+  res.json({ ok: true });
+});

--- a/packages/dashboard/src/views/improve-layout-modal.ts
+++ b/packages/dashboard/src/views/improve-layout-modal.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared markup for the "Improve layout" wizard modal on Pulse.
+ *
+ * Wizard JS is in improve-layout.js.ts and is wired in via layout.ts.
+ * Binds to:
+ *   - #improve-layout-btn — opens the modal
+ *   - #improve-layout-modal — backdrop
+ *   - #improve-layout-content — replaceable inner panel for stage swaps
+ *   - #improve-layout-pills — pill row populated on open
+ *   - #improve-layout-focus — free-form textarea
+ *   - #improve-layout-submit — submit button
+ *
+ * Pulse page renders `improveLayoutButton()` next to the edit toggle
+ * and `improveLayoutModal()` once at the bottom of the body.
+ */
+
+import { html, type SafeHtml } from './html.js';
+
+export function improveLayoutButton(): SafeHtml {
+  return html`<button type="button" class="btn btn--ghost btn--sm" id="improve-layout-btn">✨ Improve layout</button>`;
+}
+
+export function improveLayoutModal(): SafeHtml {
+  return html`
+    <div id="improve-layout-modal" class="modal-backdrop">
+      <div class="modal" style="max-width: 640px; max-height: 85vh; overflow-y: auto;">
+        <div id="improve-layout-content">
+          <h3 style="margin: 0 0 var(--space-3);">Improve layout</h3>
+          <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-3);">
+            Pick a suggestion or describe your own focus. The planner ranks your agents, groups them into containers, and asks clarifying questions before anything is applied.
+          </p>
+
+          <div style="margin-bottom: var(--space-3);">
+            <div style="font-size: var(--font-size-xs); color: var(--color-text-muted); margin-bottom: var(--space-2); font-weight: var(--weight-semibold); text-transform: uppercase; letter-spacing: 0.06em;">Suggestions</div>
+            <div id="improve-layout-pills" style="display: flex; flex-wrap: wrap; gap: var(--space-2);">
+              <span class="dim" style="font-size: var(--font-size-xs);" id="improve-layout-pills-loading">Loading suggestions...</span>
+            </div>
+          </div>
+
+          <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-4);">
+            <strong style="font-size: var(--font-size-sm);">Focus <span class="dim" style="font-weight: var(--weight-regular);">(optional)</span></strong>
+            <textarea id="improve-layout-focus" rows="3" placeholder="e.g. group by topic, surface my failing agents, pin the daily-run ones"
+              style="padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm); resize: vertical;"></textarea>
+          </label>
+
+          <div style="display: flex; gap: var(--space-2); justify-content: flex-end;">
+            <button type="button" class="btn btn--ghost btn--sm" data-close-improve-layout="1">Cancel</button>
+            <button type="button" class="btn btn--primary btn--sm" id="improve-layout-submit">Plan layout</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+}

--- a/packages/dashboard/src/views/improve-layout.js.ts
+++ b/packages/dashboard/src/views/improve-layout.js.ts
@@ -1,0 +1,298 @@
+/**
+ * Improve-layout wizard JS — multi-stage modal that asks the layout-
+ * planner agent for a Pulse rearrangement.
+ *
+ * Stage flow:
+ *   1. Open → fetch suggestions, render pill row.
+ *   2. Pill click → fill focus textarea, highlight pill.
+ *   3. Submit → POST /pulse/layout-plan, poll /pulse/layout-plan/:runId.
+ *   4. Done → render top agents + containers + clarifying questions.
+ *   5. Answer questions → "Update plan" re-runs with appended context.
+ *   6. Apply → write containers JSON to localStorage; reload.
+ *
+ * Inlined into pages via layout.ts.
+ */
+export const IMPROVE_LAYOUT_JS = `
+(function () {
+  var btn = document.getElementById('improve-layout-btn');
+  var modal = document.getElementById('improve-layout-modal');
+  var content = document.getElementById('improve-layout-content');
+  if (!btn || !modal || !content) return;
+
+  var LAYOUT_KEY = 'sua-pulse-layout';
+  var cachedAgentMetadata = null;
+  var lastFocus = '';
+
+  function esc(s) { var d = document.createElement('div'); d.textContent = s == null ? '' : String(s); return d.innerHTML; }
+  function closeModal() { modal.classList.remove('is-open'); }
+  function readLayout() {
+    try { return localStorage.getItem(LAYOUT_KEY) || ''; } catch (e) { return ''; }
+  }
+
+  btn.addEventListener('click', function () {
+    modal.classList.add('is-open');
+    loadSuggestions();
+  });
+  modal.addEventListener('click', function (e) {
+    if (e.target === modal) closeModal();
+    if (e.target && e.target.getAttribute && e.target.getAttribute('data-close-improve-layout')) closeModal();
+  });
+
+  function loadSuggestions() {
+    var pills = document.getElementById('improve-layout-pills');
+    if (!pills) return;
+    fetch('/pulse/layout-plan/suggestions', {
+      method: 'POST', credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ currentLayout: readLayout() }),
+    })
+    .then(function (r) { return r.json(); })
+    .then(function (data) {
+      if (!data.ok || !Array.isArray(data.suggestions)) {
+        pills.innerHTML = '<span class="dim" style="font-size:var(--font-size-xs);">Could not load suggestions. You can still type your own focus below.</span>';
+        return;
+      }
+      cachedAgentMetadata = data.agentMetadata || null;
+      if (data.suggestions.length === 0) {
+        pills.innerHTML = '<span class="dim" style="font-size:var(--font-size-xs);">No suggestions for this layout. Type your own focus below.</span>';
+        return;
+      }
+      pills.innerHTML = '';
+      data.suggestions.forEach(function (s) {
+        var b = document.createElement('button');
+        b.type = 'button';
+        b.className = 'btn btn--sm';
+        b.setAttribute('data-suggestion-id', s.id);
+        b.setAttribute('data-suggestion-dynamic', s.dynamic ? '1' : '0');
+        b.style.fontSize = 'var(--font-size-xs)';
+        b.style.padding = 'var(--space-1) var(--space-2)';
+        if (s.dynamic) { b.style.borderColor = 'var(--color-primary)'; }
+        b.textContent = s.label;
+        b.title = s.prompt;
+        b.addEventListener('click', function () {
+          var ta = document.getElementById('improve-layout-focus');
+          if (ta) {
+            ta.value = s.prompt;
+            ta.focus();
+          }
+          var siblings = pills.querySelectorAll('button[data-suggestion-id]');
+          for (var i = 0; i < siblings.length; i++) siblings[i].classList.remove('btn--primary');
+          b.classList.add('btn--primary');
+        });
+        pills.appendChild(b);
+      });
+    })
+    .catch(function () {
+      pills.innerHTML = '<span class="dim" style="font-size:var(--font-size-xs);">Could not load suggestions.</span>';
+    });
+  }
+
+  var submitBtn = document.getElementById('improve-layout-submit');
+  if (submitBtn) {
+    submitBtn.addEventListener('click', function () {
+      var ta = document.getElementById('improve-layout-focus');
+      var focus = ta ? ta.value.trim() : '';
+      runPlanner(focus);
+    });
+  }
+
+  function runPlanner(focus) {
+    lastFocus = focus;
+    var t0 = Date.now();
+    var cancelled = false;
+    var pollTimer = null;
+    var runId = null;
+
+    content.innerHTML =
+      '<div style="padding:var(--space-4);">' +
+      '<div style="display:flex;align-items:center;gap:var(--space-3);margin-bottom:var(--space-4);">' +
+        '<div class="spinner"></div>' +
+        '<div style="flex:1;"><div style="font-weight:var(--weight-medium);">Planning layout</div>' +
+        '<div class="dim" style="font-size:var(--font-size-xs);" id="improve-phase">Starting...</div></div>' +
+        '<div style="font-family:var(--font-mono);font-size:var(--font-size-lg);color:var(--color-text-muted);min-width:3rem;text-align:right;" id="improve-timer">0s</div>' +
+      '</div>' +
+      '<div style="text-align:right;"><button type="button" class="btn btn--ghost btn--sm" id="improve-cancel">Cancel</button></div></div>';
+
+    var tickTimer = setInterval(function () {
+      var s = Math.round((Date.now() - t0) / 1000);
+      var te = document.getElementById('improve-timer'); if (te) te.textContent = s + 's';
+    }, 1000);
+
+    var cancelEl = document.getElementById('improve-cancel');
+    if (cancelEl) cancelEl.addEventListener('click', function () {
+      cancelled = true; clearInterval(tickTimer); clearTimeout(pollTimer); closeModal();
+    });
+
+    fetch('/pulse/layout-plan', {
+      method: 'POST', credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        focus: focus,
+        currentLayout: readLayout(),
+        agentMetadata: cachedAgentMetadata,
+      }),
+    })
+    .then(function (r) { return r.json(); })
+    .then(function (start) {
+      if (!start.ok || !start.runId) {
+        clearInterval(tickTimer);
+        renderError(start.error || 'Failed to start layout planner');
+        return;
+      }
+      runId = start.runId;
+
+      function poll() {
+        if (cancelled) return;
+        fetch('/pulse/layout-plan/' + encodeURIComponent(runId), { credentials: 'same-origin' })
+          .then(function (r) { return r.json(); })
+          .then(function (data) {
+            if (!data.ok) {
+              clearInterval(tickTimer);
+              renderError(data.error || 'Layout planner failed');
+              return;
+            }
+            if (data.status === 'running') {
+              var pe = document.getElementById('improve-phase');
+              if (pe && data.phase) pe.textContent = data.phase;
+              pollTimer = setTimeout(poll, 1500);
+              return;
+            }
+            clearInterval(tickTimer);
+            if (data.status === 'done' && data.plan) {
+              renderPlan(data.plan);
+            } else {
+              var bits = [data.error || 'Layout planner failed'];
+              if (Array.isArray(data.validationErrors) && data.validationErrors.length) {
+                bits.push('Schema issues:');
+                for (var i = 0; i < data.validationErrors.length; i++) bits.push('  - ' + data.validationErrors[i]);
+              }
+              renderError(bits.join('\\n'));
+            }
+          })
+          .catch(function (e) {
+            clearInterval(tickTimer);
+            renderError('Network error: ' + (e && e.message ? e.message : 'unknown'));
+          });
+      }
+      pollTimer = setTimeout(poll, 800);
+    })
+    .catch(function (e) {
+      clearInterval(tickTimer);
+      renderError('Network error: ' + (e && e.message ? e.message : 'unknown'));
+    });
+  }
+
+  function renderError(msg) {
+    content.innerHTML =
+      '<div style="padding:var(--space-4);">' +
+      '<h3 style="margin:0 0 var(--space-3);">Layout planning failed</h3>' +
+      '<pre style="white-space:pre-wrap;font-size:var(--font-size-xs);color:var(--color-text-muted);background:var(--color-surface-raised);padding:var(--space-3);border-radius:var(--radius-sm);max-height:40vh;overflow:auto;">' + esc(msg) + '</pre>' +
+      '<div style="margin-top:var(--space-3);text-align:right;">' +
+        '<button type="button" class="btn btn--ghost btn--sm" data-close-improve-layout="1">Close</button>' +
+      '</div></div>';
+  }
+
+  function renderPlan(plan) {
+    var topRows = (plan.topAgents || []).map(function (a, i) {
+      return '<div style="display:flex;gap:var(--space-3);padding:var(--space-2) 0;border-bottom:1px solid var(--color-border);">' +
+        '<div class="dim" style="font-family:var(--font-mono);font-size:var(--font-size-xs);min-width:1.5rem;text-align:right;">' + (i + 1) + '.</div>' +
+        '<div style="flex:1;">' +
+          '<div style="font-family:var(--font-mono);font-size:var(--font-size-sm);font-weight:var(--weight-semibold);">' + esc(a.id) + (a.suggestedSize ? ' <span class="dim" style="font-weight:var(--weight-regular);">(' + esc(a.suggestedSize) + ')</span>' : '') + '</div>' +
+          '<div class="dim" style="font-size:var(--font-size-xs);">' + esc(a.rationale) + '</div>' +
+        '</div></div>';
+    }).join('');
+
+    var containerRows = (plan.containers || []).map(function (c) {
+      var tiles = (c.tiles || []).map(function (t) { return '<code style="font-size:var(--font-size-xs);background:var(--color-surface-raised);padding:0 var(--space-1);border-radius:var(--radius-sm);">' + esc(t) + '</code>'; }).join(' ');
+      return '<div style="padding:var(--space-2) 0;border-bottom:1px solid var(--color-border);">' +
+        '<div style="font-weight:var(--weight-semibold);font-size:var(--font-size-sm);margin-bottom:var(--space-1);">' + esc(c.label) + ' <span class="dim" style="font-weight:var(--weight-regular);font-size:var(--font-size-xs);">(' + (c.tiles || []).length + ')</span></div>' +
+        '<div style="display:flex;flex-wrap:wrap;gap:var(--space-1);">' + tiles + '</div></div>';
+    }).join('');
+
+    var questionsHtml = '';
+    if (Array.isArray(plan.questions) && plan.questions.length > 0) {
+      var qRows = plan.questions.map(function (q, qi) {
+        var inputHtml;
+        if (Array.isArray(q.options) && q.options.length > 0) {
+          inputHtml = '<select class="input improve-q-input" data-q-index="' + qi + '" style="font-size:var(--font-size-sm);width:100%;">' +
+            '<option value="">(pick one)</option>' +
+            q.options.map(function (o) { return '<option value="' + esc(o) + '"' + (q.suggestedAnswer === o ? ' selected' : '') + '>' + esc(o) + '</option>'; }).join('') +
+            '</select>';
+        } else {
+          inputHtml = '<input type="text" class="input improve-q-input" data-q-index="' + qi + '" placeholder="' + esc(q.suggestedAnswer || '') + '" value="' + esc(q.suggestedAnswer || '') + '" style="font-size:var(--font-size-sm);width:100%;">';
+        }
+        return '<div style="margin-bottom:var(--space-3);">' +
+          '<div style="font-size:var(--font-size-sm);margin-bottom:var(--space-1);">' + esc(q.text) + '</div>' +
+          inputHtml + '</div>';
+      }).join('');
+      questionsHtml =
+        '<div style="margin-top:var(--space-4);padding-top:var(--space-3);border-top:1px solid var(--color-border);">' +
+        '<div style="font-size:var(--font-size-xs);color:var(--color-text-muted);font-weight:var(--weight-semibold);text-transform:uppercase;letter-spacing:0.06em;margin-bottom:var(--space-2);">Clarifying questions</div>' +
+        qRows +
+        '<div style="text-align:right;"><button type="button" class="btn btn--ghost btn--sm" id="improve-update-btn">Update plan</button></div></div>';
+    }
+
+    content.innerHTML =
+      '<div style="padding:var(--space-4);">' +
+      '<h3 style="margin:0 0 var(--space-2);">Proposed layout</h3>' +
+      '<p class="dim" style="font-size:var(--font-size-xs);margin:0 0 var(--space-3);">' + esc(plan.summary || '') + '</p>' +
+      '<div style="font-size:var(--font-size-xs);color:var(--color-text-muted);font-weight:var(--weight-semibold);text-transform:uppercase;letter-spacing:0.06em;margin-bottom:var(--space-1);">Top agents</div>' +
+      '<div style="margin-bottom:var(--space-4);">' + topRows + '</div>' +
+      '<div style="font-size:var(--font-size-xs);color:var(--color-text-muted);font-weight:var(--weight-semibold);text-transform:uppercase;letter-spacing:0.06em;margin-bottom:var(--space-1);">Containers</div>' +
+      '<div style="margin-bottom:var(--space-2);">' + containerRows + '</div>' +
+      questionsHtml +
+      '<div style="margin-top:var(--space-4);padding-top:var(--space-3);border-top:1px solid var(--color-border);display:flex;gap:var(--space-2);justify-content:flex-end;">' +
+        '<button type="button" class="btn btn--ghost btn--sm" data-close-improve-layout="1">Cancel</button>' +
+        '<button type="button" class="btn btn--primary btn--sm" id="improve-apply-btn">Apply layout</button>' +
+      '</div></div>';
+
+    var applyBtn = document.getElementById('improve-apply-btn');
+    if (applyBtn) applyBtn.addEventListener('click', function () { applyPlan(plan); });
+
+    var updateBtn = document.getElementById('improve-update-btn');
+    if (updateBtn) updateBtn.addEventListener('click', function () {
+      // Append answered questions to lastFocus and re-run.
+      var inputs = content.querySelectorAll('.improve-q-input');
+      var lines = [];
+      for (var i = 0; i < inputs.length; i++) {
+        var v = (inputs[i].value || '').trim();
+        if (!v) continue;
+        var qIdx = parseInt(inputs[i].getAttribute('data-q-index') || '0', 10);
+        var qText = (plan.questions && plan.questions[qIdx] && plan.questions[qIdx].text) || '';
+        lines.push('Q: ' + qText + '\\nA: ' + v);
+      }
+      var combined = lastFocus + (lines.length ? '\\n\\nClarifications:\\n' + lines.join('\\n\\n') : '');
+      runPlanner(combined);
+    });
+  }
+
+  function applyPlan(plan) {
+    // Convert plan.containers → sua-pulse-layout shape, write, reload.
+    var existing;
+    try { existing = JSON.parse(readLayout() || '{}'); } catch (e) { existing = {}; }
+    var containerMap = {};
+    if (existing && Array.isArray(existing.containers)) {
+      existing.containers.forEach(function (c) { containerMap[(c.label || '').toLowerCase().trim()] = c; });
+    }
+    var next = {
+      containers: (plan.containers || []).map(function (c, idx) {
+        var key = (c.label || '').toLowerCase().trim();
+        var prev = containerMap[key] || {};
+        return {
+          id: prev.id || ('c-' + key.replace(/[^a-z0-9]+/g, '-') + '-' + idx),
+          label: c.label,
+          tiles: Array.from(c.tiles || []),
+        };
+      }),
+    };
+
+    try { localStorage.setItem(LAYOUT_KEY, JSON.stringify(next)); } catch (e) { /* */ }
+
+    // Best-effort telemetry; ignore the response.
+    fetch('/pulse/layout-plan/commit', { method: 'POST', credentials: 'same-origin' }).catch(function () {});
+
+    closeModal();
+    window.location.reload();
+  }
+})();
+`;

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -6,6 +6,7 @@ import { PULSE_LAYOUT_JS } from './pulse-layout.js.js';
 import { HOME_LAYOUT_JS } from './home-layout.js.js';
 import { DASHBOARDS_LAYOUT_JS } from './dashboards-layout.js.js';
 import { BUILD_FROM_GOAL_JS } from './build-from-goal.js.js';
+import { IMPROVE_LAYOUT_JS } from './improve-layout.js.js';
 import { OUTPUT_WIDGET_ACTIONS_JS } from './output-widget-actions.js.js';
 import { RUN_DETAIL_FILTER_JS } from './run-detail-filter.js.js';
 import { PULSE_CONFIGURE_JS } from './pulse-configure.js.js';
@@ -71,7 +72,7 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
   ${body}
 </main>
 ${footer()}
-<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + HOME_LAYOUT_JS + DASHBOARDS_LAYOUT_JS + BUILD_FROM_GOAL_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS + ADD_TILE_MODAL_JS)}</script>
+<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + HOME_LAYOUT_JS + DASHBOARDS_LAYOUT_JS + BUILD_FROM_GOAL_JS + IMPROVE_LAYOUT_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS + ADD_TILE_MODAL_JS)}</script>
 </body>
 </html>`;
 }

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -15,6 +15,7 @@ import { normalizeSignal, TEMPLATE_REGISTRY } from './pulse-templates.js';
 import { esc } from './pulse-helpers.js';
 import { renderTile } from './pulse-renderers.js';
 import { buildDashboardOptions, renderDashboardsDropdown } from './dashboards-dropdown.js';
+import { improveLayoutButton, improveLayoutModal } from './improve-layout-modal.js';
 export type { PulseTile, PulsePageInput, TileWrapFn } from './pulse-types.js';
 import type { PulseTile, PulsePageInput, TileWrapFn } from './pulse-types.js';
 
@@ -192,6 +193,7 @@ export function renderPulsePage(input: PulsePageInput): string {
             <button type="submit" class="btn btn--ghost btn--sm">Show all</button>
           </form>
         ` : html``}
+        ${improveLayoutButton()}
         <button type="button" class="btn btn--ghost btn--sm" id="pulse-edit-toggle">\u270E Edit layout</button>
         <button type="button" class="btn btn--ghost btn--sm" id="pulse-add-container" style="display: none;">+ Add group</button>
       </div>
@@ -222,6 +224,8 @@ export function renderPulsePage(input: PulsePageInput): string {
         </div>
       </details>
     ` : html``}
+
+    ${improveLayoutModal()}
 
     ${unsafeHtml(`<script type="application/json" id="pulse-tile-data">${JSON.stringify({ allTileIds, systemTileIds })}</script>`)}
     ${unsafeHtml(`<script type="application/json" id="pulse-template-registry">${JSON.stringify(TEMPLATE_REGISTRY)}</script>`)}


### PR DESCRIPTION
## Summary

Closes the dashboard-layout-improvement series (PRs #305, #306, #307 → this one). User-visible change: a new **✨ Improve layout** button on \`/pulse\` next to the existing Edit layout toggle.

Click flow:
1. Modal opens; fetches \`/pulse/layout-plan/suggestions\` with the current localStorage layout.
2. Suggestion pills (from the heuristic helper in #307) render above a free-form **Focus** textarea. Dynamic pills (e.g. "Hide 3 stale agents", "Combine 4 monitoring agents") appear first with the affected agent ids inlined into their prompts; static fillers ("Group by topic", etc.) fill the row to 5 max.
3. Click a pill → prefills the textarea. Or type your own. Click **Plan layout**.
4. Polls the layout-planner agent (#306). On done, renders the structured plan (#305): top agents with rationales + suggested sizes, proposed containers (label + tile chips), and any clarifying questions the planner emitted.
5. Answer questions inline → "Update plan" re-runs with appended context.
6. Click **Apply layout** → writes proposed containers JSON to \`localStorage['sua-pulse-layout']\`, posts a no-op telemetry ping to \`/commit\`, reloads.

## Four new endpoints

| Endpoint | Purpose |
|---|---|
| \`POST /pulse/layout-plan/suggestions\` | Pills + agent metadata for the modal |
| \`POST /pulse/layout-plan\` | Kick off the layout-planner agent, returns \`{ runId }\` |
| \`GET /pulse/layout-plan/:runId\` | Poll; extract \`<plan>{...}</plan>\`, validate against \`layoutPlanSchema\`, return typed plan or validation issues |
| \`POST /pulse/layout-plan/commit\` | Telemetry no-op for parity with \`/agents/build/commit\` |

## What's NOT in v1 (intentional)

- **Critic-retry loop.** \`PlannerLoopRunner\` is tightly coupled to \`BuildPlan\`; reusing it would require a refactor. The simpler validate-once flow surfaces schema issues to the modal so the user can re-submit. Can be added later if recovery rate is low.
- **Cross-run planner memory.** Skipped for v1; would auto-write each applied layout to the \`planner_memory\` table so similar future goals get prior plans injected as \`<priorPlans>\`. Easy follow-on PR.
- **Server-side layout persistence.** The commit endpoint exists but is a no-op; future multi-device sync can land server-side persistence without changing the client contract.

## Test plan

- [x] \`npm test\` — **1479 passing + 3 skipped** (no test changes; behaviour is additive)
- [x] Clean rebuild succeeds
- [ ] Manual: visit \`/pulse\` → see ✨ Improve layout button next to Edit layout
- [ ] Manual: click it → modal opens, suggestion pills appear within ~200ms
- [ ] Manual: click a pill → focus textarea fills with the pill's prompt; pill highlights
- [ ] Manual: submit → planner runs (10–30s), proposed layout renders with top agents + containers
- [ ] Manual: if questions appear, answer them and click "Update plan" → re-runs with appended context
- [ ] Manual: click Apply → \`localStorage.getItem('sua-pulse-layout')\` matches the proposed containers; page reloads with new layout
- [ ] Verify cross-run memory was NOT written (planner_memory should be empty for layout-planner runs; that's the v1 design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)