### PR TITLE
fix(layout): curation reaches drafts; hidden signals stop loading on Pulse

### DIFF
--- a/.changeset/layout-curation-drafts-and-hidden.md
+++ b/.changeset/layout-curation-drafts-and-hidden.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Layout curation now correctly handles draft/archived agents and stops loading hidden signals on Pulse.
+
+Three connected fixes after live-testing the curation flow:
+
+- **Curation reaches draft/archived agents.** The commit endpoint previously skipped agents whose status was `draft` or `archived`, so any draft agent with `pulseVisible !== false` slipped through curation and re-appeared on Pulse via the auto-"Other" container in `widget-layout.js.ts`. The Pulse view itself doesn't filter by status — only by signal + pulseVisible — so curation now matches that exactly.
+- **Planner sees the same set Pulse renders.** `gatherAgentMetadata` lost its archived/draft filter for the same reason; it now agrees with the Pulse route's actual visibility rule. The planner no longer wastes `topAgents` slots on agents that can never render (those without a `signal:` block — `build-planner`, `agent-analyzer`, `agent-builder`, etc. — already got excluded via the `!signal` skip; this PR just keeps that invariant clean).
+- **Hidden-signals section is compact.** Previously every hidden agent rendered as a full tile inside a `<details>` block. Now the section is a one-line summary (`N signals hidden from Pulse`) with **Show all** + **Manage in /agents** buttons. The route also skips the expensive `buildTile()` call for hidden agents — they only contribute to a count.

--- a/packages/dashboard/src/routes/pulse-layout-plan.ts
+++ b/packages/dashboard/src/routes/pulse-layout-plan.ts
@@ -39,13 +39,17 @@ const STALE_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 // ── Helpers ────────────────────────────────────────────────────────────
 
 /**
- * True when the agent should be considered by the layout planner.
- * Excludes archived/draft agents and any explicitly hidden from Pulse.
+ * True when the agent currently renders as a tile on the Pulse grid.
+ * Mirrors the filter in the /pulse route exactly — anything that route
+ * shows, curation should be able to hide; anything it doesn't show,
+ * curation has nothing to do with. Notably: status (archived/draft) is
+ * NOT a filter in the Pulse route, so we don't filter on it here.
+ * Agents without a signal are skipped because they can't render at all.
  */
 function isVisibleOnPulse(agent: Agent): boolean {
-  if (agent.status === 'archived' || agent.status === 'draft') return false;
+  if (!agent.signal) return false;
   if (agent.pulseVisible === false) return false;
-  if (agent.signal?.hidden === true) return false;
+  if (agent.pulseVisible === undefined && agent.signal.hidden === true) return false;
   return true;
 }
 
@@ -340,10 +344,11 @@ pulseLayoutPlanRouter.post('/pulse/layout-plan/commit', (req: Request, res: Resp
   try { agents = ctx.agentStore.listAgents(); } catch { agents = []; }
 
   for (const agent of agents) {
-    // Skip agents without a signal — they're not eligible for Pulse anyway.
+    // Agents without a signal can never render on Pulse — nothing to do.
+    // We deliberately DO NOT skip archived/draft here: the Pulse route's
+    // visibility filter is (signal && pulseVisible), not status, so
+    // curation needs to be able to hide them just like any other tile.
     if (!agent.signal) continue;
-    // Skip archived/draft — same reason.
-    if (agent.status === 'archived' || agent.status === 'draft') continue;
 
     const currentlyVisible = agent.pulseVisible !== false
       && !(agent.pulseVisible === undefined && agent.signal.hidden === true);

--- a/packages/dashboard/src/routes/pulse.ts
+++ b/packages/dashboard/src/routes/pulse.ts
@@ -129,13 +129,15 @@ pulseRouter.get('/pulse', (req: Request, res: Response) => {
   // pulseVisible takes precedence when set.
   for (const agent of agents) {
     if (!agent.signal) continue;
-    const tile = buildTile(agent as Agent & { signal: AgentSignal }, ctx);
     const pulseHidden = agent.pulseVisible === false
       || (agent.pulseVisible === undefined && agent.signal.hidden === true);
     if (pulseHidden) {
-      hiddenTiles.push(tile);
+      // Hidden agents are surfaced only as a count + bulk-restore link
+      // in the view — skip the (expensive) buildTile call so the page
+      // doesn't load their data needlessly.
+      hiddenTiles.push({} as unknown as typeof tiles[number]);
     } else {
-      tiles.push(tile);
+      tiles.push(buildTile(agent as Agent & { signal: AgentSignal }, ctx));
     }
   }
 

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -209,20 +209,13 @@ export function renderPulsePage(input: PulsePageInput): string {
     </div>
 
     ${hiddenCount > 0 ? html`
-      <details class="pulse-hidden-section" style="margin-top: var(--space-6);">
-        <summary style="cursor: pointer; font-family: var(--font-mono); font-size: var(--font-size-xs); font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-text-muted);">
-          ${String(hiddenCount)} hidden signal${hiddenCount !== 1 ? 's' : ''}
-        </summary>
-        <div style="display: flex; flex-wrap: wrap; gap: var(--space-2); margin-top: var(--space-3);">
-          ${hiddenTiles.map((t) => html`
-            <form method="POST" action="/agents/${t.agent.id}/signal/toggle" style="margin: 0; display: inline;">
-              <button type="submit" class="btn btn--ghost btn--sm" style="font-family: var(--font-mono);">
-                ${t.signal.icon ?? ''} ${t.signal.title} (${t.agent.id})
-              </button>
-            </form>
-          `) as unknown as SafeHtml[]}
-        </div>
-      </details>
+      <div class="pulse-hidden-section" style="margin-top: var(--space-6); display: flex; align-items: center; gap: var(--space-3); padding: var(--space-2) var(--space-3); border-top: 1px solid var(--color-border); font-size: var(--font-size-xs); color: var(--color-text-muted);">
+        <span>${String(hiddenCount)} signal${hiddenCount !== 1 ? 's' : ''} hidden from Pulse.</span>
+        <form method="POST" action="/pulse/show-all" style="margin: 0; display: inline;">
+          <button type="submit" class="btn btn--ghost btn--sm">Show all</button>
+        </form>
+        <a class="btn btn--ghost btn--sm" href="/agents">Manage in /agents</a>
+      </div>
     ` : html``}
 
     ${improveLayoutModal()}


### PR DESCRIPTION
## Three connected fixes after live-testing

From the layout-improvement wizard. User saw: agents still showing in an auto-"Other" bucket after Apply, hidden signals rendering as a long block on Pulse, and the agent count > 12.

### A. Curation reaches draft/archived agents

The commit endpoint had \`if (agent.status === 'archived' || agent.status === 'draft') continue;\` — meaning any draft/archived agent that was previously toggled \`pulseVisible: true\` slipped through curation. The Pulse view itself doesn't filter by status (only by signal + pulseVisible), so those agents kept rendering — and the auto-"Other" logic in \`widget-layout.js.ts\` swept them into a synthetic container.

Removed the status skip. Commit now agrees with the Pulse route's actual visibility rule: \`signal && pulseVisible !== false\`.

### B. Planner sees the same set Pulse renders

\`gatherAgentMetadata\`'s \`isVisibleOnPulse\` had the same status filter for the same wrong reason. Aligned with the Pulse route filter — now the planner ranks against the actual visible set, not a status-filtered subset.

(Side note: \`build-planner\`, \`agent-analyzer\`, \`agent-builder\` were getting promoted to topAgents previously because they passed the metadata filter; they failed the \`!signal\` skip on the commit side and ended up as ghost-tiles in the layout. With this PR they still ship in the metadata if they have a signal, and silently skip if they don't — same as today, just consistent now.)

### C. Hidden signals stop loading on Pulse

Previously \`/pulse\` rendered every hidden agent as a full tile inside a collapsed \`<details>\` block, even though they're not visible. User reasonably expected hidden = not loaded.

Now the hidden section is a single line:

> *N signals hidden from Pulse.*  [Show all] [Manage in /agents]

The route also skips \`buildTile()\` for hidden agents — no more wasted rendering work. Bulk restore (\`POST /pulse/show-all\`) is preserved. Per-agent restore moves to \`/agents\` where the toggle UI lives anyway.

## Test plan

- [x] \`npm test\` — **1482 passing + 3 skipped** (no test changes)
- [x] Clean rebuild succeeds
- [ ] Manual: rerun **Improve layout** on a Pulse with draft agents → after Apply, draft agents go to the hidden count, no longer in the grid or an auto-"Other"
- [ ] Manual: hidden signals section shows count + Show-all button + Manage-in-/agents link; no per-agent tile content rendered
- [ ] Manual: count in the page header still matches what's visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)