### PR TITLE
fix(drafter): ban field-toggle on ai-template + clarify 'Will add' copy

### DIFF
--- a/.changeset/drafter-ai-template-constraint.md
+++ b/.changeset/drafter-ai-template-constraint.md
@@ -1,0 +1,12 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Two fixes after the build-planner split:
+
+- **agent-drafter prompt**: tell it explicitly that `field-toggle` / `view-switch` controls aren't allowed on `ai-template` widgets — the HTML template owns layout. Without this rule the drafter was producing YAML that failed schema validation on every draft when it picked `ai-template`.
+- **Improve-layout proposed-layout copy**: when the plan has both `toAdd` (installed agents) and `needsNew` (to-draft specs), the "Will add N" panel headline now says "Will add N installed + M new" so the user understands Apply layout only would land just the N installed; Draft + apply lands all N+M.

--- a/agents/examples/agent-drafter.yaml
+++ b/agents/examples/agent-drafter.yaml
@@ -114,6 +114,14 @@ nodes:
         agents that take no runtime inputs.
       - outputWidget.type: one of dashboard, key-value, diff-apply, raw, ai-template.
       - outputWidget.fields[].type: one of text, code, badge, action, metric, stat.
+      - **ai-template + controls — NOT ALLOWED.** When outputWidget.type is
+        `ai-template`, the HTML template you write controls visibility and
+        layout directly — `field-toggle` and `view-switch` controls have
+        nothing to operate on and schema validation rejects them.
+          ✗ outputWidget: { type: ai-template, controls: [{type: field-toggle, ...}] }
+          ✓ outputWidget: { type: ai-template, template: "<div>...</div>" }
+        Use controls only with `dashboard` or `key-value` widgets where the
+        declared `fields[]` give the toggle something to show/hide.
       - If FOCUS mentions "daily" / "every morning" / cron-style timing, add a
         `schedule:` field (cron format).
 

--- a/packages/dashboard/src/views/improve-layout.js.ts
+++ b/packages/dashboard/src/views/improve-layout.js.ts
@@ -625,13 +625,20 @@ export const IMPROVE_LAYOUT_JS = `
     if (willAdd.length > 0) {
       var addList = willAdd.map(function (id) { return '<code style="font-size:var(--font-size-xs);background:var(--color-surface-raised);padding:0 var(--space-1);border-radius:var(--radius-sm);">' + esc(id) + '</code>'; }).join(' ');
       var addBucket = CURATE_VERB === 'remove' ? 'this dashboard' : 'Pulse';
+      // Distinguish "already-installed" adds from "draft + add". When the
+      // plan also has needsNew specs, surface the total ("1 installed + 3
+      // new") so the user knows Apply layout-only would land just the 1.
+      var headline = needsNew.length > 0
+        ? 'Will add ' + willAdd.length + ' installed agent' + (willAdd.length === 1 ? '' : 's') + ' + ' + needsNew.length + ' new'
+        : 'Will add ' + willAdd.length + ' agent' + (willAdd.length === 1 ? '' : 's') + ' to ' + addBucket;
+      var hint = needsNew.length > 0
+        ? '(the ' + needsNew.length + ' new ones are drafted via the button below)'
+        : '(installed but not yet on this surface)';
       willAddHtml =
         '<details style="margin:var(--space-3) 0;padding:var(--space-2) var(--space-3);border:1px solid var(--color-border);border-radius:var(--radius-sm);background:var(--color-surface-raised);">' +
         '<summary style="cursor:pointer;font-size:var(--font-size-sm);">' +
-        '<strong>Will add ' + willAdd.length + ' agent' + (willAdd.length === 1 ? '' : 's') + ' to ' + addBucket + '</strong> ' +
-        '<span class="dim" style="font-weight:var(--weight-regular);font-size:var(--font-size-xs);">' +
-          '(installed but not yet on this surface)' +
-        '</span>' +
+        '<strong>' + headline + '</strong> ' +
+        '<span class="dim" style="font-weight:var(--weight-regular);font-size:var(--font-size-xs);">' + hint + '</span>' +
         '</summary>' +
         '<div style="display:flex;flex-wrap:wrap;gap:var(--space-1);margin-top:var(--space-2);">' + addList + '</div></details>';
     }


### PR DESCRIPTION
## Summary

Two issues after the build-planner split (#326):

**1. All 3 drafts fail with the same schema error:**
\`\`\`
outputWidget.controls.1.type: field-toggle controls aren't supported on ai-template widgets — the template controls layout directly.
\`\`\`

The agent-drafter's prompt mentions outputWidget structure but didn't call out that \`field-toggle\` / \`view-switch\` controls aren't valid on \`ai-template\` widgets (the HTML template owns visibility). Adds an explicit STRICT rule with positive + negative examples.

**2. "Will add 1 agent" copy is misleading when needsNew is also present.**

User saw "Will add 1 agent" + "3 new agents to draft" + CTA "Draft 3 agents + apply" and read it as "only 1 will actually land." The new headline reads "Will add N installed + M new" when both lists are present, making the total obvious.

## Test plan
- [x] \`npm test\` — 1508 passing.
- [ ] Manual: re-run the drafting flow that just failed. Confirm all 3 drafts succeed (the drafter picks a valid widget shape).
- [ ] Manual: confirm the proposed-layout panel headline updates correctly when both toAdd and needsNew are non-empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)