### PR TITLE
feat(dashboard): one-click allow for CSP-blocked widget images

### DIFF
--- a/.changeset/csp-allow-blocked-host.md
+++ b/.changeset/csp-allow-blocked-host.md
@@ -1,0 +1,9 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+One-click "Allow" for CSP-blocked widget images on the run-detail page. When a widget renders an `<img>` from a host that isn't in the page `img-src` allowlist, the browser blocks it silently. The run-detail page now listens for the CSP violation, attributes it to the run's agent, and shows a banner with the blocked host(s) and an Allow button. Allowing merges each host into the agent's `permissions.imgSrc` (new version) via the new `POST /agents/:id/permissions/allow-host` endpoint, then reloads so the images render. Full URLs are normalized to bare hosts, so pasting an image URL works too. The replace-everything `/permissions` form on the agent Config tab still exists for manual edits.

--- a/packages/dashboard/src/routes/versions.ts
+++ b/packages/dashboard/src/routes/versions.ts
@@ -399,3 +399,48 @@ versionsRouter.post('/agents/:id/permissions', (req: Request, res: Response) => 
     res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent(`Permissions update failed: ${msg}`)}`);
   }
 });
+
+/**
+ * POST /agents/:id/permissions/allow-host — MERGE a single img-src host
+ * into the agent's allowlist (creating a new version), as opposed to the
+ * replace-everything /permissions form. Powers the one-click "Allow this
+ * host" affordance when a widget image is blocked by the page CSP.
+ *
+ * Body: { host: string } (a bare host or full URL — normalised here).
+ * Returns JSON { ok, host, imgSrc } so the caller can reload.
+ */
+versionsRouter.post('/agents/:id/permissions/allow-host', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const raw = typeof body.host === 'string' ? body.host : '';
+
+  const agent = ctx.agentStore.getAgent(id);
+  if (!agent) {
+    res.status(404).json({ ok: false, error: 'Agent not found.' });
+    return;
+  }
+
+  // Normalise: strip scheme/path/port, lowercase. Same rules as the
+  // replace form so a pasted full URL works.
+  const host = raw.trim().toLowerCase()
+    .replace(/^https?:\/\//, '').replace(/\/.*$/, '').replace(/:\d+$/, '');
+  if (!host || !IMG_SRC_HOST_RE.test(host)) {
+    res.status(400).json({ ok: false, error: `Invalid host: ${raw || '(empty)'}` });
+    return;
+  }
+
+  const current = agent.permissions?.imgSrc ?? [];
+  if (current.includes(host)) {
+    res.json({ ok: true, host, imgSrc: current, unchanged: true });
+    return;
+  }
+  const imgSrc = [...current, host].sort();
+  try {
+    const updated = { ...agent, permissions: { ...agent.permissions, imgSrc } };
+    ctx.agentStore.upsertAgent(updated, 'dashboard', `Allowed img-src host ${host}`);
+    res.json({ ok: true, host, imgSrc });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err instanceof Error ? err.message : String(err) });
+  }
+});

--- a/packages/dashboard/src/views/csp-allow.js.ts
+++ b/packages/dashboard/src/views/csp-allow.js.ts
@@ -1,0 +1,110 @@
+/**
+ * CSP image-block helper for the run-detail page.
+ *
+ * When a widget renders an <img> from a host that isn't in the page CSP
+ * `img-src` allowlist, the browser blocks it silently (only the console
+ * shows the violation). This listener catches those `securitypolicyviolation`
+ * events, collects the blocked hosts, and — on a page that declares a single
+ * owning agent via `[data-csp-agent]` (the run-detail container) — shows a
+ * banner with a one-click "Allow" that merges each host into the agent's
+ * `permissions.imgSrc` via POST /agents/:id/permissions/allow-host, then
+ * reloads so the now-allowed images render.
+ *
+ * Inert on pages without `[data-csp-agent]` (e.g. Pulse / dashboards, where
+ * a global violation can't be attributed to one agent).
+ */
+export const CSP_ALLOW_JS = `
+(function () {
+  var agentEl = document.querySelector('[data-csp-agent]');
+  if (!agentEl) return;
+  var agentId = agentEl.getAttribute('data-csp-agent');
+  if (!agentId) return;
+
+  var blockedHosts = {};   // host -> true
+  var banner = null;
+
+  function hostFromUri(uri) {
+    if (!uri) return '';
+    try {
+      // blockedURI may be a full URL or 'inline'/'eval' for non-resource
+      // violations. Only parse http(s) resource URIs.
+      if (uri.indexOf('http') !== 0) return '';
+      return new URL(uri).hostname.toLowerCase();
+    } catch (e) { return ''; }
+  }
+
+  function esc(s) { var d = document.createElement('div'); d.textContent = s == null ? '' : String(s); return d.innerHTML; }
+
+  function renderBanner() {
+    var hosts = Object.keys(blockedHosts);
+    if (hosts.length === 0) return;
+    if (!banner) {
+      banner = document.createElement('div');
+      banner.className = 'flash flash--info';
+      banner.style.cssText = 'margin: var(--space-3) 0; display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-3); flex-wrap: wrap;';
+      // Mount just above the run container so it's visible near the result.
+      var anchor = document.querySelector('[data-run-container]') || document.body;
+      anchor.insertBefore(banner, anchor.firstChild);
+    }
+    var chips = hosts.map(function (h) {
+      return '<code style="font-size:var(--font-size-xs);background:var(--color-surface-raised);padding:0 var(--space-1);border-radius:var(--radius-sm);">' + esc(h) + '</code>';
+    }).join(' ');
+    banner.innerHTML =
+      '<div style="flex:1;min-width:200px;">' +
+        '<strong>' + hosts.length + ' image host' + (hosts.length === 1 ? '' : 's') + ' blocked by the page security policy.</strong> ' +
+        '<span class="dim" style="font-size:var(--font-size-xs);">' + chips + '</span>' +
+        '<div class="dim" style="font-size:var(--font-size-xs);margin-top:var(--space-1);">Allowing adds ' +
+        (hosts.length === 1 ? 'it' : 'them') + ' to <code>' + esc(agentId) + '</code> permissions.imgSrc (creates a new agent version).</div>' +
+      '</div>' +
+      '<span style="display:inline-flex;gap:var(--space-2);flex-shrink:0;">' +
+        '<button type="button" class="btn btn--sm btn--ghost" id="csp-dismiss">Dismiss</button>' +
+        '<button type="button" class="btn btn--sm btn--primary" id="csp-allow">Allow ' + (hosts.length === 1 ? 'host' : 'all ' + hosts.length) + '</button>' +
+      '</span>';
+
+    document.getElementById('csp-dismiss').addEventListener('click', function () {
+      if (banner && banner.parentNode) banner.parentNode.removeChild(banner);
+      banner = null;
+    });
+    document.getElementById('csp-allow').addEventListener('click', function () {
+      var btn = document.getElementById('csp-allow');
+      btn.disabled = true; btn.textContent = 'Allowing...';
+      var pending = hosts.slice();
+      var failures = [];
+      function next() {
+        if (pending.length === 0) {
+          if (failures.length > 0) {
+            btn.disabled = false; btn.textContent = 'Retry';
+            var msg = document.createElement('div');
+            msg.className = 'dim';
+            msg.style.cssText = 'font-size:var(--font-size-xs);width:100%;color:var(--color-danger,#a00);';
+            msg.textContent = 'Failed: ' + failures.join(', ');
+            banner.appendChild(msg);
+            return;
+          }
+          window.location.reload();
+          return;
+        }
+        var host = pending.shift();
+        fetch('/agents/' + encodeURIComponent(agentId) + '/permissions/allow-host', {
+          method: 'POST', credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ host: host }),
+        })
+        .then(function (r) { return r.json(); })
+        .then(function (d) { if (!d.ok) failures.push(host); next(); })
+        .catch(function () { failures.push(host); next(); });
+      }
+      next();
+    });
+  }
+
+  window.addEventListener('securitypolicyviolation', function (e) {
+    var directive = (e.effectiveDirective || e.violatedDirective || '');
+    if (directive.indexOf('img-src') === -1) return;
+    var host = hostFromUri(e.blockedURI);
+    if (!host || blockedHosts[host]) return;
+    blockedHosts[host] = true;
+    renderBanner();
+  });
+})();
+`;

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -12,6 +12,7 @@ import { RUN_DETAIL_FILTER_JS } from './run-detail-filter.js.js';
 import { PULSE_CONFIGURE_JS } from './pulse-configure.js.js';
 import { PULSE_REFRESH_JS } from './pulse-refresh.js.js';
 import { ADD_TILE_MODAL_JS } from './add-tile-modal.js.js';
+import { CSP_ALLOW_JS } from './csp-allow.js.js';
 import { footer } from './footer.js';
 
 export interface LayoutOptions {
@@ -72,7 +73,7 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
   ${body}
 </main>
 ${footer()}
-<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + HOME_LAYOUT_JS + DASHBOARDS_LAYOUT_JS + BUILD_FROM_GOAL_JS + IMPROVE_LAYOUT_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS + ADD_TILE_MODAL_JS)}</script>
+<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + HOME_LAYOUT_JS + DASHBOARDS_LAYOUT_JS + BUILD_FROM_GOAL_JS + IMPROVE_LAYOUT_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS + ADD_TILE_MODAL_JS + CSP_ALLOW_JS)}</script>
 </body>
 </html>`;
 }

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -119,8 +119,11 @@ export function renderRunDetail(opts: RunDetailOptions): string {
         back,
       });
 
+  // data-csp-agent lets the CSP-allow helper attribute any blocked widget
+  // image to this run's agent and offer a one-click "Allow host".
+  const cspAttr = unsafeHtml(` data-csp-agent="${run.agentName.replace(/"/g, '&quot;')}"`);
   const fragment = html`
-    <div data-run-container${pollAttr}>
+    <div data-run-container${pollAttr}${cspAttr}>
       ${header}
 
       <div class="card" style="margin-bottom: var(--space-6);">


### PR DESCRIPTION
## Summary
Reported: a run's widget image (`www.thecocktaildb.com`) was blocked by the page CSP `img-src` directive, with no in-app way to fix it short of hand-editing the agent's permissions.

Adds a one-click flow on the **run-detail page** (where the owning agent is unambiguous):

1. **`POST /agents/:id/permissions/allow-host`** — merges a single host into the agent's `permissions.imgSrc` (vs the existing replace-everything form), creating a new version. Normalizes full URLs → bare host, so pasting an image URL works.
2. **`csp-allow.js`** — listens for `securitypolicyviolation` events with an `img-src` directive, attributes the blocked host to the run's agent (via `data-csp-agent` on the run container), and shows a banner: "*N image hosts blocked* — `host` — [Allow]". Allowing posts to the merge endpoint and reloads so the images render.
3. Inert on Pulse/dashboards (a global CSP violation there can't be pinned to a single agent). The Config-tab `img-src` textarea remains for manual edits.

### Verified end-to-end on the running daemon
- `/runs/<id>` emits `data-csp-agent="cocktail-of-the-day"` + the listener. ✓
- `POST .../permissions/allow-host` with a full URL → normalized host merged, new version. ✓
- Page CSP recomputed to include `https://www.thecocktaildb.com` within the 5s cache window. ✓ (Your cocktail image now loads.)

## Test plan
- [x] `npm test` — 1515 passing.
- [x] Manual via curl: endpoint normalizes + merges; CSP header updates.
- [ ] Browser: open a run whose widget pulls a blocked image → banner appears → Allow → reload → image renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)