### PR TITLE
fix(dashboards): run "Run again" in place instead of navigating to the run page

### DIFF
--- a/.changeset/replay-runs-in-place.md
+++ b/.changeset/replay-runs-in-place.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Run "Run again" in place on Pulse / dashboard widget tiles.
+
+Clicking a widget tile's "Run again" button used to start the run and then
+redirect to the run detail page, dropping you off the dashboard. It now
+re-runs the agent and refreshes the tile in place — the same in-place flow
+interactive widgets already use. Without JS the button still falls back to
+the run detail page, so nothing breaks.

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -11,6 +11,7 @@ import { OUTPUT_WIDGET_ACTIONS_JS } from './output-widget-actions.js.js';
 import { RUN_DETAIL_FILTER_JS } from './run-detail-filter.js.js';
 import { PULSE_CONFIGURE_JS } from './pulse-configure.js.js';
 import { PULSE_REFRESH_JS } from './pulse-refresh.js.js';
+import { WIDGET_REPLAY_INPLACE_JS } from './widget-replay.js.js';
 import { ADD_TILE_MODAL_JS } from './add-tile-modal.js.js';
 import { CSP_ALLOW_JS } from './csp-allow.js.js';
 import { footer } from './footer.js';
@@ -73,7 +74,7 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
   ${body}
 </main>
 ${footer()}
-<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + HOME_LAYOUT_JS + DASHBOARDS_LAYOUT_JS + BUILD_FROM_GOAL_JS + IMPROVE_LAYOUT_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS + ADD_TILE_MODAL_JS + CSP_ALLOW_JS)}</script>
+<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + HOME_LAYOUT_JS + DASHBOARDS_LAYOUT_JS + BUILD_FROM_GOAL_JS + IMPROVE_LAYOUT_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS + WIDGET_REPLAY_INPLACE_JS + ADD_TILE_MODAL_JS + CSP_ALLOW_JS)}</script>
 </body>
 </html>`;
 }

--- a/packages/dashboard/src/views/widget-replay.js.ts
+++ b/packages/dashboard/src/views/widget-replay.js.ts
@@ -1,0 +1,136 @@
+/**
+ * Client-side JS for the "Run again" (replay) control on Pulse / dashboard
+ * widget tiles.
+ *
+ * The replay control is a plain POST <form action="/agents/:id/run"> so that
+ * it still works without JS — but that route 303-redirects to the run detail
+ * page, which yanks the user off the dashboard. That's the wrong default for a
+ * tile: clicking "Run again" should re-run the agent and refresh the widget
+ * *in place*.
+ *
+ * This handler progressively enhances the form: it intercepts the submit (only
+ * when the form lives inside a `.pulse-tile`, so the agent detail page keeps
+ * its navigate-to-run behaviour), starts the run via `/agents/:id/widget-run`
+ * (JSON, no redirect), polls `/runs/:id/widget-status` until terminal, then
+ * swaps the whole tile fragment from `/pulse/tile/:id`. The swap reuses the
+ * same layout-state-preserving logic as PULSE_REFRESH_JS.
+ *
+ * Inlined via layout.ts.
+ */
+export const WIDGET_REPLAY_INPLACE_JS = `
+  // ── Widget "Run again" in place ───────────────────────────────────
+  (function () {
+    var POLL_MS = 500;
+    var POLL_CAP = 240; // ~120s ceiling before we give up polling.
+
+    function swapTile(tile, agentId) {
+      return fetch('/pulse/tile/' + encodeURIComponent(agentId), { credentials: 'same-origin' })
+        .then(function (r) { return r.ok ? r.text() : null; })
+        .then(function (html) {
+          if (!html) return null;
+          var temp = document.createElement('div');
+          temp.innerHTML = html;
+          var newTile = temp.firstElementChild;
+          if (newTile && tile.parentNode) {
+            // Preserve layout state (palette, collapsed, grid placement) the
+            // same way PULSE_REFRESH_JS does when it swaps a refreshed tile.
+            var palette = tile.getAttribute('data-palette');
+            if (palette) newTile.setAttribute('data-palette', palette);
+            if (tile.classList.contains('pulse-tile--collapsed')) newTile.classList.add('pulse-tile--collapsed');
+            if (tile.style.gridColumn) newTile.style.gridColumn = tile.style.gridColumn;
+            if (tile.style.gridRow) newTile.style.gridRow = tile.style.gridRow;
+            tile.parentNode.replaceChild(newTile, tile);
+            return newTile;
+          }
+          return null;
+        });
+    }
+
+    function restoreButton(tile, btn, label) {
+      tile.style.opacity = '1';
+      if (btn) { btn.disabled = false; btn.textContent = label; }
+    }
+
+    function flashError(tile, msg) {
+      var host = tile.querySelector('.pulse-tile__body') || tile;
+      var flash = document.createElement('div');
+      flash.className = 'flash flash--error';
+      flash.style.cssText = 'margin:var(--space-2);font-size:var(--font-size-xs);';
+      flash.textContent = msg || 'Run failed';
+      host.appendChild(flash);
+      setTimeout(function () { flash.remove(); }, 6000);
+    }
+
+    function poll(tile, agentId, runId, btn, label, count) {
+      if (count >= POLL_CAP) {
+        restoreButton(tile, btn, label);
+        flashError(tile, 'Still running — open the run for details.');
+        return;
+      }
+      fetch('/runs/' + encodeURIComponent(runId) + '/widget-status', { credentials: 'same-origin' })
+        .then(function (r) { return r.ok ? r.json() : Promise.reject(new Error('HTTP ' + r.status)); })
+        .then(function (data) {
+          if (data.status === 'completed') {
+            // Swapping the whole tile brings back a fresh, enabled button and
+            // the new result — no need to restore the old one.
+            swapTile(tile, agentId).then(function (swapped) {
+              if (!swapped) restoreButton(tile, btn, label);
+            });
+            return;
+          }
+          if (data.status === 'failed') {
+            restoreButton(tile, btn, label);
+            flashError(tile, data.error || 'Run failed.');
+            return;
+          }
+          if (data.status === 'cancelled') {
+            restoreButton(tile, btn, label);
+            return;
+          }
+          // pending / running: keep polling.
+          setTimeout(function () { poll(tile, agentId, runId, btn, label, count + 1); }, POLL_MS);
+        })
+        .catch(function (err) {
+          restoreButton(tile, btn, label);
+          flashError(tile, 'Status check failed: ' + (err.message || err));
+        });
+    }
+
+    document.addEventListener('submit', function (e) {
+      var form = e.target;
+      if (!form || !form.matches || !form.matches('form.wc-group--replay')) return;
+      var tile = form.closest ? form.closest('.pulse-tile[data-agent-id]') : null;
+      if (!tile) return; // Not a tile (e.g. agent detail page) — leave default navigation.
+      var agentId = tile.getAttribute('data-agent-id');
+      if (!agentId) return;
+      e.preventDefault();
+
+      var btn = form.querySelector('[data-widget-control="replay"]');
+      var label = btn ? btn.textContent : 'Run again';
+      if (btn) { btn.disabled = true; btn.textContent = 'Running…'; }
+      tile.style.opacity = '0.7';
+
+      var body = new URLSearchParams();
+      new FormData(form).forEach(function (v, k) { body.append(k, String(v)); });
+
+      fetch('/agents/' + encodeURIComponent(agentId) + '/widget-run', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+      })
+        .then(function (r) {
+          if (!r.ok) return r.json().then(function (d) { throw new Error(d.error || ('HTTP ' + r.status)); });
+          return r.json();
+        })
+        .then(function (data) {
+          if (!data || !data.runId) throw new Error('Run did not start.');
+          poll(tile, agentId, data.runId, btn, label, 0);
+        })
+        .catch(function (err) {
+          restoreButton(tile, btn, label);
+          flashError(tile, 'Failed to start run: ' + (err.message || err));
+        });
+    });
+  })();
+`;


### PR DESCRIPTION
## Summary

The "Run again" button on Pulse / dashboard widget tiles used to start the run and then **redirect to the run detail page**, dropping you off the dashboard. (Reported on the Spider-Man dashboard: clicking "Run again" jumped to `/runs/625c00fd-…` instead of refreshing the quote tile in place.)

Root cause: non-`interactive` widget tiles render a synthesized replay control as a plain `<form method="POST" action="/agents/:id/run">`, and that route 303-redirects to `/runs/:id`. Only `interactive` widgets had the run-in-place flow.

This PR adds `WIDGET_REPLAY_INPLACE_JS` — a delegated, progressive-enhancement handler (same pattern as `OUTPUT_WIDGET_ACTIONS_JS`):

- Intercepts replay-form submits **only when the form is inside a `.pulse-tile`** — the agent detail page keeps its navigate-to-run behavior.
- Starts the run via the existing `/agents/:id/widget-run` endpoint (JSON, no redirect), polls `/runs/:id/widget-status` until terminal.
- On success, swaps the whole tile fragment from `/pulse/tile/:id`, reusing the layout-state-preserving swap logic from `PULSE_REFRESH_JS` (palette, collapsed, grid placement).
- On failure, surfaces an inline error flash and restores the button.
- Bounded polling (240 ticks ~120s) and the submit button is disabled during the run to prevent double-submits.
- **Graceful degradation:** without JS, the form still POSTs to `/agents/:id/run` and navigates to the run page — nothing breaks.

Server-rendered HTML is unchanged; this is purely an additive client script wired into the shared `layout.ts` bundle (active on both Pulse and dashboards).

## Test Coverage

The change is a client-side JS string (browser-only, not unit-testable in vitest, consistent with the other `*.js.ts` handler modules which have no dedicated tests). The one server-side change — adding the bundle entry in `layout.ts` — is exercised by existing dashboard render tests. No new application code paths to unit-test.

Manual verification path: on the Spider-Man dashboard, "Run again" now dims the tile, runs the agent, and refreshes the quote in place instead of navigating to `/runs/…`.

## Pre-Landing Review

Self-reviewed: error rendering uses `textContent` (no XSS); tile swap pulls from the same server endpoint `PULSE_REFRESH_JS` already trusts; selector is strictly scoped to `.pulse-tile` so the agent detail page is untouched; polling is bounded.

## Test plan
- [x] Full suite passes: 1518 passed, 3 skipped (`npm run test`)
- [x] Dashboard package builds clean (`tsc` + copy-assets)
- [x] Changeset included (`.changeset/replay-runs-in-place.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)