### PR TITLE
feat(build): YAML-parse retry + wider wizard modal + auto-run on land

### DIFF
--- a/.changeset/draft-yaml-retry-modal-autorun.md
+++ b/.changeset/draft-yaml-retry-modal-autorun.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Three improvements to the Improve-layout drafting flow:
+
+- **YAML-parse retry**: the orchestrator's drafting phase now retries on a YAML parse failure (e.g. inline `python3 -c "…"` shell command without a `command: |` block scalar) the same way it retries on critic failures. The parse error is appended to FOCUS as critic-style feedback. Up to 3 attempts per drafter. Same retry path also covers the id-mismatch case (drafter drifts off SUGGESTED_NAME).
+- **Wider wizard modal**: the Improve-layout modal grows from 640px to ~960px (capped at 95vw). The Cancel / Apply layout / Draft+apply action row had buttons too close together in the narrow modal; the wider modal makes mis-clicks between "Update plan" (refine block) and "Apply layout" (action row) far less likely.
+- **Auto-run on landing**: `/agents/build/commit` now fires a single fire-and-forget run for each newly created agent immediately after `createAgent` succeeds. The user's first view of the dashboard shows real output instead of empty placeholders. Failed auto-runs surface as a normal failed-run row that the user can re-trigger with inputs.

--- a/packages/dashboard/src/routes/build-orchestrator.ts
+++ b/packages/dashboard/src/routes/build-orchestrator.ts
@@ -481,11 +481,36 @@ async function advanceDrafting(ctx: Ctx, session: BuildSession): Promise<void> {
     try {
       const a = parseAgent(fixedYaml);
       if (a.id !== validated.data.id) {
-        failedFragments.push(`${key}: parsed YAML id "${a.id}" ≠ plan id "${validated.data.id}"`);
+        // Treat id mismatch as a retry-able critique-style issue so the
+        // drafter gets a chance to fix it (same retry budget as critic
+        // failures). Common when the LLM drifts on its own SUGGESTED_NAME.
+        const attempts = session.drafterAttempts.get(key) ?? 1;
+        if (attempts < MAX_DRAFT_ATTEMPTS) {
+          retries.push({
+            key,
+            feedback: `Critic feedback:\n- newAgents[0].yaml: declared id="${validated.data.id}" but the YAML's id field is "${a.id}". They MUST match exactly. Emit the id "${validated.data.id}" in both places.`,
+          });
+          continue;
+        }
+        failedFragments.push(`${key}: parsed YAML id "${a.id}" ≠ plan id "${validated.data.id}" (after ${attempts} attempts)`);
         continue;
       }
     } catch (e) {
-      failedFragments.push(`${key}: YAML parse — ${e instanceof Error ? e.message : String(e)}`);
+      // YAML parse failure: the LLM produced text that doesn't even parse
+      // as YAML (typically a multi-line shell command without `|` block
+      // scalar, or unbalanced quotes inside an inline python -c). Feed
+      // the parser's exact error back as critic-style feedback so the
+      // retry has a concrete target.
+      const parseError = e instanceof Error ? e.message : String(e);
+      const attempts = session.drafterAttempts.get(key) ?? 1;
+      if (attempts < MAX_DRAFT_ATTEMPTS) {
+        retries.push({
+          key,
+          feedback: `Critic feedback:\n- newAgents[0].yaml: failed to parse as YAML — ${parseError}\n  Common cause: a multi-line shell command body (e.g. inline \`python3 -c "..."\`) without the YAML literal block scalar. Wrap the body in \`command: |\` with the script indented uniformly underneath. NEVER put a multi-line string after \`command:\` on the same line.`,
+        });
+        continue;
+      }
+      failedFragments.push(`${key}: YAML parse (after ${attempts} attempts) — ${parseError}`);
       continue;
     }
 

--- a/packages/dashboard/src/routes/run-now-build.ts
+++ b/packages/dashboard/src/routes/run-now-build.ts
@@ -1085,6 +1085,28 @@ buildRouter.post('/agents/build/commit', (req: Request, res: Response) => {
         `Created via Build from goal wizard (intent: ${plan.intent})`,
       );
       agentsCreated.push(ref.id);
+      // Auto-run the freshly created agent once so its Pulse tile
+      // shows actual output instead of empty placeholders the first
+      // time the user opens the dashboard. Fire-and-forget: errors
+      // surface as a failed run in /runs that the user can re-trigger
+      // with inputs if needed (e.g. agents that require user-supplied
+      // values). The agentStore.getAgent() round-trip is intentional —
+      // it picks up any normalization the store applies on insert.
+      try {
+        const stored = ctx.agentStore.getAgent(ref.id);
+        if (stored) {
+          executeAgentDag(
+            stored,
+            { triggeredBy: 'dashboard', inputs: {} },
+            {
+              runStore: ctx.runStore,
+              secretsStore: ctx.secretsStore,
+              variablesStore: ctx.variablesStore,
+              dataRoot: ctx.agentStore.dataRoot,
+            },
+          ).catch(() => { /* surfaced as a failed run row */ });
+        }
+      } catch { /* best-effort — don't let auto-run failures block the commit */ }
     } catch (e) {
       agentsSkipped.push({ id: ref.id, reason: (e as Error).message });
     }

--- a/packages/dashboard/src/views/improve-layout-modal.ts
+++ b/packages/dashboard/src/views/improve-layout-modal.ts
@@ -59,7 +59,7 @@ export function improveLayoutModal(config: ImproveLayoutConfig = PULSE_CONFIG): 
   const verbNoun = config.curateVerb === 'remove' ? 'remove from this dashboard' : 'hide from Pulse';
   return html`
     <div id="improve-layout-modal" class="modal-backdrop"${attrs}>
-      <div class="modal" style="max-width: 640px; max-height: 85vh; overflow-y: auto;">
+      <div class="modal" style="max-width: min(960px, 95vw); width: 100%; max-height: 90vh; overflow-y: auto;">
         <div id="improve-layout-content">
           <h3 style="margin: 0 0 var(--space-3);">Improve layout</h3>
           <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-3);">


### PR DESCRIPTION
## Summary

Three fixes bundled — all surfaced by the morning-briefing draft session.

### 1. YAML-parse failures now route through the retry loop

PR #333's per-drafter critic-retry only triggered when \`critiquePlan\` returned errors. YAML parse failures (a multi-line shell command without a \`command: |\` block scalar — common LLM mistake with inline \`python3 -c "..."\`) went straight to \`failedFragments\` and aborted the session.

Now: a YAML parse error is fed back to a fresh drafter run as critic-style feedback. Same MAX_DRAFT_ATTEMPTS budget (3). Same path also covers id-mismatch (drafter drifts off SUGGESTED_NAME).

### 2. Wider Improve-layout modal

Modal grows from 640px to \`min(960px, 95vw)\`. User reported accidentally hitting "Update plan" when they meant "Apply layout" — buttons were too close in the narrow modal.

### 3. Auto-run on landing

\`/agents/build/commit\` fires a single fire-and-forget run for each newly created agent right after \`createAgent\` succeeds. Dashboard tiles show real output the first time the user sees them. Failed auto-runs (e.g. agents requiring inputs) surface as a normal failed-run row.

## Test plan
- [x] \`npm test\` — 1511 passing.
- [ ] Manual: draft the morning-briefing dashboard. Confirm the inline-python YAML-parse failure now retries with critic feedback.
- [ ] Manual: confirm the wider modal reduces mis-click risk.
- [ ] Manual: after Apply, navigate to the dashboard. Confirm tiles show real output without needing to click Run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)