### PR TITLE
feat(layout-planner): inline Path B hand-off + conservative toAdd

### DIFF
--- a/.changeset/layout-planner-path-b-handoff.md
+++ b/.changeset/layout-planner-path-b-handoff.md
@@ -1,0 +1,16 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Layout planner can now draft brand-new agents inline via build-from-goal hand-off (Path B), and stops speculatively adding agents you didn't ask for.
+
+Two changes:
+
+- **Inline drafting** — clicking "Draft these agents" in the Improve-layout wizard no longer dumps you on /agents. It opens the Build-from-goal modal pre-filled with the synthesized goal, you go through the full critic-loop / questions / YAML-edit / commit flow there, and when you commit, you're returned to the layout wizard with the freshly drafted agents merged into the plan in a "Newly drafted" container. One click to Apply layout finishes the job. State is persisted in `sessionStorage` (1h TTL) so the original plan survives the round-trip.
+- **Conservative `toAdd`** — the planner used to surface available agents whenever they "fit the layout" or "filled an obvious gap", which caused unwanted additions like `system-health` showing up on dashboards where the user only asked for a couple of new agents. The prompt now requires FOCUS to explicitly name a topic or agent before anything in `toAdd` is allowed. Empty `toAdd` is the default.
+
+The build-from-goal modal is now also rendered (hidden) on `/pulse` so the hand-off works there too.

--- a/agents/examples/layout-planner.yaml
+++ b/agents/examples/layout-planner.yaml
@@ -246,15 +246,21 @@ nodes:
       when you're actually just surfacing what they already had.
 
       When to use `toAdd`:
-      - FOCUS mentions a topic and an `available` agent matches it
-        ("surface my weather agents" when weather-forecast is
-        available) — add it.
-      - FOCUS is vague and the user has many available agents — prefer
-        rearranging members; only add an available agent when you have
-        a concrete reason (matches FOCUS, fills an obvious gap).
-      - Be conservative: cap `toAdd` at ~8 agents per run. Each Apply
-        is destructive (hides un-surfaced members), so don't bury the
-        change in a flood of additions.
+      - ONLY when FOCUS explicitly asks. The user said "surface my
+        weather agents" or "bring my monitors over" or named a
+        specific available agent — add the matching ones. Otherwise
+        leave `toAdd` empty.
+      - NEVER speculatively add an available agent because it "looks
+        useful" or "fills a gap" or "complements the layout". That
+        produces unwanted additions like surfacing `system-health`
+        whenever the user is looking at a monitoring dashboard. The
+        user didn't ask for it — don't add it.
+      - The user can always re-run Improve layout with a more specific
+        FOCUS if they want more agents surfaced. Being conservative is
+        the right default.
+      - Cap `toAdd` at ~8 agents per run. Each Apply is destructive
+        (hides un-surfaced members), so don't bury the change in a
+        flood of additions.
 
       When to use `needsNew`:
       - FOCUS names an agent that does NOT exist in AGENT_METADATA

--- a/packages/dashboard/src/views/build-from-goal.js.ts
+++ b/packages/dashboard/src/views/build-from-goal.js.ts
@@ -20,7 +20,13 @@ export const BUILD_FROM_GOAL_JS = `
     if (!btn || !modal || !content) return;
 
     function esc(s) { var d = document.createElement('div'); d.textContent = s == null ? '' : String(s); return d.innerHTML; }
-    function closeModal() { modal.classList.remove('is-open'); }
+    function closeModal() {
+      modal.classList.remove('is-open');
+      // Closing/cancelling build-from-goal abandons any improve-layout
+      // handoff. The success path captures the handoff before calling
+      // closeModal, so this clear only affects cancel/backdrop paths.
+      try { sessionStorage.removeItem('sua-layout-handoff-v1'); } catch (e) {}
+    }
 
     btn.addEventListener('click', function () { modal.classList.add('is-open'); });
 
@@ -372,12 +378,49 @@ export const BUILD_FROM_GOAL_JS = `
             if (result.dashboardError) {
               summary += '<div class="dim" style="color:var(--color-danger,#a00);">Dashboard error: ' + esc(result.dashboardError) + '</div>';
             }
+            // If the improve-layout wizard handed off to us, don't
+            // redirect — close this modal and dispatch a resume event
+            // so the wizard re-opens with the freshly drafted agents
+            // merged in. The handoff has a 1h TTL; stale entries fall
+            // through to the normal redirect.
+            var handoffRaw = null;
+            try { handoffRaw = sessionStorage.getItem('sua-layout-handoff-v1'); } catch (e) {}
+            var handoff = null;
+            if (handoffRaw) {
+              try {
+                var parsed = JSON.parse(handoffRaw);
+                if (parsed && typeof parsed === 'object' && Date.now() - (parsed.createdAt || 0) < 60*60*1000) {
+                  handoff = parsed;
+                }
+              } catch (e) {}
+              if (!handoff) {
+                try { sessionStorage.removeItem('sua-layout-handoff-v1'); } catch (e) {}
+              }
+            }
+
             content.innerHTML = '<div style="padding:var(--space-3);">' +
               '<h3 style="margin:0 0 var(--space-2);">Done</h3>' +
               '<div style="font-size:var(--font-size-sm);">' + summary + '</div>' +
-              '<div class="dim" style="margin-top:var(--space-3);font-size:var(--font-size-xs);">Redirecting in 1.5s...</div>' +
+              '<div class="dim" style="margin-top:var(--space-3);font-size:var(--font-size-xs);">' +
+              (handoff ? 'Returning to layout planner...' : 'Redirecting in 1.5s...') + '</div>' +
               '</div>';
-            setTimeout(function () { window.location.href = result.redirectUrl || '/agents'; }, 1500);
+
+            if (handoff) {
+              setTimeout(function () {
+                closeModal();
+                try { sessionStorage.removeItem('sua-layout-handoff-v1'); } catch (e) {}
+                try {
+                  window.dispatchEvent(new CustomEvent('sua:resume-layout', {
+                    detail: { handoff: handoff, agentsCreated: result.agentsCreated || [] },
+                  }));
+                } catch (e) {
+                  // Older browsers without CustomEvent constructor — fall back to navigation.
+                  window.location.href = '/pulse';
+                }
+              }, 1200);
+            } else {
+              setTimeout(function () { window.location.href = result.redirectUrl || '/agents'; }, 1500);
+            }
           })
           .catch(function (err) {
             commitBtn.disabled = false;

--- a/packages/dashboard/src/views/improve-layout.js.ts
+++ b/packages/dashboard/src/views/improve-layout.js.ts
@@ -37,6 +37,120 @@ export const IMPROVE_LAYOUT_JS = `
     try { return localStorage.getItem(LAYOUT_KEY) || ''; } catch (e) { return ''; }
   }
 
+  // ── Build-from-goal hand-off ────────────────────────────────────────
+  //
+  // When the planner emits needsNew[], the wizard hands off to
+  // build-from-goal so the user gets the full critic loop. We persist
+  // enough state in sessionStorage that build-from-goal can call us
+  // back when its commit succeeds; on resume, the user sees the
+  // original plan with the freshly drafted agents merged in and only
+  // needs to click Apply layout.
+  var HANDOFF_KEY = 'sua-layout-handoff-v1';
+  var HANDOFF_TTL_MS = 60 * 60 * 1000; // 1h
+
+  function buildGoalFromNeedsNew(needsNew) {
+    var lines = needsNew.map(function (n, i) {
+      var name = n.suggestedName ? n.suggestedName + ' — ' : '';
+      return (i + 1) + '. ' + name + n.purpose;
+    }).join('\\n');
+    var bucket = CURATE_VERB === 'remove' ? 'this dashboard' : 'my Pulse layout';
+    return 'Create these agents for ' + bucket + ':\\n\\n' + lines +
+      '\\n\\nEach agent must declare a Pulse signal (metric, status, or another template) so it can render as a tile.';
+  }
+
+  function handoffToBuildFromGoal(plan, needsNew) {
+    if (!Array.isArray(needsNew) || needsNew.length === 0) return;
+    try {
+      sessionStorage.setItem(HANDOFF_KEY, JSON.stringify({
+        endpointBase: ENDPOINT_BASE,
+        storageKey: LAYOUT_KEY,
+        curateVerb: CURATE_VERB,
+        originalPlan: plan,
+        originalFocus: lastFocus || '',
+        createdAt: Date.now(),
+      }));
+    } catch (e) { /* sessionStorage may be unavailable */ }
+
+    closeModal();
+
+    // Open the build-from-goal modal. The button is rendered hidden
+    // on /pulse and /dashboards/:id pages — click it to open the modal,
+    // then fill in the goal + force agents-only target.
+    var trigger = document.getElementById('build-from-goal-btn');
+    if (!trigger) {
+      // Page doesn't host the build modal — fall back to navigation.
+      // Shouldn't happen on Pulse/dashboard pages, but be defensive.
+      window.location.href = '/agents';
+      return;
+    }
+    trigger.click();
+
+    // Defer DOM mutation so the modal markup is fully visible first.
+    setTimeout(function () {
+      var ta = document.getElementById('build-goal');
+      if (ta) ta.value = buildGoalFromNeedsNew(needsNew);
+      // Force "Just create the agent(s)" — we're not making a new
+      // dashboard from this flow.
+      var radio = document.querySelector('input[name="build-target"][value="agents"]');
+      if (radio) {
+        radio.checked = true;
+        // Trigger any UI sync (e.g. hiding the dashboard-picker row).
+        try { radio.dispatchEvent(new Event('change', { bubbles: true })); } catch (e) {}
+      }
+      if (ta) ta.focus();
+    }, 50);
+  }
+
+  function readHandoff() {
+    var raw = null;
+    try { raw = sessionStorage.getItem(HANDOFF_KEY); } catch (e) { return null; }
+    if (!raw) return null;
+    try {
+      var parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== 'object') return null;
+      if (Date.now() - (parsed.createdAt || 0) > HANDOFF_TTL_MS) return null;
+      return parsed;
+    } catch (e) { return null; }
+  }
+
+  function clearHandoff() {
+    try { sessionStorage.removeItem(HANDOFF_KEY); } catch (e) {}
+  }
+
+  function mergePlanWithDraftedAgents(plan, createdIds) {
+    if (!createdIds.length) return plan;
+    var p = JSON.parse(JSON.stringify(plan));
+    p.toAdd = (p.toAdd || []).slice();
+    for (var i = 0; i < createdIds.length; i++) {
+      if (p.toAdd.indexOf(createdIds[i]) === -1) p.toAdd.push(createdIds[i]);
+    }
+    // Place freshly drafted agents in a new container at the end so the
+    // user can see exactly what was added and shuffle them later via
+    // edit-layout. Don't try to be clever about which existing container
+    // they "belong" to — that's the next planner run's job.
+    p.containers = (p.containers || []).slice();
+    p.containers.push({ label: 'Newly drafted', tiles: createdIds.slice() });
+    p.needsNew = [];
+    p.summary = (p.summary || '') + ' Drafted ' + createdIds.length + ' new agent' +
+      (createdIds.length === 1 ? '' : 's') + ' (' + createdIds.join(', ') + ').';
+    return p;
+  }
+
+  // Listen for build-from-goal's resume signal. The event fires on the
+  // current page (we never navigate during hand-off), so we just
+  // re-open and re-render.
+  window.addEventListener('sua:resume-layout', function (ev) {
+    var detail = (ev && ev.detail) || {};
+    var handoff = detail.handoff;
+    var created = Array.isArray(detail.agentsCreated) ? detail.agentsCreated : [];
+    if (!handoff || handoff.endpointBase !== ENDPOINT_BASE) return;
+    var merged = mergePlanWithDraftedAgents(handoff.originalPlan, created);
+    lastFocus = handoff.originalFocus || '';
+    modal.classList.add('is-open');
+    renderPlan(merged);
+    clearHandoff();
+  });
+
   btn.addEventListener('click', function () {
     modal.classList.add('is-open');
     loadSuggestions();
@@ -353,8 +467,8 @@ export const IMPROVE_LAYOUT_JS = `
         '<div style="margin:var(--space-3) 0;padding:var(--space-3);border:1px solid var(--color-border);border-radius:var(--radius-sm);background:var(--color-surface-raised);">' +
         '<div style="font-weight:var(--weight-semibold);font-size:var(--font-size-sm);margin-bottom:var(--space-2);">Draft ' + needsNew.length + ' new agent' + (needsNew.length === 1 ? '' : 's') + ' <span class="dim" style="font-weight:var(--weight-regular);font-size:var(--font-size-xs);">(these don\\'t exist yet)</span></div>' +
         '<ul style="margin:0 0 var(--space-3);padding-left:var(--space-4);">' + needsNewRows + '</ul>' +
-        '<div style="font-size:var(--font-size-xs);color:var(--color-text-muted);margin-bottom:var(--space-2);">Drafting happens in Build from goal. Re-run Improve layout afterward to surface the new agent(s).</div>' +
-        '<a href="/agents" class="btn btn--ghost btn--sm" style="text-decoration:none;display:inline-block;">Open Build from goal →</a>' +
+        '<div style="font-size:var(--font-size-xs);color:var(--color-text-muted);margin-bottom:var(--space-2);">Drafting opens Build from goal with the full critic loop. When you commit there, you\\'ll come back here to apply the layout.</div>' +
+        '<button type="button" class="btn btn--ghost btn--sm" id="improve-draft-btn">Draft these agents</button>' +
         '</div>';
     }
 
@@ -408,6 +522,9 @@ export const IMPROVE_LAYOUT_JS = `
 
     var applyBtn = document.getElementById('improve-apply-btn');
     if (applyBtn) applyBtn.addEventListener('click', function () { applyPlan(plan); });
+
+    var draftBtn = document.getElementById('improve-draft-btn');
+    if (draftBtn) draftBtn.addEventListener('click', function () { handoffToBuildFromGoal(plan, needsNew); });
 
     var updateBtn = document.getElementById('improve-update-btn');
     if (updateBtn) updateBtn.addEventListener('click', function () {

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -16,6 +16,7 @@ import { esc } from './pulse-helpers.js';
 import { renderTile } from './pulse-renderers.js';
 import { buildDashboardOptions, renderDashboardsDropdown } from './dashboards-dropdown.js';
 import { improveLayoutButton, improveLayoutModal } from './improve-layout-modal.js';
+import { buildFromGoalButton, buildFromGoalModal } from './build-from-goal-modal.js';
 export type { PulseTile, PulsePageInput, TileWrapFn } from './pulse-types.js';
 import type { PulseTile, PulsePageInput, TileWrapFn } from './pulse-types.js';
 
@@ -221,6 +222,15 @@ export function renderPulsePage(input: PulsePageInput): string {
     ` : html``}
 
     ${improveLayoutModal()}
+
+    <!-- Build-from-goal modal: hidden, opened programmatically by the
+         improve-layout wizard when the planner emits needsNew[] specs.
+         The hidden button is the public handle the wizard JS clicks
+         to open it. -->
+    <span style="display: none;">${buildFromGoalButton()}</span>
+    ${buildFromGoalModal({
+      availableDashboards: (input.installedDashboards ?? []).filter((d) => !d.packId).map((d) => ({ id: d.id, name: d.name })),
+    })}
 
     ${unsafeHtml(`<script type="application/json" id="pulse-tile-data">${JSON.stringify({ allTileIds, systemTileIds })}</script>`)}
     ${unsafeHtml(`<script type="application/json" id="pulse-template-registry">${JSON.stringify(TEMPLATE_REGISTRY)}</script>`)}


### PR DESCRIPTION
## Summary

Two changes that together close the Path-B UX loop and address the system-health auto-add complaint.

**1. Inline hand-off to Build-from-goal.** Clicking "Draft these agents" in the Improve-layout wizard no longer navigates to /agents and loses your plan. Instead:

1. State (the layout plan + focus + surface config) is saved to \`sessionStorage\` (\`sua-layout-handoff-v1\`, 1h TTL).
2. The Improve-layout modal closes and the Build-from-goal modal opens, pre-filled with a goal synthesized from the planner's \`needsNew[]\` specs, and forced to "agents-only" target.
3. The user goes through the **full Build-from-goal flow** — critic loop, clarifying questions, YAML edits, commit. Nothing is shortcut.
4. On commit success, Build-from-goal reads the handoff from sessionStorage and instead of redirecting to /agents, fires a \`sua:resume-layout\` window event.
5. The Improve-layout wizard's resume listener re-opens itself, merges the freshly drafted agent ids into the original plan (added to \`toAdd[]\` + placed in a new "Newly drafted" container at the bottom), and renders the plan-review screen.
6. User clicks Apply layout — done.

Cancel paths in Build-from-goal clear the handoff so it doesn't go stale.

**2. Conservative \`toAdd\`.** Reported regression after PR #318: \`system-health\` was getting auto-added to monitoring-looking dashboards even when the user only asked for two new agents. The prompt's "fills an obvious gap" reasoning was too permissive. Now: \`toAdd\` is empty by default, and the planner is told to surface available agents ONLY when FOCUS explicitly names a topic or agent. The user can always re-run with a more specific FOCUS if they want more.

**Modal markup**: \`/pulse\` now renders the Build-from-goal modal (hidden) so the trigger button exists. Named dashboards already had it.

## Test plan
- [x] \`npm test\` — 1492 passing, 3 skipped.
- [x] \`npm run build\` — clean.
- [ ] Manual: on a named dashboard, FOCUS = "add two new agents that complement the weather forecast". Confirm \`needsNew[]\` is populated and \`toAdd\` does NOT include system-health.
- [ ] Manual: click "Draft these agents". Confirm Build-from-goal modal opens with the goal pre-filled. Go through the full critic-loop flow. Commit.
- [ ] Manual: confirm you return to the layout wizard with the new agents in a "Newly drafted" container. Apply.
- [ ] Manual: confirm the new tiles show up on the dashboard after reload.
- [ ] Manual: try Cancel inside Build-from-goal — confirm the handoff is cleared (re-open Improve-layout, run a fresh plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)