### PR TITLE
fix(layout): system tiles first, daily second; clearer Pulse count

### DIFF
--- a/.changeset/system-tiles-first-and-clearer-count.md
+++ b/.changeset/system-tiles-first-and-clearer-count.md
@@ -1,0 +1,14 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Layout planner: system tiles first, daily second. Pulse count differentiates agents from system widgets.
+
+Two clarifications after live testing:
+
+- **Canonical container order.** The prompt previously offered the LLM a choice between system-tiles-top and system-tiles-bottom. Made it prescriptive: system tiles always anchor the first container ("Health" / "Overview"), daily-glance content second, lower-frequency containers below. FOCUS can still override ("hide system stats"), but the default is now opinionated.
+- **Page count differentiates tile kinds.** The Pulse header previously read "16 signals, 28 hidden" which conflated 12 agent tiles with 4 synthetic system widgets. Now reads "12 agents + 4 system · 28 hidden" so the cap that matters to the user (agent count) is visible directly.

--- a/agents/examples/layout-planner.yaml
+++ b/agents/examples/layout-planner.yaml
@@ -118,14 +118,22 @@ nodes:
         container that scoops up the leftovers. Agents not assigned to
         a real container will be hidden. If you want an agent visible,
         put it in a container with a meaningful label.
-      - **ORDER CONTAINERS BY GLANCE-VALUE — TOP TO BOTTOM.** The wizard
-        renders containers in array order. Put the things the user wants
-        to see *first thing* near the top: daily digests, news, weather,
-        anything they check every morning. Engineering / admin / infra
-        containers go LOWER. System tiles (Pulse synthetics) usually
-        anchor either the very top OR the very bottom — pick one based
-        on whether the user's FOCUS reads "I want stats first" or "I
-        want content first". Don't bury system tiles in the middle.
+      - **ORDER CONTAINERS — SYSTEM TILES FIRST, DAILY SECOND.** The
+        wizard renders containers in array order, top to bottom. The
+        canonical order is:
+          1. A "Health" or "Overview" container holding the four system
+            tiles (_system-runs-today, _system-failure-rate,
+            _system-agent-count, _system-avg-duration) — first because
+            they're the at-a-glance status row the user wants to see
+            before anything else.
+          2. Daily-glance content next: daily digests, news, weather,
+            anything checked every morning.
+          3. Lower-frequency containers (engineering, admin, infra,
+            jobs) below that.
+        Don't bury system tiles in the middle. Don't put daily content
+        below engineering. FOCUS may override these defaults — e.g.
+        "I don't care about system stats, hide them" — but absent a
+        contrary signal, system first, daily second.
       - **NEVER include an agent id in a container if its AGENT_METADATA
         entry is absent OR has no `title`.** Those agents don't have a
         Pulse signal block and can't render as tiles — placing them in a

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -159,6 +159,8 @@ function tileFooter(tile: PulseTile): SafeHtml {
 export function renderPulsePage(input: PulsePageInput): string {
   const { systemTiles, tiles, hiddenTiles } = input;
   const allTileCount = systemTiles.length + tiles.length;
+  const agentTileCount = tiles.length;
+  const systemTileCount = systemTiles.length;
   const hiddenCount = hiddenTiles.length;
 
   const allTileIds = [...systemTiles.map((t) => t.agent.id), ...tiles.map((t) => t.agent.id)];
@@ -180,7 +182,7 @@ export function renderPulsePage(input: PulsePageInput): string {
     <div style="display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-6);">
       <h1 style="margin: 0;">Pulse</h1>
       <span style="font-size: var(--font-size-sm); color: var(--color-text-muted);">
-        ${String(allTileCount)} signal${allTileCount !== 1 ? 's' : ''}${hiddenCount > 0 ? html`, ${String(hiddenCount)} hidden` : html``}
+        ${String(agentTileCount)} agent${agentTileCount !== 1 ? 's' : ''}${systemTileCount > 0 ? html` + ${String(systemTileCount)} system` : html``}${hiddenCount > 0 ? html` · ${String(hiddenCount)} hidden` : html``}
       </span>
       <div style="margin-left: auto; display: flex; gap: var(--space-2);">
         ${tiles.length > 0 ? html`


### PR DESCRIPTION
## Two clarifications after live testing

You reported:
- "test 1 ended up with 16 signals, 28 hidden" → the planner correctly capped agents at 12, but the count display added system tiles, looking like it overshot.
- "system widgets should appear at the top of a pulse dashboard, and then daily next" → the prompt previously let the LLM pick system top OR bottom; making it prescriptive.

## Fixes

### Canonical container order in the planner prompt

\`\`\`
1. A "Health" or "Overview" container holding the four system tiles
   — first because they're the at-a-glance status row.
2. Daily-glance content next: daily digests, news, weather, anything
   checked every morning.
3. Lower-frequency containers (engineering, admin, infra, jobs) below.
\`\`\`

FOCUS can still override ("I don't care about system stats, hide them") but the default is now opinionated.

### Pulse count differentiates kinds

\`\`\`
before: 16 signals, 28 hidden
after:  12 agents + 4 system · 28 hidden
\`\`\`

So the cap-of-interest (agent count, which the planner controls) is visible directly.

## Test plan

- [x] \`npm test\` — 1482 passing + 3 skipped (no test changes)
- [x] Clean rebuild succeeds
- [ ] Manual: rerun **Improve layout** with test prompt #1 → containers ordered system-first, daily-second
- [ ] Manual: Pulse header reads "N agents + 4 system" instead of "N signals"

🤖 Generated with [Claude Code](https://claude.com/claude-code)