### PR TITLE
feat(dashboards): Improve-layout wizard now runs on named dashboards

### DIFF
--- a/.changeset/improve-layout-on-dashboards.md
+++ b/.changeset/improve-layout-on-dashboards.md
@@ -1,0 +1,27 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Extend the "Improve layout" wizard to named user-dashboards (`/dashboards/<id>`).
+
+The wizard now appears on every named dashboard page alongside the existing Pulse surface. Same flow (suggestion pills → focus textarea → planner → clarifying questions → Apply), scoped to that dashboard's agent pool.
+
+Differences from Pulse:
+
+- **Curation rewrites dashboard config**, not `pulseVisible` flags. Named dashboards have no per-tile hide switch — agent membership is declared in `dashboard.layout.sections[].agentIds[]`. Apply replaces the section list with one derived from the plan's containers. Agents the planner didn't choose are REMOVED from the dashboard config. They stay in `/agents`; the **Add tile** button can re-add them.
+- **Agent metadata is filtered to the dashboard's pool.** The planner only sees agents currently in `sections[].agentIds`, not the whole catalog. Ranking and grouping happen within the dashboard's scope.
+- **localStorage key is per-dashboard.** Each dashboard's container arrangement persists under `sua-dashboard-layout-<id>`, isolated from Pulse and other dashboards.
+- **Copy adjusted.** "Will hide N agents" reads "Will remove N agents" with the recovery hint ("restore via Add tile"). The pre-plan blurb explains that agents not chosen will be removed from this dashboard.
+
+New routes (`packages/dashboard/src/routes/dashboard-layout-plan.ts`):
+
+- `POST /dashboards/:id/layout-plan/suggestions` — pills + dashboard-scoped agent metadata
+- `POST /dashboards/:id/layout-plan` — kicks off the layout-planner
+- `GET /dashboards/:id/layout-plan/:runId` — poll
+- `POST /dashboards/:id/layout-plan/commit` — rewrite `sections[].agentIds`; returns `{ removed, retained }`
+
+The shared `improve-layout-modal.ts` + `improve-layout.js.ts` now take a config (`endpointBase`, `storageKey`, `curateVerb`) so one modal serves both surfaces.

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -52,6 +52,7 @@ import { helpRouter } from './routes/help.js';
 import { versionsRouter } from './routes/versions.js';
 import { pulseRouter } from './routes/pulse.js';
 import { pulseLayoutPlanRouter } from './routes/pulse-layout-plan.js';
+import { dashboardLayoutPlanRouter } from './routes/dashboard-layout-plan.js';
 import { packsRouter } from './routes/packs.js';
 import { dashboardsRouter } from './routes/dashboards.js';
 import { dashboardsEditRouter } from './routes/dashboards-edit.js';
@@ -245,6 +246,7 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   app.use(nodesRouter);
   app.use(pulseRouter);
   app.use(pulseLayoutPlanRouter);
+  app.use(dashboardLayoutPlanRouter);
   app.use(packsRouter);
   app.use(dashboardsEditRouter);
   app.use(dashboardsRouter);

--- a/packages/dashboard/src/routes/dashboard-layout-plan.ts
+++ b/packages/dashboard/src/routes/dashboard-layout-plan.ts
@@ -1,0 +1,397 @@
+/**
+ * Routes for the "Improve layout" wizard on named user-dashboards
+ * (`/dashboards/<id>`). Parallel to the Pulse routes in
+ * `pulse-layout-plan.ts` but scoped to a single dashboard:
+ *
+ *   POST /dashboards/:id/layout-plan/suggestions  — pills + metadata
+ *   POST /dashboards/:id/layout-plan              — kick off planner
+ *   GET  /dashboards/:id/layout-plan/:runId       — poll
+ *   POST /dashboards/:id/layout-plan/commit       — rewrite section
+ *                                                   memberships
+ *
+ * Differences from Pulse:
+ * - `agentMetadata` is filtered to the dashboard's current section
+ *   members (the planner curates *within* the dashboard's pool).
+ * - The commit endpoint rewrites `dashboard.layout.sections[].agentIds`
+ *   so un-surfaced agents are REMOVED from the dashboard. Unlike Pulse
+ *   (`pulseVisible: false`), there's no per-dashboard hide flag, so
+ *   curation modifies the dashboard config directly. Recovery: the
+ *   "Add tile" button on the dashboard page.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import {
+  executeAgentDag,
+  extractPlanJson,
+  layoutPlanSchema,
+  parseAgent,
+  type Agent,
+  type Dashboard,
+  type DashboardLayout,
+  type LayoutPlan,
+  type RunStatus,
+} from '@some-useful-agents/core';
+import { getContext } from '../context.js';
+import {
+  computeLayoutSuggestions,
+  type CurrentLayout,
+  type LayoutSuggestionAgent,
+} from '../lib/layout-suggestions.js';
+
+export const dashboardLayoutPlanRouter: Router = Router();
+
+const LAYOUT_PLANNER_AGENT_ID = 'layout-planner';
+const STALE_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function parseCurrentLayout(body: Record<string, unknown>): CurrentLayout | null {
+  const raw = body.currentLayout;
+  if (typeof raw === 'string' && raw.trim()) {
+    try { return JSON.parse(raw) as CurrentLayout; } catch { return null; }
+  }
+  if (raw && typeof raw === 'object') return raw as CurrentLayout;
+  return null;
+}
+
+/**
+ * Build metadata for the agents currently declared in this dashboard's
+ * sections. Includes run-history aggregates (lastRunAt, successRate,
+ * runCount30d) so the planner can rank intelligently. Agents without a
+ * signal block are excluded — they can't render as tiles anyway.
+ */
+function gatherDashboardAgentMetadata(
+  ctx: ReturnType<typeof getContext>,
+  dashboard: Dashboard,
+  now: number,
+): LayoutSuggestionAgent[] {
+  const memberIds = new Set<string>();
+  for (const section of dashboard.layout.sections) {
+    for (const id of section.agentIds) memberIds.add(id);
+  }
+  if (memberIds.size === 0) return [];
+
+  // Pull recent run window once and aggregate by agent.
+  let recent: Array<{ agentName: string; status: string; startedAt: string }> = [];
+  try {
+    const { rows } = ctx.runStore.queryRuns({ limit: 500, offset: 0 });
+    recent = rows.map((r) => ({ agentName: r.agentName, status: r.status, startedAt: r.startedAt }));
+  } catch {
+    /* run store unavailable */
+  }
+
+  const byAgent = new Map<string, { last?: number; successes: number; total: number }>();
+  for (const r of recent) {
+    if (!memberIds.has(r.agentName)) continue;
+    const ts = new Date(r.startedAt).getTime();
+    if (!Number.isFinite(ts)) continue;
+    if (now - ts > STALE_WINDOW_MS) continue;
+    const cell = byAgent.get(r.agentName) ?? { last: undefined, successes: 0, total: 0 };
+    if (cell.last === undefined || ts > cell.last) cell.last = ts;
+    cell.total += 1;
+    if (r.status === 'completed') cell.successes += 1;
+    byAgent.set(r.agentName, cell);
+  }
+
+  let allTimeLast = new Map<string, number>();
+  try {
+    const { rows } = ctx.runStore.queryRuns({ limit: 1000, offset: 0 });
+    for (const r of rows) {
+      if (!memberIds.has(r.agentName)) continue;
+      const ts = new Date(r.startedAt).getTime();
+      if (!Number.isFinite(ts)) continue;
+      const prev = allTimeLast.get(r.agentName);
+      if (prev === undefined || ts > prev) allTimeLast.set(r.agentName, ts);
+    }
+  } catch {
+    /* run store unavailable */
+  }
+
+  // Walk the section membership in declared order, filter out agents
+  // that can't render (no agent or no signal), emit metadata rows.
+  const out: LayoutSuggestionAgent[] = [];
+  for (const id of memberIds) {
+    const agent = ctx.agentStore.getAgent(id);
+    if (!agent || !agent.signal) continue;
+    const cell = byAgent.get(id);
+    const allTime = allTimeLast.get(id);
+    const lastTs = cell?.last ?? allTime;
+    const row: LayoutSuggestionAgent = {
+      id,
+      title: agent.signal.title,
+    };
+    if (lastTs !== undefined) row.lastRunAt = new Date(lastTs).toISOString();
+    if (cell && cell.total > 0) {
+      row.successRate = cell.successes / cell.total;
+      row.runCount30d = cell.total;
+    } else {
+      row.runCount30d = 0;
+    }
+    out.push(row);
+  }
+  return out;
+}
+
+/**
+ * Spawn the layout-planner agent run for a named dashboard. Identical
+ * to the Pulse kickoff except for the inputs (FOCUS still primary,
+ * CURRENT_LAYOUT and AGENT_METADATA are scoped to the dashboard).
+ */
+async function kickoffDashboardPlannerRun(args: {
+  ctx: ReturnType<typeof getContext>;
+  focus: string;
+  currentLayoutJson: string;
+  agentMetadataJson: string;
+}): Promise<string | null> {
+  const { ctx, focus, currentLayoutJson, agentMetadataJson } = args;
+
+  let planner: ReturnType<typeof ctx.agentStore.getAgent> = null;
+  try {
+    const yamlPath = join(resolve('agents/examples'), `${LAYOUT_PLANNER_AGENT_ID}.yaml`);
+    const yamlText = readFileSync(yamlPath, 'utf-8');
+    const parsed = parseAgent(yamlText);
+    ctx.agentStore.upsertAgent(parsed, 'import', 'Auto-imported for layout planner');
+    planner = ctx.agentStore.getAgent(LAYOUT_PLANNER_AGENT_ID);
+  } catch { /* fall through */ }
+  if (!planner) return null;
+
+  const runPromise = executeAgentDag(
+    planner,
+    {
+      triggeredBy: 'dashboard',
+      inputs: {
+        FOCUS: focus,
+        CURRENT_LAYOUT: currentLayoutJson,
+        AGENT_METADATA: agentMetadataJson,
+      },
+    },
+    {
+      runStore: ctx.runStore,
+      secretsStore: ctx.secretsStore,
+      variablesStore: ctx.variablesStore,
+      dataRoot: ctx.agentStore.dataRoot,
+    },
+  );
+
+  await Promise.race([runPromise, new Promise((r) => setTimeout(r, 200))]);
+  const { rows } = ctx.runStore.queryRuns({
+    agentName: LAYOUT_PLANNER_AGENT_ID,
+    statuses: ['running', 'completed', 'failed'] as RunStatus[],
+    limit: 1,
+    offset: 0,
+  });
+  if (rows.length > 0) return rows[0].id;
+  try {
+    const run = await runPromise;
+    return run.id;
+  } catch {
+    return null;
+  }
+}
+
+// ── Routes ─────────────────────────────────────────────────────────────
+
+/** Resolve the dashboardsStore + dashboard, or short-circuit with 404. */
+function resolveDashboard(req: Request, res: Response): Dashboard | null {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.dashboardsStore) {
+    res.status(404).json({ ok: false, error: 'Dashboards store unavailable.' });
+    return null;
+  }
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const dashboard = ctx.dashboardsStore.getDashboard(id);
+  if (!dashboard) {
+    res.status(404).json({ ok: false, error: `Dashboard "${id}" not found.` });
+    return null;
+  }
+  return dashboard;
+}
+
+dashboardLayoutPlanRouter.post('/dashboards/:id/layout-plan/suggestions', (req: Request, res: Response) => {
+  const dashboard = resolveDashboard(req, res);
+  if (!dashboard) return;
+  const ctx = getContext(req.app.locals);
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const now = Date.now();
+
+  const agentMetadata = gatherDashboardAgentMetadata(ctx, dashboard, now);
+  const currentLayout = parseCurrentLayout(body);
+  const suggestions = computeLayoutSuggestions(agentMetadata, currentLayout, now);
+
+  res.json({ ok: true, suggestions, agentMetadata });
+});
+
+dashboardLayoutPlanRouter.post('/dashboards/:id/layout-plan', async (req: Request, res: Response) => {
+  const dashboard = resolveDashboard(req, res);
+  if (!dashboard) return;
+  const ctx = getContext(req.app.locals);
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const focus = typeof body.focus === 'string' ? body.focus.trim() : '';
+  const currentLayout = parseCurrentLayout(body);
+
+  let agentMetadata: LayoutSuggestionAgent[];
+  if (Array.isArray(body.agentMetadata)) {
+    agentMetadata = body.agentMetadata as LayoutSuggestionAgent[];
+  } else {
+    agentMetadata = gatherDashboardAgentMetadata(ctx, dashboard, Date.now());
+  }
+
+  if (agentMetadata.length === 0) {
+    res.json({ ok: false, error: 'This dashboard has no renderable agents to lay out. Add tiles first via the Add tile button.' });
+    return;
+  }
+
+  const runId = await kickoffDashboardPlannerRun({
+    ctx,
+    focus,
+    currentLayoutJson: JSON.stringify(currentLayout ?? {}),
+    agentMetadataJson: JSON.stringify(agentMetadata),
+  });
+  if (!runId) {
+    res.json({
+      ok: false,
+      error: 'Layout planner agent not found. Ensure layout-planner.yaml exists in agents/examples/.',
+    });
+    return;
+  }
+  res.json({ ok: true, runId });
+});
+
+dashboardLayoutPlanRouter.get('/dashboards/:id/layout-plan/:runId', (req: Request, res: Response) => {
+  const dashboard = resolveDashboard(req, res);
+  if (!dashboard) return;
+  const ctx = getContext(req.app.locals);
+  const runId = Array.isArray(req.params.runId) ? req.params.runId[0] : req.params.runId;
+
+  const run = ctx.runStore.getRun(runId);
+  if (!run) {
+    res.json({ ok: false, status: 'not_found' });
+    return;
+  }
+
+  if (run.status === 'running' || run.status === 'pending') {
+    const execs = ctx.runStore.listNodeExecutions(runId);
+    const running = execs.find((e) => e.status === 'running');
+    const phase = running?.nodeId === 'plan' ? 'Designing layout...' : 'Starting...';
+    res.json({ ok: true, status: 'running', phase });
+    return;
+  }
+
+  if (run.status !== 'completed' || !run.result) {
+    res.json({ ok: true, status: 'failed', error: run.error ?? `Layout planner failed (${run.status}).` });
+    return;
+  }
+
+  const planJson = extractPlanJson(run.result);
+  if (!planJson) {
+    res.json({ ok: true, status: 'failed', error: 'Planner did not produce a <plan>...</plan> block.', rawResult: run.result });
+    return;
+  }
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(planJson);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    res.json({ ok: true, status: 'failed', error: `Plan JSON did not parse: ${msg}`, rawResult: planJson });
+    return;
+  }
+
+  const validated = layoutPlanSchema.safeParse(parsedJson);
+  if (!validated.success) {
+    const issues = validated.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
+    res.json({
+      ok: true,
+      status: 'failed',
+      error: 'Layout plan failed schema validation.',
+      validationErrors: issues,
+      rawResult: planJson,
+    });
+    return;
+  }
+
+  const plan: LayoutPlan = validated.data;
+  res.json({ ok: true, status: 'done', plan });
+});
+
+/**
+ * Apply the plan's curation to the dashboard's persisted layout.
+ * Unlike Pulse, named dashboards have no per-tile hide flag — agent
+ * membership is declared in `dashboard.layout.sections[].agentIds[]`.
+ * Curation rewrites that membership: un-surfaced agents are REMOVED
+ * from the dashboard config. Section structure (titles, ordering)
+ * is replaced by the plan's containers — labels become section titles.
+ *
+ * Body: { containers: Array<{ label: string; tiles: string[] }> }
+ * Returns: { ok, removed: string[], retained: string[] }
+ *
+ * System tiles (`_system-*`) are ignored — they're Pulse-only.
+ */
+dashboardLayoutPlanRouter.post('/dashboards/:id/layout-plan/commit', (req: Request, res: Response) => {
+  const dashboard = resolveDashboard(req, res);
+  if (!dashboard) return;
+  const ctx = getContext(req.app.locals);
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const containersRaw = Array.isArray(body.containers) ? body.containers : [];
+
+  // Build the new section list from the plan's containers, filtering
+  // out system tiles and de-duplicating ids.
+  const seenIds = new Set<string>();
+  const newSections: Array<{ title: string; agentIds: string[] }> = [];
+  for (const c of containersRaw) {
+    if (!c || typeof c !== 'object') continue;
+    const label = typeof (c as { label?: unknown }).label === 'string'
+      ? (c as { label: string }).label.trim()
+      : '';
+    if (!label) continue;
+    const tilesRaw = Array.isArray((c as { tiles?: unknown }).tiles)
+      ? (c as { tiles: unknown[] }).tiles
+      : [];
+    const ids: string[] = [];
+    for (const t of tilesRaw) {
+      if (typeof t !== 'string') continue;
+      if (t.startsWith('_')) continue; // skip Pulse system tiles
+      if (seenIds.has(t)) continue;
+      seenIds.add(t);
+      ids.push(t);
+    }
+    if (ids.length > 0) newSections.push({ title: label, agentIds: ids });
+  }
+
+  // Compute removed/retained vs the prior membership for the response.
+  const priorIds = new Set<string>();
+  for (const s of dashboard.layout.sections) {
+    for (const id of s.agentIds) priorIds.add(id);
+  }
+  const retained: string[] = [];
+  const removed: string[] = [];
+  for (const id of priorIds) {
+    if (seenIds.has(id)) retained.push(id);
+    else removed.push(id);
+  }
+
+  if (newSections.length === 0) {
+    res.json({
+      ok: false,
+      error: 'Refusing to commit an empty dashboard — at least one section with agents is required.',
+    });
+    return;
+  }
+
+  const newLayout: DashboardLayout = { sections: newSections };
+  try {
+    ctx.dashboardsStore!.updateLayout(dashboard.id, newLayout);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    res.status(500).json({ ok: false, error: `Failed to persist dashboard layout: ${msg}` });
+    return;
+  }
+
+  res.json({ ok: true, removed, retained });
+});
+
+// Reference unused imports defensively to keep tsc-clean if a future
+// refactor drops them — Agent is used via the agent-store call signature.
+void (null as unknown as Agent);

--- a/packages/dashboard/src/views/dashboards.ts
+++ b/packages/dashboard/src/views/dashboards.ts
@@ -14,6 +14,7 @@ import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
 import { renderTile } from './pulse-renderers.js';
 import { tileWrap, type PulseTile } from './pulse.js';
+import { improveLayoutButton, improveLayoutModal } from './improve-layout-modal.js';
 import {
   buildDashboardOptions,
   renderDashboardsDropdown,
@@ -79,6 +80,7 @@ export function renderDashboardPage(input: RenderDashboardPageInput): string {
           data-section-idx="0"
           data-section-agent-ids="${input.sections.flatMap((s) => s.agentIds).join(',')}"
           title="Add a tile to this dashboard">+ Add tile</button>
+        ${improveLayoutButton()}
         <button type="button" class="btn btn--ghost btn--sm" id="dashboard-edit-toggle">✎ Edit layout</button>
         <a class="btn btn--ghost btn--sm" href="/dashboards/${encodeURIComponent(input.dashboard.id)}/edit">Edit sections</a>
         <a class="btn btn--ghost btn--sm" href="/dashboards/${encodeURIComponent(input.dashboard.id)}/export" title="Download as a pack manifest YAML">Save as pack</a>
@@ -108,6 +110,11 @@ export function renderDashboardPage(input: RenderDashboardPageInput): string {
     ${buildFromGoalModal({
       availableDashboards: input.installedDashboards.filter((d) => !d.packId).map((d) => ({ id: d.id, name: d.name })),
       defaultDashboardId: input.dashboard.packId ? undefined : input.dashboard.id,
+    })}
+    ${improveLayoutModal({
+      endpointBase: `/dashboards/${encodeURIComponent(input.dashboard.id)}/layout-plan`,
+      storageKey: `sua-dashboard-layout-${input.dashboard.id}`,
+      curateVerb: 'remove',
     })}
   `;
 

--- a/packages/dashboard/src/views/improve-layout-modal.ts
+++ b/packages/dashboard/src/views/improve-layout-modal.ts
@@ -1,33 +1,69 @@
 /**
- * Shared markup for the "Improve layout" wizard modal on Pulse.
+ * Shared markup for the "Improve layout" wizard modal.
  *
- * Wizard JS is in improve-layout.js.ts and is wired in via layout.ts.
- * Binds to:
+ * Used on Pulse AND on each named dashboard page. The two surfaces
+ * differ in: which endpoints to hit, which localStorage key to read/
+ * write, and what "Apply" means (Pulse flips pulseVisible; dashboards
+ * rewrite section.agentIds).
+ *
+ * The differences are passed via `ImproveLayoutConfig`, serialised to
+ * data-* attributes on the modal element. The shared JS in
+ * `improve-layout.js.ts` reads them at open time.
+ *
+ * Wizard JS binds to:
  *   - #improve-layout-btn — opens the modal
- *   - #improve-layout-modal — backdrop
+ *   - #improve-layout-modal — backdrop (carries the data-* config)
  *   - #improve-layout-content — replaceable inner panel for stage swaps
  *   - #improve-layout-pills — pill row populated on open
  *   - #improve-layout-focus — free-form textarea
  *   - #improve-layout-submit — submit button
- *
- * Pulse page renders `improveLayoutButton()` next to the edit toggle
- * and `improveLayoutModal()` once at the bottom of the body.
  */
 
-import { html, type SafeHtml } from './html.js';
+import { html, unsafeHtml, type SafeHtml } from './html.js';
+
+/**
+ * Surface-specific configuration the modal JS needs at open time.
+ * Serialised onto data-attributes of the modal backdrop element.
+ */
+export interface ImproveLayoutConfig {
+  /** Endpoint base, e.g. "/pulse/layout-plan" or "/dashboards/<id>/layout-plan". */
+  endpointBase: string;
+  /** localStorage key, e.g. "sua-pulse-layout" or "sua-dashboard-layout-<id>". */
+  storageKey: string;
+  /**
+   * Verb shown to the user in the "Will N agents" details on the proposed
+   * plan ("hide" for Pulse, "remove" for named dashboards). The matching
+   * past-tense / restoration UX copy is wired up in the JS based on this.
+   */
+  curateVerb: 'hide' | 'remove';
+}
+
+/** Default config — Pulse. Keeps the existing caller signature working. */
+const PULSE_CONFIG: ImproveLayoutConfig = {
+  endpointBase: '/pulse/layout-plan',
+  storageKey: 'sua-pulse-layout',
+  curateVerb: 'hide',
+};
 
 export function improveLayoutButton(): SafeHtml {
   return html`<button type="button" class="btn btn--ghost btn--sm" id="improve-layout-btn">✨ Improve layout</button>`;
 }
 
-export function improveLayoutModal(): SafeHtml {
+export function improveLayoutModal(config: ImproveLayoutConfig = PULSE_CONFIG): SafeHtml {
+  // Data attributes are HTML-escaped by the html`` tag.
+  const attrs = unsafeHtml(
+    ` data-endpoint-base="${escapeAttr(config.endpointBase)}"`
+    + ` data-storage-key="${escapeAttr(config.storageKey)}"`
+    + ` data-curate-verb="${escapeAttr(config.curateVerb)}"`,
+  );
+  const verbNoun = config.curateVerb === 'remove' ? 'remove from this dashboard' : 'hide from Pulse';
   return html`
-    <div id="improve-layout-modal" class="modal-backdrop">
+    <div id="improve-layout-modal" class="modal-backdrop"${attrs}>
       <div class="modal" style="max-width: 640px; max-height: 85vh; overflow-y: auto;">
         <div id="improve-layout-content">
           <h3 style="margin: 0 0 var(--space-3);">Improve layout</h3>
           <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-3);">
-            Pick a suggestion or describe your own focus. The planner ranks your agents, groups them into containers, and asks clarifying questions before anything is applied.
+            Pick a suggestion or describe your own focus. The planner ranks your agents, groups them into containers, and asks clarifying questions before anything is applied. Agents not chosen will ${unsafeHtml(verbNoun)}.
           </p>
 
           <div style="margin-bottom: var(--space-3);">
@@ -51,4 +87,8 @@ export function improveLayoutModal(): SafeHtml {
       </div>
     </div>
   `;
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
 }

--- a/packages/dashboard/src/views/improve-layout.js.ts
+++ b/packages/dashboard/src/views/improve-layout.js.ts
@@ -19,7 +19,15 @@ export const IMPROVE_LAYOUT_JS = `
   var content = document.getElementById('improve-layout-content');
   if (!btn || !modal || !content) return;
 
-  var LAYOUT_KEY = 'sua-pulse-layout';
+  // Surface-specific config — set on the modal element by the view
+  // helper. Pulse uses /pulse/layout-plan + sua-pulse-layout + "hide".
+  // Each named dashboard uses /dashboards/<id>/layout-plan +
+  // sua-dashboard-layout-<id> + "remove".
+  var ENDPOINT_BASE = modal.getAttribute('data-endpoint-base') || '/pulse/layout-plan';
+  var LAYOUT_KEY = modal.getAttribute('data-storage-key') || 'sua-pulse-layout';
+  var CURATE_VERB = modal.getAttribute('data-curate-verb') || 'hide';
+  var CURATE_PAST = CURATE_VERB === 'remove' ? 'removed' : 'hidden';
+  var CURATE_BUCKET = CURATE_VERB === 'remove' ? 'this dashboard' : 'Pulse';
   var cachedAgentMetadata = null;
   var lastFocus = '';
 
@@ -41,7 +49,7 @@ export const IMPROVE_LAYOUT_JS = `
   function loadSuggestions() {
     var pills = document.getElementById('improve-layout-pills');
     if (!pills) return;
-    fetch('/pulse/layout-plan/suggestions', {
+    fetch(ENDPOINT_BASE + '/suggestions', {
       method: 'POST', credentials: 'same-origin',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ currentLayout: readLayout() }),
@@ -123,7 +131,7 @@ export const IMPROVE_LAYOUT_JS = `
       cancelled = true; clearInterval(tickTimer); clearTimeout(pollTimer); closeModal();
     });
 
-    fetch('/pulse/layout-plan', {
+    fetch(ENDPOINT_BASE, {
       method: 'POST', credentials: 'same-origin',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -143,7 +151,7 @@ export const IMPROVE_LAYOUT_JS = `
 
       function poll() {
         if (cancelled) return;
-        fetch('/pulse/layout-plan/' + encodeURIComponent(runId), { credentials: 'same-origin' })
+        fetch(ENDPOINT_BASE + '/' + encodeURIComponent(runId), { credentials: 'same-origin' })
           .then(function (r) { return r.json(); })
           .then(function (data) {
             if (!data.ok) {
@@ -318,8 +326,12 @@ export const IMPROVE_LAYOUT_JS = `
       willHideHtml =
         '<details style="margin:var(--space-3) 0;padding:var(--space-2) var(--space-3);border:1px solid var(--color-border);border-radius:var(--radius-sm);background:var(--color-surface-raised);">' +
         '<summary style="cursor:pointer;font-size:var(--font-size-sm);">' +
-        '<strong>Will hide ' + willHide.length + ' agent' + (willHide.length === 1 ? '' : 's') + '</strong> ' +
-        '<span class="dim" style="font-weight:var(--weight-regular);font-size:var(--font-size-xs);">(restore from the "hidden signals" section after applying)</span>' +
+        '<strong>Will ' + CURATE_VERB + ' ' + willHide.length + ' agent' + (willHide.length === 1 ? '' : 's') + '</strong> ' +
+        '<span class="dim" style="font-weight:var(--weight-regular);font-size:var(--font-size-xs);">' +
+          (CURATE_VERB === 'remove'
+            ? '(removed from this dashboard\\'s sections — restore with the Add tile button)'
+            : '(restore from the "hidden signals" section after applying)') +
+        '</span>' +
         '</summary>' +
         '<div style="display:flex;flex-wrap:wrap;gap:var(--space-1);margin-top:var(--space-2);">' + hideList + '</div></details>';
     }
@@ -387,7 +399,7 @@ export const IMPROVE_LAYOUT_JS = `
     var applyBtn = document.getElementById('improve-apply-btn');
     if (applyBtn) { applyBtn.disabled = true; applyBtn.textContent = 'Applying...'; }
 
-    fetch('/pulse/layout-plan/commit', {
+    fetch(ENDPOINT_BASE + '/commit', {
       method: 'POST', credentials: 'same-origin',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ containers: plan.containers || [] }),


### PR DESCRIPTION
## Summary

The "✨ Improve layout" wizard previously only worked on Pulse. This PR extends it to every named user-dashboard at \`/dashboards/<id>\`. Same modal, same planner agent, same flow — different storage key, different endpoints, different curation semantics.

## What's different for named dashboards

| | Pulse | Named dashboard |
|---|---|---|
| Endpoint base | \`/pulse/layout-plan\` | \`/dashboards/<id>/layout-plan\` |
| Storage key | \`sua-pulse-layout\` | \`sua-dashboard-layout-<id>\` |
| Curate verb | "hide" (\`pulseVisible: false\`) | "remove" (drop from \`sections[].agentIds\`) |
| Agent pool | All visible Pulse agents | Only agents currently in this dashboard |
| Recovery | "hidden signals" section | **Add tile** button |

## Why curation rewrites dashboard config

Named dashboards have no per-tile hide flag. Agent membership is declared in the dashboard config — \`dashboard.layout.sections[].agentIds[]\`. The Apply step rewrites that membership: the plan's containers become the new section list, and agents not in any container are removed. They're still in \`/agents\` (the underlying agent isn't deleted), so the user can put them back with **Add tile**.

The on-screen "Will N agents" details block reads "Will **remove** N agents" with the matching recovery copy.

## Shared modal, two configs

The Pulse and dashboard modals are now the same HTML + JS. The view helper takes an \`ImproveLayoutConfig\` object — \`{ endpointBase, storageKey, curateVerb }\` — that's serialised to \`data-*\` attributes on the modal element. The JS reads them at open time.

## Files

**New:**
- \`packages/dashboard/src/routes/dashboard-layout-plan.ts\` — four endpoints mirroring \`pulse-layout-plan.ts\` but scoped to a single dashboard
- \`.changeset/improve-layout-on-dashboards.md\`

**Modified:**
- \`packages/dashboard/src/views/improve-layout-modal.ts\` — \`improveLayoutModal(config?)\` accepts config; data-attrs on the modal element
- \`packages/dashboard/src/views/improve-layout.js.ts\` — reads data-attrs; uses \`ENDPOINT_BASE\` instead of hardcoded \`/pulse/layout-plan\`; copy varies by \`CURATE_VERB\`
- \`packages/dashboard/src/views/dashboards.ts\` — renders the button + modal with dashboard-scoped config
- \`packages/dashboard/src/index.ts\` — mounts the new router

## Test plan

- [x] \`npm test\` — **1482 passing + 3 skipped** (clean; the existing dashboards test that asserts \`not.toContain('signal/toggle')\` still passes — the improve-layout modal doesn't include that markup)
- [x] Clean rebuild succeeds
- [ ] Manual: visit \`/dashboards/<id>\` — see ✨ Improve layout button between Add tile and Edit layout
- [ ] Manual: click → suggestions load from the dashboard's agent pool (not Pulse's)
- [ ] Manual: submit a focus → plan renders with "Will remove N agents from this dashboard"
- [ ] Manual: Apply → \`sections[].agentIds\` rewritten; un-surfaced agents gone from the dashboard but still in \`/agents\`; new container arrangement in localStorage
- [ ] Manual: hit **Add tile** → previously-removed agents available to re-add

🤖 Generated with [Claude Code](https://claude.com/claude-code)