### PR TITLE
fix(drafter): apply autoFixYaml + stricter shell-command guidance

### DIFF
--- a/.changeset/drafter-shell-yaml-fix.md
+++ b/.changeset/drafter-shell-yaml-fix.md
@@ -1,0 +1,12 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Two fixes for the agent-drafter:
+
+- **Drafter prompt**: explicit STRICT rule about multi-line shell commands needing the YAML literal block scalar (`command: |` with indented body). The drafter was producing inline `python3 -c "..."` blocks that broke YAML parsing with "Implicit keys need to be on a single line."
+- **Orchestrator parse**: run `autoFixYaml` on the drafter's output before `parseAgent`, matching what the commit endpoint already does. Absorbs common LLM YAML mistakes (camelCase outputs, double-brace templates in shell nodes, etc.) so drafts don't fail validation on issues the autofixer would have caught downstream anyway. The autofixed YAML is stored on the draft so commit doesn't re-fix.

--- a/agents/examples/agent-drafter.yaml
+++ b/agents/examples/agent-drafter.yaml
@@ -103,6 +103,21 @@ nodes:
         is a type (string|number|boolean|object|array) OR an object {type, description}.
         NEVER a bare description string in the value slot.
       - Shell nodes: use $ENV_VARS for inputs, never double-brace templates.
+      - **Shell command YAML format — STRICT.** Multi-line shell commands
+        MUST use the YAML literal block scalar syntax `command: |` with the
+        body indented uniformly underneath. Do NOT put a bare multi-line
+        string after `command:` on the same line — it breaks YAML parsing
+        with "Implicit keys need to be on a single line".
+          ✓ command: |
+              echo "$DATA" | python3 -c "
+              import sys, json
+              print(json.loads(sys.stdin.read()))
+              "
+          ✗ command: echo "$DATA" | python3 -c "
+              import sys, json
+              ...
+        Same rule for any heredoc, inline Python, or multi-line jq filter —
+        always use `|` and indent the body.
       - llm-prompt / claude-code nodes: use double-brace inputs.NAME syntax in prompts.
       - signal block REQUIRED. signal.title is REQUIRED and is a short literal
         string used as the Pulse tile chrome label.

--- a/packages/dashboard/src/routes/build-orchestrator.ts
+++ b/packages/dashboard/src/routes/build-orchestrator.ts
@@ -149,7 +149,7 @@ import {
   type ToolDefinition,
 } from '@some-useful-agents/core';
 import { TEMPLATE_REGISTRY } from '../views/pulse-templates.js';
-import { formatToolCatalog } from './run-now-build.js';
+import { formatToolCatalog, autoFixYaml } from './run-now-build.js';
 
 function buildCatalogs(ctx: Ctx): { tools: string; discovery: string } {
   const builtins = listBuiltinTools();
@@ -433,9 +433,12 @@ async function advanceDrafting(ctx: Ctx, session: BuildSession): Promise<void> {
       failedFragments.push(`${key}: schema — ${issues}`);
       continue;
     }
-    // Sanity: yaml parses + id matches.
+    // Sanity: yaml parses + id matches. Run autoFixYaml first to absorb
+    // common LLM mistakes (camelCase outputs, double-braces in shell nodes,
+    // etc.) — same pre-processing the commit endpoint uses.
+    const fixedYaml = autoFixYaml(validated.data.yaml);
     try {
-      const a = parseAgent(validated.data.yaml);
+      const a = parseAgent(fixedYaml);
       if (a.id !== validated.data.id) {
         failedFragments.push(`${key}: parsed YAML id "${a.id}" ≠ plan id "${validated.data.id}"`);
         continue;
@@ -445,7 +448,9 @@ async function advanceDrafting(ctx: Ctx, session: BuildSession): Promise<void> {
       continue;
     }
 
-    session.drafts.set(key, validated.data);
+    // Persist the autofixed YAML so the commit endpoint doesn't re-fix
+    // (or, worse, accept a draft we already fixed and stored as-is).
+    session.drafts.set(key, { ...validated.data, yaml: fixedYaml });
   }
 
   session.phaseMessage = `Drafting agents... (${session.drafts.size}/${session.drafterRunIds.size} done)`;


### PR DESCRIPTION
## Summary
Reported: 3 of 3 drafts failed with
\`\`\`
Invalid YAML: Implicit keys need to be on a single line at line 97
\`\`\`

The drafter was emitting inline \`python3 -c "..."\` shell command blocks without using YAML literal-block scalar syntax, so the embedded newlines broke the parse.

Two fixes:

1. **Drafter prompt** — explicit STRICT rule on multi-line shell commands with a positive + negative example showing the exact failure mode (inline \`python3 -c\`).
2. **Orchestrator** — run \`autoFixYaml\` on each drafter's output before \`parseAgent\`, matching what \`/agents/build/commit\` already does. So the drafter doesn't fail on YAML issues the commit pipeline would have fixed anyway (camelCase outputs, double-brace templates in shell nodes). The autofixed YAML is stored on the draft so commit doesn't re-fix.

## Test plan
- [x] \`npm test\` — 1508 passing.
- [ ] Manual: re-run the 3-agent draft that just hit this. Confirm all 3 now produce valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)