### PR TITLE
feat(build): critic check for external <img> hosts in ai-template widgets

### DIFF
--- a/.changeset/drafter-img-src-permissions.md
+++ b/.changeset/drafter-img-src-permissions.md
@@ -1,0 +1,14 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Add a critic check + drafter prompt guidance so external `<img>` URLs in ai-template widgets don't get blocked by the page CSP.
+
+- **Critic**: `critiquePlan` now scans each ai-template for `<img src="https://HOST/...">` references. Hosts not declared in the agent's `permissions.imgSrc` (or matched by a wildcard like `*.example.com`) become critic errors. The per-drafter retry loop feeds them back so the drafter adds the missing host on the next attempt.
+- **Drafter prompt**: explicit STRICT rule with examples — when a template references external image URLs, declare each host in `permissions.imgSrc`. Wildcards supported.
+
+Closes the symptom where a drafted agent rendered with broken images and the browser console showed "violates the following Content Security Policy directive: img-src ..." (`www.thecocktaildb.com` reported).

--- a/agents/examples/agent-drafter.yaml
+++ b/agents/examples/agent-drafter.yaml
@@ -129,6 +129,24 @@ nodes:
         agents that take no runtime inputs.
       - outputWidget.type: one of dashboard, key-value, diff-apply, raw, ai-template.
       - outputWidget.fields[].type: one of text, code, badge, action, metric, stat.
+      - **External images need permissions.imgSrc.** When an ai-template
+        references `<img src="https://HOST/...">` for a host other than
+        `img.youtube.com` / `i.vimeocdn.com` (the baseline CSP allowlist),
+        the agent MUST declare each external host in
+        `permissions.imgSrc`. The dashboard's page CSP otherwise blocks
+        the load with "violates ... img-src" and the widget renders
+        with broken images.
+          ✓ permissions:
+              imgSrc:
+                - www.thecocktaildb.com
+                - "*.unsplash.com"   # wildcard subdomain
+            outputWidget:
+              type: ai-template
+              template: |
+                <img src="https://www.thecocktaildb.com/images/drink.jpg">
+        Use a wildcard (`*.example.com`) when the URL host varies (CDN
+        rotations). `data:` image URIs and the YouTube/Vimeo thumbnail
+        CDNs are already allowed — no declaration needed for those.
       - **ai-template + controls — NOT ALLOWED.** When outputWidget.type is
         `ai-template`, the HTML template you write controls visibility and
         layout directly — `field-toggle` and `view-switch` controls have

--- a/packages/core/src/build-plan-critic.test.ts
+++ b/packages/core/src/build-plan-critic.test.ts
@@ -165,6 +165,80 @@ describe('critiquePlan ai-template path checks', () => {
   });
 });
 
+describe('critiquePlan CSP img-src checks', () => {
+  const yamlWithImgTemplate = (template: string, declaredHosts: string[] = []) => {
+    // Wildcard hosts begin with `*.` which YAML reads as an alias unless
+    // single-quoted. Always quote to keep the test fixture predictable.
+    const permissions = declaredHosts.length === 0
+      ? ''
+      : `permissions:\n  imgSrc:\n${declaredHosts.map((h) => `    - '${h}'`).join('\n')}\n`;
+    return `id: drinks\nname: Drinks\nnodes:\n  - id: n1\n    type: shell\n    command: echo hi\n${permissions}outputWidget:\n  type: ai-template\n  template: |\n    ${template.replace(/\n/g, '\n    ')}\n`;
+  };
+
+  it('flags an <img> host not declared in permissions.imgSrc', () => {
+    const result = critiquePlan(
+      planFor({
+        newAgents: [{
+          id: 'drinks',
+          purpose: 'p',
+          yaml: yamlWithImgTemplate('<img src="https://www.thecocktaildb.com/images/drink.jpg">'),
+        }],
+      }),
+      { existingAgentIds: new Set() },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.message.includes('www.thecocktaildb.com') && e.path.endsWith('permissions.imgSrc'))).toBe(true);
+  });
+
+  it('accepts an <img> host that IS declared in permissions.imgSrc', () => {
+    const result = critiquePlan(
+      planFor({
+        newAgents: [{
+          id: 'drinks',
+          purpose: 'p',
+          yaml: yamlWithImgTemplate(
+            '<img src="https://www.thecocktaildb.com/images/drink.jpg">',
+            ['www.thecocktaildb.com'],
+          ),
+        }],
+      }),
+      { existingAgentIds: new Set() },
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts a host matched by a wildcard subdomain declaration', () => {
+    const result = critiquePlan(
+      planFor({
+        newAgents: [{
+          id: 'drinks',
+          purpose: 'p',
+          yaml: yamlWithImgTemplate(
+            '<img src="https://www.thecocktaildb.com/img.jpg">',
+            ['*.thecocktaildb.com'],
+          ),
+        }],
+      }),
+      { existingAgentIds: new Set() },
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('does not flag data: image URIs (already allowed by baseline CSP)', () => {
+    const result = critiquePlan(
+      planFor({
+        newAgents: [{
+          id: 'drinks',
+          purpose: 'p',
+          yaml: yamlWithImgTemplate('<img src="data:image/png;base64,iVBORw0KGgo=">'),
+        }],
+      }),
+      { existingAgentIds: new Set() },
+    );
+    expect(result.ok).toBe(true);
+  });
+});
+
 describe('formatCriticFeedback', () => {
   it('returns empty string when no errors', () => {
     expect(formatCriticFeedback([])).toBe('');

--- a/packages/core/src/build-plan-critic.ts
+++ b/packages/core/src/build-plan-critic.ts
@@ -170,6 +170,34 @@ export function critiquePlan(plan: BuildPlan, ctx: PlanCriticContext): PlanCriti
           message: `ai-template uses nested item path "${hit.replace(/^\{\{\{?\s*/, '').trim()}…}}" inside an #each block — only single-level item.FIELD is supported. Flatten the per-row value into a scalar (e.g. away_pitcher_name) on each array element.`,
         });
       }
+
+      // CSP img-src check: every external <img> host referenced by the
+      // template must be declared in the agent's permissions.imgSrc.
+      // Otherwise the page CSP blocks the load and the widget renders
+      // with broken images (browser console: "violates ... img-src").
+      const declaredHosts = new Set<string>(
+        ((agent as { permissions?: { imgSrc?: string[] } }).permissions?.imgSrc ?? []).map((h) => h.toLowerCase()),
+      );
+      // Wildcards (`*.example.com`) match any subdomain of `example.com`.
+      const matchesDeclared = (host: string): boolean => {
+        if (declaredHosts.has(host)) return true;
+        for (const d of declaredHosts) {
+          if (d.startsWith('*.') && host.endsWith(d.slice(1))) return true;
+        }
+        return false;
+      };
+      const imgRe = /<img\b[^>]*\bsrc\s*=\s*["']https?:\/\/([^/'"\s]+)/gi;
+      const missingHosts = new Set<string>();
+      while ((m = imgRe.exec(tpl)) !== null) {
+        const host = m[1].toLowerCase();
+        if (!matchesDeclared(host)) missingHosts.add(host);
+      }
+      for (const host of missingHosts) {
+        errors.push({
+          path: `newAgents[${i}].yaml.permissions.imgSrc`,
+          message: `Template references <img src="https://${host}/..."> but "${host}" is not in permissions.imgSrc — the page CSP will block the image. Add "${host}" to the agent's permissions.imgSrc array (or "*.${host.split('.').slice(-2).join('.')}" for a wildcard if the host varies).`,
+        });
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
Reported on \`user:morning-briefing\`:
\`\`\`
Loading the image 'https://www.thecocktaildb.com/...' violates the following Content Security Policy directive: "img-src 'self' data: https://img.youtube.com https://i.vimeocdn.com..."
\`\`\`

The drafted agent's ai-template referenced an external image URL, but the agent didn't declare \`www.thecocktaildb.com\` in \`permissions.imgSrc\` — required to widen the page CSP at render time.

Two fixes:

1. **Critic check** — \`critiquePlan\` now scans each ai-template for \`<img src="https://HOST/...">\`. Hosts not in \`permissions.imgSrc\` (or matched by a wildcard like \`*.example.com\`) become critic errors. The per-drafter retry loop feeds them back so the drafter declares the missing host on the next attempt.
2. **Drafter prompt** — explicit STRICT rule with examples (bare hosts, wildcards, data: URIs / YouTube + Vimeo CDNs that don't need declaration).

## Test plan
- [x] \`npm test\` — 1515 passing, 3 skipped (4 new CSP-img-src tests).
- [ ] Manual: re-draft an agent that pulls images from an external API. Confirm permissions.imgSrc lists the host, the page CSP allows the image, and the tile renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)