### PR TITLE
fix(layout-planner): no empty containers on named dashboards

### DIFF
--- a/.changeset/layout-planner-no-empty-containers.md
+++ b/.changeset/layout-planner-no-empty-containers.md
@@ -1,0 +1,11 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Layout planner no longer emits empty containers on named dashboards.
+
+The prompt previously told the planner to lead with a "Health" container holding the four system tiles. Pulse has those tiles; named dashboards don't. On a dashboard, the planner would dutifully emit an empty Health container and the whole plan failed schema validation (`containers.0.tiles must have at least one entry`). The rule is now conditional on `CURRENT_LAYOUT` actually containing system tiles, with an explicit "never emit a container with zero tiles" rule up top.

--- a/agents/examples/layout-planner.yaml
+++ b/agents/examples/layout-planner.yaml
@@ -138,22 +138,29 @@ nodes:
         container that scoops up the leftovers. Agents not assigned to
         a real container will be hidden. If you want an agent visible,
         put it in a container with a meaningful label.
-      - **ORDER CONTAINERS — SYSTEM TILES FIRST, DAILY SECOND.** The
-        wizard renders containers in array order, top to bottom. The
-        canonical order is:
-          1. A "Health" or "Overview" container holding the four system
-            tiles (_system-runs-today, _system-failure-rate,
-            _system-agent-count, _system-avg-duration) — first because
-            they're the at-a-glance status row the user wants to see
-            before anything else.
+      - **NEVER emit a container with zero tiles.** Every container
+        MUST have at least one tile. If a themed grouping (Health,
+        Monitoring, etc.) has no agents that fit, OMIT that container
+        — don't emit it as an empty placeholder. The schema rejects
+        empty containers and the whole plan fails.
+      - **ORDER CONTAINERS — SYSTEM TILES FIRST (Pulse only), DAILY
+        SECOND.** The wizard renders containers in array order, top to
+        bottom. Canonical order:
+          1. **Only if CURRENT_LAYOUT actually contains system tiles**
+            (`_system-runs-today`, `_system-failure-rate`,
+            `_system-agent-count`, `_system-avg-duration`): a "Health"
+            or "Overview" container holding them — first because
+            they're the at-a-glance status row. **Named dashboards have
+            NO system tiles — do not emit a Health container there.**
           2. Daily-glance content next: daily digests, news, weather,
             anything checked every morning.
           3. Lower-frequency containers (engineering, admin, infra,
             jobs) below that.
-        Don't bury system tiles in the middle. Don't put daily content
-        below engineering. FOCUS may override these defaults — e.g.
-        "I don't care about system stats, hide them" — but absent a
-        contrary signal, system first, daily second.
+        If CURRENT_LAYOUT has no system tiles, skip step 1 entirely
+        and start with daily content. FOCUS may override these
+        defaults — e.g. "I don't care about system stats, hide them"
+        — but absent a contrary signal, system first (when present),
+        daily second.
       - **NEVER include an agent id in a container if its AGENT_METADATA
         entry is absent OR has no `title`.** Those agents don't have a
         Pulse signal block and can't render as tiles — placing them in a


### PR DESCRIPTION
## Summary
Reported via screenshot: planner failed schema validation with \`containers.0.tiles must have at least one entry\` on a named dashboard.

Root cause: the "system tiles first" rule in the prompt was unconditional. Pulse has the four \`_system-*\` tiles; named dashboards don't. On a dashboard the LLM still tried to lead with a Health container and emitted it empty.

Fix: prompt now (1) explicitly forbids empty containers up front and (2) only asks for the Health container when \`CURRENT_LAYOUT\` actually contains system tiles.

## Test plan
- [x] \`npm test\` — 1492 passing.
- [ ] Manual: re-run Improve layout on the dashboard that just failed; confirm no empty Health container is emitted and the plan validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)