### PR TITLE
fix(layout-planner): auto-retry schema fails + stricter id-format rule

### DIFF
--- a/.changeset/layout-planner-id-self-heal.md
+++ b/.changeset/layout-planner-id-self-heal.md
@@ -1,0 +1,9 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+The Improve-layout wizard now auto-retries once on schema-validation failures, and the planner prompt has a strict, example-laden agent-id-format rule up front. Cuts down on user-facing schema errors like `topAgents.id must be lowercase_with_dashes_or_underscores` that the planner can fix itself.

--- a/agents/examples/layout-planner.yaml
+++ b/agents/examples/layout-planner.yaml
@@ -98,6 +98,23 @@ nodes:
       WHAT YOU DO
       ════════════════════════════════════════════════════════════════
 
+      AGENT ID FORMAT — STRICT. Every agent id you emit (in
+      `topAgents[].id`, `containers[].tiles[]`, `toAdd[]`,
+      `needsNew[].suggestedName`) MUST match `^[a-z0-9][a-z0-9_-]*$`:
+      lowercase ASCII letters, digits, hyphens, underscores. No
+      spaces, no capitals, no slashes, no dots. Examples:
+        ✓ stock-ticker
+        ✓ api_monitor_v2
+        ✓ hn-top-3
+        ✗ Stock Ticker        (spaces + caps)
+        ✗ stockTicker         (camelCase)
+        ✗ Stock-Ticker        (caps)
+        ✗ stock.ticker        (dot)
+      System tiles (only in `containers[].tiles[]`) additionally
+      allow a single leading underscore: `_system-runs-today`.
+      Violating this rule fails schema validation and the whole plan
+      is rejected.
+
       STEP 1 — RANK. Pick the agents that should be most prominent on
       Pulse. You're ranking BOTH members and selected available agents
       together — an available agent that perfectly matches FOCUS should

--- a/packages/dashboard/src/views/improve-layout.js.ts
+++ b/packages/dashboard/src/views/improve-layout.js.ts
@@ -30,6 +30,12 @@ export const IMPROVE_LAYOUT_JS = `
   var CURATE_BUCKET = CURATE_VERB === 'remove' ? 'this dashboard' : 'Pulse';
   var cachedAgentMetadata = null;
   var lastFocus = '';
+  // Auto-retry budget for schema-validation failures. Reset each time
+  // the user explicitly invokes the planner (submit / refine / draft
+  // hand-off); we only auto-retry inside the same user-initiated run
+  // to avoid infinite loops when the LLM can't satisfy the schema.
+  var validationRetriesLeft = 0;
+  var AUTO_RETRY_BUDGET = 1;
 
   function esc(s) { var d = document.createElement('div'); d.textContent = s == null ? '' : String(s); return d.innerHTML; }
   function closeModal() { modal.classList.remove('is-open'); }
@@ -214,6 +220,7 @@ export const IMPROVE_LAYOUT_JS = `
     submitBtn.addEventListener('click', function () {
       var ta = document.getElementById('improve-layout-focus');
       var focus = ta ? ta.value.trim() : '';
+      validationRetriesLeft = AUTO_RETRY_BUDGET;
       runPlanner(focus);
     });
   }
@@ -283,9 +290,22 @@ export const IMPROVE_LAYOUT_JS = `
             if (data.status === 'done' && data.plan) {
               renderPlan(data.plan);
             } else {
+              var ve = Array.isArray(data.validationErrors) ? data.validationErrors : [];
+              // Auto-retry once on schema-validation failures: append the
+              // errors as feedback and re-run silently. Saves the user
+              // from seeing the error UI when the planner can fix the
+              // issue itself (typo'd ids, missing rationales, etc.).
+              if (ve.length > 0 && validationRetriesLeft > 0) {
+                validationRetriesLeft -= 1;
+                var nextFocus = lastFocus
+                  ? lastFocus + '\\n\\nPrevious attempt failed validation. Fix these issues:\\n' + ve.map(function (m) { return '  - ' + m; }).join('\\n')
+                  : 'Previous attempt failed validation. Fix these issues:\\n' + ve.map(function (m) { return '  - ' + m; }).join('\\n');
+                runPlanner(nextFocus);
+                return;
+              }
               renderError({
                 message: data.error || 'Layout planner failed',
-                validationErrors: Array.isArray(data.validationErrors) ? data.validationErrors : [],
+                validationErrors: ve,
                 rawResult: typeof data.rawResult === 'string' ? data.rawResult : '',
               });
             }
@@ -375,6 +395,7 @@ export const IMPROVE_LAYOUT_JS = `
       }
       if (feedback) parts.push('User feedback:\\n' + feedback);
       var combined = parts.join('\\n\\n');
+      validationRetriesLeft = AUTO_RETRY_BUDGET;
       runPlanner(combined);
     });
   }
@@ -570,6 +591,7 @@ export const IMPROVE_LAYOUT_JS = `
       if (lastFocus) parts.push(lastFocus);
       if (lines.length) parts.push('Clarifications:\\n' + lines.join('\\n\\n'));
       if (refine) parts.push('Refinement:\\n' + refine);
+      validationRetriesLeft = AUTO_RETRY_BUDGET;
       runPlanner(parts.join('\\n\\n'));
     });
   }


### PR DESCRIPTION
## Summary
Reported via screenshot: clicking "Update plan" surfaced \`topAgents.1.id: topAgents.id must be lowercase_with_dashes_or_underscores\`. The planner emitted a malformed id under refinement pressure and the user saw a raw schema error instead of a working plan.

Two complementary fixes:

1. **Stricter prompt** — agent-id-format is now an explicit STRICT section near the top of \`WHAT YOU DO\`, with positive AND negative examples covering every field that takes an id (\`topAgents\`, container tiles, \`toAdd\`, \`needsNew.suggestedName\`).
2. **Auto-retry on schema failure** — the wizard silently re-runs the planner once with the validation errors appended as feedback before showing the error UI. Budget of 1 retry per user-initiated invocation (submit / refine / draft / manual retry-with-feedback), reset on each new user action to avoid infinite loops. If the second attempt also fails, the error UI surfaces as today.

## Test plan
- [x] \`npm test\` — 1492 passing.
- [ ] Manual: trigger the failure mode again (likely with the same refinement that hit it). Confirm the wizard quietly retries and shows a valid plan instead of the error screen.
- [ ] Manual: deliberately ask the planner for something impossible (e.g. "topAgents must contain a system tile") so both attempts fail; confirm the error UI eventually appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)