### PR TITLE
fix(dashboards): tile X confirms + stays on dashboard view

### DIFF
--- a/.changeset/dashboard-tile-delete-stay.md
+++ b/.changeset/dashboard-tile-delete-stay.md
@@ -1,0 +1,9 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Tile removal on a named dashboard now (1) shows a confirm dialog before deleting and (2) keeps the user on the dashboard view afterward instead of bouncing them to `/dashboards/<id>/edit`. The X button in the dashboard view passes `returnTo=dashboard` to the delete route; the edit-sections page's existing flow (which legitimately wants to land on /edit) is unchanged.

--- a/packages/dashboard/src/routes/dashboards-edit.ts
+++ b/packages/dashboard/src/routes/dashboards-edit.ts
@@ -129,6 +129,15 @@ dashboardsEditRouter.post('/dashboards/:id/sections/:idx/tiles/:tileIdx/delete',
       arr[idx] = { ...arr[idx], agentIds };
     });
     ctx.dashboardsStore!.updateLayout(id, { sections });
+    // The × button on a tile in the dashboard view (not the
+    // edit-sections page) passes returnTo=dashboard so we land the
+    // user back where they were, instead of bouncing them to
+    // /dashboards/<id>/edit. The flash carries through to either page.
+    const returnTo = typeof req.body?.returnTo === 'string' ? req.body.returnTo : '';
+    if (returnTo === 'dashboard') {
+      res.redirect(303, `/dashboards/${encodeURIComponent(id)}?ok=${encodeURIComponent('Tile removed.')}`);
+      return;
+    }
     redirectOk(res, id, `Tile removed.`);
   });
 });

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -126,7 +126,8 @@ function tileHeader(tile: PulseTile, isSystem: boolean, ctx: TileWrapContext): S
         <button type="button" class="pulse-tile__palette-btn" data-tile-id="${tile.agent.id}" title="Change palette">\u25CF</button>
         ${isSystem ? html`` : (ctx.kind === 'dashboard'
           ? html`
-              <form method="POST" action="/dashboards/${encodeURIComponent(ctx.dashboardId)}/sections/${String(ctx.sectionIdx)}/tiles/${String(ctx.tileIdx)}/delete" style="margin: 0;">
+              <form method="POST" action="/dashboards/${encodeURIComponent(ctx.dashboardId)}/sections/${String(ctx.sectionIdx)}/tiles/${String(ctx.tileIdx)}/delete" style="margin: 0;" onsubmit="return confirm('Remove ${tile.signal.title.replace(/'/g, "&#39;")} from this dashboard?');">
+                <input type="hidden" name="returnTo" value="dashboard">
                 <button type="submit" class="pulse-tile__toggle" title="Remove from this dashboard">\u00D7</button>
               </form>
             `


### PR DESCRIPTION
## Summary
Reported: clicking × on a tile in a named dashboard (edit mode) silently submitted, then bounced the user to \`/dashboards/<id>/edit\`. Felt like "a system alert and then sent to another screen."

**Two fixes:**

1. The × form now wraps with \`onsubmit="return confirm('Remove <title> from this dashboard?')"\` — explicit confirmation before the destructive action.
2. The form passes \`returnTo=dashboard\`; the delete route honors it by redirecting back to \`/dashboards/<id>\` (with the success flash) instead of \`/dashboards/<id>/edit\`. The edit-sections page's own delete buttons (which legitimately stay on /edit) are unchanged.

## Test plan
- [x] \`npm test\` — 1515 passing.
- [ ] Manual: on a named dashboard, hit × on a tile. Confirm the dialog appears with the tile title. Accept → tile is gone and you stay on the dashboard view with the green success banner.
- [ ] Manual: on \`/dashboards/<id>/edit\`, delete a tile via the page's own controls — confirm you stay on /edit (existing behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)