### PR TITLE
fix(build): move chmod +x to root build script

### DIFF
--- a/.changeset/root-build-chmod.md
+++ b/.changeset/root-build-chmod.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Move the `chmod +x packages/cli/dist/index.js` from the cli package's build script into the root `npm run build` script.
+
+PR #299 added the chmod to `packages/cli/package.json`'s `build` script, intending to restore the execute bit on every CLI rebuild. But the root `npm run build` uses `tsc --build` (the TypeScript composite-project orchestrator), which compiles every workspace package but doesn't execute per-package npm scripts. So the chmod was bypassed on every full root rebuild — which is the workflow contributors actually use after a clean (per `CLAUDE.md` / `feedback_clean_build_before_push.md`).
+
+Symptom: `sua --version` started printing `permission denied: sua` again after any `rm -rf packages/*/dist && npm run build` cycle. Now the chmod is in the root build script so it's guaranteed to run after every full build, regardless of which entry point was used.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "tsc --build && node packages/dashboard/scripts/copy-assets.mjs",
+    "build": "tsc --build && node packages/dashboard/scripts/copy-assets.mjs && chmod +x packages/cli/dist/index.js",
     "clean": "tsc --build --clean",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary

PR #299 added \`chmod +x dist/index.js\` to \`packages/cli/package.json\`'s build script. The intent was to restore the bit on every CLI rebuild. **It didn't work** because the root \`npm run build\` uses \`tsc --build\` (TypeScript's composite-project orchestrator), which compiles every workspace package but skips per-package npm scripts. So the chmod was silently bypassed every time you ran the standard clean-rebuild cycle.

Symptom: \`sua --version\` started printing \`zsh: permission denied: sua\` again after \`rm -rf packages/*/dist *.tsbuildinfo && npm run build\` — which is the recommended pre-push workflow (\`CLAUDE.md\` § feedback_clean_build_before_push).

## Fix

Move the chmod into the root \`build\` script:

\`\`\`json
"build": "tsc --build && node packages/dashboard/scripts/copy-assets.mjs && chmod +x packages/cli/dist/index.js"
\`\`\`

Verified locally — \`rm -rf packages/*/dist && npm run build\` now leaves \`dist/index.js\` at \`-rwxr-xr-x\` and \`sua --version\` works without remediation.

The per-package chmod in \`packages/cli/package.json\` is harmless to leave in place (still useful if someone runs \`npm run build -w @some-useful-agents/cli\` directly), so this PR doesn't touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)