### PR TITLE
feat(build): split build-planner into per-agent drafters + orchestrator

### DIFF
--- a/.changeset/build-planner-split-refactor.md
+++ b/.changeset/build-planner-split-refactor.md
@@ -1,0 +1,24 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Split the monolithic build-planner into three focused agents orchestrated at the route layer. Per-agent drafting now runs as its own LLM call, so each draft has its own timeout and the Improve-layout Path B hand-off can run 3 drafters in parallel instead of one timeout-prone megacall.
+
+**New agents:**
+- `goal-surveyor` — classifies intent, decomposes goal into fragments, matches against installed agents.
+- `agent-drafter` — drafts ONE agent from ONE fragment.
+- `dashboard-designer` — designs the dashboard section layout from a finalized agent-id list.
+
+**New endpoint:** `POST /agents/draft-one { purpose, suggestedName?, focus? }` — fast path used by the Improve-layout wizard. Skips the surveyor and designer, runs one drafter, returns a single-agent BuildPlan when complete. Polling reuses `GET /agents/build/:runId`.
+
+**`POST /agents/build` rewrite:** now kicks off a session-based orchestrator that runs surveyor → fans out drafters in parallel → optionally runs designer → assembles the BuildPlan. External contract unchanged; the wizard still polls one runId and gets the same BuildPlan shape back, with per-drafter progress surfaced during the running phase.
+
+**Improve-layout wizard:** the "Draft N agents + apply" button no longer hands off to Build-from-goal. It drives N parallel `/agents/draft-one` calls inline, shows a card per draft with independent progress, then commits the drafted agents + the layout in one flow. The sessionStorage hand-off (`sua-layout-handoff-v1`) is removed. The Build-from-goal modal is no longer rendered on `/pulse`.
+
+**Build-from-goal wizard:** unchanged externally except the spinner stage now renders per-drafter progress pills when the orchestrator is in its drafting phase.
+
+`build-planner.yaml` remains in `agents/examples/` for now but the orchestrator never invokes it.

--- a/agents/examples/agent-drafter.yaml
+++ b/agents/examples/agent-drafter.yaml
@@ -1,0 +1,177 @@
+# Agent Drafter — drafts ONE agent from ONE fragment.
+#
+# Stage 2 of 3 in the build orchestrator. The surveyor passes one
+# fragment at a time; the orchestrator fans out N instances of this
+# in parallel. Each drafter focuses on a single purpose — clearer
+# prompt, smaller context, independent timeout/retry.
+#
+# The improve-layout wizard's Path B hand-off also uses this directly
+# via /agents/draft-one, skipping the surveyor entirely.
+
+id: agent-drafter
+name: Agent Drafter
+description: >
+  Drafts a single sua agent YAML from a one-sentence purpose. Reused
+  by the build orchestrator (one instance per missing fragment) and
+  by the Improve-layout wizard for inline drafting of needsNew specs.
+status: active
+source: examples
+
+inputs:
+  PURPOSE:
+    type: string
+    required: true
+    description: One-sentence description of what this agent should do.
+  SUGGESTED_NAME:
+    type: string
+    required: false
+    default: ""
+    description: >
+      Optional preferred id (lowercase-with-hyphens). The drafter may
+      rename to avoid collisions with EXISTING_AGENT_IDS.
+  FOCUS:
+    type: string
+    required: false
+    default: ""
+    description: Optional constraints (e.g. "schedule daily", "shell only").
+  EXISTING_AGENT_IDS:
+    type: string
+    required: false
+    default: ""
+    description: >
+      Comma-separated list of agent ids already installed OR already drafted
+      by sibling drafters in this build session. Prevents id collisions.
+  AVAILABLE_TOOLS:
+    type: string
+    required: false
+    default: ""
+    description: Dynamically injected tool catalog. Populated at build time.
+  DISCOVERY_CATALOG:
+    type: string
+    required: false
+    default: ""
+    description: >
+      Node types, signal templates, output widgets, INSTALLED AGENTS, and
+      architecture patterns. Injected at build time.
+
+nodes:
+  - id: draft
+    type: llm-prompt
+    prompt: |
+      You are the agent drafter for the sua agent platform.
+
+      Draft ONE complete agent YAML from the given purpose. The orchestrator
+      called you with exactly one purpose to keep the prompt focused — don't
+      try to anticipate other agents; another drafter is handling those.
+
+      ════════════════════════════════════════════════════════════════
+      PURPOSE:
+      {{inputs.PURPOSE}}
+
+      SUGGESTED NAME (preferred id, may be empty):
+      {{inputs.SUGGESTED_NAME}}
+
+      OPTIONAL FOCUS / CONSTRAINTS:
+      {{inputs.FOCUS}}
+
+      EXISTING AGENT IDS (must NOT collide):
+      {{inputs.EXISTING_AGENT_IDS}}
+
+      AVAILABLE TOOLS:
+      {{inputs.AVAILABLE_TOOLS}}
+
+      DISCOVERY CATALOG:
+      {{inputs.DISCOVERY_CATALOG}}
+      ════════════════════════════════════════════════════════════════
+
+      AGENT ID FORMAT — STRICT. The id you emit MUST match
+      `^[a-z0-9][a-z0-9_-]*$`: lowercase ASCII letters, digits,
+      hyphens, underscores. No spaces, no capitals.
+        ✓ stock-ticker
+        ✓ notes-list-daily
+        ✗ Stock Ticker
+        ✗ stockTicker
+
+      ID COLLISION RULE — the id you emit MUST NOT appear in EXISTING_AGENT_IDS.
+      If SUGGESTED_NAME is given and not already taken, use it. Otherwise pick
+      a sensible alternative ("stock-ticker" → "stock-ticker-v2" / "stock-watch").
+
+      YAML CONTENT — the agent's YAML must be a complete, parseable sua agent:
+      - source: must be "local".
+      - inputs: an object/map. Input names UPPERCASE_WITH_UNDERSCORES.
+      - outputs: object. Names lowercase_snake_case (NOT camelCase). Each value
+        is a type (string|number|boolean|object|array) OR an object {type, description}.
+        NEVER a bare description string in the value slot.
+      - Shell nodes: use $ENV_VARS for inputs, never double-brace templates.
+      - llm-prompt / claude-code nodes: use double-brace inputs.NAME syntax in prompts.
+      - signal block REQUIRED. signal.title is REQUIRED and is a short literal
+        string used as the Pulse tile chrome label.
+      - When the agent declares an outputWidget, set signal.template: widget.
+        Pulse tile rendering is dispatched by signal.template, not outputWidget.type.
+        Omit signal.mapping when template is "widget" — the widget drives layout.
+      - When the agent declares any inputs:, set outputWidget.interactive: true so
+        Pulse renders an inline inputs form. Skip this flag for purely scheduled
+        agents that take no runtime inputs.
+      - outputWidget.type: one of dashboard, key-value, diff-apply, raw, ai-template.
+      - outputWidget.fields[].type: one of text, code, badge, action, metric, stat.
+      - If FOCUS mentions "daily" / "every morning" / cron-style timing, add a
+        `schedule:` field (cron format).
+
+      COMPOSE OVER EXISTING AGENTS (the `loop + agent-invoke` pattern).
+      Before drafting a brand-new monolithic agent, ask: is this purpose a
+      list × primitive? (e.g. "jobs across companies", "weather in 5 cities").
+      If YES AND DISCOVERY CATALOG shows an existing primitive that already does
+      the per-item work, draft an ORCHESTRATOR that loops over the list and
+      invokes the existing primitive — do NOT re-implement the primitive.
+
+      Orchestrator recipe (3 nodes — parse → loop → summarise). The angle-
+      bracket placeholders below are PSEUDOCODE — replace «X» with real
+      double-brace template syntax in the emitted YAML.
+
+        nodes:
+          - id: parse
+            type: shell
+            command: |
+              # split the input into a JSON array, one entry per item.
+              # Output: {"items":[{"slug":"x"},{"slug":"y"}]}
+              python3 -c '...'
+          - id: search
+            type: loop
+            dependsOn: [parse]
+            loopConfig:
+              over: items
+              agentId: <existing-primitive-id>
+              maxIterations: 10
+              inputMapping:
+                COMPANY_SLUG: "$item.slug"
+                JOB_QUERY: "«inputs.JOB_QUERY»"
+          - id: summarise
+            type: llm-prompt
+            dependsOn: [search]
+            prompt: |
+              Summarise per-company results in «upstream.search.result».
+
+      Skip composition (just draft a normal multi-node agent) when:
+      - The purpose is one-off, not list-shaped.
+      - No matching primitive exists yet.
+      - The per-item operation is trivial (one curl + jq) — inline it.
+
+      OUTPUT FORMAT — wrap in <plan>…</plan> tags. Body MUST be valid JSON
+      matching this exact shape:
+
+      <plan>
+      {
+        "id": "stock-ticker",
+        "purpose": "Show the current price and daily change for a configurable stock symbol.",
+        "yaml": "id: stock-ticker\nname: Stock Ticker\n... (full YAML)"
+      }
+      </plan>
+
+      VALIDATION:
+      - `id` is required, matches the agent-id regex, does not collide with EXISTING_AGENT_IDS.
+      - `purpose` is required, non-empty.
+      - `yaml` is required, parses as a complete sua agent, and `parsed.id === plan.id`.
+
+      Output ONLY the <plan>…</plan> block. No explanation before or after.
+    maxTurns: 4
+    timeout: 180

--- a/agents/examples/dashboard-designer.yaml
+++ b/agents/examples/dashboard-designer.yaml
@@ -1,0 +1,102 @@
+# Dashboard Designer — designs the layout for a build-time dashboard.
+#
+# Stage 3 of 3 in the build orchestrator. Only invoked when the
+# surveyor classified intent as dashboard-existing / dashboard-new /
+# dashboard-mixed. Receives the finalized list of agent ids (existing
+# + freshly drafted) and emits the dashboard's sections.
+#
+# Distinct from the in-app layout-planner — that one curates an
+# existing dashboard's tiles. Dashboard-designer bootstraps the
+# initial layout when the user is building from a goal.
+
+id: dashboard-designer
+name: Dashboard Designer
+description: >
+  Designs the section layout for a brand-new dashboard given the agents
+  that should appear on it. Stage 3 of 3 in the build orchestrator;
+  skipped for agent-only builds.
+status: active
+source: examples
+
+inputs:
+  INTENT:
+    type: string
+    required: true
+    description: One of dashboard-existing, dashboard-new, dashboard-mixed.
+  GOAL:
+    type: string
+    required: true
+    description: The original user goal, for context (naming, theme).
+  AGENT_IDS:
+    type: string
+    required: true
+    description: >
+      Comma-separated list of agent ids that should appear on the dashboard.
+      Mix of existing (matched by surveyor) + freshly drafted (from drafters).
+  AGENT_DESCRIPTIONS:
+    type: string
+    required: false
+    default: ""
+    description: >
+      Optional JSON array of { id, purpose } for the agents the designer is
+      laying out, so it can group them by theme intelligently.
+
+nodes:
+  - id: design
+    type: llm-prompt
+    prompt: |
+      You are the dashboard designer for the sua agent platform.
+
+      Given a set of agents that should appear on a brand-new dashboard,
+      design the section layout — group them by topic into 1-3 sections,
+      pick a Title Case dashboard name, and emit a structured dashboard
+      JSON. Do NOT propose any new agents — that's already done.
+
+      ════════════════════════════════════════════════════════════════
+      INTENT:
+      {{inputs.INTENT}}
+
+      ORIGINAL GOAL (for naming + theme):
+      {{inputs.GOAL}}
+
+      AGENT IDS (all must appear in dashboard.sections):
+      {{inputs.AGENT_IDS}}
+
+      AGENT DESCRIPTIONS (optional, for grouping):
+      {{inputs.AGENT_DESCRIPTIONS}}
+      ════════════════════════════════════════════════════════════════
+
+      RULES:
+      - Dashboard id MUST start with `user:` followed by lowercase-with-hyphens
+        (e.g. `user:morning-briefing`).
+      - Pick a Title Case `name` (e.g. "Morning Briefing", "Job Hunt Hub").
+      - Group tiles into 1-3 sections by topic. Fewer is better; don't make
+        a section per agent.
+      - Section titles: short, human-readable nouns ("News", "Weather", "Notes").
+      - EVERY id in AGENT_IDS must appear in exactly one section's `agentIds[]`.
+        No duplicates across sections. No omissions.
+
+      OUTPUT FORMAT — wrap in <plan>…</plan> tags. Body MUST be valid JSON:
+
+      <plan>
+      {
+        "id": "user:morning-briefing",
+        "name": "Morning Briefing",
+        "sections": [
+          { "title": "News", "agentIds": ["hn-top-stories"] },
+          { "title": "Weather", "agentIds": ["weather-forecast"] },
+          { "title": "Notes", "agentIds": ["notes-list-daily"] }
+        ]
+      }
+      </plan>
+
+      VALIDATION:
+      - `id` starts with "user:" and the rest is lowercase-with-dashes-or-underscores.
+      - `name` is non-empty.
+      - `sections[]` has at least 1 entry. Each has a non-empty `title` and
+        at least 1 entry in `agentIds[]`.
+      - Every id in AGENT_IDS appears in exactly one section's agentIds[].
+
+      Output ONLY the <plan>…</plan> block. No explanation before or after.
+    maxTurns: 2
+    timeout: 120

--- a/agents/examples/goal-surveyor.yaml
+++ b/agents/examples/goal-surveyor.yaml
@@ -1,0 +1,131 @@
+# Goal Surveyor — first stage of the per-agent build flow.
+#
+# Reads a free-form goal + the live discovery catalog, classifies the
+# user's intent, decomposes the goal into fragments, and matches each
+# fragment against installed agents. Emits a structured survey that
+# the build orchestrator uses to fan out per-fragment drafters.
+#
+# Replaces STEPS 1-2 of the legacy monolithic build-planner. The
+# downstream pieces (agent-drafter, dashboard-designer) consume this
+# survey but don't re-run intent classification — each does one job.
+
+id: goal-surveyor
+name: Goal Surveyor
+description: >
+  Classifies build-from-goal intent and decomposes the goal into
+  fragments matched against installed agents. Stage 1 of 3 in the
+  build orchestrator.
+status: active
+source: examples
+
+inputs:
+  GOAL:
+    type: string
+    required: true
+    description: Natural language description of what the user wants built.
+  FOCUS:
+    type: string
+    required: false
+    default: ""
+    description: Optional constraints or preferences (e.g. "schedule daily", "shell only").
+  DISCOVERY_CATALOG:
+    type: string
+    required: false
+    default: ""
+    description: >
+      Node types, signal templates, output widgets, INSTALLED AGENTS,
+      INSTALLED DASHBOARDS, INSTALLED + AVAILABLE PACKS, and architecture
+      patterns. Injected at build time.
+
+nodes:
+  - id: survey
+    type: llm-prompt
+    prompt: |
+      You are the goal surveyor for the sua agent platform.
+
+      Read the user's goal + the catalog of installed agents/dashboards/packs.
+      Classify the intent, decompose the goal into fragments, and match each
+      fragment against installed agents. Do NOT draft any YAML — that's the
+      next stage's job.
+
+      ════════════════════════════════════════════════════════════════
+      GOAL:
+      {{inputs.GOAL}}
+
+      OPTIONAL FOCUS / CONSTRAINTS:
+      {{inputs.FOCUS}}
+
+      DISCOVERY CATALOG:
+      {{inputs.DISCOVERY_CATALOG}}
+      ════════════════════════════════════════════════════════════════
+
+      STEP 1 — CLASSIFY INTENT.
+      One of:
+        - "agent"              : the goal is one agent, no dashboard.
+        - "dashboard-existing" : the goal is a dashboard composed entirely of existing agents.
+        - "dashboard-new"      : the goal is a dashboard composed entirely of new agents.
+        - "dashboard-mixed"    : the goal is a dashboard mixing existing + new agents.
+
+      STEP 2 — DECOMPOSE THE GOAL INTO FRAGMENTS.
+      A fragment is one logical thing the goal needs ("today's weather",
+      "HN top stories", "my notes list"). For each fragment:
+        - Search INSTALLED AGENTS for a fuzzy id+description match.
+        - Match found → add to `matchedAgents` with the fragment text in `matchedFor`.
+        - No match → add a fragment entry to `fragments[]` with `purpose` set to
+          a clean one-sentence description of what the missing agent should do,
+          and an optional `suggestedName` (lowercase-with-hyphens) for it. This
+          is what the next stage drafts.
+
+      Also scan INSTALLED DASHBOARDS. If any look like overlap (same theme),
+      mention them in `existingDashboards` so the orchestrator can warn the user.
+
+      STEP 3 — PACK SUGGESTIONS (optional).
+      If a pack labelled "available" in the catalog already covers a fragment,
+      add a `packSuggestions[]` entry with the pack id and the fragment it covers.
+      The orchestrator surfaces these as suggestions, not auto-installs.
+
+      STEP 4 — CLARIFYING QUESTIONS.
+      Anything ambiguous (file paths, frequency, region, units, source URL) goes
+      in `questions[]`. Provide `suggestedAnswer` when reasonable. The orchestrator
+      passes these through to the drafters as part of each fragment's purpose.
+
+      AGENT ID FORMAT — STRICT. Every id in `matchedAgents[].id` and every
+      `suggestedName` MUST match `^[a-z0-9][a-z0-9_-]*$`: lowercase ASCII
+      letters, digits, hyphens, underscores. No spaces, no capitals.
+        ✓ weather-forecast
+        ✓ hn-top-stories
+        ✗ Weather Forecast
+        ✗ weatherForecast
+
+      OUTPUT FORMAT — wrap in <survey>…</survey> tags. Body MUST be valid JSON:
+
+      <survey>
+      {
+        "intent": "agent" | "dashboard-existing" | "dashboard-new" | "dashboard-mixed",
+        "summary": "one-line description of what the build needs",
+        "matchedAgents": [
+          { "id": "weather-forecast", "matchedFor": "today's weather" }
+        ],
+        "fragments": [
+          { "purpose": "Read markdown files from a notes folder and return the latest 10 titles.", "suggestedName": "notes-list-daily" }
+        ],
+        "existingDashboards": [],
+        "packSuggestions": [],
+        "questions": [
+          { "text": "Which folder should the notes agent read from?", "suggestedAnswer": "~/Documents/Notes" }
+        ]
+      }
+      </survey>
+
+      VALIDATION RULES:
+      - `intent` is required and one of the four enum values.
+      - `summary` is required and non-empty.
+      - `matchedAgents[].id` and `fragments[].suggestedName` must be lowercase-with-dashes-or-underscores.
+      - intent="agent" → `fragments` has exactly one entry, `matchedAgents` may be empty.
+      - intent="dashboard-existing" → `fragments` is empty.
+      - intent="dashboard-new" → `matchedAgents` is empty, `fragments` has 1+ entries.
+      - intent="dashboard-mixed" → both `matchedAgents` and `fragments` have 1+ entries.
+
+      Output ONLY the <survey>…</survey> block. No explanation before or after.
+    maxTurns: 2
+    timeout: 90

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -157,6 +157,16 @@ export {
   type BuildPlanInput,
 } from './build-plan-schema.js';
 export {
+  surveySchema,
+  draftSchema,
+  dashboardDesignSchema,
+  extractSurveyJson,
+  type Survey,
+  type SurveyInput,
+  type Draft,
+  type DashboardDesign,
+} from './survey-schema.js';
+export {
   layoutPlanSchema,
   SIGNAL_SIZES,
   type LayoutPlan,

--- a/packages/core/src/survey-schema.test.ts
+++ b/packages/core/src/survey-schema.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { surveySchema, draftSchema, dashboardDesignSchema } from './survey-schema.js';
+
+const validMixedSurvey = {
+  intent: 'dashboard-mixed' as const,
+  summary: 'Morning briefing dashboard',
+  matchedAgents: [{ id: 'weather-forecast', matchedFor: "today's weather" }],
+  fragments: [{ purpose: 'List the latest 10 markdown titles from a notes folder.', suggestedName: 'notes-list' }],
+  existingDashboards: [],
+  packSuggestions: [],
+  questions: [],
+};
+
+describe('surveySchema', () => {
+  it('accepts a minimal well-formed dashboard-mixed survey', () => {
+    const r = surveySchema.safeParse(validMixedSurvey);
+    expect(r.success).toBe(true);
+  });
+
+  it('defaults optional arrays when omitted', () => {
+    const r = surveySchema.safeParse({
+      intent: 'agent',
+      summary: 'just one agent',
+      fragments: [{ purpose: 'do the thing' }],
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.matchedAgents).toEqual([]);
+      expect(r.data.existingDashboards).toEqual([]);
+      expect(r.data.packSuggestions).toEqual([]);
+      expect(r.data.questions).toEqual([]);
+    }
+  });
+
+  it('coerces existingDashboards string entries into objects', () => {
+    const r = surveySchema.safeParse({
+      ...validMixedSurvey,
+      existingDashboards: ['user:morning'],
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.existingDashboards[0]).toEqual({ id: 'user:morning', name: '', reason: '' });
+    }
+  });
+
+  it('rejects intent="agent" with multiple fragments', () => {
+    const r = surveySchema.safeParse({
+      intent: 'agent',
+      summary: 's',
+      fragments: [{ purpose: 'a' }, { purpose: 'b' }],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects intent="dashboard-existing" with non-empty fragments', () => {
+    const r = surveySchema.safeParse({
+      intent: 'dashboard-existing',
+      summary: 's',
+      fragments: [{ purpose: 'a' }],
+      matchedAgents: [{ id: 'a-b', matchedFor: 'x' }],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects intent="dashboard-new" with non-empty matchedAgents', () => {
+    const r = surveySchema.safeParse({
+      intent: 'dashboard-new',
+      summary: 's',
+      fragments: [{ purpose: 'a' }],
+      matchedAgents: [{ id: 'a-b', matchedFor: 'x' }],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects intent="dashboard-mixed" with empty fragments', () => {
+    const r = surveySchema.safeParse({
+      intent: 'dashboard-mixed',
+      summary: 's',
+      matchedAgents: [{ id: 'a-b', matchedFor: 'x' }],
+      fragments: [],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects malformed matchedAgents.id', () => {
+    const r = surveySchema.safeParse({
+      ...validMixedSurvey,
+      matchedAgents: [{ id: 'Weather Forecast', matchedFor: 'x' }],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects malformed fragments.suggestedName', () => {
+    const r = surveySchema.safeParse({
+      ...validMixedSurvey,
+      fragments: [{ purpose: 'p', suggestedName: 'Notes List' }],
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('draftSchema', () => {
+  it('accepts a complete draft', () => {
+    const r = draftSchema.safeParse({
+      id: 'stock-ticker',
+      purpose: 'show stock prices',
+      yaml: 'id: stock-ticker\nname: Stock\n...',
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects malformed id', () => {
+    const r = draftSchema.safeParse({
+      id: 'Stock Ticker',
+      purpose: 'show stock prices',
+      yaml: 'id: stock-ticker\n',
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects empty yaml', () => {
+    const r = draftSchema.safeParse({ id: 'x', purpose: 'p', yaml: '' });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('dashboardDesignSchema', () => {
+  it('accepts a valid design', () => {
+    const r = dashboardDesignSchema.safeParse({
+      id: 'user:morning',
+      name: 'Morning Briefing',
+      sections: [{ title: 'News', agentIds: ['hn-top-stories'] }],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects dashboard.id without user: prefix', () => {
+    const r = dashboardDesignSchema.safeParse({
+      id: 'morning',
+      name: 'Morning',
+      sections: [{ title: 'X', agentIds: ['a'] }],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects empty sections', () => {
+    const r = dashboardDesignSchema.safeParse({
+      id: 'user:a',
+      name: 'A',
+      sections: [],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects section with empty agentIds', () => {
+    const r = dashboardDesignSchema.safeParse({
+      id: 'user:a',
+      name: 'A',
+      sections: [{ title: 'X', agentIds: [] }],
+    });
+    expect(r.success).toBe(false);
+  });
+});

--- a/packages/core/src/survey-schema.ts
+++ b/packages/core/src/survey-schema.ts
@@ -1,0 +1,169 @@
+/**
+ * Schema for the structured output of the goal-surveyor agent (stage 1
+ * of the build orchestrator).
+ *
+ * The build orchestrator reads a free-form goal → kicks off the surveyor
+ * → parses the survey → fans out one agent-drafter per fragment in
+ * parallel → optionally kicks off the dashboard-designer → assembles
+ * everything into a BuildPlan (see `build-plan-schema.ts`).
+ *
+ * The survey itself is intermediate state; the user-facing artifact
+ * remains the BuildPlan. We validate this loosely (optional fields
+ * default to []) but strictly enough to catch obvious LLM noise.
+ */
+
+import { z } from 'zod';
+
+const AGENT_ID_RE = /^[a-z0-9][a-z0-9_-]*$/;
+
+export const surveySchema = z.object({
+  intent: z.enum(['agent', 'dashboard-existing', 'dashboard-new', 'dashboard-mixed']),
+  summary: z.string().min(1, 'summary is required'),
+
+  /**
+   * Agents the surveyor matched against the goal. Existing agents the
+   * orchestrator will reuse — no drafting needed.
+   */
+  matchedAgents: z.array(z.object({
+    id: z.string().regex(AGENT_ID_RE, 'matchedAgents.id must be lowercase_with_dashes_or_underscores'),
+    matchedFor: z.string().min(1),
+  })).default([]),
+
+  /**
+   * Goal fragments that have no installed match — these become
+   * agent-drafter invocations. Each is one purpose, optionally with a
+   * suggested id (the drafter may rename to avoid collisions).
+   */
+  fragments: z.array(z.object({
+    purpose: z.string().min(1, 'fragments.purpose is required'),
+    suggestedName: z.string().regex(AGENT_ID_RE, 'fragments.suggestedName must be lowercase_with_dashes_or_underscores').optional(),
+  })).default([]),
+
+  /**
+   * Installed dashboards that overlap with the goal theme. Surfaced to
+   * the user as "looks like you have one of these already" — no
+   * automatic merge.
+   */
+  existingDashboards: z.array(
+    z.union([
+      z.string().min(1).transform((id) => ({ id, name: '', reason: '' })),
+      z.object({
+        id: z.string().min(1),
+        name: z.string().optional().default(''),
+        reason: z.string().optional().default(''),
+      }),
+    ]),
+  ).default([]),
+
+  /**
+   * Available packs the surveyor thinks could cover one or more
+   * fragments. Orchestrator surfaces these as suggestions, not
+   * auto-installs.
+   */
+  packSuggestions: z.array(z.object({
+    packId: z.string().min(1),
+    coversFragment: z.string().min(1),
+  })).default([]),
+
+  /**
+   * Clarifying questions, same shape as build-planner's questions[].
+   * The orchestrator passes these through to the BuildPlan unchanged
+   * so the wizard can render the existing questions UI.
+   */
+  questions: z.array(z.object({
+    text: z.string().min(1),
+    suggestedAnswer: z.string().optional(),
+    options: z.array(z.string().min(1)).optional(),
+  })).default([]),
+}).superRefine((survey, ctx) => {
+  // Intent vs. content consistency. These mirror the validator rules
+  // in build-plan-schema.ts, but applied to the survey shape so the
+  // orchestrator can fail fast before fanning out drafters.
+  if (survey.intent === 'agent' && survey.fragments.length !== 1) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['fragments'],
+      message: `intent="agent" requires exactly one fragment, got ${survey.fragments.length}`,
+    });
+  }
+  if (survey.intent === 'dashboard-existing' && survey.fragments.length !== 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['fragments'],
+      message: `intent="dashboard-existing" requires zero fragments, got ${survey.fragments.length}`,
+    });
+  }
+  if (survey.intent === 'dashboard-new' && survey.matchedAgents.length !== 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['matchedAgents'],
+      message: `intent="dashboard-new" requires zero matchedAgents, got ${survey.matchedAgents.length}`,
+    });
+  }
+  if (survey.intent === 'dashboard-mixed') {
+    if (survey.matchedAgents.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['matchedAgents'],
+        message: `intent="dashboard-mixed" requires at least one matchedAgent`,
+      });
+    }
+    if (survey.fragments.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['fragments'],
+        message: `intent="dashboard-mixed" requires at least one fragment`,
+      });
+    }
+  }
+});
+
+export type Survey = z.output<typeof surveySchema>;
+export type SurveyInput = z.input<typeof surveySchema>;
+
+/**
+ * Schema for the single-agent output of the agent-drafter agent.
+ * Matches one entry of `newAgents[]` in the assembled BuildPlan.
+ */
+export const draftSchema = z.object({
+  id: z.string().regex(AGENT_ID_RE, 'id must be lowercase_with_dashes_or_underscores'),
+  purpose: z.string().min(1, 'purpose is required'),
+  yaml: z.string().min(1, 'yaml is required'),
+});
+
+export type Draft = z.output<typeof draftSchema>;
+
+/**
+ * Schema for the dashboard-designer's output. Matches the `dashboard`
+ * sub-object in the assembled BuildPlan.
+ */
+const DASHBOARD_ID_RE = /^user:[a-z0-9][a-z0-9_-]*$/;
+
+export const dashboardDesignSchema = z.object({
+  id: z.string().regex(DASHBOARD_ID_RE, 'dashboard.id must start with "user:" followed by lowercase_with_dashes_or_underscores'),
+  name: z.string().min(1, 'dashboard.name is required'),
+  sections: z.array(z.object({
+    title: z.string().min(1, 'sections.title is required'),
+    agentIds: z.array(z.string().regex(AGENT_ID_RE, 'sections.agentIds[] must be lowercase_with_dashes_or_underscores')).min(1, 'sections.agentIds must have at least one entry'),
+  })).min(1, 'dashboard must have at least one section'),
+});
+
+export type DashboardDesign = z.output<typeof dashboardDesignSchema>;
+
+/**
+ * Extract a survey JSON string from a raw LLM response. Mirrors
+ * `extractPlanJson` from build-plan-schema.ts but looks for
+ * `<survey>…</survey>` first. Falls back to bare JSON.
+ */
+export function extractSurveyJson(raw: string): string | null {
+  const surveyTag = /<survey>([\s\S]*?)<\/survey>/i.exec(raw);
+  if (surveyTag) return surveyTag[1].trim();
+
+  const fenced = /```(?:json)?\s*([\s\S]*?)```/i.exec(raw);
+  if (fenced) return fenced[1].trim();
+
+  const bare = raw.trim();
+  if (bare.startsWith('{') && bare.endsWith('}')) return bare;
+
+  return null;
+}

--- a/packages/dashboard/src/routes/build-orchestrator.ts
+++ b/packages/dashboard/src/routes/build-orchestrator.ts
@@ -1,0 +1,657 @@
+/**
+ * Build-from-goal orchestrator.
+ *
+ * Replaces the legacy monolithic build-planner with a three-stage flow:
+ *   1. goal-surveyor   — classifies intent + decomposes goal into fragments
+ *   2. agent-drafter   — drafts ONE agent per fragment, fanned out in parallel
+ *   3. dashboard-designer (optional) — designs the dashboard layout from the
+ *      finalized agent-id list
+ *
+ * Sessions are kept in-process (a Map). Lifecycle:
+ *   - POST /agents/build creates a session, kicks off the surveyor, returns the
+ *     session-id (which the wizard polls as if it were a runId).
+ *   - GET /agents/build/:id (in run-now-build.ts) calls advanceSession() to
+ *     drive the state machine, then formats the response.
+ *
+ * /agents/draft-one uses the same machinery with a one-spec, no-surveyor,
+ * no-designer fast path.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import {
+  executeAgentDag,
+  extractPlanJson,
+  extractSurveyJson,
+  parseAgent,
+  surveySchema,
+  draftSchema,
+  dashboardDesignSchema,
+  buildPlanSchema,
+  type Agent,
+  type BuildPlan,
+  type Draft,
+  type Survey,
+  type DashboardDesign,
+  type RunStatus,
+} from '@some-useful-agents/core';
+import type { getContext } from '../context.js';
+
+type Ctx = ReturnType<typeof getContext>;
+
+const SURVEYOR_AGENT_ID = 'goal-surveyor';
+const DRAFTER_AGENT_ID = 'agent-drafter';
+const DESIGNER_AGENT_ID = 'dashboard-designer';
+
+const SESSION_TTL_MS = 60 * 60 * 1000; // 1h
+
+export type SessionPhase = 'survey' | 'drafting' | 'design' | 'assembling' | 'done' | 'failed';
+
+interface BuildSession {
+  id: string;
+  goal: string;
+  focus: string;
+  createdAt: number;
+
+  phase: SessionPhase;
+  phaseMessage: string;
+
+  surveyorRunId?: string;
+  drafterRunIds: Map<string, string>; // fragmentKey -> runId
+  designerRunId?: string;
+
+  survey?: Survey;
+  drafts: Map<string, Draft>;
+  dashboard?: DashboardDesign;
+  plan?: BuildPlan;
+  error?: string;
+
+  /** When true, this is a single-drafter /agents/draft-one session. Skip surveyor + designer. */
+  draftOnly: boolean;
+  /** Cached for /agents/draft-one — the spec the user requested. */
+  draftOnlySpec?: { purpose: string; suggestedName?: string };
+}
+
+const sessions = new Map<string, BuildSession>();
+
+function newSessionId(prefix = 'build'): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Best-effort GC: drop sessions older than TTL on each create. Cheap because
+ * we expect <100 concurrent sessions.
+ */
+function gcSessions(now: number = Date.now()): void {
+  for (const [id, s] of sessions) {
+    if (now - s.createdAt > SESSION_TTL_MS) sessions.delete(id);
+  }
+}
+
+// ── Agent kickoff helpers ──────────────────────────────────────────────
+
+/**
+ * Auto-import an example agent into the store on first use, then return it.
+ * Mirrors the pattern in pulse-layout-plan.ts / dashboard-layout-plan.ts so
+ * fresh installs work without the user running `sua agent install` manually.
+ */
+function loadExampleAgent(ctx: Ctx, agentId: string): Agent | null {
+  try {
+    const yamlPath = join(resolve('agents/examples'), `${agentId}.yaml`);
+    const yamlText = readFileSync(yamlPath, 'utf-8');
+    const parsed = parseAgent(yamlText);
+    ctx.agentStore.upsertAgent(parsed, 'import', `Auto-imported for build orchestrator (${agentId})`);
+  } catch { /* fall through — agent may already be installed */ }
+  return ctx.agentStore.getAgent(agentId);
+}
+
+async function kickoffAgentRun(args: {
+  ctx: Ctx;
+  agent: Agent;
+  inputs: Record<string, string>;
+}): Promise<string | null> {
+  const { ctx, agent, inputs } = args;
+  const runPromise = executeAgentDag(
+    agent,
+    {
+      triggeredBy: 'dashboard',
+      inputs,
+    },
+    {
+      runStore: ctx.runStore,
+      secretsStore: ctx.secretsStore,
+      variablesStore: ctx.variablesStore,
+      dataRoot: ctx.agentStore.dataRoot,
+    },
+  );
+  // Race the run-record creation; we only need the id, not the result.
+  await Promise.race([runPromise, new Promise((r) => setTimeout(r, 200))]);
+  const { rows } = ctx.runStore.queryRuns({
+    agentName: agent.id,
+    statuses: ['running', 'completed', 'failed'] as RunStatus[],
+    limit: 1,
+    offset: 0,
+  });
+  if (rows.length > 0) return rows[0].id;
+  try {
+    const run = await runPromise;
+    return run.id;
+  } catch {
+    return null;
+  }
+}
+
+// ── Catalog helpers ────────────────────────────────────────────────────
+
+import {
+  buildDiscoveryCatalog,
+  listBuiltinTools,
+  type ToolDefinition,
+} from '@some-useful-agents/core';
+import { TEMPLATE_REGISTRY } from '../views/pulse-templates.js';
+import { formatToolCatalog } from './run-now-build.js';
+
+function buildCatalogs(ctx: Ctx): { tools: string; discovery: string } {
+  const builtins = listBuiltinTools();
+  let userTools: ToolDefinition[] = [];
+  try {
+    if (ctx.toolStore) userTools = ctx.toolStore.listTools();
+  } catch { /* tool store unavailable */ }
+  return {
+    tools: formatToolCatalog([...builtins, ...userTools]),
+    discovery: buildDiscoveryCatalog({
+      agents: ctx.agentStore.listAgents(),
+      tools: [...builtins, ...userTools],
+      templateRegistry: TEMPLATE_REGISTRY,
+      dashboards: ctx.dashboardsStore?.listDashboards(),
+      packs: ctx.packsStore?.listPacks(),
+    }),
+  };
+}
+
+function existingAgentIds(ctx: Ctx): Set<string> {
+  try {
+    return new Set(ctx.agentStore.listAgents().map((a) => a.id));
+  } catch {
+    return new Set();
+  }
+}
+
+// ── Public API ─────────────────────────────────────────────────────────
+
+/**
+ * Start a build session from a free-form goal. Kicks off the goal-surveyor
+ * and returns the session id (which the wizard polls as the runId).
+ *
+ * Returns null when the surveyor agent can't be loaded.
+ */
+export async function startBuildSession(args: {
+  ctx: Ctx;
+  goal: string;
+  focus: string;
+}): Promise<string | null> {
+  const { ctx, goal, focus } = args;
+  gcSessions();
+
+  const surveyor = loadExampleAgent(ctx, SURVEYOR_AGENT_ID);
+  if (!surveyor) return null;
+
+  const { discovery } = buildCatalogs(ctx);
+  const runId = await kickoffAgentRun({
+    ctx,
+    agent: surveyor,
+    inputs: {
+      GOAL: goal,
+      FOCUS: focus,
+      DISCOVERY_CATALOG: discovery,
+    },
+  });
+  if (!runId) return null;
+
+  const sessionId = newSessionId('build');
+  sessions.set(sessionId, {
+    id: sessionId,
+    goal,
+    focus,
+    createdAt: Date.now(),
+    phase: 'survey',
+    phaseMessage: 'Surveying your goal...',
+    surveyorRunId: runId,
+    drafterRunIds: new Map(),
+    drafts: new Map(),
+    draftOnly: false,
+  });
+  return sessionId;
+}
+
+/**
+ * Start a single-drafter session from one spec. Used by /agents/draft-one
+ * for the Improve-layout Path B inline-drafting flow. Skips surveyor and
+ * designer — assembles a single-agent BuildPlan when the drafter finishes.
+ */
+export async function startDraftOneSession(args: {
+  ctx: Ctx;
+  purpose: string;
+  suggestedName?: string;
+  focus: string;
+}): Promise<string | null> {
+  const { ctx, purpose, suggestedName, focus } = args;
+  gcSessions();
+
+  const drafter = loadExampleAgent(ctx, DRAFTER_AGENT_ID);
+  if (!drafter) return null;
+
+  const { tools, discovery } = buildCatalogs(ctx);
+  const existingIds = Array.from(existingAgentIds(ctx)).join(', ');
+
+  const runId = await kickoffAgentRun({
+    ctx,
+    agent: drafter,
+    inputs: {
+      PURPOSE: purpose,
+      SUGGESTED_NAME: suggestedName ?? '',
+      FOCUS: focus,
+      EXISTING_AGENT_IDS: existingIds,
+      AVAILABLE_TOOLS: tools,
+      DISCOVERY_CATALOG: discovery,
+    },
+  });
+  if (!runId) return null;
+
+  const sessionId = newSessionId('draft');
+  const drafterRunIds = new Map<string, string>();
+  drafterRunIds.set('fragment-0', runId);
+  sessions.set(sessionId, {
+    id: sessionId,
+    goal: purpose,
+    focus,
+    createdAt: Date.now(),
+    phase: 'drafting',
+    phaseMessage: 'Drafting agent...',
+    drafterRunIds,
+    drafts: new Map(),
+    draftOnly: true,
+    draftOnlySpec: { purpose, ...(suggestedName ? { suggestedName } : {}) },
+  });
+  return sessionId;
+}
+
+export function getSession(sessionId: string): BuildSession | undefined {
+  return sessions.get(sessionId);
+}
+
+/**
+ * Drive the session state machine. Called on each GET /agents/build/:id poll.
+ * Idempotent — calling twice while in the same phase is a no-op.
+ */
+export async function advanceSession(ctx: Ctx, session: BuildSession): Promise<void> {
+  if (session.phase === 'done' || session.phase === 'failed') return;
+
+  if (session.phase === 'survey') return advanceSurvey(ctx, session);
+  if (session.phase === 'drafting') return advanceDrafting(ctx, session);
+  if (session.phase === 'design') return advanceDesign(ctx, session);
+  if (session.phase === 'assembling') return advanceAssembling(session);
+}
+
+async function advanceSurvey(ctx: Ctx, session: BuildSession): Promise<void> {
+  if (!session.surveyorRunId) {
+    fail(session, 'Surveyor run was never started.');
+    return;
+  }
+  const run = ctx.runStore.getRun(session.surveyorRunId);
+  if (!run) {
+    fail(session, 'Surveyor run record missing.');
+    return;
+  }
+  if (run.status === 'running' || run.status === 'pending') return;
+  if (run.status !== 'completed' || !run.result) {
+    fail(session, run.error ?? `Surveyor failed (${run.status}).`);
+    return;
+  }
+
+  const surveyJson = extractSurveyJson(run.result);
+  if (!surveyJson) {
+    fail(session, 'Surveyor did not produce a <survey>...</survey> block.');
+    return;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(surveyJson);
+  } catch (e) {
+    fail(session, `Survey JSON did not parse: ${e instanceof Error ? e.message : String(e)}`);
+    return;
+  }
+  const validated = surveySchema.safeParse(parsed);
+  if (!validated.success) {
+    const issues = validated.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+    fail(session, `Survey failed validation: ${issues}`);
+    return;
+  }
+  session.survey = validated.data;
+
+  // No fragments → skip drafting. If intent is dashboard-existing, jump to
+  // designer; if it's somehow "agent" with zero fragments, fail.
+  if (session.survey.fragments.length === 0) {
+    if (session.survey.intent === 'dashboard-existing') {
+      await startDesignerStage(ctx, session);
+    } else {
+      fail(session, `Survey returned intent=${session.survey.intent} with no fragments to draft.`);
+    }
+    return;
+  }
+
+  // Fan out drafters in parallel.
+  const knownIds = new Set<string>([...existingAgentIds(ctx)]);
+  session.survey.matchedAgents.forEach((m) => knownIds.add(m.id));
+  // Also reserve any suggestedName up front so drafters don't race on the same id.
+  const reservedSuggestions = new Set<string>();
+  session.survey.fragments.forEach((f) => {
+    if (f.suggestedName && !knownIds.has(f.suggestedName)) {
+      reservedSuggestions.add(f.suggestedName);
+    }
+  });
+
+  const drafter = loadExampleAgent(ctx, DRAFTER_AGENT_ID);
+  if (!drafter) {
+    fail(session, 'Agent-drafter not found. Ensure agent-drafter.yaml exists in agents/examples/.');
+    return;
+  }
+
+  const { tools, discovery } = buildCatalogs(ctx);
+
+  // Fire all kickoffs concurrently; collect run-ids.
+  const kickoffs = session.survey.fragments.map(async (fragment, i) => {
+    // Each drafter sees: existing agents + matched agents + sibling-reserved suggestions
+    // (minus its own reservation). Prevents collisions.
+    const own = fragment.suggestedName;
+    const blocked = new Set(knownIds);
+    reservedSuggestions.forEach((s) => {
+      if (s !== own) blocked.add(s);
+    });
+    const runId = await kickoffAgentRun({
+      ctx,
+      agent: drafter,
+      inputs: {
+        PURPOSE: fragment.purpose,
+        SUGGESTED_NAME: fragment.suggestedName ?? '',
+        FOCUS: session.focus,
+        EXISTING_AGENT_IDS: Array.from(blocked).join(', '),
+        AVAILABLE_TOOLS: tools,
+        DISCOVERY_CATALOG: discovery,
+      },
+    });
+    return [`fragment-${i}`, runId] as const;
+  });
+  const results = await Promise.all(kickoffs);
+
+  for (const [key, runId] of results) {
+    if (!runId) {
+      fail(session, `Failed to kick off drafter for ${key}.`);
+      return;
+    }
+    session.drafterRunIds.set(key, runId);
+  }
+  session.phase = 'drafting';
+  session.phaseMessage = `Drafting ${session.drafterRunIds.size} agents in parallel...`;
+}
+
+async function advanceDrafting(ctx: Ctx, session: BuildSession): Promise<void> {
+  let stillRunning = 0;
+  const failedFragments: string[] = [];
+  for (const [key, runId] of session.drafterRunIds) {
+    if (session.drafts.has(key)) continue; // already collected
+
+    const run = ctx.runStore.getRun(runId);
+    if (!run) {
+      failedFragments.push(`${key}: run record missing`);
+      continue;
+    }
+    if (run.status === 'running' || run.status === 'pending') {
+      stillRunning += 1;
+      continue;
+    }
+    if (run.status !== 'completed' || !run.result) {
+      failedFragments.push(`${key}: ${run.error ?? run.status}`);
+      continue;
+    }
+
+    const planJson = extractPlanJson(run.result);
+    if (!planJson) {
+      failedFragments.push(`${key}: no <plan>…</plan> block`);
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(planJson);
+    } catch (e) {
+      failedFragments.push(`${key}: ${e instanceof Error ? e.message : String(e)}`);
+      continue;
+    }
+    const validated = draftSchema.safeParse(parsed);
+    if (!validated.success) {
+      const issues = validated.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+      failedFragments.push(`${key}: schema — ${issues}`);
+      continue;
+    }
+    // Sanity: yaml parses + id matches.
+    try {
+      const a = parseAgent(validated.data.yaml);
+      if (a.id !== validated.data.id) {
+        failedFragments.push(`${key}: parsed YAML id "${a.id}" ≠ plan id "${validated.data.id}"`);
+        continue;
+      }
+    } catch (e) {
+      failedFragments.push(`${key}: YAML parse — ${e instanceof Error ? e.message : String(e)}`);
+      continue;
+    }
+
+    session.drafts.set(key, validated.data);
+  }
+
+  session.phaseMessage = `Drafting agents... (${session.drafts.size}/${session.drafterRunIds.size} done)`;
+
+  if (stillRunning > 0) return;
+
+  if (failedFragments.length > 0) {
+    fail(session, `Drafter(s) failed: ${failedFragments.join(' | ')}`);
+    return;
+  }
+
+  // All drafters done. Decide next stage.
+  if (session.draftOnly) {
+    assembleAgentOnlyPlan(session);
+    return;
+  }
+  if (!session.survey) {
+    fail(session, 'Drafting completed without a survey — invariant violation.');
+    return;
+  }
+  if (session.survey.intent === 'agent') {
+    assembleAgentOnlyPlan(session);
+    return;
+  }
+  // dashboard-* → designer.
+  await startDesignerStage(ctx, session);
+}
+
+async function startDesignerStage(ctx: Ctx, session: BuildSession): Promise<void> {
+  if (!session.survey) {
+    fail(session, 'Designer stage entered without a survey — invariant violation.');
+    return;
+  }
+  const designer = loadExampleAgent(ctx, DESIGNER_AGENT_ID);
+  if (!designer) {
+    fail(session, 'Dashboard-designer not found. Ensure dashboard-designer.yaml exists in agents/examples/.');
+    return;
+  }
+  const allAgentIds = [
+    ...session.survey.matchedAgents.map((a) => a.id),
+    ...Array.from(session.drafts.values()).map((d) => d.id),
+  ];
+  const descriptions = [
+    ...session.survey.matchedAgents.map((a) => ({ id: a.id, purpose: a.matchedFor })),
+    ...Array.from(session.drafts.values()).map((d) => ({ id: d.id, purpose: d.purpose })),
+  ];
+  const runId = await kickoffAgentRun({
+    ctx,
+    agent: designer,
+    inputs: {
+      INTENT: session.survey.intent,
+      GOAL: session.goal,
+      AGENT_IDS: allAgentIds.join(', '),
+      AGENT_DESCRIPTIONS: JSON.stringify(descriptions),
+    },
+  });
+  if (!runId) {
+    fail(session, 'Failed to kick off dashboard-designer.');
+    return;
+  }
+  session.designerRunId = runId;
+  session.phase = 'design';
+  session.phaseMessage = 'Designing dashboard layout...';
+}
+
+async function advanceDesign(ctx: Ctx, session: BuildSession): Promise<void> {
+  if (!session.designerRunId) {
+    fail(session, 'Designer stage entered without a runId — invariant violation.');
+    return;
+  }
+  const run = ctx.runStore.getRun(session.designerRunId);
+  if (!run) {
+    fail(session, 'Designer run record missing.');
+    return;
+  }
+  if (run.status === 'running' || run.status === 'pending') return;
+  if (run.status !== 'completed' || !run.result) {
+    fail(session, run.error ?? `Designer failed (${run.status}).`);
+    return;
+  }
+  const planJson = extractPlanJson(run.result);
+  if (!planJson) {
+    fail(session, 'Designer did not produce a <plan>...</plan> block.');
+    return;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(planJson);
+  } catch (e) {
+    fail(session, `Designer JSON did not parse: ${e instanceof Error ? e.message : String(e)}`);
+    return;
+  }
+  const validated = dashboardDesignSchema.safeParse(parsed);
+  if (!validated.success) {
+    const issues = validated.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+    fail(session, `Dashboard design failed validation: ${issues}`);
+    return;
+  }
+  session.dashboard = validated.data;
+  session.phase = 'assembling';
+  session.phaseMessage = 'Assembling plan...';
+  advanceAssembling(session);
+}
+
+function advanceAssembling(session: BuildSession): void {
+  if (!session.survey) {
+    fail(session, 'Assembling without a survey — invariant violation.');
+    return;
+  }
+  const plan: BuildPlan = {
+    intent: session.survey.intent,
+    summary: session.survey.summary,
+    survey: {
+      matchedAgents: session.survey.matchedAgents,
+      missingFor: session.survey.fragments.map((f) => f.purpose),
+      existingDashboards: session.survey.existingDashboards,
+    },
+    newAgents: Array.from(session.drafts.values()),
+    dashboard: session.dashboard
+      ? {
+          id: session.dashboard.id,
+          name: session.dashboard.name,
+          sections: session.dashboard.sections,
+        }
+      : null,
+    questions: session.survey.questions,
+  };
+  const validated = buildPlanSchema.safeParse(plan);
+  if (!validated.success) {
+    const issues = validated.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+    fail(session, `Assembled BuildPlan failed validation: ${issues}`);
+    return;
+  }
+  session.plan = validated.data;
+  session.phase = 'done';
+  session.phaseMessage = 'Done.';
+}
+
+function assembleAgentOnlyPlan(session: BuildSession): void {
+  const drafts = Array.from(session.drafts.values());
+  if (drafts.length === 0) {
+    fail(session, 'No drafted agents to assemble.');
+    return;
+  }
+  const plan: BuildPlan = {
+    intent: 'agent',
+    summary: session.draftOnly
+      ? `Drafted ${drafts[0].id}: ${drafts[0].purpose}`
+      : `Drafted ${drafts.length} agent${drafts.length === 1 ? '' : 's'}.`,
+    survey: {
+      matchedAgents: session.survey?.matchedAgents ?? [],
+      missingFor: drafts.map((d) => d.purpose),
+      existingDashboards: session.survey?.existingDashboards ?? [],
+    },
+    newAgents: drafts,
+    dashboard: null,
+    questions: session.survey?.questions ?? [],
+  };
+  const validated = buildPlanSchema.safeParse(plan);
+  if (!validated.success) {
+    const issues = validated.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+    fail(session, `Assembled single-agent BuildPlan failed validation: ${issues}`);
+    return;
+  }
+  session.plan = validated.data;
+  session.phase = 'done';
+  session.phaseMessage = 'Done.';
+}
+
+function fail(session: BuildSession, error: string): void {
+  session.phase = 'failed';
+  session.error = error;
+  session.phaseMessage = error;
+}
+
+/**
+ * Per-drafter progress for the wizard UI. Returns null when the session has
+ * no drafters yet (still in survey).
+ */
+export function drafterProgress(ctx: Ctx, session: BuildSession): Array<{
+  key: string;
+  status: 'running' | 'done' | 'failed';
+  id?: string;
+  purpose?: string;
+}> | null {
+  if (session.drafterRunIds.size === 0) return null;
+  const rows: Array<{ key: string; status: 'running' | 'done' | 'failed'; id?: string; purpose?: string }> = [];
+  for (const [key, runId] of session.drafterRunIds) {
+    const draft = session.drafts.get(key);
+    if (draft) {
+      rows.push({ key, status: 'done', id: draft.id, purpose: draft.purpose });
+      continue;
+    }
+    const run = ctx.runStore.getRun(runId);
+    if (!run) {
+      rows.push({ key, status: 'failed' });
+      continue;
+    }
+    if (run.status === 'running' || run.status === 'pending') {
+      rows.push({ key, status: 'running' });
+    } else if (run.status === 'completed') {
+      // Completed but not yet parsed into drafts map (advanceDrafting hasn't run)
+      rows.push({ key, status: 'running' });
+    } else {
+      rows.push({ key, status: 'failed' });
+    }
+  }
+  return rows;
+}

--- a/packages/dashboard/src/routes/run-now-build.ts
+++ b/packages/dashboard/src/routes/run-now-build.ts
@@ -27,6 +27,13 @@ import { parse as parseRawYaml, stringify as stringifyRawYaml } from 'yaml';
 import { readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { getContext } from '../context.js';
+import {
+  startBuildSession,
+  startDraftOneSession,
+  getSession,
+  advanceSession,
+  drafterProgress,
+} from './build-orchestrator.js';
 
 export const buildRouter: Router = Router();
 
@@ -268,7 +275,7 @@ export function autoFixYaml(yaml: string): string {
  * Format a list of tool definitions into a human-readable catalog string
  * for injection into the builder agent prompt.
  */
-function formatToolCatalog(tools: ToolDefinition[]): string {
+export function formatToolCatalog(tools: ToolDefinition[]): string {
   return tools
     .map((t) => {
       const inputNames = Object.keys(t.inputs ?? {}).join(', ');
@@ -763,8 +770,9 @@ Output ONLY the complete fixed YAML. Nothing else.`,
 // ── Agent Builder (goal-driven wizard) ─────────────────────────────────
 
 /**
- * POST /agents/build — run the agent-builder with a goal prompt.
- * Returns { runId } immediately for polling.
+ * POST /agents/build — run the multi-stage build orchestrator
+ * (goal-surveyor → agent-drafter × N → dashboard-designer).
+ * Returns a session id (used as runId) for polling.
  */
 buildRouter.post('/agents/build', async (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
@@ -777,35 +785,95 @@ buildRouter.post('/agents/build', async (req: Request, res: Response) => {
     return;
   }
 
-  // First-attempt memory retrieval: intent is unknown yet, so Jaccard
-  // alone picks candidates. Empty result is a no-op.
-  const priorPlans = ctx.plannerMemoryStore
-    ? findSimilarCommittedPlans(ctx.plannerMemoryStore, { goal })
-    : [];
-
-  const runId = await kickoffPlannerRun({ ctx, goal, focus, priorPlans });
-  if (!runId) {
-    res.json({ ok: false, error: 'Build planner agent not found. Ensure build-planner.yaml exists in agents/examples/.' });
+  const sessionId = await startBuildSession({ ctx, goal, focus });
+  if (!sessionId) {
+    res.json({
+      ok: false,
+      error: 'Goal surveyor agent not found. Ensure goal-surveyor.yaml exists in agents/examples/.',
+    });
     return;
   }
 
-  res.json({ ok: true, status: 'started', runId });
+  res.json({ ok: true, status: 'started', runId: sessionId });
 
-  // Telemetry: record this planner run with its goal so /metrics/planner
-  // can correlate timing + outcome later. Best-effort — failure is silent.
+  // Telemetry: record the session as a planner run for /metrics/planner
+  // continuity. Best-effort — failure is silent.
   if (ctx.plannerTelemetryStore) {
-    try { ctx.plannerTelemetryStore.recordStart(runId, goal); } catch { /* swallow */ }
+    try { ctx.plannerTelemetryStore.recordStart(sessionId, goal); } catch { /* swallow */ }
   }
 });
 
 /**
- * GET /agents/build/:runId — poll builder run status.
- * Returns YAML when done so the client can preview + create.
+ * POST /agents/draft-one — single-spec drafter for the Improve-layout
+ * Path B inline-drafting flow. Skips the goal-surveyor (the layout
+ * planner already produced the spec) and the dashboard-designer (the
+ * layout planner owns dashboard layout). Just runs one agent-drafter
+ * and assembles a single-agent BuildPlan when it completes.
+ *
+ * Body: { purpose: string, suggestedName?: string, focus?: string }
+ * Returns: { ok, runId } where runId is a session-id polled via
+ * GET /agents/build/:runId — the orchestrator state machine handles both.
+ */
+buildRouter.post('/agents/draft-one', async (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const purpose = typeof body.purpose === 'string' ? body.purpose.trim() : '';
+  const suggestedName = typeof body.suggestedName === 'string' && body.suggestedName.trim()
+    ? body.suggestedName.trim()
+    : undefined;
+  const focus = typeof body.focus === 'string' ? body.focus.trim() : '';
+
+  if (!purpose) {
+    res.json({ ok: false, error: 'purpose is required.' });
+    return;
+  }
+
+  const sessionId = await startDraftOneSession({ ctx, purpose, suggestedName, focus });
+  if (!sessionId) {
+    res.json({
+      ok: false,
+      error: 'Agent drafter not found. Ensure agent-drafter.yaml exists in agents/examples/.',
+    });
+    return;
+  }
+  res.json({ ok: true, status: 'started', runId: sessionId });
+});
+
+/**
+ * GET /agents/build/:runId — poll the orchestrator session.
+ * Drives the session state machine on each poll, then formats the
+ * current phase for the wizard.
  */
 buildRouter.get('/agents/build/:runId', async (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
   const runId = Array.isArray(req.params.runId) ? req.params.runId[0] : req.params.runId;
 
+  // Orchestrator session: dispatch state machine on each poll.
+  const session = getSession(runId);
+  if (session) {
+    await advanceSession(ctx, session);
+    if (session.phase === 'failed') {
+      res.json({ ok: true, status: 'failed', error: session.error ?? 'Build failed.' });
+      return;
+    }
+    if (session.phase === 'done' && session.plan) {
+      res.json({ ok: true, status: 'done', plan: session.plan });
+      return;
+    }
+    // Still running. Surface per-drafter progress when present.
+    const progress = drafterProgress(ctx, session);
+    res.json({
+      ok: true,
+      status: 'running',
+      phase: session.phaseMessage,
+      ...(progress ? { progress } : {}),
+    });
+    return;
+  }
+
+  // Fall-through: a legacy raw runId (no session). Preserved for
+  // backward compat with any external script polling a planner runId
+  // directly — should be unused in the wizard now.
   const run = ctx.runStore.getRun(runId);
   if (!run) {
     res.json({ ok: false, status: 'not_found' });

--- a/packages/dashboard/src/views/build-from-goal.js.ts
+++ b/packages/dashboard/src/views/build-from-goal.js.ts
@@ -20,13 +20,7 @@ export const BUILD_FROM_GOAL_JS = `
     if (!btn || !modal || !content) return;
 
     function esc(s) { var d = document.createElement('div'); d.textContent = s == null ? '' : String(s); return d.innerHTML; }
-    function closeModal() {
-      modal.classList.remove('is-open');
-      // Closing/cancelling build-from-goal abandons any improve-layout
-      // handoff. The success path captures the handoff before calling
-      // closeModal, so this clear only affects cancel/backdrop paths.
-      try { sessionStorage.removeItem('sua-layout-handoff-v1'); } catch (e) {}
-    }
+    function closeModal() { modal.classList.remove('is-open'); }
 
     btn.addEventListener('click', function () { modal.classList.add('is-open'); });
 
@@ -87,6 +81,7 @@ export const BUILD_FROM_GOAL_JS = `
         '<div style="height:4px;background:var(--color-border);border-radius:2px;overflow:hidden;margin-bottom:var(--space-3);">' +
           '<div id="build-bar" style="height:100%;background:var(--color-primary);border-radius:2px;width:0%;transition:width 1s linear;"></div>' +
         '</div>' +
+        '<div id="build-drafter-progress" style="display:flex;flex-wrap:wrap;gap:var(--space-2);margin-bottom:var(--space-3);min-height:1.25em;"></div>' +
         '<div style="text-align:right;"><button type="button" class="btn btn--ghost btn--sm" id="build-cancel">Cancel</button></div></div>';
 
       var serverPhase = '';
@@ -130,6 +125,22 @@ export const BUILD_FROM_GOAL_JS = `
                   serverPhase = data.phase;
                   var pe = document.getElementById('build-phase');
                   if (pe) pe.textContent = data.phase;
+                }
+                // Per-drafter progress pills (orchestrator surfaces these
+                // during the drafting phase). Render below the phase text.
+                if (Array.isArray(data.progress) && data.progress.length > 0) {
+                  var pp = document.getElementById('build-drafter-progress');
+                  if (pp) {
+                    pp.innerHTML = data.progress.map(function (p) {
+                      var statusColor = p.status === 'done' ? 'var(--color-success, #0a0)' :
+                                        p.status === 'failed' ? 'var(--color-danger, #a00)' :
+                                        'var(--color-text-muted)';
+                      var label = p.id ? esc(p.id) : 'agent #' + esc(p.key.replace('fragment-', ''));
+                      var statusLabel = p.status === 'done' ? '✓' : p.status === 'failed' ? '✗' : '⏳';
+                      return '<span style="display:inline-flex;align-items:center;gap:var(--space-1);padding:0 var(--space-1);font-family:var(--font-mono);font-size:var(--font-size-xs);color:' + statusColor + ';">' +
+                        statusLabel + ' ' + label + '</span>';
+                    }).join(' ');
+                  }
                 }
                 pollTimer = setTimeout(poll, 2000);
               } else if (data.status === 'retrying' && data.runId) {
@@ -378,49 +389,12 @@ export const BUILD_FROM_GOAL_JS = `
             if (result.dashboardError) {
               summary += '<div class="dim" style="color:var(--color-danger,#a00);">Dashboard error: ' + esc(result.dashboardError) + '</div>';
             }
-            // If the improve-layout wizard handed off to us, don't
-            // redirect — close this modal and dispatch a resume event
-            // so the wizard re-opens with the freshly drafted agents
-            // merged in. The handoff has a 1h TTL; stale entries fall
-            // through to the normal redirect.
-            var handoffRaw = null;
-            try { handoffRaw = sessionStorage.getItem('sua-layout-handoff-v1'); } catch (e) {}
-            var handoff = null;
-            if (handoffRaw) {
-              try {
-                var parsed = JSON.parse(handoffRaw);
-                if (parsed && typeof parsed === 'object' && Date.now() - (parsed.createdAt || 0) < 60*60*1000) {
-                  handoff = parsed;
-                }
-              } catch (e) {}
-              if (!handoff) {
-                try { sessionStorage.removeItem('sua-layout-handoff-v1'); } catch (e) {}
-              }
-            }
-
             content.innerHTML = '<div style="padding:var(--space-3);">' +
               '<h3 style="margin:0 0 var(--space-2);">Done</h3>' +
               '<div style="font-size:var(--font-size-sm);">' + summary + '</div>' +
-              '<div class="dim" style="margin-top:var(--space-3);font-size:var(--font-size-xs);">' +
-              (handoff ? 'Returning to layout planner...' : 'Redirecting in 1.5s...') + '</div>' +
+              '<div class="dim" style="margin-top:var(--space-3);font-size:var(--font-size-xs);">Redirecting in 1.5s...</div>' +
               '</div>';
-
-            if (handoff) {
-              setTimeout(function () {
-                closeModal();
-                try { sessionStorage.removeItem('sua-layout-handoff-v1'); } catch (e) {}
-                try {
-                  window.dispatchEvent(new CustomEvent('sua:resume-layout', {
-                    detail: { handoff: handoff, agentsCreated: result.agentsCreated || [] },
-                  }));
-                } catch (e) {
-                  // Older browsers without CustomEvent constructor — fall back to navigation.
-                  window.location.href = '/pulse';
-                }
-              }, 1200);
-            } else {
-              setTimeout(function () { window.location.href = result.redirectUrl || '/agents'; }, 1500);
-            }
+            setTimeout(function () { window.location.href = result.redirectUrl || '/agents'; }, 1500);
           })
           .catch(function (err) {
             commitBtn.disabled = false;

--- a/packages/dashboard/src/views/improve-layout.js.ts
+++ b/packages/dashboard/src/views/improve-layout.js.ts
@@ -43,85 +43,18 @@ export const IMPROVE_LAYOUT_JS = `
     try { return localStorage.getItem(LAYOUT_KEY) || ''; } catch (e) { return ''; }
   }
 
-  // ── Build-from-goal hand-off ────────────────────────────────────────
+  // ── Inline parallel drafting ────────────────────────────────────────
   //
-  // When the planner emits needsNew[], the wizard hands off to
-  // build-from-goal so the user gets the full critic loop. We persist
-  // enough state in sessionStorage that build-from-goal can call us
-  // back when its commit succeeds; on resume, the user sees the
-  // original plan with the freshly drafted agents merged in and only
-  // needs to click Apply layout.
-  var HANDOFF_KEY = 'sua-layout-handoff-v1';
-  var HANDOFF_TTL_MS = 60 * 60 * 1000; // 1h
-
-  function buildGoalFromNeedsNew(needsNew) {
-    var lines = needsNew.map(function (n, i) {
-      var name = n.suggestedName ? n.suggestedName + ' — ' : '';
-      return (i + 1) + '. ' + name + n.purpose;
-    }).join('\\n');
-    var bucket = CURATE_VERB === 'remove' ? 'this dashboard' : 'my Pulse layout';
-    return 'Create these agents for ' + bucket + ':\\n\\n' + lines +
-      '\\n\\nEach agent must declare a Pulse signal (metric, status, or another template) so it can render as a tile.';
-  }
-
-  function handoffToBuildFromGoal(plan, needsNew) {
-    if (!Array.isArray(needsNew) || needsNew.length === 0) return;
-    try {
-      sessionStorage.setItem(HANDOFF_KEY, JSON.stringify({
-        endpointBase: ENDPOINT_BASE,
-        storageKey: LAYOUT_KEY,
-        curateVerb: CURATE_VERB,
-        originalPlan: plan,
-        originalFocus: lastFocus || '',
-        createdAt: Date.now(),
-      }));
-    } catch (e) { /* sessionStorage may be unavailable */ }
-
-    closeModal();
-
-    // Open the build-from-goal modal. The button is rendered hidden
-    // on /pulse and /dashboards/:id pages — click it to open the modal,
-    // then fill in the goal + force agents-only target.
-    var trigger = document.getElementById('build-from-goal-btn');
-    if (!trigger) {
-      // Page doesn't host the build modal — fall back to navigation.
-      // Shouldn't happen on Pulse/dashboard pages, but be defensive.
-      window.location.href = '/agents';
-      return;
-    }
-    trigger.click();
-
-    // Defer DOM mutation so the modal markup is fully visible first.
-    setTimeout(function () {
-      var ta = document.getElementById('build-goal');
-      if (ta) ta.value = buildGoalFromNeedsNew(needsNew);
-      // Force "Just create the agent(s)" — we're not making a new
-      // dashboard from this flow.
-      var radio = document.querySelector('input[name="build-target"][value="agents"]');
-      if (radio) {
-        radio.checked = true;
-        // Trigger any UI sync (e.g. hiding the dashboard-picker row).
-        try { radio.dispatchEvent(new Event('change', { bubbles: true })); } catch (e) {}
-      }
-      if (ta) ta.focus();
-    }, 50);
-  }
-
-  function readHandoff() {
-    var raw = null;
-    try { raw = sessionStorage.getItem(HANDOFF_KEY); } catch (e) { return null; }
-    if (!raw) return null;
-    try {
-      var parsed = JSON.parse(raw);
-      if (!parsed || typeof parsed !== 'object') return null;
-      if (Date.now() - (parsed.createdAt || 0) > HANDOFF_TTL_MS) return null;
-      return parsed;
-    } catch (e) { return null; }
-  }
-
-  function clearHandoff() {
-    try { sessionStorage.removeItem(HANDOFF_KEY); } catch (e) {}
-  }
+  // When the planner emits needsNew[], the wizard drives N parallel
+  // /agents/draft-one runs inline — no hand-off to build-from-goal.
+  // Each draft renders as a card with independent progress. When all
+  // drafters finish, the original plan is re-rendered with the new
+  // agents merged into a "Newly drafted" container, ready for Apply.
+  //
+  // Each /agents/draft-one runId is polled independently; when all
+  // resolve, we POST the assembled agents to /agents/build/commit
+  // (agents-only target) and then post the layout commit. The user
+  // never leaves this modal.
 
   function mergePlanWithDraftedAgents(plan, createdIds) {
     if (!createdIds.length) return plan;
@@ -130,10 +63,6 @@ export const IMPROVE_LAYOUT_JS = `
     for (var i = 0; i < createdIds.length; i++) {
       if (p.toAdd.indexOf(createdIds[i]) === -1) p.toAdd.push(createdIds[i]);
     }
-    // Place freshly drafted agents in a new container at the end so the
-    // user can see exactly what was added and shuffle them later via
-    // edit-layout. Don't try to be clever about which existing container
-    // they "belong" to — that's the next planner run's job.
     p.containers = (p.containers || []).slice();
     p.containers.push({ label: 'Newly drafted', tiles: createdIds.slice() });
     p.needsNew = [];
@@ -142,20 +71,176 @@ export const IMPROVE_LAYOUT_JS = `
     return p;
   }
 
-  // Listen for build-from-goal's resume signal. The event fires on the
-  // current page (we never navigate during hand-off), so we just
-  // re-open and re-render.
-  window.addEventListener('sua:resume-layout', function (ev) {
-    var detail = (ev && ev.detail) || {};
-    var handoff = detail.handoff;
-    var created = Array.isArray(detail.agentsCreated) ? detail.agentsCreated : [];
-    if (!handoff || handoff.endpointBase !== ENDPOINT_BASE) return;
-    var merged = mergePlanWithDraftedAgents(handoff.originalPlan, created);
-    lastFocus = handoff.originalFocus || '';
-    modal.classList.add('is-open');
-    renderPlan(merged);
-    clearHandoff();
-  });
+  function startInlineDrafting(plan, needsNew) {
+    if (!Array.isArray(needsNew) || needsNew.length === 0) return;
+
+    // Render the drafting stage. N cards, one per spec, each starting
+    // in "starting" state and transitioning through "running" → "done"
+    // / "failed" as polls return.
+    var cardsHtml = needsNew.map(function (n, i) {
+      var name = n.suggestedName || ('agent-' + (i + 1));
+      return '<div class="improve-draft-card" data-card-index="' + i + '" style="padding:var(--space-3);border:1px solid var(--color-border);border-radius:var(--radius-sm);background:var(--color-surface-raised);">' +
+        '<div style="display:flex;align-items:center;gap:var(--space-2);margin-bottom:var(--space-1);">' +
+          '<span class="improve-draft-status" data-card-index="' + i + '" style="font-family:var(--font-mono);font-size:var(--font-size-xs);">⏳</span>' +
+          '<code class="improve-draft-id" data-card-index="' + i + '" style="font-size:var(--font-size-sm);">' + esc(name) + '</code>' +
+          '<span class="dim improve-draft-phase" data-card-index="' + i + '" style="font-size:var(--font-size-xs);margin-left:auto;">Starting...</span>' +
+        '</div>' +
+        '<div class="dim" style="font-size:var(--font-size-xs);">' + esc(n.purpose) + '</div>' +
+      '</div>';
+    }).join('');
+
+    content.innerHTML =
+      '<div style="padding:var(--space-4);">' +
+      '<h3 style="margin:0 0 var(--space-2);">Drafting ' + needsNew.length + ' agent' + (needsNew.length === 1 ? '' : 's') + '</h3>' +
+      '<p class="dim" style="font-size:var(--font-size-xs);margin:0 0 var(--space-3);">Each draft is its own LLM call so they run in parallel. The layout will apply after they all finish.</p>' +
+      '<div style="display:flex;flex-direction:column;gap:var(--space-2);">' + cardsHtml + '</div>' +
+      '<div style="margin-top:var(--space-4);padding-top:var(--space-3);border-top:1px solid var(--color-border);text-align:right;">' +
+        '<button type="button" class="btn btn--ghost btn--sm" id="improve-draft-cancel">Cancel</button>' +
+      '</div>' +
+      '</div>';
+
+    var cancelled = false;
+    var draftCancelBtn = document.getElementById('improve-draft-cancel');
+    if (draftCancelBtn) draftCancelBtn.addEventListener('click', function () {
+      cancelled = true;
+      closeModal();
+    });
+
+    var results = new Array(needsNew.length);   // index → { id, yaml, purpose } | { error }
+    var doneCount = 0;
+    var failedCount = 0;
+
+    function updateCard(i, opts) {
+      var statusEl = document.querySelector('.improve-draft-status[data-card-index="' + i + '"]');
+      var idEl = document.querySelector('.improve-draft-id[data-card-index="' + i + '"]');
+      var phaseEl = document.querySelector('.improve-draft-phase[data-card-index="' + i + '"]');
+      if (opts.status === 'done' && statusEl) { statusEl.textContent = '✓'; statusEl.style.color = 'var(--color-success, #0a0)'; }
+      if (opts.status === 'failed' && statusEl) { statusEl.textContent = '✗'; statusEl.style.color = 'var(--color-danger, #a00)'; }
+      if (opts.id && idEl) idEl.textContent = opts.id;
+      if (opts.phase && phaseEl) phaseEl.textContent = opts.phase;
+    }
+
+    function maybeFinish() {
+      if (cancelled) return;
+      if (doneCount + failedCount < needsNew.length) return;
+      if (failedCount > 0) {
+        // Show a soft error state — user can retry the whole flow.
+        var failedSummaries = [];
+        for (var ri = 0; ri < results.length; ri++) {
+          if (results[ri] && results[ri].error) failedSummaries.push('agent ' + (ri + 1) + ': ' + results[ri].error);
+        }
+        renderError({
+          message: failedCount + ' of ' + needsNew.length + ' drafts failed.\\n\\n' + failedSummaries.join('\\n'),
+        });
+        return;
+      }
+      finishApply(plan, results);
+    }
+
+    for (var i = 0; i < needsNew.length; i++) {
+      (function (idx) {
+        var spec = needsNew[idx];
+        var body = { purpose: spec.purpose, focus: lastFocus || '' };
+        if (spec.suggestedName) body.suggestedName = spec.suggestedName;
+
+        fetch('/agents/draft-one', {
+          method: 'POST', credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        })
+        .then(function (r) { return r.json(); })
+        .then(function (start) {
+          if (cancelled) return;
+          if (!start.ok || !start.runId) {
+            results[idx] = { error: start.error || 'Failed to start drafter.' };
+            failedCount += 1;
+            updateCard(idx, { status: 'failed', phase: start.error || 'Failed to start' });
+            maybeFinish();
+            return;
+          }
+          updateCard(idx, { phase: 'Drafting...' });
+          var runId = start.runId;
+
+          function pollDrafter() {
+            if (cancelled) return;
+            fetch('/agents/build/' + encodeURIComponent(runId), { credentials: 'same-origin' })
+              .then(function (r) { return r.json(); })
+              .then(function (data) {
+                if (cancelled) return;
+                if (data.status === 'running') {
+                  if (data.phase) updateCard(idx, { phase: data.phase });
+                  setTimeout(pollDrafter, 1500);
+                } else if (data.status === 'done' && data.plan && Array.isArray(data.plan.newAgents) && data.plan.newAgents[0]) {
+                  var draft = data.plan.newAgents[0];
+                  results[idx] = { id: draft.id, yaml: draft.yaml, purpose: draft.purpose };
+                  doneCount += 1;
+                  updateCard(idx, { status: 'done', id: draft.id, phase: 'Done' });
+                  maybeFinish();
+                } else {
+                  results[idx] = { error: data.error || 'Drafter failed.' };
+                  failedCount += 1;
+                  updateCard(idx, { status: 'failed', phase: data.error || 'Failed' });
+                  maybeFinish();
+                }
+              })
+              .catch(function () { if (!cancelled) setTimeout(pollDrafter, 3000); });
+          }
+          setTimeout(pollDrafter, 800);
+        })
+        .catch(function (e) {
+          if (cancelled) return;
+          results[idx] = { error: 'Network: ' + (e && e.message ? e.message : 'unknown') };
+          failedCount += 1;
+          updateCard(idx, { status: 'failed', phase: 'Network error' });
+          maybeFinish();
+        });
+      })(i);
+    }
+  }
+
+  function finishApply(originalPlan, results) {
+    // Commit the drafted agents first via /agents/build/commit (agents-only),
+    // then apply the layout with the original plan merged with the new ids.
+    var newAgents = results.map(function (r) {
+      return { id: r.id, purpose: r.purpose, yaml: r.yaml };
+    });
+    var draftedIds = newAgents.map(function (a) { return a.id; });
+
+    var commitPlan = {
+      intent: 'agent',
+      summary: 'Drafted ' + draftedIds.length + ' agent' + (draftedIds.length === 1 ? '' : 's') + ' for layout.',
+      survey: { matchedAgents: [], missingFor: newAgents.map(function (a) { return a.purpose; }), existingDashboards: [] },
+      newAgents: newAgents,
+      dashboard: null,
+      questions: [],
+    };
+
+    content.innerHTML =
+      '<div style="padding:var(--space-4);">' +
+      '<div style="display:flex;align-items:center;gap:var(--space-3);">' +
+        '<div class="spinner"></div>' +
+        '<div style="font-size:var(--font-size-sm);">Committing ' + draftedIds.length + ' new agent' + (draftedIds.length === 1 ? '' : 's') + '...</div>' +
+      '</div></div>';
+
+    fetch('/agents/build/commit', {
+      method: 'POST', credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ plan: commitPlan, target: { kind: 'agents-only' } }),
+    })
+    .then(function (r) { return r.json(); })
+    .then(function (data) {
+      if (!data.ok) {
+        renderError({ message: 'Failed to commit agents: ' + (data.error || 'unknown') });
+        return;
+      }
+      var actuallyCreated = Array.isArray(data.agentsCreated) ? data.agentsCreated : draftedIds;
+      var merged = mergePlanWithDraftedAgents(originalPlan, actuallyCreated);
+      renderPlan(merged);
+    })
+    .catch(function (e) {
+      renderError({ message: 'Network error committing agents: ' + (e && e.message ? e.message : 'unknown') });
+    });
+  }
 
   btn.addEventListener('click', function () {
     modal.classList.add('is-open');
@@ -571,7 +656,7 @@ export const IMPROVE_LAYOUT_JS = `
     if (applyBtn) applyBtn.addEventListener('click', function () { applyPlan(plan); });
 
     var draftBtn = document.getElementById('improve-draft-btn');
-    if (draftBtn) draftBtn.addEventListener('click', function () { handoffToBuildFromGoal(plan, needsNew); });
+    if (draftBtn) draftBtn.addEventListener('click', function () { startInlineDrafting(plan, needsNew); });
 
     var updateBtn = document.getElementById('improve-update-btn');
     if (updateBtn) updateBtn.addEventListener('click', function () {

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -16,7 +16,6 @@ import { esc } from './pulse-helpers.js';
 import { renderTile } from './pulse-renderers.js';
 import { buildDashboardOptions, renderDashboardsDropdown } from './dashboards-dropdown.js';
 import { improveLayoutButton, improveLayoutModal } from './improve-layout-modal.js';
-import { buildFromGoalButton, buildFromGoalModal } from './build-from-goal-modal.js';
 export type { PulseTile, PulsePageInput, TileWrapFn } from './pulse-types.js';
 import type { PulseTile, PulsePageInput, TileWrapFn } from './pulse-types.js';
 
@@ -222,15 +221,6 @@ export function renderPulsePage(input: PulsePageInput): string {
     ` : html``}
 
     ${improveLayoutModal()}
-
-    <!-- Build-from-goal modal: hidden, opened programmatically by the
-         improve-layout wizard when the planner emits needsNew[] specs.
-         The hidden button is the public handle the wizard JS clicks
-         to open it. -->
-    <span style="display: none;">${buildFromGoalButton()}</span>
-    ${buildFromGoalModal({
-      availableDashboards: (input.installedDashboards ?? []).filter((d) => !d.packId).map((d) => ({ id: d.id, name: d.name })),
-    })}
 
     ${unsafeHtml(`<script type="application/json" id="pulse-tile-data">${JSON.stringify({ allTileIds, systemTileIds })}</script>`)}
     ${unsafeHtml(`<script type="application/json" id="pulse-template-registry">${JSON.stringify(TEMPLATE_REGISTRY)}</script>`)}


### PR DESCRIPTION
## Summary

Replaces the monolithic build-planner with **three focused agents** orchestrated at the route layer. Per-agent drafting now runs as its own LLM call with its own timeout — solves the timeout-on-batch problem reported on PR #321 (run \`36be7256…\`).

### New agents

| Agent | Job | Timeout |
|---|---|---|
| \`goal-surveyor\` | Classify intent, decompose goal into fragments, match against installed agents. | 90s |
| \`agent-drafter\` | Draft ONE agent from ONE fragment. Includes the \`loop + agent-invoke\` composition guidance. | 180s |
| \`dashboard-designer\` | Design the dashboard section layout from a finalized agent-id list. | 120s |

### Orchestrator

\`POST /agents/build\` now creates a **session** that drives a state machine:

\`\`\`
survey → drafters (parallel × N) → [designer] → assemble BuildPlan
\`\`\`

\`GET /agents/build/:runId\` advances the state machine on each poll and surfaces per-drafter progress to the wizard during the drafting phase. **External contract unchanged** — wizard still polls one runId, still gets a BuildPlan back, still posts to \`/agents/build/commit\`.

### New endpoint

\`POST /agents/draft-one { purpose, suggestedName?, focus? }\` — fast path for the Improve-layout wizard's per-spec drafting. Skips surveyor + designer; runs one drafter; returns a single-agent BuildPlan when complete. Polling reuses \`/agents/build/:runId\`.

### Improve-layout wizard rewrite

The "Draft N agents + apply" CTA no longer hands off to Build-from-goal. It now:

1. Fires N parallel \`/agents/draft-one\` requests.
2. Renders one card per draft with independent progress pills (⏳ → ✓ / ✗).
3. When all drafters finish, commits the drafted agents via \`/agents/build/commit\` (agents-only).
4. Merges the new agent ids into the original layout plan in a "Newly drafted" container.
5. User clicks Apply layout — same as before.

No modal swap. No sessionStorage hand-off. No cross-modal state.

### Cleanup

- Removed \`sua-layout-handoff-v1\` sessionStorage + \`sua:resume-layout\` window event (introduced in #321).
- Dropped the hidden \`buildFromGoalButton\` / \`buildFromGoalModal\` markup from \`/pulse\` (added in #321 for the hand-off, no longer needed).
- \`build-planner.yaml\` remains in \`agents/examples/\` for now but the orchestrator never invokes it.

## Test plan

- [x] \`npm run build\` — clean.
- [x] \`npm test\` — 1508 passing, 3 skipped (16 new survey-schema tests).
- [ ] Manual: free-form goal on /agents → Build from goal. Confirm phase progression Surveying → Drafting × N → (optional Designing) → Done. BuildPlan shape unchanged.
- [ ] Manual: Improve-layout on Pulse with FOCUS asking for 3 new agents. Confirm needsNew[3] returns. Click Draft + apply. Confirm 3 cards in parallel, independent timing. All finish → layout commits with the new agents in a "Newly drafted" container.
- [ ] Manual: trigger one drafter to fail. Confirm the other two still complete and the error UI shows the failed one's reason.
- [ ] Manual: agent-only goal ("create an agent that prints the date"). Confirm surveyor → 1 drafter → done, no designer call.

## Out of scope (next PR)

- Per-drafter critic loops (PlannerLoopRunner integration per drafter). Each drafter's prompt is tight enough that first-output usually works; will add if needed.
- Documentation sync. Tracked as the follow-on PR per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)