### PR TITLE
feat(build): per-drafter critic retry loop + ai-template path critic

### DIFF
--- a/.changeset/drafter-critic-and-retry.md
+++ b/.changeset/drafter-critic-and-retry.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Wire the build-orchestrator drafters into the critic-retry loop so the structural critic gets a second pass instead of leaking broken drafts to the user.
+
+- **New critic check**: `critiquePlan` now flags `ai-template` widgets that use nested placeholder paths (`{{outputs.X.Y}}` or `{{item.X.Y}}` inside `#each`). The placeholder substituter only supports single-level paths; nested paths leak the literal `{{…}}` into the rendered tile. Each offending placeholder produces a concrete error with guidance to flatten the value into a scalar top-level output.
+- **Per-drafter retry**: after a drafter completes successfully (autoFix + parseAgent), the orchestrator wraps the draft in a synthetic single-agent BuildPlan and runs `critiquePlan` on it. If errors are found and the drafter still has retry budget (up to 3 attempts), the orchestrator kicks off a fresh drafter run with the critic feedback appended to FOCUS. After exhausting retries, the critic errors surface as the failure reason instead of accepting a broken draft.
+- Same logic applies to single-spec drafters (the Improve-layout `/agents/draft-one` path).

--- a/packages/core/src/build-plan-critic.test.ts
+++ b/packages/core/src/build-plan-critic.test.ts
@@ -124,6 +124,47 @@ describe('critiquePlan', () => {
   });
 });
 
+describe('critiquePlan ai-template path checks', () => {
+  const yamlWithTemplate = (template: string) =>
+    `id: pitching\nname: Pitching\nnodes:\n  - id: n1\n    type: shell\n    command: echo hi\noutputWidget:\n  type: ai-template\n  template: |\n    ${template.replace(/\n/g, '\n    ')}\n`;
+
+  it('flags outer nested outputs.X.Y paths', () => {
+    const result = critiquePlan(
+      planFor({
+        newAgents: [{ id: 'pitching', purpose: 'p', yaml: yamlWithTemplate('<h2>{{outputs.featured_duel.title}}</h2>') }],
+      }),
+      { existingAgentIds: new Set() },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.message.includes('outputs.featured_duel.title'))).toBe(true);
+  });
+
+  it('flags nested item.X.Y paths inside #each', () => {
+    const result = critiquePlan(
+      planFor({
+        newAgents: [{ id: 'pitching', purpose: 'p', yaml: yamlWithTemplate(
+          '{{#each outputs.games as item}}<td>{{item.away_pitcher.name}}</td>{{/each}}',
+        ) }],
+      }),
+      { existingAgentIds: new Set() },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.message.includes('item.away_pitcher.name'))).toBe(true);
+  });
+
+  it('passes single-level outputs and item paths', () => {
+    const result = critiquePlan(
+      planFor({
+        newAgents: [{ id: 'pitching', purpose: 'p', yaml: yamlWithTemplate(
+          '<h2>{{outputs.title}}</h2>{{#each outputs.games as item}}<td>{{item.away_pitcher_name}}</td>{{/each}}',
+        ) }],
+      }),
+      { existingAgentIds: new Set() },
+    );
+    expect(result.ok).toBe(true);
+  });
+});
+
 describe('formatCriticFeedback', () => {
   it('returns empty string when no errors', () => {
     expect(formatCriticFeedback([])).toBe('');

--- a/packages/core/src/build-plan-critic.ts
+++ b/packages/core/src/build-plan-critic.ts
@@ -134,6 +134,43 @@ export function critiquePlan(plan: BuildPlan, ctx: PlanCriticContext): PlanCriti
         }
       }
     });
+
+    // ai-template path check: the placeholder substituter ONLY supports
+    // single-level paths (`{{outputs.NAME}}`, `{{item.FIELD}}`). Nested
+    // paths like `outputs.featured_duel.title` or `item.away_pitcher.name`
+    // leak the literal placeholder into the rendered widget. Flag them so
+    // the drafter can flatten on retry.
+    const widget = (agent as { outputWidget?: { type?: string; template?: string } }).outputWidget;
+    if (widget?.type === 'ai-template' && typeof widget.template === 'string') {
+      const tpl = widget.template;
+      // Outer outputs.X.Y — match anything past the first dot-segment.
+      const outerNestedRe = /\{\{\{?\s*outputs\.[a-zA-Z_][a-zA-Z0-9_]*\.[a-zA-Z_][a-zA-Z0-9_]*/g;
+      let m: RegExpExecArray | null;
+      const outerHits = new Set<string>();
+      while ((m = outerNestedRe.exec(tpl)) !== null) outerHits.add(m[0]);
+      for (const hit of outerHits) {
+        errors.push({
+          path: `newAgents[${i}].yaml.outputWidget.template`,
+          message: `ai-template uses nested path "${hit.replace(/^\{\{\{?\s*/, '').trim()}…}}" — the substituter only supports single-level outputs.NAME. Flatten the value into a top-level scalar output (e.g. featured_duel_title) and reference it without nesting.`,
+        });
+      }
+      // Inner item.X.Y inside #each blocks. Match across all #each bodies.
+      const eachRe = /\{\{\s*#each\s+outputs\.[a-zA-Z_][a-zA-Z0-9_]*\s+as\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}([\s\S]*?)\{\{\s*\/each\s*\}\}/g;
+      const innerHits = new Set<string>();
+      while ((m = eachRe.exec(tpl)) !== null) {
+        const itemName = m[1];
+        const body = m[2];
+        const innerRe = new RegExp(`\\{\\{\\{?\\s*${itemName}\\.[a-zA-Z_][a-zA-Z0-9_]*\\.[a-zA-Z_][a-zA-Z0-9_]*`, 'g');
+        let im: RegExpExecArray | null;
+        while ((im = innerRe.exec(body)) !== null) innerHits.add(im[0]);
+      }
+      for (const hit of innerHits) {
+        errors.push({
+          path: `newAgents[${i}].yaml.outputWidget.template`,
+          message: `ai-template uses nested item path "${hit.replace(/^\{\{\{?\s*/, '').trim()}…}}" inside an #each block — only single-level item.FIELD is supported. Flatten the per-row value into a scalar (e.g. away_pitcher_name) on each array element.`,
+        });
+      }
+    }
   });
 
   return { ok: errors.length === 0, errors };

--- a/packages/dashboard/src/routes/build-orchestrator.ts
+++ b/packages/dashboard/src/routes/build-orchestrator.ts
@@ -29,6 +29,8 @@ import {
   draftSchema,
   dashboardDesignSchema,
   buildPlanSchema,
+  critiquePlan,
+  formatCriticFeedback,
   type Agent,
   type BuildPlan,
   type Draft,
@@ -44,6 +46,13 @@ const DRAFTER_AGENT_ID = 'agent-drafter';
 const DESIGNER_AGENT_ID = 'dashboard-designer';
 
 const SESSION_TTL_MS = 60 * 60 * 1000; // 1h
+/**
+ * How many TIMES each drafter is allowed to run (initial + N-1 retries).
+ * On critic failure within budget the orchestrator kicks off a new drafter
+ * run with the critic feedback appended to FOCUS. Mirrors the
+ * MAX_CRITIC_RETRIES constant the legacy build-planner used.
+ */
+const MAX_DRAFT_ATTEMPTS = 3;
 
 export type SessionPhase = 'survey' | 'drafting' | 'design' | 'assembling' | 'done' | 'failed';
 
@@ -58,6 +67,7 @@ interface BuildSession {
 
   surveyorRunId?: string;
   drafterRunIds: Map<string, string>; // fragmentKey -> runId
+  drafterAttempts: Map<string, number>; // fragmentKey -> attempt count (1-indexed)
   designerRunId?: string;
 
   survey?: Survey;
@@ -174,6 +184,32 @@ function existingAgentIds(ctx: Ctx): Set<string> {
   }
 }
 
+/**
+ * Look up the original fragment spec ({ purpose, suggestedName? }) for a
+ * given fragmentKey. Reads from session.survey.fragments for build sessions
+ * or session.draftOnlySpec for /agents/draft-one sessions. Used during
+ * critic-retry to re-kick a drafter with the same intent + fresh feedback.
+ */
+function resolveFragment(session: BuildSession, key: string): { purpose: string; suggestedName?: string } | null {
+  if (session.draftOnly) {
+    return session.draftOnlySpec ?? null;
+  }
+  if (!session.survey) return null;
+  const match = /^fragment-(\d+)$/.exec(key);
+  if (!match) return null;
+  const idx = Number(match[1]);
+  const fragment = session.survey.fragments[idx];
+  if (!fragment) return null;
+  return {
+    purpose: fragment.purpose,
+    ...(fragment.suggestedName ? { suggestedName: fragment.suggestedName } : {}),
+  };
+}
+
+function appendFeedback(focus: string, feedback: string): string {
+  return focus ? `${focus}\n\n${feedback}` : feedback;
+}
+
 // ── Public API ─────────────────────────────────────────────────────────
 
 /**
@@ -215,6 +251,7 @@ export async function startBuildSession(args: {
     phaseMessage: 'Surveying your goal...',
     surveyorRunId: runId,
     drafterRunIds: new Map(),
+    drafterAttempts: new Map(),
     drafts: new Map(),
     draftOnly: false,
   });
@@ -258,6 +295,8 @@ export async function startDraftOneSession(args: {
   const sessionId = newSessionId('draft');
   const drafterRunIds = new Map<string, string>();
   drafterRunIds.set('fragment-0', runId);
+  const drafterAttempts = new Map<string, number>();
+  drafterAttempts.set('fragment-0', 1);
   sessions.set(sessionId, {
     id: sessionId,
     goal: purpose,
@@ -266,6 +305,7 @@ export async function startDraftOneSession(args: {
     phase: 'drafting',
     phaseMessage: 'Drafting agent...',
     drafterRunIds,
+    drafterAttempts,
     drafts: new Map(),
     draftOnly: true,
     draftOnlySpec: { purpose, ...(suggestedName ? { suggestedName } : {}) },
@@ -386,6 +426,7 @@ async function advanceSurvey(ctx: Ctx, session: BuildSession): Promise<void> {
       return;
     }
     session.drafterRunIds.set(key, runId);
+    session.drafterAttempts.set(key, 1);
   }
   session.phase = 'drafting';
   session.phaseMessage = `Drafting ${session.drafterRunIds.size} agents in parallel...`;
@@ -394,6 +435,10 @@ async function advanceSurvey(ctx: Ctx, session: BuildSession): Promise<void> {
 async function advanceDrafting(ctx: Ctx, session: BuildSession): Promise<void> {
   let stillRunning = 0;
   const failedFragments: string[] = [];
+  // Drafts that failed the critic AND still have retry budget. Queued so
+  // we can fire fresh drafter kickoffs at the end of the pass.
+  const retries: Array<{ key: string; feedback: string }> = [];
+
   for (const [key, runId] of session.drafterRunIds) {
     if (session.drafts.has(key)) continue; // already collected
 
@@ -444,14 +489,86 @@ async function advanceDrafting(ctx: Ctx, session: BuildSession): Promise<void> {
       continue;
     }
 
+    // Structural critic pass. We wrap this drafter's output in a synthetic
+    // single-agent BuildPlan so critiquePlan can apply its newAgent walk
+    // (cross-refs + ai-template path checks). When the critic finds issues
+    // AND we still have retry budget, queue a fresh drafter kickoff with
+    // criticFeedback appended to FOCUS instead of accepting the draft.
+    const candidateDraft = { ...validated.data, yaml: fixedYaml };
+    const synthetic = buildPlanSchema.safeParse({
+      intent: 'agent' as const,
+      summary: candidateDraft.purpose,
+      survey: { matchedAgents: [], missingFor: [candidateDraft.purpose], existingDashboards: [] },
+      newAgents: [candidateDraft],
+      dashboard: null,
+      questions: [],
+    });
+    if (synthetic.success) {
+      const critique = critiquePlan(synthetic.data, { existingAgentIds: existingAgentIds(ctx) });
+      if (!critique.ok) {
+        const attempts = session.drafterAttempts.get(key) ?? 1;
+        if (attempts < MAX_DRAFT_ATTEMPTS) {
+          retries.push({ key, feedback: formatCriticFeedback(critique.errors) });
+          continue;
+        }
+        // Exhausted budget — surface the critic errors as the failure.
+        failedFragments.push(`${key}: critic (after ${attempts} attempts) — ${critique.errors.map((e) => e.message).join(' | ')}`);
+        continue;
+      }
+    }
+
     // Persist the autofixed YAML so the commit endpoint doesn't re-fix
     // (or, worse, accept a draft we already fixed and stored as-is).
-    session.drafts.set(key, { ...validated.data, yaml: fixedYaml });
+    session.drafts.set(key, candidateDraft);
   }
 
-  session.phaseMessage = `Drafting agents... (${session.drafts.size}/${session.drafterRunIds.size} done)`;
+  // Fire retries (parallel — kickoffAgentRun uses caller-supplied runIds
+  // now so the old race is gone).
+  if (retries.length > 0) {
+    const drafter = loadExampleAgent(ctx, DRAFTER_AGENT_ID);
+    if (!drafter) {
+      fail(session, 'Agent-drafter not found while attempting retry.');
+      return;
+    }
+    const { tools, discovery } = buildCatalogs(ctx);
+    const knownIds = existingAgentIds(ctx);
+    // Reserve sibling drafted ids so the retry doesn't collide.
+    for (const d of session.drafts.values()) knownIds.add(d.id);
 
-  if (stillRunning > 0) return;
+    const retryKickoffs = retries.map(async ({ key, feedback }) => {
+      const spec = resolveFragment(session, key);
+      if (!spec) return [key, null] as const;
+      const blocked = new Set(knownIds);
+      const newRunId = await kickoffAgentRun({
+        ctx,
+        agent: drafter,
+        inputs: {
+          PURPOSE: spec.purpose,
+          SUGGESTED_NAME: spec.suggestedName ?? '',
+          FOCUS: appendFeedback(session.focus, feedback),
+          EXISTING_AGENT_IDS: Array.from(blocked).join(', '),
+          AVAILABLE_TOOLS: tools,
+          DISCOVERY_CATALOG: discovery,
+        },
+      });
+      return [key, newRunId] as const;
+    });
+    const retryResults = await Promise.all(retryKickoffs);
+    for (const [key, newRunId] of retryResults) {
+      if (!newRunId) {
+        failedFragments.push(`${key}: failed to start retry`);
+        continue;
+      }
+      session.drafterRunIds.set(key, newRunId);
+      session.drafterAttempts.set(key, (session.drafterAttempts.get(key) ?? 1) + 1);
+    }
+  }
+
+  session.phaseMessage = retries.length > 0
+    ? `Retrying ${retries.length} drafter${retries.length === 1 ? '' : 's'} with critic feedback...`
+    : `Drafting agents... (${session.drafts.size}/${session.drafterRunIds.size} done)`;
+
+  if (stillRunning > 0 || retries.length > 0) return;
 
   if (failedFragments.length > 0) {
     fail(session, `Drafter(s) failed: ${failedFragments.join(' | ')}`);


### PR DESCRIPTION
## Summary

Closes the symptom you reported on run \`1df4b091…\`: the drafted \`pitching-matchup-preview\` landed, but the widget rendered literal \`{{outputs.featured_duel.title}}\` text because the drafter's first output was never critiqued.

Two pieces:

### 1. New critic check: nested ai-template paths

\`critiquePlan\` now flags any \`ai-template\` widget whose template uses nested placeholder paths:

- \`{{outputs.featured_duel.title}}\` — two levels past \`outputs.\` (substituter only matches one segment)
- \`{{item.away_pitcher.name}}\` inside \`{{#each ... as item}}\` — two levels past the iterator (same limitation)

Each offending placeholder becomes a concrete error pointing at the template, with guidance to flatten the value into a scalar top-level output (e.g. \`featured_duel_title\` / \`away_pitcher_name\`).

### 2. Per-drafter critic retry loop

The build-orchestrator now wraps each completed drafter in a synthetic single-agent BuildPlan and runs \`critiquePlan\` on it. When the critic finds issues AND the drafter still has retry budget (up to 3 attempts), the orchestrator kicks off a fresh drafter run with \`formatCriticFeedback(errors)\` appended to FOCUS. After exhausting retries, the critic errors surface as the failure reason — not a broken accept.

Same logic applies to \`/agents/draft-one\` (the Improve-layout inline drafting path).

## Test plan
- [x] \`npm test\` — 1511 passing, 3 skipped (3 new critic tests covering outer + inner nested paths + clean single-level templates).
- [ ] Manual: re-draft the failing pitching-matchup-preview. Expected: first drafter attempt produces nested paths → critic flags → orchestrator retries with feedback → second attempt produces flattened paths → tile renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)