### PR TITLE
fix(dashboards): single in-app modal for tile delete, not two natives

### DIFF
--- a/.changeset/dashboard-tile-delete-modal.md
+++ b/.changeset/dashboard-tile-delete-modal.md
@@ -1,0 +1,9 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Replace the two stacked native browser prompts on dashboard tile removal with a single in-app confirm modal. Previously, deleting a tile in edit mode fired the `onsubmit` `confirm()` AND the edit-mode `beforeunload` "Leave site?" guard — two system dialogs for one action. Now: tile-delete forms use `data-confirm-modal`, intercepted by a styled in-app modal (reusing the existing `pulse-configure-modal` chrome); confirming sets an intentional-navigation flag so the `beforeunload` guard doesn't double-prompt. Any plain form submit in edit mode also clears the guard so deliberate server actions don't trigger the "Leave site?" dialog.

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -126,7 +126,7 @@ function tileHeader(tile: PulseTile, isSystem: boolean, ctx: TileWrapContext): S
         <button type="button" class="pulse-tile__palette-btn" data-tile-id="${tile.agent.id}" title="Change palette">\u25CF</button>
         ${isSystem ? html`` : (ctx.kind === 'dashboard'
           ? html`
-              <form method="POST" action="/dashboards/${encodeURIComponent(ctx.dashboardId)}/sections/${String(ctx.sectionIdx)}/tiles/${String(ctx.tileIdx)}/delete" style="margin: 0;" onsubmit="return confirm('Remove ${tile.signal.title.replace(/'/g, "&#39;")} from this dashboard?');">
+              <form method="POST" action="/dashboards/${encodeURIComponent(ctx.dashboardId)}/sections/${String(ctx.sectionIdx)}/tiles/${String(ctx.tileIdx)}/delete" style="margin: 0;" data-confirm-modal="Remove ${tile.signal.title.replace(/"/g, "&quot;")} from this dashboard? You can add it back later from the Add tile button.">
                 <input type="hidden" name="returnTo" value="dashboard">
                 <button type="submit" class="pulse-tile__toggle" title="Remove from this dashboard">\u00D7</button>
               </form>

--- a/packages/dashboard/src/views/widget-layout.js.ts
+++ b/packages/dashboard/src/views/widget-layout.js.ts
@@ -394,11 +394,76 @@ export function widgetLayoutJS(config: WidgetLayoutConfig): string {
     // still arranging tiles. Browsers ignore the returned string and
     // show their own generic dialog text; presence of a return value
     // is what triggers the prompt.
+    //
+    // intentionalNav is set right before a deliberate same-app submit
+    // (e.g. confirming a tile delete via the in-app modal) so we don't
+    // stack the browser's "Leave site?" dialog on top of an action the
+    // user already confirmed.
+    var intentionalNav = false;
     window.addEventListener('beforeunload', function (e) {
-      if (!editMode) return;
+      if (!editMode || intentionalNav) return;
       e.preventDefault();
       e.returnValue = '';
       return '';
+    });
+
+    // ── In-app confirm modal ────────────────────────────────────────
+    // Replaces native confirm() for destructive tile actions. Forms
+    // tagged with data-confirm-modal="message" are intercepted here:
+    // we show a styled modal, and only submit on confirm (setting
+    // intentionalNav so the beforeunload guard doesn't double-prompt).
+    var confirmModal = null;
+    var pendingForm = null;
+    function ensureConfirmModal() {
+      if (confirmModal) return confirmModal;
+      confirmModal = document.createElement('div');
+      confirmModal.className = 'pulse-configure-modal';
+      confirmModal.style.display = 'none';
+      confirmModal.innerHTML =
+        '<div class="pulse-configure-modal__content" style="max-width: 360px;">' +
+          '<div class="pulse-configure-modal__header">' +
+            '<h3 style="margin: 0;" id="wl-confirm-title">Remove tile?</h3>' +
+            '<button type="button" class="pulse-configure-modal__close" title="Close">\\u00D7</button>' +
+          '</div>' +
+          '<div class="pulse-configure-modal__section">' +
+            '<p style="margin: 0; font-size: var(--font-size-sm);" id="wl-confirm-message"></p>' +
+          '</div>' +
+          '<div class="pulse-configure-modal__footer">' +
+            '<button type="button" class="btn btn--ghost btn--sm" id="wl-confirm-cancel">Cancel</button>' +
+            '<button type="button" class="btn btn--primary btn--sm" id="wl-confirm-ok">Remove</button>' +
+          '</div>' +
+        '</div>';
+      document.body.appendChild(confirmModal);
+      function close() { confirmModal.style.display = 'none'; pendingForm = null; }
+      confirmModal.addEventListener('click', function (e) { if (e.target === confirmModal) close(); });
+      confirmModal.querySelector('.pulse-configure-modal__close').addEventListener('click', close);
+      document.getElementById('wl-confirm-cancel').addEventListener('click', close);
+      document.getElementById('wl-confirm-ok').addEventListener('click', function () {
+        var form = pendingForm;
+        close();
+        if (form) {
+          // Bypass the edit-mode beforeunload guard — the user just
+          // confirmed this navigation.
+          intentionalNav = true;
+          form.submit();
+        }
+      });
+      return confirmModal;
+    }
+    document.addEventListener('submit', function (e) {
+      var form = e.target;
+      if (!form || !form.matches) return;
+      if (form.matches('form[data-confirm-modal]')) {
+        e.preventDefault();
+        pendingForm = form;
+        var modal = ensureConfirmModal();
+        document.getElementById('wl-confirm-message').textContent = form.getAttribute('data-confirm-modal') || 'Are you sure?';
+        modal.style.display = 'flex';
+        return;
+      }
+      // Any other form submission is a deliberate server action — let it
+      // through without the edit-mode "Leave site?" guard stacking on top.
+      intentionalNav = true;
     });
 
     // Whether the user confirms or refreshes, exit edit mode on the way


### PR DESCRIPTION
## Summary
Follow-up to #339. Reported: removing a tile gives "two system prompts instead of a modal that gives me information and closes cleanly."

**Root cause of the second prompt**: the \`onsubmit="return confirm()"\` added in #339 fired first, then the form submit navigated the page, which triggered the edit-mode \`beforeunload\` "Leave site?" guard — two native browser dialogs for one action.

**Fix** — one styled in-app modal:

1. Tile-delete forms now carry \`data-confirm-modal="Remove <title>…"\` instead of \`onsubmit="return confirm(...)"\`.
2. \`widget-layout.js\` intercepts \`form[data-confirm-modal]\` submits and shows an in-app modal (reuses the existing \`pulse-configure-modal\` chrome — consistent with the Add-group modal).
3. Confirming sets \`intentionalNav = true\` before \`form.submit()\`, so the \`beforeunload\` guard skips the deliberate navigation.
4. Any other form submit in edit mode also clears the guard, so deliberate server actions (e.g. the Pulse hide ×) don't trigger "Leave site?" either.

## Test plan
- [x] \`npm test\` — 1515 passing (the one scheduler-catchup blip was a clock-boundary flake at ~08:00, unrelated; passes now).
- [ ] Manual: enter edit mode on a named dashboard, click × on a tile. Confirm a single styled modal appears with the tile title. Cancel → nothing happens, stay in edit mode. Confirm → tile removed, land on dashboard view with success flash, no "Leave site?" dialog.
- [ ] Manual: Pulse hide × in edit mode — confirm no "Leave site?" prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)