### PR TITLE
fix(drafter): kickoff race + speculative toAdd

### DIFF
--- a/.changeset/drafter-race-and-toadd-fix.md
+++ b/.changeset/drafter-race-and-toadd-fix.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Two fixes for the Improve-layout draft flow:
+
+1. **Drafter run-id race**: serialize the orchestrator's drafter kickoffs. `kickoffAgentRun` resolves the new run-id via `queryRuns(agentName, limit: 1)` which is racy when N parallel kickoffs target the same agent — all three queries returned the same most-recent run-id and downstream polling observed the SAME run thrice. Symptom: 3 parallel "drafts" all produced identical output (same id, "agent-id already exists" collisions on 2 of 3). Serializing the kickoffs (a few-hundred-ms overhead) makes each query see its own freshly-created run. The LLM calls themselves still run in parallel.
+
+2. **Speculative `toAdd`**: tighten the layout-planner prompt with a `BEFORE_TOADD_RULE`. Every id in `toAdd[]` must be justified by a quotable substring of FOCUS. "Complements the layout" / "is a useful default" are NOT valid justifications. Adds 4 concrete examples (when toAdd is allowed vs must stay empty). Addresses `system-health` showing up whenever the user looks at a monitoring-themed dashboard, even when they asked for 3 brand-new agents.

--- a/agents/examples/layout-planner.yaml
+++ b/agents/examples/layout-planner.yaml
@@ -262,22 +262,46 @@ nodes:
       breaks user trust — they think they're getting fresh code
       when you're actually just surfacing what they already had.
 
-      When to use `toAdd`:
-      - ONLY when FOCUS explicitly asks. The user said "surface my
-        weather agents" or "bring my monitors over" or named a
-        specific available agent — add the matching ones. Otherwise
-        leave `toAdd` empty.
-      - NEVER speculatively add an available agent because it "looks
-        useful" or "fills a gap" or "complements the layout". That
-        produces unwanted additions like surfacing `system-health`
-        whenever the user is looking at a monitoring dashboard. The
-        user didn't ask for it — don't add it.
-      - The user can always re-run Improve layout with a more specific
-        FOCUS if they want more agents surfaced. Being conservative is
-        the right default.
-      - Cap `toAdd` at ~8 agents per run. Each Apply is destructive
-        (hides un-surfaced members), so don't bury the change in a
-        flood of additions.
+      When to use `toAdd` — THE DEFAULT IS EMPTY.
+
+      `toAdd[]` is ONLY for cases where FOCUS literally names an agent
+      id OR uses a topic word that obviously matches the available
+      agent's title/id/description. Examples of when it's allowed:
+
+        FOCUS = "surface my weather agents"
+          → ✓ toAdd may include `weather-forecast` (topic match)
+        FOCUS = "add system-health"
+          → ✓ toAdd may include `system-health` (id literally named)
+        FOCUS = "bring my monitors over"
+          → ✓ toAdd may include `api-monitor`, `uptime-watch` (topic match)
+
+      Examples of when toAdd MUST stay empty (even if available agents
+      look tempting):
+
+        FOCUS = "add a stock ticker"
+          → toAdd = [] (stock-ticker doesn't exist, use needsNew)
+        FOCUS = "create 3 new agents to complement my weather"
+          → toAdd = [] (user asked for NEW agents, not existing ones)
+        FOCUS = "improve this dashboard"
+          → toAdd = [] (vague, nothing named)
+        FOCUS = "" (empty)
+          → toAdd = [] (no signal at all)
+
+      RULE OF THUMB: before putting an id into toAdd, point to the
+      exact substring of FOCUS that justified it. If you can't quote
+      a substring that names the topic or id, the entry doesn't belong
+      in toAdd. "It complements the layout" / "it's a useful default"
+      / "it pairs well with X" are NOT valid justifications and produce
+      unwanted additions like `system-health` showing up whenever the
+      user looks at a monitoring-themed dashboard.
+
+      The user can always re-run Improve layout with a more specific
+      FOCUS if they want more agents surfaced. Empty toAdd is the
+      right default.
+
+      Cap `toAdd` at ~8 entries when the rule above does allow it.
+      Each Apply is destructive (hides un-surfaced members) so don't
+      bury the change in a flood of additions.
 
       When to use `needsNew`:
       - FOCUS names an agent that does NOT exist in AGENT_METADATA

--- a/packages/dashboard/src/routes/build-orchestrator.ts
+++ b/packages/dashboard/src/routes/build-orchestrator.ts
@@ -359,10 +359,18 @@ async function advanceSurvey(ctx: Ctx, session: BuildSession): Promise<void> {
 
   const { tools, discovery } = buildCatalogs(ctx);
 
-  // Fire all kickoffs concurrently; collect run-ids.
-  const kickoffs = session.survey.fragments.map(async (fragment, i) => {
-    // Each drafter sees: existing agents + matched agents + sibling-reserved suggestions
-    // (minus its own reservation). Prevents collisions.
+  // Fire kickoffs SEQUENTIALLY (NOT Promise.all). kickoffAgentRun
+  // identifies the run-id via queryRuns(agentName=…, limit:1) — racy
+  // when multiple parallel kickoffs target the same agent: all three
+  // queries would return the same most-recent run-id and downstream
+  // polling would observe the SAME run thrice. Symptom: 3 "drafts"
+  // produce identical output (same id, agent-id-already-exists
+  // collisions). Serializing the kickoffs makes each queryRuns see
+  // its own just-created run as most-recent. The LLM calls themselves
+  // still run in parallel because executeAgentDag returns a promise
+  // we don't await for completion.
+  for (let i = 0; i < session.survey.fragments.length; i++) {
+    const fragment = session.survey.fragments[i];
     const own = fragment.suggestedName;
     const blocked = new Set(knownIds);
     reservedSuggestions.forEach((s) => {
@@ -380,16 +388,11 @@ async function advanceSurvey(ctx: Ctx, session: BuildSession): Promise<void> {
         DISCOVERY_CATALOG: discovery,
       },
     });
-    return [`fragment-${i}`, runId] as const;
-  });
-  const results = await Promise.all(kickoffs);
-
-  for (const [key, runId] of results) {
     if (!runId) {
-      fail(session, `Failed to kick off drafter for ${key}.`);
+      fail(session, `Failed to kick off drafter for fragment-${i}.`);
       return;
     }
-    session.drafterRunIds.set(key, runId);
+    session.drafterRunIds.set(`fragment-${i}`, runId);
   }
   session.phase = 'drafting';
   session.phaseMessage = `Drafting ${session.drafterRunIds.size} agents in parallel...`;


### PR DESCRIPTION
## Summary

Two bugs reported from a 3-agent draft session:

### Bug 1: All three drafts produced the same agent

The summary read **"Drafted 1 new agent (astronomy-pic-of-the-day). (2 failed: astronomy-pic-of-the-day: agent id already exists; astronomy-pic-of-the-day: agent id already exists)"** — all three parallel drafters were polling the same run.

**Root cause**: \`kickoffAgentRun\` returns the new run-id by calling \`queryRuns({ agentName: 'agent-drafter', limit: 1 })\` after the race-or-200ms timer. When three kickoffs fan out via \`Promise.all\`, all three queries hit the runStore within microseconds and return the SAME most-recent run-id — so all three orchestrator "drafters" actually observe one run.

**Fix**: serialize the kickoffs (Promise.all → for-await loop). Each kickoff's queryRuns now sees its own freshly-created run as the most-recent. The LLM calls themselves still run in parallel because executeAgentDag's promise isn't awaited for completion — only its initial createRun is.

Cost: ~600ms of sequential setup overhead for 3 drafts. Worth it.

### Bug 2: \`system-health\` keeps showing up in \`toAdd\`

User asked for 3 brand-new agents to complement a weather forecast. The planner correctly emitted \`needsNew[3]\` for the new agents, but also added \`system-health\` to \`toAdd\` because the dashboard had a "Health" container with system tiles. The "ONLY when FOCUS explicitly asks" rule wasn't strong enough.

**Fix**: BEFORE_TOADD_RULE in the layout-planner prompt — every id in \`toAdd[]\` must be justified by a quotable substring of FOCUS. "Complements the layout" / "is a useful default" are explicitly disallowed. 4 concrete examples covering allowed vs must-stay-empty cases.

## Test plan
- [x] \`npm test\` — 1508 passing.
- [ ] Manual: re-run the 3-agent draft. Confirm all 3 produce distinct ids, all land in the layout's "Newly drafted" container.
- [ ] Manual: rerun the same FOCUS that triggered system-health. Confirm \`toAdd\` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)