### PR TITLE
fix(build-planner): bump timeout 180→360s, maxTurns 3→5

### DIFF
--- a/.changeset/build-planner-bump-timeout.md
+++ b/.changeset/build-planner-bump-timeout.md
@@ -1,0 +1,9 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Bump the build-planner's `plan` node from `timeout: 180 / maxTurns: 3` to `timeout: 360 / maxTurns: 5`. Three-minute ceiling was too tight when the planner has to draft multiple agents in one shot (now common via the Improve-layout → Build-from-goal hand-off, which can hand off up to 3 needsNew specs at once). Six minutes / five turns gives Claude room to produce the full plan without router-level timeouts.

--- a/agents/examples/build-planner.yaml
+++ b/agents/examples/build-planner.yaml
@@ -233,5 +233,5 @@ nodes:
       - newAgents[].id and matchedAgents[].id must be lowercase-with-hyphens.
 
       Output ONLY the <plan>…</plan> block. No explanation before or after.
-    maxTurns: 3
-    timeout: 180
+    maxTurns: 5
+    timeout: 360


### PR DESCRIPTION
## Summary
Reported timeout on a 3-agent draft run via the Improve-layout → Build-from-goal hand-off (#321). The build-planner's \`plan\` node had \`timeout: 180\` / \`maxTurns: 3\`, which is fine for single-agent drafts but tight when the planner is producing three full agent YAMLs plus a survey + dashboard layout in one shot.

Bumped to \`timeout: 360\` / \`maxTurns: 5\`. The \`fix\` node (single-agent YAML repair) stays at 180s.

## Test plan
- [x] Build is config-only, no test impact.
- [ ] Manual: re-run the 3-agent Path B flow that just timed out. Confirm the planner returns a plan within the new ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)