### PR TITLE
fix(build): handle 'goal already covered' instead of crashing survey

### DIFF
--- a/.changeset/build-survey-nothing-to-build.md
+++ b/.changeset/build-survey-nothing-to-build.md
@@ -1,0 +1,9 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Build-from-goal no longer crashes when the goal is already covered by an existing agent. The goal-surveyor can legitimately return `intent="agent"` with a matched existing agent and zero fragments to draft ("you already have this") — the old strict survey validation rejected that with `Survey failed validation: fragments: intent="agent" requires exactly one fragment, got 0`. Intent is now treated as a hint rather than a contract: the survey-schema drops the intent-vs-content cross-validation, and the orchestrator decides from the actual fragments + matched agents. When there's nothing new to draft but the goal matches installed agents, the wizard shows a friendly "Nothing to build — already covered by these agents" screen (with links) instead of an error.

--- a/packages/core/src/survey-schema.test.ts
+++ b/packages/core/src/survey-schema.test.ts
@@ -43,43 +43,29 @@ describe('surveySchema', () => {
     }
   });
 
-  it('rejects intent="agent" with multiple fragments', () => {
+  it('accepts intent="agent" fully covered by an existing match (zero fragments)', () => {
+    // Legit "nothing to build" survey — the goal maps entirely to an
+    // installed agent. Intent is a hint, not a contract; the orchestrator
+    // decides what to do. This used to be rejected and crashed the flow.
     const r = surveySchema.safeParse({
       intent: 'agent',
-      summary: 's',
-      fragments: [{ purpose: 'a' }, { purpose: 'b' }],
-    });
-    expect(r.success).toBe(false);
-  });
-
-  it('rejects intent="dashboard-existing" with non-empty fragments', () => {
-    const r = surveySchema.safeParse({
-      intent: 'dashboard-existing',
-      summary: 's',
-      fragments: [{ purpose: 'a' }],
-      matchedAgents: [{ id: 'a-b', matchedFor: 'x' }],
-    });
-    expect(r.success).toBe(false);
-  });
-
-  it('rejects intent="dashboard-new" with non-empty matchedAgents', () => {
-    const r = surveySchema.safeParse({
-      intent: 'dashboard-new',
-      summary: 's',
-      fragments: [{ purpose: 'a' }],
-      matchedAgents: [{ id: 'a-b', matchedFor: 'x' }],
-    });
-    expect(r.success).toBe(false);
-  });
-
-  it('rejects intent="dashboard-mixed" with empty fragments', () => {
-    const r = surveySchema.safeParse({
-      intent: 'dashboard-mixed',
-      summary: 's',
-      matchedAgents: [{ id: 'a-b', matchedFor: 'x' }],
+      summary: 'already covered by cocktail-of-the-day',
+      matchedAgents: [{ id: 'cocktail-of-the-day', matchedFor: 'daily drink recipe' }],
       fragments: [],
     });
-    expect(r.success).toBe(false);
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts intent/content combinations without cross-validation', () => {
+    // intent is advisory — these shapes all parse; the orchestrator
+    // acts on the actual fragments + matchedAgents.
+    expect(surveySchema.safeParse({
+      intent: 'agent', summary: 's', fragments: [{ purpose: 'a' }, { purpose: 'b' }],
+    }).success).toBe(true);
+    expect(surveySchema.safeParse({
+      intent: 'dashboard-new', summary: 's', fragments: [{ purpose: 'a' }],
+      matchedAgents: [{ id: 'a-b', matchedFor: 'x' }],
+    }).success).toBe(true);
   });
 
   it('rejects malformed matchedAgents.id', () => {

--- a/packages/core/src/survey-schema.ts
+++ b/packages/core/src/survey-schema.ts
@@ -75,48 +75,15 @@ export const surveySchema = z.object({
     suggestedAnswer: z.string().optional(),
     options: z.array(z.string().min(1)).optional(),
   })).default([]),
-}).superRefine((survey, ctx) => {
-  // Intent vs. content consistency. These mirror the validator rules
-  // in build-plan-schema.ts, but applied to the survey shape so the
-  // orchestrator can fail fast before fanning out drafters.
-  if (survey.intent === 'agent' && survey.fragments.length !== 1) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['fragments'],
-      message: `intent="agent" requires exactly one fragment, got ${survey.fragments.length}`,
-    });
-  }
-  if (survey.intent === 'dashboard-existing' && survey.fragments.length !== 0) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['fragments'],
-      message: `intent="dashboard-existing" requires zero fragments, got ${survey.fragments.length}`,
-    });
-  }
-  if (survey.intent === 'dashboard-new' && survey.matchedAgents.length !== 0) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['matchedAgents'],
-      message: `intent="dashboard-new" requires zero matchedAgents, got ${survey.matchedAgents.length}`,
-    });
-  }
-  if (survey.intent === 'dashboard-mixed') {
-    if (survey.matchedAgents.length === 0) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['matchedAgents'],
-        message: `intent="dashboard-mixed" requires at least one matchedAgent`,
-      });
-    }
-    if (survey.fragments.length === 0) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['fragments'],
-        message: `intent="dashboard-mixed" requires at least one fragment`,
-      });
-    }
-  }
 });
+// NOTE: intent is treated as a HINT, not a strict contract. We deliberately
+// do NOT cross-validate intent against fragment/matchedAgent counts here —
+// that brittleness rejected legitimate surveys (e.g. intent="agent" with the
+// goal fully covered by an existing matched agent and zero fragments to
+// draft, which is a valid "nothing to build" outcome). The build orchestrator
+// decides what to do from the actual fragments + matchedAgents + whether a
+// dashboard is wanted. Field-shape validation (id formats, non-empty
+// purpose) still applies above.
 
 export type Survey = z.output<typeof surveySchema>;
 export type SurveyInput = z.input<typeof surveySchema>;

--- a/packages/dashboard/src/routes/build-orchestrator.ts
+++ b/packages/dashboard/src/routes/build-orchestrator.ts
@@ -54,7 +54,7 @@ const SESSION_TTL_MS = 60 * 60 * 1000; // 1h
  */
 const MAX_DRAFT_ATTEMPTS = 3;
 
-export type SessionPhase = 'survey' | 'drafting' | 'design' | 'assembling' | 'done' | 'failed';
+export type SessionPhase = 'survey' | 'drafting' | 'design' | 'assembling' | 'done' | 'failed' | 'nothing_to_build';
 
 interface BuildSession {
   id: string;
@@ -322,7 +322,7 @@ export function getSession(sessionId: string): BuildSession | undefined {
  * Idempotent — calling twice while in the same phase is a no-op.
  */
 export async function advanceSession(ctx: Ctx, session: BuildSession): Promise<void> {
-  if (session.phase === 'done' || session.phase === 'failed') return;
+  if (session.phase === 'done' || session.phase === 'failed' || session.phase === 'nothing_to_build') return;
 
   if (session.phase === 'survey') return advanceSurvey(ctx, session);
   if (session.phase === 'drafting') return advanceDrafting(ctx, session);
@@ -366,13 +366,24 @@ async function advanceSurvey(ctx: Ctx, session: BuildSession): Promise<void> {
   }
   session.survey = validated.data;
 
-  // No fragments → skip drafting. If intent is dashboard-existing, jump to
-  // designer; if it's somehow "agent" with zero fragments, fail.
+  // No fragments → nothing to draft. Decide based on what the survey
+  // DID find, not the (advisory) intent label:
+  //   - wants a dashboard + has matched agents → designer over existing.
+  //   - has matched agents, no dashboard → the goal is already covered
+  //     by installed agents. Terminal "nothing to build" (friendly), not
+  //     an error.
+  //   - nothing matched either → genuinely empty; fail with guidance.
   if (session.survey.fragments.length === 0) {
-    if (session.survey.intent === 'dashboard-existing') {
+    const wantsDashboard = session.survey.intent === 'dashboard-existing'
+      || session.survey.intent === 'dashboard-new'
+      || session.survey.intent === 'dashboard-mixed';
+    if (wantsDashboard && session.survey.matchedAgents.length > 0) {
       await startDesignerStage(ctx, session);
+    } else if (session.survey.matchedAgents.length > 0) {
+      session.phase = 'nothing_to_build';
+      session.phaseMessage = 'Already covered by existing agents.';
     } else {
-      fail(session, `Survey returned intent=${session.survey.intent} with no fragments to draft.`);
+      fail(session, 'Nothing to build — the goal didn\'t match any installed agent and produced no new agents to draft. Try rephrasing with more specifics.');
     }
     return;
   }

--- a/packages/dashboard/src/routes/run-now-build.ts
+++ b/packages/dashboard/src/routes/run-now-build.ts
@@ -860,6 +860,16 @@ buildRouter.get('/agents/build/:runId', async (req: Request, res: Response) => {
       res.json({ ok: true, status: 'done', plan: session.plan });
       return;
     }
+    if (session.phase === 'nothing_to_build') {
+      // Goal already covered by installed agents — nothing new to draft.
+      res.json({
+        ok: true,
+        status: 'nothing_to_build',
+        summary: session.survey?.summary ?? 'Your goal is already covered by existing agents.',
+        matchedAgents: session.survey?.matchedAgents ?? [],
+      });
+      return;
+    }
     // Still running. Surface per-drafter progress when present.
     const progress = drafterProgress(ctx, session);
     res.json({

--- a/packages/dashboard/src/views/build-from-goal.js.ts
+++ b/packages/dashboard/src/views/build-from-goal.js.ts
@@ -155,6 +155,9 @@ export const BUILD_FROM_GOAL_JS = `
                   if (per) per.textContent = data.phase;
                 }
                 pollTimer = setTimeout(poll, 2000);
+              } else if (data.status === 'nothing_to_build') {
+                clearInterval(tickTimer);
+                renderNothingToBuild(data.summary, data.matchedAgents || []);
               } else if (data.status === 'done' && data.plan) {
                 clearInterval(tickTimer);
                 renderPlanReview(data.plan, data.criticErrors, data.criticWarning);
@@ -183,6 +186,21 @@ export const BUILD_FROM_GOAL_JS = `
         clearInterval(tickTimer);
         renderError(String(err));
       });
+
+      function renderNothingToBuild(summary, matched) {
+        var rows = (matched || []).map(function (m) {
+          return '<li style="margin-bottom:var(--space-1);"><a href="/agents/' + encodeURIComponent(m.id) + '"><code>' + esc(m.id) + '</code></a>' +
+            (m.matchedFor ? ' <span class="dim" style="font-size:var(--font-size-xs);">— ' + esc(m.matchedFor) + '</span>' : '') + '</li>';
+        }).join('');
+        content.innerHTML =
+          '<div style="padding:var(--space-3);">' +
+          '<h3 style="margin:0 0 var(--space-2);">Nothing to build</h3>' +
+          '<p class="dim" style="font-size:var(--font-size-sm);margin:0 0 var(--space-3);">' + esc(summary || 'Your goal is already covered by existing agents.') + '</p>' +
+          (rows ? '<div style="font-size:var(--font-size-xs);color:var(--color-text-muted);font-weight:var(--weight-semibold);text-transform:uppercase;letter-spacing:0.06em;margin-bottom:var(--space-1);">Already covers this</div><ul style="margin:0 0 var(--space-3);padding-left:var(--space-4);">' + rows + '</ul>' : '') +
+          '<p class="dim" style="font-size:var(--font-size-xs);margin:0 0 var(--space-3);">Want something different? Close and re-run with a more specific goal (e.g. a distinct data source, format, or schedule).</p>' +
+          '<div style="text-align:right;"><button type="button" class="btn btn--primary btn--sm" data-close-build="1">Got it</button></div>' +
+          '</div>';
+      }
 
       function renderError(msg) {
         content.innerHTML = '<div class="flash flash--error">' + esc(msg) + '</div>' +


### PR DESCRIPTION
## Summary
Reported (run \`ddbcfacc…\`):
\`\`\`
Survey failed validation: fragments: intent="agent" requires exactly one fragment, got 0
\`\`\`

The goal-surveyor was **right** — the goal ("daily drink recipe agent") is fully covered by the existing \`cocktail-of-the-day\` agent, so it returned \`intent: agent, matchedAgents: [cocktail-of-the-day], fragments: []\`. My strict survey-schema cross-validation treated that legitimate "nothing to build" outcome as a hard error.

Fixes:
- **survey-schema**: drop the intent ↔ fragment/matchedAgent cross-validation. Intent is a hint, not a contract. Field-shape validation (id formats, non-empty purpose) still applies.
- **orchestrator**: when there are 0 fragments, branch on what was actually found — dashboard intent + matches → designer; matches only → terminal \`nothing_to_build\`; nothing at all → fail with guidance.
- **GET /agents/build/:runId** surfaces \`status: 'nothing_to_build'\` with the matched agents.
- **wizard**: renders a friendly "Nothing to build — already covered by these agents" screen (with links to each) instead of the error UI.

## Test plan
- [x] \`npm test\` — 1513 passing (consolidated the now-removed intent-rejection tests into accept-tests).
- [ ] Manual: re-run the cocktail goal → "Nothing to build — already covered by cocktail-of-the-day" with a link, not a crash.
- [ ] Manual: a goal needing new agents still drafts normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)