### PR TITLE
fix(layout): suppress empty buckets, order containers by glance-value

### DIFF
--- a/.changeset/layout-empty-bucket-ordering.md
+++ b/.changeset/layout-empty-bucket-ordering.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Three layout-planner fixes after live testing.
+
+1. **Empty containers no longer render.** `widget-layout.js.ts` skips a container at render time if none of its tile ids resolve to a rendered tile in the DOM (e.g. the planner included no-signal agents, or a tile was hidden between sessions and its id lingers in the saved layout). Edit mode still shows empty containers so the user can drag.
+2. **Planner orders containers by glance-value.** Prompt updated: high-frequency / daily containers go near the top of the array (containers render top-to-bottom); engineering/admin/infra containers go lower; system tiles anchor either the very top or the very bottom, not the middle.
+3. **Planner explicitly told not to include no-signal agents in containers.** Belt-and-suspenders: even though `gatherAgentMetadata` already filters them, the prompt now spells out that an AGENT_METADATA entry without a `title` means the agent has no Pulse signal and placing it in a container leaves the container empty.

--- a/agents/examples/layout-planner.yaml
+++ b/agents/examples/layout-planner.yaml
@@ -118,6 +118,18 @@ nodes:
         container that scoops up the leftovers. Agents not assigned to
         a real container will be hidden. If you want an agent visible,
         put it in a container with a meaningful label.
+      - **ORDER CONTAINERS BY GLANCE-VALUE — TOP TO BOTTOM.** The wizard
+        renders containers in array order. Put the things the user wants
+        to see *first thing* near the top: daily digests, news, weather,
+        anything they check every morning. Engineering / admin / infra
+        containers go LOWER. System tiles (Pulse synthetics) usually
+        anchor either the very top OR the very bottom — pick one based
+        on whether the user's FOCUS reads "I want stats first" or "I
+        want content first". Don't bury system tiles in the middle.
+      - **NEVER include an agent id in a container if its AGENT_METADATA
+        entry is absent OR has no `title`.** Those agents don't have a
+        Pulse signal block and can't render as tiles — placing them in a
+        container leaves it visually empty.
       - Tiles can be EITHER agent ids (lowercase-with-dashes, from
         AGENT_METADATA) OR system tiles (Pulse-synthetic widgets in
         CURRENT_LAYOUT with a leading underscore: "_system-runs-today",

--- a/packages/dashboard/src/views/widget-layout.js.ts
+++ b/packages/dashboard/src/views/widget-layout.js.ts
@@ -156,6 +156,15 @@ export function widgetLayoutJS(config: WidgetLayoutConfig): string {
 
       for (var ci = 0; ci < layout.containers.length; ci++) {
         var c = layout.containers[ci];
+        // Skip containers whose every tile is missing from the rendered
+        // set (e.g. agents the planner included but which have no
+        // signal, or now-hidden agents whose ids linger in the saved
+        // layout). Edit mode keeps them visible so the user can drag.
+        if (!editMode) {
+          var anyRendered = false;
+          for (var ck = 0; ck < c.tiles.length; ck++) { if (tileEls[c.tiles[ck]]) { anyRendered = true; break; } }
+          if (!anyRendered) continue;
+        }
         var section = document.createElement('section');
         section.className = 'pulse-container';
         section.setAttribute('data-container-id', c.id);


### PR DESCRIPTION
## Three issues after live testing

Reported on the latest curation run:
1. Empty **Engineering** bucket — the planner put no-signal agents (\`build-planner\`, \`agent-analyzer\`, \`agent-builder\`) in a container; they don't render, so the section appeared empty.
2. **Daily** items buried in the middle — good dashboard design puts daily-glance content at the top.
3. **"Other"** section still showing — the auto-bucket in \`widget-layout.js.ts\` was re-creating it (or its empty shell was lingering in localStorage from before).

## Fixes

### 1. Renderer suppresses empty containers (\`widget-layout.js.ts\`)

Skip a container at render time if none of its tile ids resolve to a rendered DOM tile. Belt-and-suspenders for empty Engineering AND any orphan "Other" that persists in localStorage from before the curation flow hid the underlying agents. Edit mode still shows empty containers so the user can drag.

### 2. Planner orders by glance-value (\`agents/examples/layout-planner.yaml\`)

> **ORDER CONTAINERS BY GLANCE-VALUE — TOP TO BOTTOM.** The wizard renders containers in array order. Put the things the user wants to see *first thing* near the top: daily digests, news, weather, anything they check every morning. Engineering / admin / infra containers go LOWER. System tiles (Pulse synthetics) usually anchor either the very top OR the very bottom — pick one based on whether the user's FOCUS reads "I want stats first" or "I want content first". Don't bury system tiles in the middle.

### 3. Planner doesn't include no-signal agents (\`agents/examples/layout-planner.yaml\`)

Belt-and-suspenders rule added — \`gatherAgentMetadata\` already filters them, but the prompt now spells out that an AGENT_METADATA entry without a \`title\` means the agent has no Pulse signal and shouldn't go in a container.

## Test plan

- [x] \`npm test\` — 1482 passing + 3 skipped
- [x] Clean rebuild succeeds
- [ ] Manual: rerun **Improve layout** → containers ordered with daily content near the top, system tiles top or bottom
- [ ] Manual: any container whose tiles are all hidden/missing should not appear on the grid (try inspecting localStorage to confirm the "_other" remnant doesn't render)
- [ ] Manual: planner output's containers should NOT include \`build-planner\` / \`agent-analyzer\` / \`agent-builder\` (or any no-signal agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)