### PR TITLE
feat(layout): curation mode — top N visible, rest hidden on Apply

### DIFF
--- a/.changeset/layout-curation-mode.md
+++ b/.changeset/layout-curation-mode.md
@@ -1,0 +1,18 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Layout planner becomes curation, not just rearrangement.
+
+Previously the planner bucketed every visible agent — typically dumping the long tail into an "Other" container. That's not what users actually want when they invoke "Improve layout": they want the top ~12 agents surfaced and the rest hidden. This release makes that the default behaviour.
+
+Changes:
+- **Prompt** (`agents/examples/layout-planner.yaml`): capped \`topAgents\` at 12, explicitly told the LLM that anything not in a container will have its \`pulseVisible\` set to false, and forbade catch-all "Other" / "Misc" containers.
+- **Commit endpoint** (`POST /pulse/layout-plan/commit`): no longer a no-op. Walks the agent store, sets \`pulseVisible=false\` on any visible agent absent from the plan's containers, and \`pulseVisible=true\` on any container-mentioned agent that was previously hidden. System tiles (`_system-*`) are skipped. Returns \`{ hidden: string[], unhidden: string[] }\`.
+- **Modal UI**: the proposed-layout screen now shows a "Will hide N agents" `<details>` block listing the agent ids that will be hidden, between the containers and the Apply button. Apply waits for the server commit before reloading.
+
+Hidden agents remain restorable from the "hidden signals" details section below the Pulse grid — single click brings them back.

--- a/agents/examples/layout-planner.yaml
+++ b/agents/examples/layout-planner.yaml
@@ -90,11 +90,16 @@ nodes:
       - Otherwise, rank by a combination of recency + reliability +
         frequency. Agents that have never run or haven't run in 30+ days
         rank lower.
-      - Emit at most 10 topAgents. Each MUST have a one-line `rationale`
+      - Emit at most 12 topAgents. Each MUST have a one-line `rationale`
         explaining why it's there ("daily run, 98% success" / "matches
         FOCUS=API monitors" / "user-pinned in current layout"). The
         rationale is rendered next to the agent in the UI — keep it
         concise and concrete.
+      - This is a CURATED top list. Agents that don't make the cut will
+        be HIDDEN from Pulse on Apply (their `pulseVisible` flag flips
+        to false; users can restore them from the "hidden signals"
+        section below the grid). Be deliberate — choose the agents
+        worth showing today, not "everything that exists".
       - `suggestedSize` is optional. Default to the agent's existing
         size if set; otherwise pick a size that fits the content:
         - "metric" / "status" templates → 1x1
@@ -109,6 +114,10 @@ nodes:
         agent.
       - Container labels are short, human-readable nouns ("Monitoring",
         "Daily news", "Personal projects"). Capitalize.
+      - DO NOT emit a catch-all "Other" / "Misc" / "Everything else"
+        container that scoops up the leftovers. Agents not assigned to
+        a real container will be hidden. If you want an agent visible,
+        put it in a container with a meaningful label.
       - Tiles can be EITHER agent ids (lowercase-with-dashes, from
         AGENT_METADATA) OR system tiles (Pulse-synthetic widgets in
         CURRENT_LAYOUT with a leading underscore: "_system-runs-today",
@@ -120,10 +129,12 @@ nodes:
       - Each tile belongs to EXACTLY ONE container. Tiles appearing in
         two containers is an error.
       - Container labels must be unique (case-insensitive).
-      - Every agent in topAgents SHOULD be assigned to a container. You
-        MAY also include lower-ranked agents in containers without
-        promoting them to topAgents (e.g. a "Misc" container at the
-        bottom catches everything else).
+      - Every agent in topAgents MUST be assigned to a container.
+      - You MAY include lower-ranked agents (not in topAgents) in
+        containers if they fit the theme — they'll be surfaced too.
+        But keep the total container-tile count modest (~12 agents,
+        plus the four system tiles when present). Anything you omit
+        from containers will be hidden.
       - Honor CURRENT_LAYOUT's container structure when it's clearly
         intentional. If the user already has a "Monitoring" container,
         keep it; don't rename to "Health" for no reason.
@@ -160,7 +171,7 @@ nodes:
           { "label": "Health", "tiles": ["_system-runs-today", "_system-failure-rate", "_system-agent-count", "_system-avg-duration"] },
           { "label": "Monitoring", "tiles": ["api-monitor", "system-health"] },
           { "label": "Daily news", "tiles": ["hn-top-3", "weather-forecast"] },
-          { "label": "Misc", "tiles": ["daily-joke", "cat-video-finder"] }
+          { "label": "Light reading", "tiles": ["daily-joke"] }
         ],
         "questions": [
           {

--- a/packages/dashboard/src/routes/pulse-layout-plan.ts
+++ b/packages/dashboard/src/routes/pulse-layout-plan.ts
@@ -308,11 +308,59 @@ pulseLayoutPlanRouter.get('/pulse/layout-plan/:runId', (req: Request, res: Respo
 });
 
 /**
- * POST /pulse/layout-plan/commit — telemetry no-op. The real "commit"
- * happens client-side when the user clicks Apply (writes to localStorage).
- * Endpoint exists so a future PR can add server-side layout persistence
- * without changing the client contract.
+ * POST /pulse/layout-plan/commit — apply the visibility side of a
+ * LayoutPlan. The CONTAINERS side (which tile lives where) is still
+ * persisted client-side in localStorage; this endpoint handles the
+ * curation side: any agent NOT referenced by any container has its
+ * `pulseVisible` flipped to false; any agent IN a container that was
+ * previously hidden has it flipped back to true. System tiles
+ * (leading-underscore ids) are skipped — they're synthetic.
+ *
+ * Body: { containers: Array<{ label, tiles: string[] }> }
+ * Returns: { ok, hidden: string[], unhidden: string[] }
  */
-pulseLayoutPlanRouter.post('/pulse/layout-plan/commit', (_req: Request, res: Response) => {
-  res.json({ ok: true });
+pulseLayoutPlanRouter.post('/pulse/layout-plan/commit', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const containersRaw = Array.isArray(body.containers) ? body.containers : [];
+
+  const surfacedIds = new Set<string>();
+  for (const c of containersRaw) {
+    if (c && Array.isArray((c as { tiles?: unknown }).tiles)) {
+      for (const t of (c as { tiles: unknown[] }).tiles) {
+        if (typeof t === 'string' && !t.startsWith('_')) surfacedIds.add(t);
+      }
+    }
+  }
+
+  const hidden: string[] = [];
+  const unhidden: string[] = [];
+
+  let agents: Agent[];
+  try { agents = ctx.agentStore.listAgents(); } catch { agents = []; }
+
+  for (const agent of agents) {
+    // Skip agents without a signal — they're not eligible for Pulse anyway.
+    if (!agent.signal) continue;
+    // Skip archived/draft — same reason.
+    if (agent.status === 'archived' || agent.status === 'draft') continue;
+
+    const currentlyVisible = agent.pulseVisible !== false
+      && !(agent.pulseVisible === undefined && agent.signal.hidden === true);
+    const shouldBeVisible = surfacedIds.has(agent.id);
+
+    if (currentlyVisible && !shouldBeVisible) {
+      try {
+        ctx.agentStore.updateAgentMeta(agent.id, { pulseVisible: false });
+        hidden.push(agent.id);
+      } catch { /* swallow — best-effort */ }
+    } else if (!currentlyVisible && shouldBeVisible) {
+      try {
+        ctx.agentStore.updateAgentMeta(agent.id, { pulseVisible: true });
+        unhidden.push(agent.id);
+      } catch { /* swallow */ }
+    }
+  }
+
+  res.json({ ok: true, hidden, unhidden });
 });

--- a/packages/dashboard/src/views/improve-layout.js.ts
+++ b/packages/dashboard/src/views/improve-layout.js.ts
@@ -297,6 +297,33 @@ export const IMPROVE_LAYOUT_JS = `
         '<div style="text-align:right;"><button type="button" class="btn btn--ghost btn--sm" id="improve-update-btn">Update plan</button></div></div>';
     }
 
+    // Compute which agents will be hidden: every visible agent that
+    // isn't referenced by any container (system tiles excluded).
+    var surfacedSet = {};
+    (plan.containers || []).forEach(function (c) {
+      (c.tiles || []).forEach(function (t) {
+        if (typeof t === 'string' && t.charAt(0) !== '_') surfacedSet[t] = true;
+      });
+    });
+    var willHide = [];
+    if (Array.isArray(cachedAgentMetadata)) {
+      for (var hi = 0; hi < cachedAgentMetadata.length; hi++) {
+        var ai = cachedAgentMetadata[hi];
+        if (ai && ai.id && !surfacedSet[ai.id]) willHide.push(ai.id);
+      }
+    }
+    var willHideHtml = '';
+    if (willHide.length > 0) {
+      var hideList = willHide.map(function (id) { return '<code style="font-size:var(--font-size-xs);background:var(--color-surface-raised);padding:0 var(--space-1);border-radius:var(--radius-sm);">' + esc(id) + '</code>'; }).join(' ');
+      willHideHtml =
+        '<details style="margin:var(--space-3) 0;padding:var(--space-2) var(--space-3);border:1px solid var(--color-border);border-radius:var(--radius-sm);background:var(--color-surface-raised);">' +
+        '<summary style="cursor:pointer;font-size:var(--font-size-sm);">' +
+        '<strong>Will hide ' + willHide.length + ' agent' + (willHide.length === 1 ? '' : 's') + '</strong> ' +
+        '<span class="dim" style="font-weight:var(--weight-regular);font-size:var(--font-size-xs);">(restore from the "hidden signals" section after applying)</span>' +
+        '</summary>' +
+        '<div style="display:flex;flex-wrap:wrap;gap:var(--space-1);margin-top:var(--space-2);">' + hideList + '</div></details>';
+    }
+
     content.innerHTML =
       '<div style="padding:var(--space-4);">' +
       '<h3 style="margin:0 0 var(--space-2);">Proposed layout</h3>' +
@@ -305,6 +332,7 @@ export const IMPROVE_LAYOUT_JS = `
       '<div style="margin-bottom:var(--space-4);">' + topRows + '</div>' +
       '<div style="font-size:var(--font-size-xs);color:var(--color-text-muted);font-weight:var(--weight-semibold);text-transform:uppercase;letter-spacing:0.06em;margin-bottom:var(--space-1);">Containers</div>' +
       '<div style="margin-bottom:var(--space-2);">' + containerRows + '</div>' +
+      willHideHtml +
       questionsHtml +
       '<div style="margin-top:var(--space-4);padding-top:var(--space-3);border-top:1px solid var(--color-border);display:flex;gap:var(--space-2);justify-content:flex-end;">' +
         '<button type="button" class="btn btn--ghost btn--sm" data-close-improve-layout="1">Cancel</button>' +
@@ -332,7 +360,8 @@ export const IMPROVE_LAYOUT_JS = `
   }
 
   function applyPlan(plan) {
-    // Convert plan.containers → sua-pulse-layout shape, write, reload.
+    // Build the localStorage layout JSON from the plan, preserving any
+    // container ids that already existed under a matching label.
     var existing;
     try { existing = JSON.parse(readLayout() || '{}'); } catch (e) { existing = {}; }
     var containerMap = {};
@@ -351,13 +380,25 @@ export const IMPROVE_LAYOUT_JS = `
       }),
     };
 
-    try { localStorage.setItem(LAYOUT_KEY, JSON.stringify(next)); } catch (e) { /* */ }
+    // Tell the server to flip pulseVisible: hide anything not surfaced,
+    // unhide anything previously hidden that's now in a container. This
+    // is the curation half of "Apply". The layout (containers + tile
+    // order) stays client-side in localStorage.
+    var applyBtn = document.getElementById('improve-apply-btn');
+    if (applyBtn) { applyBtn.disabled = true; applyBtn.textContent = 'Applying...'; }
 
-    // Best-effort telemetry; ignore the response.
-    fetch('/pulse/layout-plan/commit', { method: 'POST', credentials: 'same-origin' }).catch(function () {});
-
-    closeModal();
-    window.location.reload();
+    fetch('/pulse/layout-plan/commit', {
+      method: 'POST', credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ containers: plan.containers || [] }),
+    })
+    .then(function (r) { return r.json(); })
+    .catch(function () { return {}; })
+    .then(function () {
+      try { localStorage.setItem(LAYOUT_KEY, JSON.stringify(next)); } catch (e) { /* */ }
+      closeModal();
+      window.location.reload();
+    });
   }
 })();
 `;


### PR DESCRIPTION
## Why

User report: the planner was emitting a "Top 12 + Other (17)" layout. Real intent of **Improve layout** was *"surface the agents worth showing today; hide the rest."*

## Changes

### Prompt (\`agents/examples/layout-planner.yaml\`)
- Cap on \`topAgents\` raised to 12 with the explicit instruction that this is a curated list.
- Tells the LLM that agents NOT in any container will have \`pulseVisible\` flipped to false on Apply.
- Forbids catch-all "Other" / "Misc" / "Everything else" containers.
- In-prompt example replaced its "Misc" container with a topical one.

### Commit endpoint (\`POST /pulse/layout-plan/commit\`)
- No longer a no-op. Body: \`{ containers: Array<{ label, tiles: string[] }> }\`.
- Server walks \`agentStore.listAgents()\`:
  - **Hide:** any visible agent absent from any container → \`pulseVisible=false\`.
  - **Unhide:** any container-mentioned agent that was previously hidden → \`pulseVisible=true\`.
  - System tiles (\`_system-*\`) skipped — they're synthetic.
- Returns \`{ hidden: string[], unhidden: string[] }\`.

### Modal UI (\`improve-layout.js.ts\`)
- Proposed-layout screen now shows a \`<details>\` block titled "Will hide N agents" between the containers and the Apply button. Listing the actual ids so the user knows what's going away.
- Apply now POSTs the plan's containers to the commit endpoint, waits for the response, then writes localStorage and reloads. Button shows "Applying..." during the round-trip.

### Recovery path

Hidden agents remain restorable from the existing "hidden signals" details section below the Pulse grid — single click brings them back. So the "blast radius" of a bad plan is limited.

## Test plan

- [x] \`npm test\` — **1482 passing + 3 skipped** (no test changes; the helper and schema tests don't care about the new behaviour)
- [x] Clean rebuild succeeds
- [ ] Manual: Improve layout → confirm the plan no longer has an "Other" bucket
- [ ] Manual: expand "Will hide N agents" details on the proposed-layout screen → see the ids that'll go away
- [ ] Manual: click Apply → page reloads with a curated grid; hidden agents appear in the "hidden signals" section
- [ ] Manual: re-run Improve layout with FOCUS="surface my hidden weather agents" → previously-hidden weather agents flip back to visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)