### PR TITLE
feat(layout-planner): needsNew[] for draft suggestions + prompt cleanup

### DIFF
--- a/.changeset/layout-planner-needs-new.md
+++ b/.changeset/layout-planner-needs-new.md
@@ -1,0 +1,16 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Layout planner can now suggest brand-new agents to draft (Path B-lite), and the wizard stops calling installed agents "new".
+
+Two changes:
+
+- **Prompt vocabulary** — the planner used to call already-installed agents "new" when surfacing them via `toAdd`, which implied fresh code. It now says "from your catalog" / "already installed" and reserves "new" for agents that don't exist yet.
+- **`needsNew[]`** — a new optional field on `LayoutPlan` for brand-new agent specs (`purpose` + optional `suggestedName`). When FOCUS asks for an agent that doesn't exist anywhere, the planner emits the spec here instead of inventing an id. The wizard renders a "Draft N new agents" section with a link to Build from goal; drafting happens out-of-band, and the user re-runs Improve layout afterward to surface the new agent. Schema validates that needsNew names don't collide with container tiles or `toAdd[]`.
+
+Full inline build-planner orchestration (Path B proper) is still deferred.

--- a/agents/examples/layout-planner.yaml
+++ b/agents/examples/layout-planner.yaml
@@ -12,6 +12,11 @@
 # The wizard renders the plan, lets the user answer questions to refine
 # (re-runs with appended context), then applies — the apply step writes
 # the proposed containers to localStorage and reloads the Pulse view.
+#
+# The planner can also suggest brand-new agents that don't exist yet
+# via `needsNew[]`. The wizard surfaces these as a "Draft these agents"
+# link to Build from goal; nothing is committed inline — the user re-runs
+# Improve layout after drafting and the new agents appear as `available`.
 
 id: layout-planner
 name: Layout Planner
@@ -205,23 +210,33 @@ nodes:
       - Curate members of this surface — choose which to keep in
         containers and which to drop (un-surfaced agents get hidden on
         Pulse or removed from this dashboard's sections).
-      - Bring AVAILABLE agents onto this surface. To add an available
-        agent, place it in a container AND list its id in `toAdd[]`.
-        Both are required: the container placement gives it a slot;
+      - Bring AVAILABLE agents (already installed, not yet on this
+        surface) onto this surface. To surface an available agent,
+        place it in a container AND list its id in `toAdd[]`. Both
+        are required: the container placement gives it a slot;
         `toAdd[]` declares your intent so the UI can show "Will add N".
+      - Suggest agents that DO NOT exist yet, by listing short specs
+        in `needsNew[]`. The user will be sent to Build from goal to
+        draft them; they re-run Improve layout afterward and the new
+        agent appears as available.
       - Reorder containers and tiles.
       - Suggest new container labels and groupings.
 
       You CANNOT:
-      - Suggest agents that aren't anywhere in AGENT_METADATA. If you
-        catch yourself listing "daily-greeting", "weather-dashboard",
-        "chart-creator-mcp", or any other id that doesn't appear in
-        AGENT_METADATA, DELETE that suggestion. Drafting brand-new
-        agents is a different agent's job (build-planner / "Build from
-        goal").
+      - Invent agent ids and place them in containers or `toAdd[]`.
+        Every id in containers and `toAdd[]` MUST appear in
+        AGENT_METADATA. Brand-new agents go in `needsNew[]` ONLY
+        — they're specs, not ids; the commit step ignores them.
       - Reference agents from your training data that aren't in
         AGENT_METADATA. Doing so produces a plan the commit step
         cannot apply.
+
+      VOCABULARY: NEVER call an installed-but-not-here agent "new".
+      Available agents are "installed", "from your catalog", or
+      "already installed". The word "new" is reserved for agents
+      that don't exist yet (the `needsNew[]` list). Mis-labeling
+      breaks user trust — they think they're getting fresh code
+      when you're actually just surfacing what they already had.
 
       When to use `toAdd`:
       - FOCUS mentions a topic and an `available` agent matches it
@@ -234,19 +249,30 @@ nodes:
         is destructive (hides un-surfaced members), so don't bury the
         change in a flood of additions.
 
-      If FOCUS asks for an agent that does NOT exist in AGENT_METADATA
-      ("add a stock ticker" when no stock agent is installed or
-      available), emit a single plain-text question:
-        text: "No stock ticker agent is installed yet. I can only
-          surface agents you already have. Want me to proceed with
-          what's here, or cancel so you can draft a new agent with
-          Build from goal?"
-        options: ["proceed with installed agents", "cancel"]
-      (No markdown, no bullet list. Keep it short.)
+      When to use `needsNew`:
+      - FOCUS names an agent that does NOT exist in AGENT_METADATA
+        ("add a stock ticker" when no stock agent is installed or
+        available) — emit a `needsNew[]` entry instead of pretending
+        the agent exists.
+      - Each entry is `{ purpose, suggestedName? }`. `purpose` is one
+        plain sentence describing what the agent should do ("Show the
+        current price of a configurable stock ticker"). `suggestedName`
+        is optional lowercase-with-dashes ("stock-ticker") — the
+        build-planner may rename it.
+      - Cap at 3 per run. The user has to draft each one manually in
+        Build from goal; long lists are wasted suggestions.
+      - NEVER include a needsNew id in containers or `toAdd[]` — those
+        agents don't exist yet. They appear in the layout only after
+        the user drafts them and re-runs Improve layout.
 
-      The plan's `summary` field SHOULD reflect what you actually did
-      ("Rearranged 8 agents and added 2 from your catalog"). Don't
-      claim to draft new agents — that's not in scope.
+      The plan's `summary` field SHOULD reflect what you actually did,
+      using the right vocabulary:
+      - "Rearranged 8 agents and added 2 from your catalog."
+      - "Surfaced weather-forecast and api-monitor (already installed)."
+      - "Suggested 1 agent to draft (stock-ticker) — see Build from
+        goal."
+      Never write "Suggesting 2 new agents" when you mean two already-
+      installed agents. That phrasing implies fresh code.
 
       STEP 4 — emit the plan. Wrap the JSON in <plan>…</plan> tags.
       Output ONLY the <plan> block. No explanation before or after.
@@ -257,7 +283,7 @@ nodes:
 
       <plan>
       {
-        "summary": "Grouped 12 agents into 3 containers and surfaced 1 available agent (weather-forecast) to match FOCUS=daily.",
+        "summary": "Grouped 12 agents into 3 containers and surfaced 1 from your catalog (weather-forecast) to match FOCUS=daily. Suggested 1 agent to draft (stock-ticker).",
         "topAgents": [
           { "id": "api-monitor", "rationale": "runs every 5 minutes, 100% success last 30d", "suggestedSize": "2x1" },
           { "id": "hn-top-3", "rationale": "matches FOCUS=news, ran successfully today", "suggestedSize": "2x2" }
@@ -269,6 +295,9 @@ nodes:
           { "label": "Light reading", "tiles": ["daily-joke"] }
         ],
         "toAdd": ["weather-forecast"],
+        "needsNew": [
+          { "purpose": "Show the current price and 24h change for a configurable stock ticker.", "suggestedName": "stock-ticker" }
+        ],
         "questions": [
           {
             "text": "Rank by what?",
@@ -297,6 +326,10 @@ nodes:
       - `toAdd[]` may be empty (the common case). When set, every id
         MUST also appear in some container's `tiles[]` — declaring an
         add without placing it is a validation error. No duplicates.
+      - `needsNew[]` may be empty. When set, each entry has a non-empty
+        `purpose`; `suggestedName` (if set) must be valid
+        lowercase-with-dashes. Never reference a needsNew name from
+        containers or `toAdd[]`.
 
       Output ONLY the <plan>…</plan> block. No explanation before or after.
     maxTurns: 3

--- a/packages/core/src/layout-plan-schema.test.ts
+++ b/packages/core/src/layout-plan-schema.test.ts
@@ -187,6 +187,63 @@ describe('layoutPlanSchema', () => {
     }
   });
 
+  it('defaults needsNew to an empty array when omitted', () => {
+    const r = layoutPlanSchema.safeParse(validPlan);
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.needsNew).toEqual([]);
+  });
+
+  it('accepts needsNew specs with a purpose and optional suggestedName', () => {
+    const r = layoutPlanSchema.safeParse({
+      ...validPlan,
+      needsNew: [
+        { purpose: 'Show stock prices.', suggestedName: 'stock-ticker' },
+        { purpose: 'Track crypto prices.' },
+      ],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects needsNew entries with an empty purpose', () => {
+    const r = layoutPlanSchema.safeParse({
+      ...validPlan,
+      needsNew: [{ purpose: '', suggestedName: 'stock-ticker' }],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects needsNew.suggestedName that collides with a container tile', () => {
+    const r = layoutPlanSchema.safeParse({
+      ...validPlan,
+      needsNew: [{ purpose: 'fake', suggestedName: 'api-monitor' }],
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.message.includes("appears in a container"))).toBe(true);
+    }
+  });
+
+  it('rejects needsNew.suggestedName that collides with toAdd', () => {
+    const r = layoutPlanSchema.safeParse({
+      ...validPlan,
+      containers: [
+        { label: 'Monitoring', tiles: ['api-monitor'] },
+        { label: 'Personal', tiles: ['weather-forecast', 'stock-ticker'] },
+      ],
+      toAdd: ['stock-ticker'],
+      needsNew: [{ purpose: 'fake', suggestedName: 'stock-ticker' }],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects malformed needsNew.suggestedName', () => {
+    const r = layoutPlanSchema.safeParse({
+      ...validPlan,
+      needsNew: [{ purpose: 'fake', suggestedName: 'Has Spaces' }],
+    });
+    expect(r.success).toBe(false);
+  });
+
   it('rejects duplicate toAdd ids', () => {
     const r = layoutPlanSchema.safeParse({
       ...validPlan,

--- a/packages/core/src/layout-plan-schema.ts
+++ b/packages/core/src/layout-plan-schema.ts
@@ -78,6 +78,21 @@ export const layoutPlanSchema = z.object({
    */
   toAdd: z.array(z.string().regex(AGENT_ID_RE, 'toAdd[] must be a valid agent id'))
     .default([]),
+
+  /**
+   * Brand-new agents the planner thinks the user should draft, but
+   * which don't exist anywhere yet. The wizard surfaces these as a
+   * "Draft these agents" link to Build from goal — drafting happens
+   * out-of-band; nothing is committed inline. After the user drafts
+   * + saves, they re-run Improve layout and the new agent appears as
+   * `available`. `purpose` is a one-sentence description; `suggestedName`
+   * is an optional lowercase-with-dashes proposal that build-planner
+   * may rename.
+   */
+  needsNew: z.array(z.object({
+    purpose: z.string().min(1, 'needsNew.purpose is required'),
+    suggestedName: z.string().regex(AGENT_ID_RE, 'needsNew.suggestedName must be lowercase-with-dashes-or-underscores').optional(),
+  })).default([]),
 }).superRefine((plan, ctx) => {
   // Tiles must reference agents declared in topAgents OR be marked as
   // additional context (full agent metadata reaches the planner; the
@@ -153,6 +168,39 @@ export const layoutPlanSchema = z.object({
         code: z.ZodIssueCode.custom,
         path: ['toAdd', idx],
         message: `toAdd[${idx}] "${id}" is not placed in any container — every added agent must be assigned to a container`,
+      });
+    }
+  });
+
+  // needsNew entries are specs, not ids — they MUST NOT appear in any
+  // container or in toAdd[]. A suggestedName matching a container tile
+  // means the planner is conflating an existing-id placement with a
+  // draft-this-agent suggestion.
+  const seenNeedsNew = new Map<string, number>();
+  plan.needsNew.forEach((entry, idx) => {
+    if (!entry.suggestedName) return;
+    const prev = seenNeedsNew.get(entry.suggestedName);
+    if (prev !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['needsNew', idx, 'suggestedName'],
+        message: `needsNew[${idx}].suggestedName "${entry.suggestedName}" duplicates needsNew[${prev}].suggestedName`,
+      });
+      return;
+    }
+    seenNeedsNew.set(entry.suggestedName, idx);
+    if (seenTiles.has(entry.suggestedName)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['needsNew', idx, 'suggestedName'],
+        message: `needsNew[${idx}].suggestedName "${entry.suggestedName}" also appears in a container — needsNew is for agents that DON'T exist yet`,
+      });
+    }
+    if (seenToAdd.has(entry.suggestedName)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['needsNew', idx, 'suggestedName'],
+        message: `needsNew[${idx}].suggestedName "${entry.suggestedName}" also appears in toAdd[] — pick one: brand-new (needsNew) or surface existing (toAdd)`,
       });
     }
   });

--- a/packages/dashboard/src/views/improve-layout.js.ts
+++ b/packages/dashboard/src/views/improve-layout.js.ts
@@ -336,6 +336,28 @@ export const IMPROVE_LAYOUT_JS = `
         if (m && m.available && m.id && surfacedSet[m.id]) willAdd.push(m.id);
       }
     }
+    // needsNew: brand-new agents the planner thinks should exist but
+    // don't. These can't be committed inline — the user has to draft
+    // them in Build from goal. Render a "Draft these agents" section
+    // with a link out to /agents.
+    var needsNew = Array.isArray(plan.needsNew) ? plan.needsNew.filter(function (n) {
+      return n && typeof n === 'object' && typeof n.purpose === 'string' && n.purpose.length > 0;
+    }) : [];
+    var needsNewHtml = '';
+    if (needsNew.length > 0) {
+      var needsNewRows = needsNew.map(function (n) {
+        var name = n.suggestedName ? '<code style="font-size:var(--font-size-xs);background:var(--color-surface-raised);padding:0 var(--space-1);border-radius:var(--radius-sm);">' + esc(n.suggestedName) + '</code> ' : '';
+        return '<li style="margin-bottom:var(--space-2);">' + name + '<span style="font-size:var(--font-size-sm);">' + esc(n.purpose) + '</span></li>';
+      }).join('');
+      needsNewHtml =
+        '<div style="margin:var(--space-3) 0;padding:var(--space-3);border:1px solid var(--color-border);border-radius:var(--radius-sm);background:var(--color-surface-raised);">' +
+        '<div style="font-weight:var(--weight-semibold);font-size:var(--font-size-sm);margin-bottom:var(--space-2);">Draft ' + needsNew.length + ' new agent' + (needsNew.length === 1 ? '' : 's') + ' <span class="dim" style="font-weight:var(--weight-regular);font-size:var(--font-size-xs);">(these don\\'t exist yet)</span></div>' +
+        '<ul style="margin:0 0 var(--space-3);padding-left:var(--space-4);">' + needsNewRows + '</ul>' +
+        '<div style="font-size:var(--font-size-xs);color:var(--color-text-muted);margin-bottom:var(--space-2);">Drafting happens in Build from goal. Re-run Improve layout afterward to surface the new agent(s).</div>' +
+        '<a href="/agents" class="btn btn--ghost btn--sm" style="text-decoration:none;display:inline-block;">Open Build from goal →</a>' +
+        '</div>';
+    }
+
     var willAddHtml = '';
     if (willAdd.length > 0) {
       var addList = willAdd.map(function (id) { return '<code style="font-size:var(--font-size-xs);background:var(--color-surface-raised);padding:0 var(--space-1);border-radius:var(--radius-sm);">' + esc(id) + '</code>'; }).join(' ');
@@ -377,6 +399,7 @@ export const IMPROVE_LAYOUT_JS = `
       '<div style="margin-bottom:var(--space-2);">' + containerRows + '</div>' +
       willAddHtml +
       willHideHtml +
+      needsNewHtml +
       questionsHtml +
       '<div style="margin-top:var(--space-4);padding-top:var(--space-3);border-top:1px solid var(--color-border);display:flex;gap:var(--space-2);justify-content:flex-end;">' +
         '<button type="button" class="btn btn--ghost btn--sm" data-close-improve-layout="1">Cancel</button>' +


### PR DESCRIPTION
## Summary
- **Prompt cleanup** — stop calling installed-but-not-here agents "new". Reserve "new" for agents that don't exist yet; use "from your catalog" / "already installed" for the `toAdd` case. Addresses the confusing UX from #318 where the wizard said "Suggesting 2 new agents" for agents the user already had.
- **`needsNew[]` (Path B-lite)** — new optional field on `LayoutPlan` for brand-new agent specs (\`{ purpose, suggestedName? }\`). When FOCUS asks for an agent that doesn't exist anywhere, the planner emits a spec here instead of inventing an id. Wizard renders a "Draft N new agents" panel with a link to **Build from goal**.
- **Schema validation** — \`needsNew.suggestedName\` must not collide with any container tile or \`toAdd[]\` entry (one or the other, not both). Empty \`purpose\` rejected. Malformed names rejected.

Drafting still happens out-of-band: user clicks through to Build from goal, drafts the agent, then re-runs Improve layout — the new agent appears as \`available\` and Path A surfaces it. Full inline build-planner orchestration (Path B proper, ~3 more PRs) is still deferred per the handoff doc.

## Test plan
- [x] \`npm test\` — 1492 passing, 3 skipped. 6 new schema tests on \`needsNew\`.
- [x] \`npm run build\` — clean.
- [ ] Manual: on Pulse with no stock agent installed, FOCUS = "add a stock ticker". Confirm the planner emits a \`needsNew\` entry instead of inventing an id, and the "Draft 1 new agent" panel renders with the link to Build from goal.
- [ ] Manual: re-run on the dashboard from #318 — confirm the planner no longer calls installed agents "new" in its summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)