### PR TITLE
fix(build): critic flags outputWidget agents with non-widget signal.template

### DIFF
--- a/.changeset/drafter-signal-template-widget.md
+++ b/.changeset/drafter-signal-template-widget.md
@@ -1,0 +1,9 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Critic + drafter-prompt fix for broken Pulse tiles on drafted agents. Pulse renders a tile from `signal.template`, not `outputWidget.type` — so an agent that declares an `ai-template` outputWidget but sets `signal.template` to a named slot template (e.g. `text-image`) renders the empty slot template on the tile and the rich widget never shows. `critiquePlan` now flags this (outputWidget present + `signal.template !== 'widget'`) so the per-drafter retry self-corrects, and the drafter prompt spells out the rule with ✓/✗ examples.

--- a/agents/examples/agent-drafter.yaml
+++ b/agents/examples/agent-drafter.yaml
@@ -121,8 +121,15 @@ nodes:
       - llm-prompt / claude-code nodes: use double-brace inputs.NAME syntax in prompts.
       - signal block REQUIRED. signal.title is REQUIRED and is a short literal
         string used as the Pulse tile chrome label.
-      - When the agent declares an outputWidget, set signal.template: widget.
-        Pulse tile rendering is dispatched by signal.template, not outputWidget.type.
+      - **When the agent declares an outputWidget, signal.template MUST be
+        `widget` — never a named slot template like `text-image`, `metric`,
+        `text-headline`, etc.** Pulse renders the tile from signal.template,
+        NOT outputWidget.type. If you set signal.template to a slot template
+        while also declaring an outputWidget, Pulse renders that empty slot
+        template and the rich widget never shows (the tile looks broken).
+          ✓ signal: { title: "Cocktail of the Day", template: widget }
+            outputWidget: { type: ai-template, template: "<div>...</div>" }
+          ✗ signal: { template: text-image }   # with an outputWidget present
         Omit signal.mapping when template is "widget" — the widget drives layout.
       - When the agent declares any inputs:, set outputWidget.interactive: true so
         Pulse renders an inline inputs form. Skip this flag for purely scheduled

--- a/packages/core/src/build-plan-critic.test.ts
+++ b/packages/core/src/build-plan-critic.test.ts
@@ -239,6 +239,28 @@ describe('critiquePlan CSP img-src checks', () => {
   });
 });
 
+describe('critiquePlan signal.template vs outputWidget', () => {
+  const yamlWidgetSignal = (signalTemplate: string) =>
+    `id: drinks\nname: Drinks\nnodes:\n  - id: n1\n    type: shell\n    command: echo hi\nsignal:\n  title: Drinks\n  template: ${signalTemplate}\noutputWidget:\n  type: ai-template\n  template: |\n    <h2>{{outputs.name}}</h2>\n`;
+
+  it('flags an outputWidget agent whose signal.template is not "widget"', () => {
+    const result = critiquePlan(
+      planFor({ newAgents: [{ id: 'drinks', purpose: 'p', yaml: yamlWidgetSignal('text-image') }] }),
+      { existingAgentIds: new Set() },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.path.endsWith('signal.template') && e.message.includes('widget'))).toBe(true);
+  });
+
+  it('accepts an outputWidget agent with signal.template: widget', () => {
+    const result = critiquePlan(
+      planFor({ newAgents: [{ id: 'drinks', purpose: 'p', yaml: yamlWidgetSignal('widget') }] }),
+      { existingAgentIds: new Set() },
+    );
+    expect(result.ok).toBe(true);
+  });
+});
+
 describe('formatCriticFeedback', () => {
   it('returns empty string when no errors', () => {
     expect(formatCriticFeedback([])).toBe('');

--- a/packages/core/src/build-plan-critic.ts
+++ b/packages/core/src/build-plan-critic.ts
@@ -199,6 +199,21 @@ export function critiquePlan(plan: BuildPlan, ctx: PlanCriticContext): PlanCriti
         });
       }
     }
+
+    // Pulse dispatches tile rendering on signal.template, NOT
+    // outputWidget.type. An agent that declares an outputWidget but sets
+    // signal.template to a named slot template (e.g. "text-image",
+    // "metric") renders that slot template on the Pulse tile — with no
+    // mapping — instead of the rich widget, so the tile shows up empty
+    // or broken. When an outputWidget is present, signal.template MUST be
+    // "widget" so Pulse mirrors it.
+    const signal = (agent as { signal?: { template?: string } }).signal;
+    if (widget && signal && signal.template && signal.template !== 'widget') {
+      errors.push({
+        path: `newAgents[${i}].yaml.signal.template`,
+        message: `Agent declares an outputWidget but signal.template is "${signal.template}". Pulse renders the tile from signal.template (not outputWidget.type), so the rich widget never shows. Set signal.template: widget (and drop signal.mapping — the widget drives layout).`,
+      });
+    }
   });
 
   return { ok: errors.length === 0, errors };


### PR DESCRIPTION
## Summary
Reported: the `cocktail-of-the-day` agent rendered a broken/empty Pulse tile (Configure modal showed an empty TEMPLATE). Its YAML declared an `ai-template` outputWidget **and** `signal.template: text-image`. Pulse dispatches tile rendering on `signal.template` (not `outputWidget.type`), so it rendered the empty `text-image` slot template — with no mapping — instead of the rich widget.

- **critic**: `critiquePlan` now flags `outputWidget` present + `signal.template !== 'widget'`, so the per-drafter critic-retry (#333) self-corrects on the next attempt.
- **drafter prompt**: explicit ✓/✗ rule that `signal.template` MUST be `widget` when an outputWidget is declared.

## Test plan
- [x] `npm test` — 1517 passing (2 new critic tests).
- [ ] Manual: re-draft an agent with a rich widget → tile renders the widget (signal.template: widget), not an empty slot.

Note: the already-created `cocktail-of-the-day` agent needs its `signal.template` flipped to `widget` separately (one-off data fix) — this PR prevents *new* drafts from hitting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)