### PR TITLE
feat(dashboard): build stamp in /health + footer

### DIFF
--- a/.changeset/dashboard-build-stamp.md
+++ b/.changeset/dashboard-build-stamp.md
@@ -1,0 +1,9 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Add a build stamp so you can tell which code a running daemon is serving. `npm run build` now writes `dist/build-info.json` with the git short SHA (suffixed `-dirty` for an unclean tree) and an ISO build timestamp. The dashboard footer shows the commit next to the version (`sua v0.x · 260589e`, build time on hover), and `/health` returns `commit` + `builtAt`. Verify with `curl -s localhost:3000/health | jq '{commit, builtAt}'` against `git rev-parse --short HEAD`. Falls back to `dev` when the stamp is absent (running straight from tsc without the post-build step, or in tests).

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "tsc --build && node packages/dashboard/scripts/copy-assets.mjs && chmod +x packages/cli/dist/index.js",
+    "build": "tsc --build && node packages/dashboard/scripts/copy-assets.mjs && node packages/dashboard/scripts/gen-build-info.mjs && chmod +x packages/cli/dist/index.js",
     "clean": "tsc --build --clean",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/dashboard/scripts/gen-build-info.mjs
+++ b/packages/dashboard/scripts/gen-build-info.mjs
@@ -1,0 +1,35 @@
+// Generate dist/build-info.json with the git commit + build timestamp.
+// Run after tsc in the root build so the running daemon can report
+// exactly which code it's serving (surfaced in /health and the footer).
+// Best-effort: if git isn't available (e.g. building from a tarball),
+// fall back to "unknown" so the build never fails on this.
+import { execSync } from 'node:child_process';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const distRoot = resolve(here, '..', 'dist');
+
+function git(cmd) {
+  try {
+    return execSync(`git ${cmd}`, { cwd: here, stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString().trim();
+  } catch {
+    return '';
+  }
+}
+
+let commit = git('rev-parse --short HEAD') || 'unknown';
+// Mark a dirty working tree so a build off uncommitted changes is
+// distinguishable from a clean one.
+if (commit !== 'unknown') {
+  const dirty = git('status --porcelain');
+  if (dirty) commit += '-dirty';
+}
+
+const info = { commit, builtAt: new Date().toISOString() };
+
+mkdirSync(distRoot, { recursive: true });
+writeFileSync(resolve(distRoot, 'build-info.json'), JSON.stringify(info, null, 2) + '\n');
+console.log(`build-info: ${info.commit} @ ${info.builtAt}`);

--- a/packages/dashboard/src/build-info.ts
+++ b/packages/dashboard/src/build-info.ts
@@ -1,0 +1,29 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+export interface BuildInfo {
+  /** Git short SHA at build time (suffixed `-dirty` for an unclean tree), or "dev". */
+  commit: string;
+  /** ISO build timestamp, or "" when unknown. */
+  builtAt: string;
+}
+
+/**
+ * Build stamp written by `scripts/gen-build-info.mjs` into dist/build-info.json
+ * during `npm run build`. Lets the running daemon report exactly which code
+ * it's serving (see /health and the footer). Falls back to a dev marker when
+ * the file is absent — e.g. running straight from a tsc build without the
+ * post-build step, or in tests.
+ */
+let cached: BuildInfo | null = null;
+export function getBuildInfo(): BuildInfo {
+  if (cached) return cached;
+  try {
+    // Compiled to dist/build-info.js; the JSON sits beside it at dist/build-info.json.
+    cached = require('./build-info.json') as BuildInfo;
+  } catch {
+    cached = { commit: 'dev', builtAt: '' };
+  }
+  return cached;
+}

--- a/packages/dashboard/src/routes/health.ts
+++ b/packages/dashboard/src/routes/health.ts
@@ -1,6 +1,7 @@
 import { Router, type Request, type Response } from 'express';
 import { getSchedulerStatus } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
+import { getBuildInfo } from '../build-info.js';
 
 const startedAt = Date.now();
 
@@ -37,10 +38,13 @@ healthRouter.get('/health', (req: Request, res: Response) => {
     } : {}),
   };
 
+  const build = getBuildInfo();
   res.json({
     status: 'ok',
     uptime_s: uptimeSeconds,
     runs_last_hour: runsLastHour,
     scheduler,
+    commit: build.commit,
+    builtAt: build.builtAt,
   });
 });

--- a/packages/dashboard/src/views/footer.ts
+++ b/packages/dashboard/src/views/footer.ts
@@ -1,5 +1,6 @@
 import { html, type SafeHtml } from './html.js';
 import { createRequire } from 'node:module';
+import { getBuildInfo } from '../build-info.js';
 
 const require = createRequire(import.meta.url);
 
@@ -21,10 +22,17 @@ function readVersion(): string {
 
 export function footer(): SafeHtml {
   const version = readVersion();
+  const build = getBuildInfo();
+  // Build stamp: git short SHA (+ "-dirty") so you can tell at a glance
+  // whether the running daemon is serving the code you just built.
+  // Title carries the full build timestamp on hover.
+  const buildLabel = build.commit && build.commit !== 'dev'
+    ? html` <span class="mono dim" title="built ${build.builtAt}">· ${build.commit}</span>`
+    : html` <span class="mono dim">· dev</span>`;
   return html`
     <footer class="app-footer">
       <div class="app-footer__inner">
-        <span class="app-footer__brand">sua <span class="mono dim">v${version}</span></span>
+        <span class="app-footer__brand">sua <span class="mono dim">v${version}</span>${buildLabel}</span>
         <nav class="app-footer__nav">
           <a href="/help">Help &amp; tutorial</a>
           <a href="https://github.com/gregmeyer/some-useful-agents" target="_blank" rel="noreferrer">GitHub</a>


### PR DESCRIPTION
## Summary
You asked "how do I know if I'm running this new code?" — there was no version/commit signal in the running app. This adds a build stamp baked at compile time.

- **`scripts/gen-build-info.mjs`** (runs after tsc in the root build) writes `dist/build-info.json` with the git short SHA (suffixed `-dirty` for an unclean tree) + ISO build timestamp. Best-effort — falls back to "unknown" if git isn't present (tarball builds).
- **`src/build-info.ts`** reads it at runtime with a `dev` fallback (running straight from tsc / tests).
- **Footer**: `sua v0.x · 260589e` (build time on hover).
- **`/health`**: now returns `commit` + `builtAt`.

### How you'll verify a running daemon
\`\`\`bash
curl -s localhost:3000/health | jq '{commit, builtAt}'
git rev-parse --short HEAD   # compare
\`\`\`
Or just glance at the dashboard footer.

\`dist/build-info.json\` is gitignored (build artifact).

## Test plan
- [x] \`npm run build\` — prints \`build-info: <sha> @ <ts>\`, writes dist/build-info.json.
- [x] \`npm test\` — 1515 passing.
- [ ] Manual: restart daemon, hit /health, confirm commit matches HEAD; check footer shows the SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)