### PR TITLE
fix(drafter): forbid nested paths in ai-template placeholders

### DIFF
--- a/.changeset/drafter-template-paths.md
+++ b/.changeset/drafter-template-paths.md
@@ -1,0 +1,9 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Tighten the agent-drafter prompt with an explicit rule: ai-template placeholder paths are SINGLE LEVEL ONLY. The substituter supports `{{outputs.NAME}}` / `{{item.FIELD}}` but NOT nested paths like `{{outputs.featured_duel.title}}` or `{{item.away_pitcher.name}}`. The discovery catalog already documented this, but the drafter kept generating nested paths and the literals leaked into rendered tiles. The rule now lives in the drafter's own prompt with paired ✗/✓ examples and guidance to flatten nested outputs in a post-processing node.

--- a/agents/examples/agent-drafter.yaml
+++ b/agents/examples/agent-drafter.yaml
@@ -137,6 +137,31 @@ nodes:
           ✓ outputWidget: { type: ai-template, template: "<div>...</div>" }
         Use controls only with `dashboard` or `key-value` widgets where the
         declared `fields[]` give the toggle something to show/hide.
+      - **ai-template path syntax — SINGLE LEVEL ONLY.** The placeholder
+        substituter supports ONLY:
+          - `{{outputs.NAME}}` and `{{{outputs.NAME}}}` — single-level path.
+          - `{{result}}` — raw run output.
+          - `{{#each outputs.NAME as item}}…{{/each}}` — iterate an array.
+            Inside the each block, `{{item}}` / `{{item.FIELD}}` /
+            `{{@index}}`. FIELD is also single-level — `item.x.y` does NOT
+            work.
+          - `{{#if outputs.NAME}}…{{/if}}` / `{{#unless outputs.NAME}}…{{/unless}}`
+            (also `{{#if item.FIELD}}` inside an #each).
+        NESTED dot paths are NOT substituted — the literal placeholder
+        leaks into the rendered widget. If your output has nested objects,
+        FLATTEN them into top-level scalar outputs in the agent's
+        post-processing node before declaring the widget.
+          ✗ template: "<h2>{{outputs.featured_duel.title}}</h2>"
+            (outputs.featured_duel.title — TWO levels, won't substitute)
+          ✗ template: "{{#each outputs.games as item}}{{item.away_pitcher.name}}{{/each}}"
+            (item.away_pitcher.name — TWO levels inside each)
+          ✓ template: "<h2>{{outputs.featured_duel_title}}</h2>"
+            (single-level flat output)
+          ✓ template: "{{#each outputs.games as item}}{{item.away_pitcher_name}}{{/each}}"
+            (item.away_pitcher_name — flat per-row field)
+        When designing the agent, plan the outputs as a flat object whose
+        top-level scalar fields match every placeholder in the template;
+        for `#each`, plan an array of flat objects.
       - If FOCUS mentions "daily" / "every morning" / cron-style timing, add a
         `schedule:` field (cron format).
 


### PR DESCRIPTION
## Summary
Reported on the drafted \`pitching-matchup-preview\` agent: the widget rendered literal \`{{outputs.featured_duel.title}}\` and \`{{item.away_pitcher.name}}\` text instead of substituted values.

**Root cause**: the ai-template placeholder substituter only supports single-level paths:
- \`{{outputs.NAME}}\` ✓
- \`{{outputs.NAME.SUB}}\` ✗ (regex only matches one path segment)
- \`{{item.FIELD}}\` inside \`{{#each}}\` ✓
- \`{{item.FIELD.SUB}}\` ✗

The discovery catalog already documented this constraint, but the drafter kept generating nested paths and the literals leaked into rendered tiles.

**Fix**: explicit STRICT rule in the drafter's own prompt with paired ✗/✓ examples covering both the outer (\`outputs.X.Y\`) and inner (\`item.X.Y\`) cases, plus guidance to flatten nested outputs into scalar top-level fields in a post-processing node.

## Test plan
- [x] \`npm test\` — 1508 passing.
- [ ] Manual: re-draft an agent with an ai-template widget. Confirm placeholders use single-level paths and substitute at render time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)