### PR TITLE
fix(layout-planner): curation-only scope + plain-text question format

### DIFF
--- a/.changeset/layout-planner-scope-and-question-format.md
+++ b/.changeset/layout-planner-scope-and-question-format.md
@@ -1,0 +1,14 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Constrain the layout-planner to curation-only and require plain-text question fields.
+
+Two prompt fixes after live testing:
+
+1. **Scope.** The planner was hallucinating a "suggest new agents" capability. It would list agents from training data (or from the prompt's own example agent ids) and claim to be adding them to the dashboard — but the commit endpoint can only curate within the agents already on the surface (`AGENT_METADATA`). The prompt now explicitly says: *you cannot suggest agents that aren't in `AGENT_METADATA`*. If the user's FOCUS asks for new agents, the planner emits a question redirecting them to Add tile / Build from goal. The `summary` field is also constrained — never claim to "suggest N new agents".
+2. **Question format.** Clarifying questions were rendering as raw `**markdown**` and unbroken text because the LLM was stuffing multi-line bulleted catalogs into a single question's `text` field. The renderer (correctly) escapes HTML. Prompt now requires: one short plain-text question per entry, no markdown, no line breaks, alternatives live in `options[]` for select-style rendering — not enumerated inside `text`.

--- a/agents/examples/layout-planner.yaml
+++ b/agents/examples/layout-planner.yaml
@@ -161,17 +161,62 @@ nodes:
 
       STEP 3 — ASK clarifying questions when FOCUS is ambiguous. Use
       `questions[]` for ambiguities the user must resolve before commit.
+
+      QUESTION FORMAT RULES (the renderer escapes HTML, so markdown
+      will appear as literal characters):
+      - `text` is ONE short question. No markdown, no bullet lists, no
+        line breaks, no `**bold**` or `*italic*`.
+      - When the user is picking between alternatives, populate
+        `options: ["A", "B", "C"]` and the renderer shows a select.
+        DO NOT enumerate options inside the `text` field with bullets.
+      - `suggestedAnswer` is the default pick, optional.
+
       Examples:
-      - FOCUS is empty AND there's no clear ranking signal → ask "Rank
-        by what — most recently run / most reliable / most frequent / I
-        will pin manually?" Include the options array for select-style
-        rendering.
-      - FOCUS mentions a topic that matches multiple distinct groups →
-        ask "Did you mean A or B?"
-      - Two-thirds of agents have never run → ask "Should I hide agents
-        that have never run from the layout?"
+      - FOCUS empty AND no clear ranking signal → text: "Rank by what?",
+        options: ["recency", "reliability", "frequency", "I'll pin manually"].
+      - FOCUS mentions a topic matching multiple groups → text:
+        "Which group did you mean?", options: ["Daily news", "Engineering monitors"].
+      - Two-thirds of agents have never run → text: "Hide agents that
+        have never run?", options: ["yes", "no"].
+
       Skip questions when FOCUS is specific and the metadata clearly
       supports a single answer. Empty `questions: []` is fine.
+
+      ════════════════════════════════════════════════════════════════
+      SCOPE RULES — what you CAN and CANNOT do
+      ════════════════════════════════════════════════════════════════
+
+      You CAN:
+      - Curate the agents already in AGENT_METADATA — choose which to
+        surface (in containers) and which to drop (outside containers,
+        which the commit step will hide or remove).
+      - Reorder containers and tiles.
+      - Suggest new container labels and groupings.
+
+      You CANNOT:
+      - Suggest agents that aren't already in AGENT_METADATA. If you
+        catch yourself listing "daily-greeting", "weather-dashboard",
+        "chart-creator-mcp", or any other id that doesn't appear in
+        AGENT_METADATA, DELETE that suggestion. The user can only see
+        agents already on this surface.
+      - Create new agents. That's a different agent's job
+        (build-planner / "Build from goal").
+      - Reference agents from your training data that aren't in
+        AGENT_METADATA. Doing so produces a plan the commit step
+        cannot apply.
+
+      If the user's FOCUS asks for new agents ("add a weather widget",
+      "I need a stock ticker"), emit a single plain-text question:
+        text: "I can only rearrange agents that are already on this
+          surface. To add new ones, use the Add tile button or Build
+          from goal. Should I proceed with rearranging what's here?"
+        options: ["yes, rearrange", "cancel"]
+      (No markdown, no bullet list — same format rules as every other
+      question. Keep it short.)
+
+      The plan's `summary` field MUST describe ONLY what you're doing
+      (rearranging the agents in AGENT_METADATA). NEVER claim to
+      "suggest N new agents" or "add" anything — that's outside scope.
 
       STEP 4 — emit the plan. Wrap the JSON in <plan>…</plan> tags.
       Output ONLY the <plan> block. No explanation before or after.


### PR DESCRIPTION
## Two bugs from live testing

### 1. Planner hallucinated a "suggest new agents" capability

You saw: *"Proposed layout — Suggesting 5 new agents to complement the existing dashboard: daily-greeting, weather-dashboard, chart-creator-mcp, churn-watcher, research-digest."* The actual topAgents list was your existing dashboard agents — because the commit endpoint can only rewrite \`sections[].agentIds\` from \`AGENT_METADATA\`. The planner can't add new agents; it shouldn't say it can.

Prompt now explicitly forbids it:

> You CANNOT suggest agents that aren't already in AGENT_METADATA. If you catch yourself listing "daily-greeting", "weather-dashboard", "chart-creator-mcp", or any other id that doesn't appear in AGENT_METADATA, DELETE that suggestion.

> The plan's \`summary\` field MUST describe ONLY what you're doing (rearranging the agents in AGENT_METADATA). NEVER claim to "suggest N new agents" or "add" anything — that's outside scope.

If the user's FOCUS asks for new agents ("add a stock ticker"), the planner now emits one short redirect question:

> "I can only rearrange agents that are already on this surface. To add new ones, use the Add tile button or Build from goal. Should I proceed with rearranging what's here?"

### 2. Clarifying questions rendered as raw markdown

You saw a single question whose \`text\` field contained a bulleted catalog with \`**bold**\` formatting — rendered as literal asterisks because the modal correctly HTML-escapes question text.

Prompt now requires plain-text questions:

> QUESTION FORMAT RULES (the renderer escapes HTML, so markdown will appear as literal characters):
> - \`text\` is ONE short question. No markdown, no bullet lists, no line breaks.
> - When the user is picking between alternatives, populate \`options: ["A", "B", "C"]\` and the renderer shows a select. DO NOT enumerate options inside the \`text\` field with bullets.

## Test plan

- [x] \`npm test\` — **1482 passing + 3 skipped** (prompt-example regression test still passes against the schema)
- [x] Clean rebuild succeeds
- [ ] Manual: rerun **Improve layout** on the dashboard that misbehaved → summary describes only what's being rearranged, no claim to "suggest N new agents"
- [ ] Manual: questions render as a single short line of text + (if applicable) a select dropdown — no \`**asterisks**\` visible
- [ ] Manual: FOCUS = "add a weather widget" → planner replies with a redirect question pointing at Add tile / Build from goal

🤖 Generated with [Claude Code](https://claude.com/claude-code)