### PR TITLE
fix(build): pre-generated runId eliminates kickoff race at the source

### DIFF
--- a/.changeset/dag-executor-pre-generated-runid.md
+++ b/.changeset/dag-executor-pre-generated-runid.md
@@ -1,0 +1,9 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Eliminate the kickoff race in the build orchestrator by accepting a caller-supplied `runId` on `executeAgentDag`'s options. `kickoffAgentRun` now pre-generates the run-id via `randomUUID()` and passes it through instead of trying to look up the just-created run via `queryRuns(agentName, limit: 1)` — that pattern was racy whenever multiple parallel kickoffs targeted the same agent (e.g. three `/agents/draft-one` requests, three `agent-drafter` runs, same agent name → all three queries returned the same most-recent row → all three "drafts" polled the same run → 1 succeeded, 2 failed with "agent id already exists"). Serializing the kickoffs (the previous fix in #330) only patched the in-orchestrator fan-out; this fix addresses the root cause so parallel `/agents/draft-one` calls work too.

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -188,6 +188,15 @@ export interface DagExecuteOptions {
    * unset and get per-call notify dispatch as before.
    */
   suppressNotify?: boolean;
+  /**
+   * Pre-generated run id. When set, the executor uses this instead of
+   * generating a fresh UUID. Lets callers know the run-id BEFORE the
+   * promise resolves — eliminates the race in patterns that try to
+   * "look up the run by agent name + most-recent" right after kickoff
+   * (multiple parallel kickoffs targeting the same agent would
+   * otherwise collide on the same most-recent row).
+   */
+  runId?: string;
 }
 
 
@@ -205,7 +214,7 @@ export async function executeAgentDag(
   options: DagExecuteOptions,
   deps: DagExecutorDeps,
 ): Promise<Run> {
-  const runId = randomUUID();
+  const runId = options.runId ?? randomUUID();
   const startedAt = new Date().toISOString();
 
   // Parent run row created up-front in 'running' state. Lets anyone polling

--- a/packages/dashboard/src/routes/build-orchestrator.ts
+++ b/packages/dashboard/src/routes/build-orchestrator.ts
@@ -18,6 +18,7 @@
  */
 
 import { readFileSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import { join, resolve } from 'node:path';
 import {
   executeAgentDag,
@@ -33,7 +34,6 @@ import {
   type Draft,
   type Survey,
   type DashboardDesign,
-  type RunStatus,
 } from '@some-useful-agents/core';
 import type { getContext } from '../context.js';
 
@@ -111,11 +111,22 @@ async function kickoffAgentRun(args: {
   inputs: Record<string, string>;
 }): Promise<string | null> {
   const { ctx, agent, inputs } = args;
-  const runPromise = executeAgentDag(
+  // Pre-generate the run-id. Eliminates the race in the old code path
+  // (which queried runStore for "most-recent run by agentName" — when
+  // N parallel kickoffs target the same agent, the query returns the
+  // same row for all N callers, so all N orchestrator sessions end up
+  // polling the same drafter run). Passing runId in via DagExecuteOptions
+  // means we know the id without ever needing the query.
+  const runId = randomUUID();
+  // Fire-and-forget: don't await the run completion here; callers poll
+  // runStore later. Swallow errors so a startup failure doesn't reject
+  // the kickoff promise — the polling path surfaces the failed run.
+  executeAgentDag(
     agent,
     {
       triggeredBy: 'dashboard',
       inputs,
+      runId,
     },
     {
       runStore: ctx.runStore,
@@ -123,22 +134,8 @@ async function kickoffAgentRun(args: {
       variablesStore: ctx.variablesStore,
       dataRoot: ctx.agentStore.dataRoot,
     },
-  );
-  // Race the run-record creation; we only need the id, not the result.
-  await Promise.race([runPromise, new Promise((r) => setTimeout(r, 200))]);
-  const { rows } = ctx.runStore.queryRuns({
-    agentName: agent.id,
-    statuses: ['running', 'completed', 'failed'] as RunStatus[],
-    limit: 1,
-    offset: 0,
-  });
-  if (rows.length > 0) return rows[0].id;
-  try {
-    const run = await runPromise;
-    return run.id;
-  } catch {
-    return null;
-  }
+  ).catch(() => { /* failure surfaces via runStore.getRun(runId).status */ });
+  return runId;
 }
 
 // ── Catalog helpers ────────────────────────────────────────────────────
@@ -359,18 +356,10 @@ async function advanceSurvey(ctx: Ctx, session: BuildSession): Promise<void> {
 
   const { tools, discovery } = buildCatalogs(ctx);
 
-  // Fire kickoffs SEQUENTIALLY (NOT Promise.all). kickoffAgentRun
-  // identifies the run-id via queryRuns(agentName=…, limit:1) — racy
-  // when multiple parallel kickoffs target the same agent: all three
-  // queries would return the same most-recent run-id and downstream
-  // polling would observe the SAME run thrice. Symptom: 3 "drafts"
-  // produce identical output (same id, agent-id-already-exists
-  // collisions). Serializing the kickoffs makes each queryRuns see
-  // its own just-created run as most-recent. The LLM calls themselves
-  // still run in parallel because executeAgentDag returns a promise
-  // we don't await for completion.
-  for (let i = 0; i < session.survey.fragments.length; i++) {
-    const fragment = session.survey.fragments[i];
+  // Kickoffs run in parallel. kickoffAgentRun now pre-generates the
+  // run-id via randomUUID() + passes it to executeAgentDag, so each
+  // caller gets a unique id without any runStore round-trip race.
+  const kickoffs = session.survey.fragments.map(async (fragment, i) => {
     const own = fragment.suggestedName;
     const blocked = new Set(knownIds);
     reservedSuggestions.forEach((s) => {
@@ -388,11 +377,15 @@ async function advanceSurvey(ctx: Ctx, session: BuildSession): Promise<void> {
         DISCOVERY_CATALOG: discovery,
       },
     });
+    return [`fragment-${i}`, runId] as const;
+  });
+  const results = await Promise.all(kickoffs);
+  for (const [key, runId] of results) {
     if (!runId) {
-      fail(session, `Failed to kick off drafter for fragment-${i}.`);
+      fail(session, `Failed to kick off drafter for ${key}.`);
       return;
     }
-    session.drafterRunIds.set(`fragment-${i}`, runId);
+    session.drafterRunIds.set(key, runId);
   }
   session.phase = 'drafting';
   session.phaseMessage = `Drafting ${session.drafterRunIds.size} agents in parallel...`;


### PR DESCRIPTION
## Summary

Reported (again, after #330):
\`\`\`
Drafted 1 new agent (pitching-matchup-preview).
(2 failed: pitching-matchup-preview: agent id already exists; pitching-matchup-preview: agent id already exists)
\`\`\`

PR #330 serialized the orchestrator's drafter fan-out to dodge the \`queryRuns(agentName, limit:1)\` race in \`kickoffAgentRun\`. That worked for the orchestrator's internal fan-out, but the Improve-layout wizard fires **three parallel \`/agents/draft-one\` POSTs** — each one calls \`startDraftOneSession\` → \`kickoffAgentRun\` → same query → same race. All three sessions ended up polling the same drafter run, so the wizard "received" the same drafted agent three times → id collision on commit.

**Root-cause fix**: pre-generate the run-id in \`kickoffAgentRun\` and pass it through to \`executeAgentDag\`. New optional \`DagExecuteOptions.runId\` field — when set, the executor uses it instead of \`randomUUID()\`. No runStore round-trip, no race possible. Orchestrator fan-out goes back to \`Promise.all\` (parallel).

## Test plan
- [x] \`npm test\` — 1508 passing.
- [ ] Manual: re-run the 3-agent Improve-layout draft. Confirm 3 distinct ids land in the agentStore and the layout's "Newly drafted" container contains all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)