### PR TITLE
fix(improve-layout): dedupe 'Newly drafted' to prevent overlap

### DIFF
--- a/.changeset/improve-layout-merge-dedup.md
+++ b/.changeset/improve-layout-merge-dedup.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Fix duplicate-container overlap in the dashboard layout after repeated Improve-layout runs:
+
+- **Merge instead of duplicate**: `mergePlanWithDraftedAgents` now reuses an existing "Newly drafted" container if one is in the plan (carried over from a prior session by the planner). Previously it always appended a new one, producing two sections with the same label that overlapped visually.
+- **applyPlan dedupes by label**: the wizard's localStorage writeback now collapses any duplicate-label containers (case-insensitive) before saving, so even a plan that slips through with duplicates resolves into one section with the union of tiles.
+- **Server-side commit dedupes too**: `/dashboards/:id/layout-plan/commit` now merges duplicate-title sections before writing `dashboard.layout.sections`. Defensive — keeps the persisted layout clean regardless of what the client sent.

--- a/packages/dashboard/src/routes/dashboard-layout-plan.ts
+++ b/packages/dashboard/src/routes/dashboard-layout-plan.ts
@@ -355,15 +355,22 @@ dashboardLayoutPlanRouter.post('/dashboards/:id/layout-plan/commit', (req: Reque
   // Build the new section list from the plan's containers, filtering
   // out system tiles, de-duplicating ids, and dropping ids that don't
   // resolve to a real installed agent (phantom suggestions from the LLM).
+  // Section TITLES are also deduped (case-insensitive): if two containers
+  // share a title, their agent ids are merged into a single section. This
+  // prevents the dashboard renderer from drawing two sections with the
+  // same header on top of each other (e.g. after a "Newly drafted" merge
+  // where the planner kept a prior session's container).
   const seenIds = new Set<string>();
   const skippedUnknown: string[] = [];
-  const newSections: Array<{ title: string; agentIds: string[] }> = [];
+  const sectionsByTitle = new Map<string, { title: string; agentIds: string[] }>();
+  const sectionOrder: string[] = [];
   for (const c of containersRaw) {
     if (!c || typeof c !== 'object') continue;
     const label = typeof (c as { label?: unknown }).label === 'string'
       ? (c as { label: string }).label.trim()
       : '';
     if (!label) continue;
+    const titleKey = label.toLowerCase();
     const tilesRaw = Array.isArray((c as { tiles?: unknown }).tiles)
       ? (c as { tiles: unknown[] }).tiles
       : [];
@@ -379,8 +386,18 @@ dashboardLayoutPlanRouter.post('/dashboards/:id/layout-plan/commit', (req: Reque
       seenIds.add(t);
       ids.push(t);
     }
-    if (ids.length > 0) newSections.push({ title: label, agentIds: ids });
+    if (ids.length === 0) continue;
+    const existing = sectionsByTitle.get(titleKey);
+    if (existing) {
+      for (const id of ids) {
+        if (!existing.agentIds.includes(id)) existing.agentIds.push(id);
+      }
+    } else {
+      sectionsByTitle.set(titleKey, { title: label, agentIds: ids });
+      sectionOrder.push(titleKey);
+    }
   }
+  const newSections: Array<{ title: string; agentIds: string[] }> = sectionOrder.map((k) => sectionsByTitle.get(k)!);
 
   // Compute removed/retained/added vs the prior membership for the
   // response. `added` is the newly-surfaced delta (installed agents

--- a/packages/dashboard/src/views/improve-layout.js.ts
+++ b/packages/dashboard/src/views/improve-layout.js.ts
@@ -64,7 +64,26 @@ export const IMPROVE_LAYOUT_JS = `
       if (p.toAdd.indexOf(createdIds[i]) === -1) p.toAdd.push(createdIds[i]);
     }
     p.containers = (p.containers || []).slice();
-    p.containers.push({ label: 'Newly drafted', tiles: createdIds.slice() });
+    // Find an existing "Newly drafted" container (case-insensitive). On
+    // repeat runs the planner often keeps the prior session's container
+    // around — appending a second container with the same label creates
+    // a duplicate section header that visually overlaps in the rendered
+    // dashboard. Reuse the existing slot and merge ids into it.
+    var existing = null;
+    for (var ci = 0; ci < p.containers.length; ci++) {
+      if ((p.containers[ci].label || '').toLowerCase().trim() === 'newly drafted') {
+        existing = p.containers[ci];
+        break;
+      }
+    }
+    if (existing) {
+      existing.tiles = (existing.tiles || []).slice();
+      for (var ti = 0; ti < createdIds.length; ti++) {
+        if (existing.tiles.indexOf(createdIds[ti]) === -1) existing.tiles.push(createdIds[ti]);
+      }
+    } else {
+      p.containers.push({ label: 'Newly drafted', tiles: createdIds.slice() });
+    }
     p.needsNew = [];
     p.summary = (p.summary || '') + ' Drafted ' + createdIds.length + ' new agent' +
       (createdIds.length === 1 ? '' : 's') + ' (' + createdIds.join(', ') + ').';
@@ -726,14 +745,35 @@ export const IMPROVE_LAYOUT_JS = `
     if (existing && Array.isArray(existing.containers)) {
       existing.containers.forEach(function (c) { containerMap[(c.label || '').toLowerCase().trim()] = c; });
     }
+    // Dedupe plan.containers by label (case-insensitive). If a plan
+    // somehow carries two containers with the same label (e.g. the
+    // planner kept a prior "Newly drafted" AND our merge added one too),
+    // collapse them into a single entry so we don't write two sections
+    // with the same id+label into localStorage — which the dashboard
+    // renderer would draw on top of itself.
+    var byLabel = {};
+    var orderedKeys = [];
+    (plan.containers || []).forEach(function (c) {
+      var key = (c.label || '').toLowerCase().trim();
+      if (!key) return;
+      if (byLabel[key]) {
+        var prev = byLabel[key];
+        var tiles = prev.tiles.slice();
+        (c.tiles || []).forEach(function (t) { if (tiles.indexOf(t) === -1) tiles.push(t); });
+        prev.tiles = tiles;
+      } else {
+        byLabel[key] = { label: c.label, tiles: Array.from(c.tiles || []) };
+        orderedKeys.push(key);
+      }
+    });
     var next = {
-      containers: (plan.containers || []).map(function (c, idx) {
-        var key = (c.label || '').toLowerCase().trim();
+      containers: orderedKeys.map(function (key, idx) {
+        var c = byLabel[key];
         var prev = containerMap[key] || {};
         return {
           id: prev.id || ('c-' + key.replace(/[^a-z0-9]+/g, '-') + '-' + idx),
           label: c.label,
-          tiles: Array.from(c.tiles || []),
+          tiles: c.tiles,
         };
       }),
     };


### PR DESCRIPTION
## Summary
Reported on \`/dashboards/user:morning-briefing\` after a second Improve-layout draft session: container headers visually overlapping ("Newly drafted" stacked on top of "News" and others).

**Root cause**: \`mergePlanWithDraftedAgents\` always APPENDED a new "Newly drafted" container to the plan. But the layout-planner often KEPT the prior session's "Newly drafted" container in its plan output (it sees the existing dashboard sections and preserves them by default). The wizard then committed two sections with the same label — the dashboard renderer drew both, headers overlapped.

**Three-layer fix**:

1. \`mergePlanWithDraftedAgents\` — reuse an existing "Newly drafted" container (case-insensitive label match) and union the new tile ids in instead of appending a duplicate.
2. \`applyPlan\` — the wizard's localStorage writeback now dedupes by label as a defensive layer. Any plan that slips through with duplicates collapses before save.
3. \`/dashboards/:id/layout-plan/commit\` — server-side merge of duplicate-title sections before writing \`dashboard.layout.sections\`. Persisted layout stays clean regardless of client input.

## Test plan
- [x] \`npm test\` — 1511 passing.
- [ ] Manual: on the dashboard that showed overlap, run Improve layout twice with new agents each time. Confirm "Newly drafted" remains a single section with merged ids — no header overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)