### PR TITLE
fix(layout): allow system tiles in LayoutPlan containers

### DIFF
--- a/.changeset/layout-plan-system-tiles.md
+++ b/.changeset/layout-plan-system-tiles.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Allow system tiles (Pulse-synthetic widgets) in `LayoutPlan.containers.tiles`.
+
+The schema's tile regex was `/^[a-z0-9][a-z0-9_-]*$/` — letter/digit first. But Pulse's system tiles (Runs Today, Failure Rate, Avg Duration, Agent Count) use a leading underscore by convention (`_system-runs-today`, etc.) to mark them as synthetic. When the layout-planner saw them in `CURRENT_LAYOUT` it correctly placed them in containers, but validation rejected the plan.
+
+Tiles now match `/^_?[a-z0-9][a-z0-9_-]*$/` — the leading underscore is optional. The `topAgents.id` regex stays unchanged: that field is real agents only.
+
+The layout-planner prompt was also updated to teach the LLM the new rule explicitly (and to include a system-tile container in its in-prompt example).

--- a/agents/examples/layout-planner.yaml
+++ b/agents/examples/layout-planner.yaml
@@ -109,8 +109,16 @@ nodes:
         agent.
       - Container labels are short, human-readable nouns ("Monitoring",
         "Daily news", "Personal projects"). Capitalize.
-      - Each tile (agent id) belongs to EXACTLY ONE container. Tiles
-        appearing in two containers is an error.
+      - Tiles can be EITHER agent ids (lowercase-with-dashes, from
+        AGENT_METADATA) OR system tiles (Pulse-synthetic widgets in
+        CURRENT_LAYOUT with a leading underscore: "_system-runs-today",
+        "_system-failure-rate", "_system-agent-count",
+        "_system-avg-duration"). Preserve system tiles when they're in
+        CURRENT_LAYOUT; place them in a sensible container (e.g. one
+        labeled "Health" or "Overview"). NEVER include system tiles in
+        `topAgents` — that field is real agents only.
+      - Each tile belongs to EXACTLY ONE container. Tiles appearing in
+        two containers is an error.
       - Container labels must be unique (case-insensitive).
       - Every agent in topAgents SHOULD be assigned to a container. You
         MAY also include lower-ranked agents in containers without
@@ -149,6 +157,7 @@ nodes:
           { "id": "hn-top-3", "rationale": "matches FOCUS=news, ran successfully today", "suggestedSize": "2x2" }
         ],
         "containers": [
+          { "label": "Health", "tiles": ["_system-runs-today", "_system-failure-rate", "_system-agent-count", "_system-avg-duration"] },
           { "label": "Monitoring", "tiles": ["api-monitor", "system-health"] },
           { "label": "Daily news", "tiles": ["hn-top-3", "weather-forecast"] },
           { "label": "Misc", "tiles": ["daily-joke", "cat-video-finder"] }

--- a/packages/core/src/layout-plan-schema.test.ts
+++ b/packages/core/src/layout-plan-schema.test.ts
@@ -126,6 +126,33 @@ describe('layoutPlanSchema', () => {
     expect(r.success).toBe(false);
   });
 
+  it('accepts system-tile ids (leading underscore) in container.tiles', () => {
+    const r = layoutPlanSchema.safeParse({
+      ...validPlan,
+      containers: [
+        { label: 'Health', tiles: ['_system-runs-today', '_system-failure-rate'] },
+        { label: 'Agents', tiles: ['api-monitor', 'weather-forecast'] },
+      ],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('still rejects malformed tile ids that are neither agents nor system tiles', () => {
+    const r = layoutPlanSchema.safeParse({
+      ...validPlan,
+      containers: [{ label: 'Bad', tiles: ['Has Spaces'] }],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects leading underscore in topAgents.id (real agents only)', () => {
+    const r = layoutPlanSchema.safeParse({
+      ...validPlan,
+      topAgents: [{ id: '_system-runs-today', rationale: 'a' }],
+    });
+    expect(r.success).toBe(false);
+  });
+
   it('requires a non-empty summary', () => {
     const r = layoutPlanSchema.safeParse({ ...validPlan, summary: '' });
     expect(r.success).toBe(false);

--- a/packages/core/src/layout-plan-schema.ts
+++ b/packages/core/src/layout-plan-schema.ts
@@ -20,6 +20,13 @@
 import { z } from 'zod';
 
 const AGENT_ID_RE = /^[a-z0-9][a-z0-9_-]*$/;
+/**
+ * Tile ids include both real agent ids AND system tiles (Pulse's synthetic
+ * widgets: `_system-runs-today`, `_system-failure-rate`, etc.). System
+ * tiles use a leading underscore. Containers reference both kinds, so the
+ * tile regex permits one optional leading underscore.
+ */
+const TILE_ID_RE = /^_?[a-z0-9][a-z0-9_-]*$/;
 
 export const SIGNAL_SIZES = ['1x1', '2x1', '1x2', '2x2'] as const;
 export type SignalSize = typeof SIGNAL_SIZES[number];
@@ -45,7 +52,7 @@ export const layoutPlanSchema = z.object({
    */
   containers: z.array(z.object({
     label: z.string().min(1, 'containers.label is required'),
-    tiles: z.array(z.string().regex(AGENT_ID_RE, 'containers.tiles[] must be a valid agent id'))
+    tiles: z.array(z.string().regex(TILE_ID_RE, 'containers.tiles[] must be a valid tile id (agent id, or system tile starting with "_")'))
       .min(1, 'containers.tiles must have at least one entry'),
   })).min(1, 'layout must have at least one container'),
 


### PR DESCRIPTION
## Bug

When the user clicked **Improve layout** on a Pulse with system tiles in their saved layout, the layout-planner correctly placed them in a "Health" container — but the response failed validation:

\`\`\`
Layout plan failed schema validation.
Schema issues:
  - containers.0.tiles.0: containers.tiles[] must be a valid agent id
  - containers.0.tiles.1: containers.tiles[] must be a valid agent id
  - containers.0.tiles.2: containers.tiles[] must be a valid agent id
  - containers.0.tiles.3: containers.tiles[] must be a valid agent id
\`\`\`

The offending tiles were \`_system-runs-today\`, \`_system-failure-rate\`, \`_system-agent-count\`, \`_system-avg-duration\` — Pulse's synthetic system widgets, which use a leading-underscore convention.

## Root cause

\`LayoutPlan.containers.tiles[]\` used the same regex as agent ids: \`/^[a-z0-9][a-z0-9_-]*$/\`. Tiles aren't strictly agent ids though — they're *layout entries*, which include system synthetics.

## Fix

- Tile regex relaxed to \`/^_?[a-z0-9][a-z0-9_-]*$/\` — optional leading underscore.
- \`topAgents.id\` regex stays unchanged: that field is real agents only.
- Layout-planner prompt updated to teach the rule explicitly and includes a system-tile container in its in-prompt example.
- Tests added: accept system-tile ids in containers, reject leading underscore in \`topAgents.id\`, still reject spaces.

## Test plan

- [x] \`npm test\` — **1482 passing + 3 skipped** (+3 new schema tests)
- [x] Clean rebuild succeeds; the prompt-example regression test from PR #306 still passes against the updated example
- [ ] Manual: retry **Improve layout** on the same Pulse — plan now validates and Apply works

🤖 Generated with [Claude Code](https://claude.com/claude-code)