### PR TITLE
fix(dashboards): emit template registry so Configure tile picker works

### DIFF
--- a/.changeset/configure-tile-template-registry.md
+++ b/.changeset/configure-tile-template-registry.md
@@ -1,0 +1,14 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Fix blank TEMPLATE picker in the Configure-tile modal on dashboard pages.
+
+The Configure-tile modal builds its template grid from a `#pulse-template-registry`
+JSON island that was only emitted on `/pulse`. Named dashboards (`/dashboards/:id`)
+reuse the same modal but never rendered the island, so opening Configure tile there
+showed an empty Template section. The island is now emitted on dashboard pages too.

--- a/packages/dashboard/src/views/dashboards.test.ts
+++ b/packages/dashboard/src/views/dashboards.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import type { Dashboard } from '@some-useful-agents/core';
+import { renderDashboardPage } from './dashboards.js';
+
+function makeDashboard(): Dashboard {
+  return {
+    id: 'user:cocktails',
+    packId: null,
+    name: 'Cocktails',
+    layout: { sections: [{ title: 'Drinks', agentIds: ['cocktail-of-the-day'] }] },
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+describe('renderDashboardPage', () => {
+  // The Configure-tile modal (PULSE_CONFIGURE_JS) builds its template grid from
+  // a #pulse-template-registry JSON island. dashboards.ts reuses that modal via
+  // renderTile/tileWrap, so it must emit the island too — otherwise the TEMPLATE
+  // picker renders blank on /dashboards/:id (regression: blank template field).
+  it('emits the pulse-template-registry island the configure modal depends on', () => {
+    const html = renderDashboardPage({
+      dashboard: makeDashboard(),
+      sections: [{ title: 'Drinks', tiles: [], missingAgentIds: [], agentIds: ['cocktail-of-the-day'] }],
+      installedDashboards: [makeDashboard()],
+      availableAgents: [],
+    });
+    expect(html).toContain('id="pulse-template-registry"');
+    // Registry payload should carry real template definitions, not an empty object.
+    expect(html).toMatch(/id="pulse-template-registry"[^>]*>\s*\{.*"widget"/s);
+  });
+});

--- a/packages/dashboard/src/views/dashboards.ts
+++ b/packages/dashboard/src/views/dashboards.ts
@@ -14,6 +14,7 @@ import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
 import { renderTile } from './pulse-renderers.js';
 import { tileWrap, type PulseTile } from './pulse.js';
+import { TEMPLATE_REGISTRY } from './pulse-templates.js';
 import { improveLayoutButton, improveLayoutModal } from './improve-layout-modal.js';
 import {
   buildDashboardOptions,
@@ -114,6 +115,7 @@ export function renderDashboardPage(input: RenderDashboardPageInput): string {
     ${unsafeHtml(`<script type="application/json" id="dashboard-available-agents">${
       JSON.stringify(input.availableAgents).replace(/</g, '\\u003c')
     }</script>`)}
+    ${unsafeHtml(`<script type="application/json" id="pulse-template-registry">${JSON.stringify(TEMPLATE_REGISTRY)}</script>`)}
     <span style="display: none;">${buildFromGoalButton()}</span>
     ${buildFromGoalModal({
       availableDashboards: input.installedDashboards.filter((d) => !d.packId).map((d) => ({ id: d.id, name: d.name })),


### PR DESCRIPTION
## Summary
- The Configure-tile modal builds its TEMPLATE grid from a `#pulse-template-registry` JSON island that was only emitted on `/pulse`. Named dashboards (`/dashboards/:id`) reuse the same modal via `renderTile`/`tileWrap` but never rendered the island, so opening **Configure tile** there showed a blank TEMPLATE section.
- Emit the island on dashboard pages too, and add a regression test asserting it's present with real template definitions.

## Test plan
- [x] `npx vitest run packages/dashboard/src/views/dashboards.test.ts` passes
- [x] `npm run build` clean
- [x] Verified live: opening Configure tile on a named dashboard now renders the template cards (cocktail-of-the-day dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)