### PR TITLE
fix(dashboards): stay in edit mode after delete + Pulse confirm modal

### DIFF
--- a/.changeset/tile-delete-modal-followups.md
+++ b/.changeset/tile-delete-modal-followups.md
@@ -1,0 +1,14 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Two follow-ups to the tile-removal confirm modal:
+
+- **Stay in edit mode after removing a tile.** The `pagehide` handler cleared edit mode on every navigation, including the delete redirect — so removing a tile bounced you out of edit mode. It now skips the clear when the navigation is a deliberate in-app action (confirmed delete / form submit), so you stay in edit mode and can keep arranging.
+- **Pulse tiles get the same confirm modal.** The Pulse "hide from Pulse" × now shows the in-app modal too (previously it submitted with no confirmation). Confirm button label + title are per-form ("Hide" / "Hide tile?" on Pulse, "Remove" / "Remove tile?" on dashboards).
+
+Also fixes a double-escaping bug in the confirm message — the tile title was manually `&quot;`-escaped and then re-escaped by the `html` tag, surfacing literal `&quot;` in the dialog. The manual escape is removed; the tag handles it.

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -126,13 +126,13 @@ function tileHeader(tile: PulseTile, isSystem: boolean, ctx: TileWrapContext): S
         <button type="button" class="pulse-tile__palette-btn" data-tile-id="${tile.agent.id}" title="Change palette">\u25CF</button>
         ${isSystem ? html`` : (ctx.kind === 'dashboard'
           ? html`
-              <form method="POST" action="/dashboards/${encodeURIComponent(ctx.dashboardId)}/sections/${String(ctx.sectionIdx)}/tiles/${String(ctx.tileIdx)}/delete" style="margin: 0;" data-confirm-modal="Remove ${tile.signal.title.replace(/"/g, "&quot;")} from this dashboard? You can add it back later from the Add tile button.">
+              <form method="POST" action="/dashboards/${encodeURIComponent(ctx.dashboardId)}/sections/${String(ctx.sectionIdx)}/tiles/${String(ctx.tileIdx)}/delete" style="margin: 0;" data-confirm-modal="Remove ${tile.signal.title} from this dashboard? You can add it back later from the Add tile button." data-confirm-label="Remove" data-confirm-title="Remove tile?">
                 <input type="hidden" name="returnTo" value="dashboard">
                 <button type="submit" class="pulse-tile__toggle" title="Remove from this dashboard">\u00D7</button>
               </form>
             `
           : html`
-              <form method="POST" action="/agents/${tile.agent.id}/signal/toggle" style="margin: 0;">
+              <form method="POST" action="/agents/${tile.agent.id}/signal/toggle" style="margin: 0;" data-confirm-modal="Hide ${tile.signal.title} from Pulse? You can restore it from the hidden signals section below the grid." data-confirm-label="Hide" data-confirm-title="Hide tile?">
                 <button type="submit" class="pulse-tile__toggle" title="Hide from Pulse">\u00D7</button>
               </form>
             `)}

--- a/packages/dashboard/src/views/widget-layout.js.ts
+++ b/packages/dashboard/src/views/widget-layout.js.ts
@@ -458,6 +458,10 @@ export function widgetLayoutJS(config: WidgetLayoutConfig): string {
         pendingForm = form;
         var modal = ensureConfirmModal();
         document.getElementById('wl-confirm-message').textContent = form.getAttribute('data-confirm-modal') || 'Are you sure?';
+        // Per-form confirm button label + title (Remove vs Hide etc.).
+        var okLabel = form.getAttribute('data-confirm-label') || 'Remove';
+        document.getElementById('wl-confirm-ok').textContent = okLabel;
+        document.getElementById('wl-confirm-title').textContent = form.getAttribute('data-confirm-title') || (okLabel + ' tile?');
         modal.style.display = 'flex';
         return;
       }
@@ -466,11 +470,15 @@ export function widgetLayoutJS(config: WidgetLayoutConfig): string {
       intentionalNav = true;
     });
 
-    // Whether the user confirms or refreshes, exit edit mode on the way
-    // out so coming back lands on the normal view. Edit mode is meant
-    // to be a focused arranging session, not a sticky surface state —
-    // re-entering edit mode unexpectedly on a return visit was confusing.
+    // Leaving the page exits edit mode so a return visit lands on the
+    // normal view — EXCEPT when the navigation is a deliberate in-app
+    // action (tile delete / hide), where the user is mid-arranging and
+    // expects to stay in edit mode after the page round-trips. The
+    // intentionalNav flag distinguishes the two: set on confirmed
+    // delete + plain form submits, left false for back-button / tab
+    // close / typing a URL.
     window.addEventListener('pagehide', function () {
+      if (intentionalNav) return;
       saveEditMode(false);
     });
 


### PR DESCRIPTION
## Summary
Two follow-ups to the in-app confirm modal (#340):

1. **Stay in edit mode after removing a tile.** The \`pagehide\` handler ran \`saveEditMode(false)\` on every navigation — including the delete redirect — so removing a tile kicked you out of edit mode. It now skips the clear when \`intentionalNav\` is set (a confirmed delete or deliberate form submit), so you stay in edit mode and keep arranging. Back-button / tab-close / URL navigation still exits edit mode as before.

2. **Pulse tiles get the same confirm modal.** The Pulse "hide from Pulse" × submitted with no confirmation. It now uses \`data-confirm-modal\` too. The confirm button label + dialog title are per-form: "Hide" / "Hide tile?" on Pulse (restorable), "Remove" / "Remove tile?" on dashboards.

Also fixes a double-escape — the tile title was manually \`&quot;\`-escaped and then re-escaped by the \`html\` tag, leaking literal \`&quot;\` into the dialog. Removed the manual escape; the tag handles it.

## Test plan
- [x] \`npm test\` — 1515 passing.
- [ ] Manual (dashboard): edit mode → × a tile → modal "Remove tile?" → confirm → tile gone, **still in edit mode**, success flash.
- [ ] Manual (Pulse): × a tile → modal "Hide tile?" with restore copy → confirm → tile hidden.
- [ ] Manual: a tile whose title contains a quote renders cleanly in the dialog (no literal &quot;).

🤖 Generated with [Claude Code](https://claude.com/claude-code)