### PR TITLE
feat(layout-planner): surface installed agents via toAdd (Path A)

### DIFF
--- a/.changeset/layout-planner-add-installed-agents.md
+++ b/.changeset/layout-planner-add-installed-agents.md
@@ -1,0 +1,11 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Layout planner can now surface installed agents that aren't on the current dashboard.
+
+The Improve-layout wizard previously only rearranged agents already on the surface (curation-only). It now also sees the rest of your installed catalog as `available` agents and can bring them onto Pulse or a named dashboard. The `LayoutPlan` schema gains an optional `toAdd[]` field; the wizard shows a "Will add N agents" details panel alongside the existing "Will hide/remove N agents" panel. Drafting brand-new agents that don't exist yet is still the job of build-planner / "Build from goal".

--- a/agents/examples/layout-planner.yaml
+++ b/agents/examples/layout-planner.yaml
@@ -36,8 +36,12 @@ inputs:
     type: string
     required: true
     description: >
-      JSON array of every visible agent with metadata used for ranking:
-      [{ "id", "title", "size"?, "lastRunAt"?, "successRate"?, "runCount30d"? }].
+      JSON array of agents the planner may surface. Each row carries
+      `available?: boolean` — true means the agent is installed but NOT
+      currently on this surface (eligible for `toAdd`); false/absent
+      means the agent is already on this surface (a "member").
+      Shape: [{ "id", "title", "size"?, "lastRunAt"?, "successRate"?,
+      "runCount30d"?, "available"?, "description"? }].
       Injected at request time by the route handler.
   FOCUS:
     type: string
@@ -68,7 +72,7 @@ nodes:
       CURRENT_LAYOUT (JSON, may be empty string):
       {{inputs.CURRENT_LAYOUT}}
 
-      AGENT_METADATA (JSON array, one row per visible agent):
+      AGENT_METADATA (JSON array, mixed members + available agents):
       {{inputs.AGENT_METADATA}}
 
       Each AGENT_METADATA row may have:
@@ -78,15 +82,26 @@ nodes:
       - lastRunAt: ISO timestamp of the most recent run — optional
       - successRate: 0-1 fraction over recent runs — optional
       - runCount30d: count of runs in the last 30 days — optional
+      - available: TRUE when the agent is installed but NOT currently
+        on this surface — you may bring it onto the surface by placing
+        it in a container AND listing its id in `toAdd[]`. FALSE/absent
+        means it's already a member of this surface.
+      - description: short agent description — only present for
+        available agents, used to match them against FOCUS.
 
       ════════════════════════════════════════════════════════════════
       WHAT YOU DO
       ════════════════════════════════════════════════════════════════
 
       STEP 1 — RANK. Pick the agents that should be most prominent on
-      Pulse. Use these signals (FOCUS overrides everything else):
+      Pulse. You're ranking BOTH members and selected available agents
+      together — an available agent that perfectly matches FOCUS should
+      rank above a stale member. Use these signals (FOCUS overrides
+      everything else):
       - If FOCUS names a topic ("API monitors", "weather"), match agent
-        titles + ids to it and rank those first.
+        titles + descriptions + ids to it and rank those first. If a
+        matching agent is `available: true`, surface it (add to a
+        container, declare in `toAdd[]`).
       - Otherwise, rank by a combination of recency + reliability +
         frequency. Agents that have never run or haven't run in 30+ days
         rank lower.
@@ -187,36 +202,51 @@ nodes:
       ════════════════════════════════════════════════════════════════
 
       You CAN:
-      - Curate the agents already in AGENT_METADATA — choose which to
-        surface (in containers) and which to drop (outside containers,
-        which the commit step will hide or remove).
+      - Curate members of this surface — choose which to keep in
+        containers and which to drop (un-surfaced agents get hidden on
+        Pulse or removed from this dashboard's sections).
+      - Bring AVAILABLE agents onto this surface. To add an available
+        agent, place it in a container AND list its id in `toAdd[]`.
+        Both are required: the container placement gives it a slot;
+        `toAdd[]` declares your intent so the UI can show "Will add N".
       - Reorder containers and tiles.
       - Suggest new container labels and groupings.
 
       You CANNOT:
-      - Suggest agents that aren't already in AGENT_METADATA. If you
+      - Suggest agents that aren't anywhere in AGENT_METADATA. If you
         catch yourself listing "daily-greeting", "weather-dashboard",
         "chart-creator-mcp", or any other id that doesn't appear in
-        AGENT_METADATA, DELETE that suggestion. The user can only see
-        agents already on this surface.
-      - Create new agents. That's a different agent's job
-        (build-planner / "Build from goal").
+        AGENT_METADATA, DELETE that suggestion. Drafting brand-new
+        agents is a different agent's job (build-planner / "Build from
+        goal").
       - Reference agents from your training data that aren't in
         AGENT_METADATA. Doing so produces a plan the commit step
         cannot apply.
 
-      If the user's FOCUS asks for new agents ("add a weather widget",
-      "I need a stock ticker"), emit a single plain-text question:
-        text: "I can only rearrange agents that are already on this
-          surface. To add new ones, use the Add tile button or Build
-          from goal. Should I proceed with rearranging what's here?"
-        options: ["yes, rearrange", "cancel"]
-      (No markdown, no bullet list — same format rules as every other
-      question. Keep it short.)
+      When to use `toAdd`:
+      - FOCUS mentions a topic and an `available` agent matches it
+        ("surface my weather agents" when weather-forecast is
+        available) — add it.
+      - FOCUS is vague and the user has many available agents — prefer
+        rearranging members; only add an available agent when you have
+        a concrete reason (matches FOCUS, fills an obvious gap).
+      - Be conservative: cap `toAdd` at ~8 agents per run. Each Apply
+        is destructive (hides un-surfaced members), so don't bury the
+        change in a flood of additions.
 
-      The plan's `summary` field MUST describe ONLY what you're doing
-      (rearranging the agents in AGENT_METADATA). NEVER claim to
-      "suggest N new agents" or "add" anything — that's outside scope.
+      If FOCUS asks for an agent that does NOT exist in AGENT_METADATA
+      ("add a stock ticker" when no stock agent is installed or
+      available), emit a single plain-text question:
+        text: "No stock ticker agent is installed yet. I can only
+          surface agents you already have. Want me to proceed with
+          what's here, or cancel so you can draft a new agent with
+          Build from goal?"
+        options: ["proceed with installed agents", "cancel"]
+      (No markdown, no bullet list. Keep it short.)
+
+      The plan's `summary` field SHOULD reflect what you actually did
+      ("Rearranged 8 agents and added 2 from your catalog"). Don't
+      claim to draft new agents — that's not in scope.
 
       STEP 4 — emit the plan. Wrap the JSON in <plan>…</plan> tags.
       Output ONLY the <plan> block. No explanation before or after.
@@ -227,7 +257,7 @@ nodes:
 
       <plan>
       {
-        "summary": "Grouped 12 agents into 3 containers: Monitoring, Daily news, Misc. Topped by api-monitor and hn-top-3.",
+        "summary": "Grouped 12 agents into 3 containers and surfaced 1 available agent (weather-forecast) to match FOCUS=daily.",
         "topAgents": [
           { "id": "api-monitor", "rationale": "runs every 5 minutes, 100% success last 30d", "suggestedSize": "2x1" },
           { "id": "hn-top-3", "rationale": "matches FOCUS=news, ran successfully today", "suggestedSize": "2x2" }
@@ -238,6 +268,7 @@ nodes:
           { "label": "Daily news", "tiles": ["hn-top-3", "weather-forecast"] },
           { "label": "Light reading", "tiles": ["daily-joke"] }
         ],
+        "toAdd": ["weather-forecast"],
         "questions": [
           {
             "text": "Rank by what?",
@@ -263,6 +294,9 @@ nodes:
       - `suggestedSize` if set must be one of "1x1", "2x1", "1x2", "2x2".
       - `questions[]` may be empty. When set, each entry has non-empty
         `text`; `suggestedAnswer` and `options` are optional.
+      - `toAdd[]` may be empty (the common case). When set, every id
+        MUST also appear in some container's `tiles[]` — declaring an
+        add without placing it is a validation error. No duplicates.
 
       Output ONLY the <plan>…</plan> block. No explanation before or after.
     maxTurns: 3

--- a/packages/core/src/layout-plan-schema.test.ts
+++ b/packages/core/src/layout-plan-schema.test.ts
@@ -157,4 +157,45 @@ describe('layoutPlanSchema', () => {
     const r = layoutPlanSchema.safeParse({ ...validPlan, summary: '' });
     expect(r.success).toBe(false);
   });
+
+  it('defaults toAdd to an empty array when omitted', () => {
+    const r = layoutPlanSchema.safeParse(validPlan);
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.toAdd).toEqual([]);
+  });
+
+  it('accepts toAdd when every id is placed in a container', () => {
+    const r = layoutPlanSchema.safeParse({
+      ...validPlan,
+      containers: [
+        { label: 'Monitoring', tiles: ['api-monitor'] },
+        { label: 'Personal', tiles: ['weather-forecast', 'stock-ticker'] },
+      ],
+      toAdd: ['stock-ticker'],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects toAdd ids that are not placed in any container', () => {
+    const r = layoutPlanSchema.safeParse({
+      ...validPlan,
+      toAdd: ['phantom-agent'],
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.message.includes('not placed in any container'))).toBe(true);
+    }
+  });
+
+  it('rejects duplicate toAdd ids', () => {
+    const r = layoutPlanSchema.safeParse({
+      ...validPlan,
+      containers: [
+        { label: 'Monitoring', tiles: ['api-monitor', 'stock-ticker'] },
+        { label: 'Personal', tiles: ['weather-forecast'] },
+      ],
+      toAdd: ['stock-ticker', 'stock-ticker'],
+    });
+    expect(r.success).toBe(false);
+  });
 });

--- a/packages/core/src/layout-plan-schema.ts
+++ b/packages/core/src/layout-plan-schema.ts
@@ -68,6 +68,16 @@ export const layoutPlanSchema = z.object({
     /** When set, render as a select instead of a free-form textarea. */
     options: z.array(z.string().min(1)).optional(),
   })).default([]),
+
+  /**
+   * Installed-but-not-yet-on-this-surface agents the planner is bringing
+   * onto the surface. Declarative signal — the commit step also infers
+   * the same agents from container membership, so this field is for UI
+   * affordance ("Will add N agents") and contract clarity. Every id here
+   * MUST also appear in some container's `tiles[]`.
+   */
+  toAdd: z.array(z.string().regex(AGENT_ID_RE, 'toAdd[] must be a valid agent id'))
+    .default([]),
 }).superRefine((plan, ctx) => {
   // Tiles must reference agents declared in topAgents OR be marked as
   // additional context (full agent metadata reaches the planner; the
@@ -120,6 +130,30 @@ export const layoutPlanSchema = z.object({
       });
     } else {
       seenAgents.set(a.id, aIdx);
+    }
+  });
+
+  // toAdd entries must be unique AND must be placed in some container —
+  // declaring an agent in toAdd but not placing it would leave it
+  // unsurfaced even though the planner said it wanted to add it.
+  const seenToAdd = new Map<string, number>();
+  plan.toAdd.forEach((id, idx) => {
+    const prev = seenToAdd.get(id);
+    if (prev !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['toAdd', idx],
+        message: `toAdd[${idx}] "${id}" duplicates toAdd[${prev}]`,
+      });
+      return;
+    }
+    seenToAdd.set(id, idx);
+    if (!seenTiles.has(id)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['toAdd', idx],
+        message: `toAdd[${idx}] "${id}" is not placed in any container — every added agent must be assigned to a container`,
+      });
     }
   });
 });

--- a/packages/dashboard/src/lib/layout-suggestions.ts
+++ b/packages/dashboard/src/lib/layout-suggestions.ts
@@ -22,6 +22,15 @@ export interface LayoutSuggestionAgent {
   successRate?: number | null;
   /** Count of runs in the last 30 days. */
   runCount30d?: number | null;
+  /**
+   * True when this agent is installed but not yet on the current surface —
+   * the planner may surface it via `toAdd`. False/omitted means already
+   * on this surface (a "member"). Pill heuristics ignore available
+   * agents; only the LLM planner sees them.
+   */
+  available?: boolean;
+  /** Short description from the agent metadata, used by the planner to match available agents against FOCUS. */
+  description?: string;
 }
 
 export interface CurrentLayout {
@@ -183,7 +192,10 @@ export function computeLayoutSuggestions(
   layout: CurrentLayout | null,
   now: number = Date.now(),
 ): LayoutSuggestion[] {
-  const dynamic = computeDynamicSuggestions(agents, layout, now);
+  // Pill heuristics only consider members (already on this surface).
+  // Available-but-not-here agents are LLM-only signal.
+  const members = agents.filter((a) => !a.available);
+  const dynamic = computeDynamicSuggestions(members, layout, now);
   const remaining = MAX_SUGGESTIONS - dynamic.length;
   const fillers = STATIC_SUGGESTIONS.slice(0, Math.max(0, remaining));
   return [...dynamic, ...fillers];

--- a/packages/dashboard/src/routes/dashboard-layout-plan.ts
+++ b/packages/dashboard/src/routes/dashboard-layout-plan.ts
@@ -71,7 +71,8 @@ function gatherDashboardAgentMetadata(
   for (const section of dashboard.layout.sections) {
     for (const id of section.agentIds) memberIds.add(id);
   }
-  if (memberIds.size === 0) return [];
+  // No early return on empty dashboards — the planner can still suggest
+  // adding installed agents via `toAdd`.
 
   // Pull recent run window once and aggregate by agent.
   let recent: Array<{ agentName: string; status: string; startedAt: string }> = [];
@@ -129,6 +130,21 @@ function gatherDashboardAgentMetadata(
     } else {
       row.runCount30d = 0;
     }
+    out.push(row);
+  }
+
+  // Available agents: installed and renderable (have a signal block) but
+  // not currently a member of this dashboard. The planner may surface
+  // them via `toAdd`; the commit step appends them into containers.
+  for (const agent of ctx.agentStore.listAgents()) {
+    if (memberIds.has(agent.id)) continue;
+    if (!agent.signal) continue;
+    const row: LayoutSuggestionAgent = {
+      id: agent.id,
+      title: agent.signal.title,
+      available: true,
+    };
+    if (agent.description) row.description = agent.description;
     out.push(row);
   }
   return out;
@@ -239,7 +255,7 @@ dashboardLayoutPlanRouter.post('/dashboards/:id/layout-plan', async (req: Reques
   }
 
   if (agentMetadata.length === 0) {
-    res.json({ ok: false, error: 'This dashboard has no renderable agents to lay out. Add tiles first via the Add tile button.' });
+    res.json({ ok: false, error: 'No installed agents with a Pulse signal — create one before planning a layout.' });
     return;
   }
 
@@ -337,8 +353,10 @@ dashboardLayoutPlanRouter.post('/dashboards/:id/layout-plan/commit', (req: Reque
   const containersRaw = Array.isArray(body.containers) ? body.containers : [];
 
   // Build the new section list from the plan's containers, filtering
-  // out system tiles and de-duplicating ids.
+  // out system tiles, de-duplicating ids, and dropping ids that don't
+  // resolve to a real installed agent (phantom suggestions from the LLM).
   const seenIds = new Set<string>();
+  const skippedUnknown: string[] = [];
   const newSections: Array<{ title: string; agentIds: string[] }> = [];
   for (const c of containersRaw) {
     if (!c || typeof c !== 'object') continue;
@@ -354,22 +372,32 @@ dashboardLayoutPlanRouter.post('/dashboards/:id/layout-plan/commit', (req: Reque
       if (typeof t !== 'string') continue;
       if (t.startsWith('_')) continue; // skip Pulse system tiles
       if (seenIds.has(t)) continue;
+      if (!ctx.agentStore.getAgent(t)) {
+        skippedUnknown.push(t);
+        continue;
+      }
       seenIds.add(t);
       ids.push(t);
     }
     if (ids.length > 0) newSections.push({ title: label, agentIds: ids });
   }
 
-  // Compute removed/retained vs the prior membership for the response.
+  // Compute removed/retained/added vs the prior membership for the
+  // response. `added` is the newly-surfaced delta (installed agents
+  // that weren't on this dashboard before but are now).
   const priorIds = new Set<string>();
   for (const s of dashboard.layout.sections) {
     for (const id of s.agentIds) priorIds.add(id);
   }
   const retained: string[] = [];
   const removed: string[] = [];
+  const added: string[] = [];
   for (const id of priorIds) {
     if (seenIds.has(id)) retained.push(id);
     else removed.push(id);
+  }
+  for (const id of seenIds) {
+    if (!priorIds.has(id)) added.push(id);
   }
 
   if (newSections.length === 0) {
@@ -389,7 +417,7 @@ dashboardLayoutPlanRouter.post('/dashboards/:id/layout-plan/commit', (req: Reque
     return;
   }
 
-  res.json({ ok: true, removed, retained });
+  res.json({ ok: true, removed, retained, added, skippedUnknown });
 });
 
 // Reference unused imports defensively to keep tsc-clean if a future

--- a/packages/dashboard/src/routes/pulse-layout-plan.ts
+++ b/packages/dashboard/src/routes/pulse-layout-plan.ts
@@ -59,7 +59,13 @@ function isVisibleOnPulse(agent: Agent): boolean {
  * for typical installs.
  */
 function gatherAgentMetadata(ctx: ReturnType<typeof getContext>, now: number): LayoutSuggestionAgent[] {
-  const agents = ctx.agentStore.listAgents().filter(isVisibleOnPulse);
+  const all = ctx.agentStore.listAgents();
+  const agents = all.filter(isVisibleOnPulse);
+  // Available = installed agents that COULD render on Pulse (have a
+  // signal block) but are currently hidden. The planner can surface
+  // them via `toAdd`. Agents with no signal block are skipped — they
+  // can't render as Pulse tiles regardless.
+  const availableAgents = all.filter((a) => a.signal && !isVisibleOnPulse(a));
   // Pull the recent run window once.
   let recent: Array<{ agentName: string; status: string; startedAt: string }> = [];
   try {
@@ -96,7 +102,7 @@ function gatherAgentMetadata(ctx: ReturnType<typeof getContext>, now: number): L
     /* run store unavailable */
   }
 
-  return agents.map((a) => {
+  const members = agents.map((a) => {
     const cell = byAgent.get(a.id);
     const allTime = allTimeLast.get(a.id);
     const lastTs = cell?.last ?? allTime;
@@ -113,6 +119,20 @@ function gatherAgentMetadata(ctx: ReturnType<typeof getContext>, now: number): L
     }
     return out;
   });
+
+  const available = availableAgents.map((a) => {
+    const row: LayoutSuggestionAgent = {
+      id: a.id,
+      title: a.signal?.title,
+      available: true,
+    };
+    if (a.description) row.description = a.description;
+    const allTime = allTimeLast.get(a.id);
+    if (allTime !== undefined) row.lastRunAt = new Date(allTime).toISOString();
+    return row;
+  });
+
+  return [...members, ...available];
 }
 
 function parseCurrentLayout(body: Record<string, unknown>): CurrentLayout | null {
@@ -227,7 +247,7 @@ pulseLayoutPlanRouter.post('/pulse/layout-plan', async (req: Request, res: Respo
   }
 
   if (agentMetadata.length === 0) {
-    res.json({ ok: false, error: 'No visible agents on Pulse — nothing to lay out. Create an agent first.' });
+    res.json({ ok: false, error: 'No agents installed — nothing to lay out. Create an agent first.' });
     return;
   }
 
@@ -322,6 +342,9 @@ pulseLayoutPlanRouter.get('/pulse/layout-plan/:runId', (req: Request, res: Respo
  *
  * Body: { containers: Array<{ label, tiles: string[] }> }
  * Returns: { ok, hidden: string[], unhidden: string[] }
+ *
+ * `unhidden` doubles as the "added to surface" list — Path A surfaces
+ * installed-but-hidden agents by flipping pulseVisible:true.
  */
 pulseLayoutPlanRouter.post('/pulse/layout-plan/commit', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);

--- a/packages/dashboard/src/views/improve-layout.js.ts
+++ b/packages/dashboard/src/views/improve-layout.js.ts
@@ -305,8 +305,10 @@ export const IMPROVE_LAYOUT_JS = `
         '<div style="text-align:right;"><button type="button" class="btn btn--ghost btn--sm" id="improve-update-btn">Update plan</button></div></div>';
     }
 
-    // Compute which agents will be hidden: every visible agent that
+    // Compute which agents will be hidden: every MEMBER agent that
     // isn't referenced by any container (system tiles excluded).
+    // Available agents aren't "hidden" if un-surfaced — they were
+    // never on this surface to begin with.
     var surfacedSet = {};
     (plan.containers || []).forEach(function (c) {
       (c.tiles || []).forEach(function (t) {
@@ -317,9 +319,38 @@ export const IMPROVE_LAYOUT_JS = `
     if (Array.isArray(cachedAgentMetadata)) {
       for (var hi = 0; hi < cachedAgentMetadata.length; hi++) {
         var ai = cachedAgentMetadata[hi];
-        if (ai && ai.id && !surfacedSet[ai.id]) willHide.push(ai.id);
+        if (!ai || !ai.id || ai.available) continue;
+        if (!surfacedSet[ai.id]) willHide.push(ai.id);
       }
     }
+
+    // willAdd: the plan's toAdd[] — installed-but-not-here agents
+    // being brought onto this surface. Falls back to inferring from
+    // container membership when toAdd is empty (older plans).
+    var willAdd = [];
+    if (Array.isArray(plan.toAdd) && plan.toAdd.length > 0) {
+      willAdd = plan.toAdd.filter(function (id) { return typeof id === 'string' && id.charAt(0) !== '_'; });
+    } else if (Array.isArray(cachedAgentMetadata)) {
+      for (var ai2 = 0; ai2 < cachedAgentMetadata.length; ai2++) {
+        var m = cachedAgentMetadata[ai2];
+        if (m && m.available && m.id && surfacedSet[m.id]) willAdd.push(m.id);
+      }
+    }
+    var willAddHtml = '';
+    if (willAdd.length > 0) {
+      var addList = willAdd.map(function (id) { return '<code style="font-size:var(--font-size-xs);background:var(--color-surface-raised);padding:0 var(--space-1);border-radius:var(--radius-sm);">' + esc(id) + '</code>'; }).join(' ');
+      var addBucket = CURATE_VERB === 'remove' ? 'this dashboard' : 'Pulse';
+      willAddHtml =
+        '<details style="margin:var(--space-3) 0;padding:var(--space-2) var(--space-3);border:1px solid var(--color-border);border-radius:var(--radius-sm);background:var(--color-surface-raised);">' +
+        '<summary style="cursor:pointer;font-size:var(--font-size-sm);">' +
+        '<strong>Will add ' + willAdd.length + ' agent' + (willAdd.length === 1 ? '' : 's') + ' to ' + addBucket + '</strong> ' +
+        '<span class="dim" style="font-weight:var(--weight-regular);font-size:var(--font-size-xs);">' +
+          '(installed but not yet on this surface)' +
+        '</span>' +
+        '</summary>' +
+        '<div style="display:flex;flex-wrap:wrap;gap:var(--space-1);margin-top:var(--space-2);">' + addList + '</div></details>';
+    }
+
     var willHideHtml = '';
     if (willHide.length > 0) {
       var hideList = willHide.map(function (id) { return '<code style="font-size:var(--font-size-xs);background:var(--color-surface-raised);padding:0 var(--space-1);border-radius:var(--radius-sm);">' + esc(id) + '</code>'; }).join(' ');
@@ -344,6 +375,7 @@ export const IMPROVE_LAYOUT_JS = `
       '<div style="margin-bottom:var(--space-4);">' + topRows + '</div>' +
       '<div style="font-size:var(--font-size-xs);color:var(--color-text-muted);font-weight:var(--weight-semibold);text-transform:uppercase;letter-spacing:0.06em;margin-bottom:var(--space-1);">Containers</div>' +
       '<div style="margin-bottom:var(--space-2);">' + containerRows + '</div>' +
+      willAddHtml +
       willHideHtml +
       questionsHtml +
       '<div style="margin-top:var(--space-4);padding-top:var(--space-3);border-top:1px solid var(--color-border);display:flex;gap:var(--space-2);justify-content:flex-end;">' +


### PR DESCRIPTION
## Summary
- Layout planner now sees the full installed catalog, not just members of the current surface. Agents installed but not yet on Pulse / this dashboard come through as `available: true` rows in `AGENT_METADATA`.
- New optional `toAdd[]` field on `LayoutPlan` — the planner declares which available agents it's bringing onto the surface; schema validates every id is also placed in a container.
- Wizard renders a "Will add N agents" details panel paired with the existing "Will hide/remove N" panel.
- Dashboard commit validates ids against `agentStore` (drops phantom suggestions) and returns `added` + `skippedUnknown` alongside `removed` + `retained`.

Drafting brand-new agents that don't exist anywhere is still build-planner's job — Path B in `~/.claude/plans/handoff-layout-planner-meets-build-planner.md` covers that follow-on.

## Test plan
- [x] `npm test` — 1486 passing, 3 skipped. 4 new tests on `toAdd` schema validation.
- [x] `npm run build` — clean.
- [ ] Manual: install an agent, hide it from Pulse, run Improve layout with a matching FOCUS, confirm the planner adds it to `toAdd[]` and that Apply unhides it.
- [ ] Manual: on a named dashboard, run Improve layout with FOCUS naming an installed-but-not-here agent; confirm it lands in a section after Apply.
- [ ] Manual: ask for a brand-new agent ("add a stock ticker" with none installed); confirm the planner emits the redirect question instead of inventing an id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)