### PR TITLE
feat(layout): retry-with-feedback on the improve-layout error screen

### DIFF
--- a/.changeset/improve-layout-retry-with-feedback.md
+++ b/.changeset/improve-layout-retry-with-feedback.md
@@ -1,0 +1,31 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Add "Retry with feedback" on the Improve-layout error screen.
+
+When the layout-planner emits an invalid plan (or the run fails for any other reason), the modal's error screen now offers:
+
+- The error message (plus a `<details>` block exposing the raw planner output, if any)
+- A bulleted list of schema-validation issues when applicable
+- A **Feedback for the planner** textarea, pre-filled with the validation issues as a hint
+- A **Retry with feedback** button
+
+Clicking retry re-runs the planner with the combined focus:
+
+```
+<original focus>
+
+Previous attempt failed validation. Issues:
+  - <issue>
+  - <issue>
+
+User feedback:
+  <textarea value>
+```
+
+So the LLM sees exactly what schema rules it broke + the user's correction. Same mechanism the post-plan questions UI uses for clarifying answers.

--- a/packages/dashboard/src/views/improve-layout.js.ts
+++ b/packages/dashboard/src/views/improve-layout.js.ts
@@ -136,7 +136,7 @@ export const IMPROVE_LAYOUT_JS = `
     .then(function (start) {
       if (!start.ok || !start.runId) {
         clearInterval(tickTimer);
-        renderError(start.error || 'Failed to start layout planner');
+        renderError({ message: start.error || 'Failed to start layout planner' });
         return;
       }
       runId = start.runId;
@@ -161,35 +161,100 @@ export const IMPROVE_LAYOUT_JS = `
             if (data.status === 'done' && data.plan) {
               renderPlan(data.plan);
             } else {
-              var bits = [data.error || 'Layout planner failed'];
-              if (Array.isArray(data.validationErrors) && data.validationErrors.length) {
-                bits.push('Schema issues:');
-                for (var i = 0; i < data.validationErrors.length; i++) bits.push('  - ' + data.validationErrors[i]);
-              }
-              renderError(bits.join('\\n'));
+              renderError({
+                message: data.error || 'Layout planner failed',
+                validationErrors: Array.isArray(data.validationErrors) ? data.validationErrors : [],
+                rawResult: typeof data.rawResult === 'string' ? data.rawResult : '',
+              });
             }
           })
           .catch(function (e) {
             clearInterval(tickTimer);
-            renderError('Network error: ' + (e && e.message ? e.message : 'unknown'));
+            renderError({ message: 'Network error: ' + (e && e.message ? e.message : 'unknown') });
           });
       }
       pollTimer = setTimeout(poll, 800);
     })
     .catch(function (e) {
       clearInterval(tickTimer);
-      renderError('Network error: ' + (e && e.message ? e.message : 'unknown'));
+      renderError({ message: 'Network error: ' + (e && e.message ? e.message : 'unknown') });
     });
   }
 
-  function renderError(msg) {
+  /**
+   * Render the failure screen with a feedback textarea + Retry button.
+   * \`info\` shape: { message, validationErrors?: string[], rawResult?: string }
+   * On retry, the focus passed to the next planner run is:
+   *   lastFocus
+   *   + "Previous attempt failed validation:\\n  - <error>\\n  - <error>"
+   *   + "User feedback:\\n  <textarea value>"
+   * so the LLM sees exactly which schema rules it broke + the user's
+   * suggested correction.
+   */
+  function renderError(info) {
+    if (typeof info === 'string') info = { message: info };
+    var validation = Array.isArray(info.validationErrors) ? info.validationErrors : [];
+    var rawResult = typeof info.rawResult === 'string' ? info.rawResult : '';
+
+    var errorBlock =
+      '<pre style="white-space:pre-wrap;font-size:var(--font-size-xs);color:var(--color-text-muted);background:var(--color-surface-raised);padding:var(--space-3);border-radius:var(--radius-sm);max-height:30vh;overflow:auto;margin:0;">' + esc(info.message || 'Layout planner failed') + '</pre>';
+
+    var validationBlock = '';
+    if (validation.length > 0) {
+      var listItems = validation.map(function (v) { return '<li style="margin:0;">' + esc(v) + '</li>'; }).join('');
+      validationBlock =
+        '<div style="margin-top:var(--space-3);">' +
+        '<div style="font-size:var(--font-size-xs);font-weight:var(--weight-semibold);color:var(--color-text-muted);text-transform:uppercase;letter-spacing:0.06em;margin-bottom:var(--space-1);">Schema issues</div>' +
+        '<ul style="margin:0;padding-left:var(--space-4);font-family:var(--font-mono);font-size:var(--font-size-xs);">' + listItems + '</ul></div>';
+    }
+
+    var rawBlock = '';
+    if (rawResult) {
+      rawBlock =
+        '<details style="margin-top:var(--space-3);">' +
+        '<summary class="dim" style="cursor:pointer;font-size:var(--font-size-xs);">Show raw planner output</summary>' +
+        '<pre style="white-space:pre-wrap;font-size:var(--font-size-xs);background:var(--color-surface-raised);padding:var(--space-2);border-radius:var(--radius-sm);max-height:30vh;overflow:auto;margin-top:var(--space-1);">' + esc(rawResult) + '</pre></details>';
+    }
+
+    // Pre-fill the feedback textarea with the validation issues as a hint
+    // so the user has signal about what to ask the planner to change.
+    var prefill = validation.length > 0
+      ? 'The previous plan had these schema issues:\\n' + validation.map(function (v) { return '  - ' + v; }).join('\\n') + '\\n\\nFix them by '
+      : '';
+
     content.innerHTML =
       '<div style="padding:var(--space-4);">' +
       '<h3 style="margin:0 0 var(--space-3);">Layout planning failed</h3>' +
-      '<pre style="white-space:pre-wrap;font-size:var(--font-size-xs);color:var(--color-text-muted);background:var(--color-surface-raised);padding:var(--space-3);border-radius:var(--radius-sm);max-height:40vh;overflow:auto;">' + esc(msg) + '</pre>' +
-      '<div style="margin-top:var(--space-3);text-align:right;">' +
-        '<button type="button" class="btn btn--ghost btn--sm" data-close-improve-layout="1">Close</button>' +
-      '</div></div>';
+      errorBlock +
+      validationBlock +
+      rawBlock +
+      '<div style="margin-top:var(--space-4);padding-top:var(--space-3);border-top:1px solid var(--color-border);">' +
+      '<label style="display:flex;flex-direction:column;gap:var(--space-1);">' +
+      '<strong style="font-size:var(--font-size-sm);">Feedback for the planner <span class="dim" style="font-weight:var(--weight-regular);">(optional)</span></strong>' +
+      '<textarea id="improve-retry-feedback" rows="4" style="padding:var(--space-2) var(--space-3);border:1px solid var(--color-border-strong);border-radius:var(--radius-sm);font-size:var(--font-size-sm);resize:vertical;font-family:inherit;" placeholder="Tell the planner what to fix or do differently...">' + esc(prefill) + '</textarea>' +
+      '</label>' +
+      '<div style="display:flex;gap:var(--space-2);justify-content:flex-end;margin-top:var(--space-3);">' +
+      '<button type="button" class="btn btn--ghost btn--sm" data-close-improve-layout="1">Close</button>' +
+      '<button type="button" class="btn btn--primary btn--sm" id="improve-retry-btn">Retry with feedback</button>' +
+      '</div></div></div>';
+
+    var retryBtn = document.getElementById('improve-retry-btn');
+    if (retryBtn) retryBtn.addEventListener('click', function () {
+      var ta = document.getElementById('improve-retry-feedback');
+      var feedback = ta ? (ta.value || '').trim() : '';
+      // Build the next focus: original + validation context + user feedback.
+      // Skip the validation block if the original error wasn't validation-shaped.
+      var parts = [];
+      if (lastFocus) parts.push(lastFocus);
+      if (validation.length > 0) {
+        parts.push('Previous attempt failed validation. Issues:\\n' + validation.map(function (v) { return '  - ' + v; }).join('\\n'));
+      } else if (info.message) {
+        parts.push('Previous attempt failed: ' + info.message);
+      }
+      if (feedback) parts.push('User feedback:\\n' + feedback);
+      var combined = parts.join('\\n\\n');
+      runPlanner(combined);
+    });
   }
 
   function renderPlan(plan) {


### PR DESCRIPTION
## Summary

Previously the Improve-layout modal's error screen was a dead end — read the validation issues, close. This PR adds a feedback textarea + **Retry with feedback** button.

When validation fails, the screen now shows:
- The error message (plus a \`<details>\` block exposing the raw planner output)
- A bulleted list of schema-validation issues
- A **Feedback for the planner** textarea, pre-filled with the validation issues as a hint ("The previous plan had these schema issues:\\n  - … \\n\\nFix them by ")
- **Retry with feedback** button

Clicking retry re-runs the planner with the combined focus:

\`\`\`
<original focus>

Previous attempt failed validation. Issues:
  - <issue>
  - <issue>

User feedback:
  <textarea value>
\`\`\`

So the LLM sees the exact schema rule it broke plus the user's correction. Same wire shape the post-plan questions UI already uses for clarifications.

## Why this matters

Without the retry, every validation failure required the user to dismiss the modal and resubmit from scratch — losing their original focus, the system's diagnosis, and any context they could feed back. With it, the modal becomes a tight loop: see what went wrong → tell the planner → try again.

Bonus: when the planner has a systemic bug (like the underscore-system-tile issue from #310), the validation errors surface immediately in the modal, making the prompt-engineering problem visible to a contributor reading their own failure output.

## Test plan

- [x] \`npm test\` — **1482 passing + 3 skipped** (no test changes; UI-only)
- [x] Clean rebuild succeeds
- [ ] Manual: force a validation failure (e.g. by reverting #310 locally), submit a layout plan → error screen renders with validation issues, textarea pre-filled
- [ ] Manual: add user feedback in the textarea, click Retry → planner re-runs with the combined focus; if successful, the proposed plan renders
- [ ] Manual: a non-validation failure (e.g. planner agent missing) still renders the error with retry available — and the next run goes through normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)