### PR TITLE
feat(dashboard): more in-app context + fix stale node-type labels

### DIFF
--- a/.changeset/dashboard-in-app-context.md
+++ b/.changeset/dashboard-in-app-context.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Give dashboard users more in-app context, and fix stale node-type labels.
+
+Adds compact, dismissible one-line intros to the Home, Pulse, and Integrations
+surfaces (dismissal persists in localStorage), a guided empty state on Home when
+no agents exist, and an actionable "no runs yet" state on the agent Runs tab.
+Fixes rendered terminology: `llm-prompt` nodes are no longer mislabeled as
+`claude-code` (node badges, control-flow "goes to" badges, the shared type
+badge, the /nodes catalog, and DAG node coloring all show the canonical name;
+`claude-code` is still accepted as the legacy alias).

--- a/packages/dashboard/src/assets/components.css
+++ b/packages/dashboard/src/assets/components.css
@@ -1011,3 +1011,34 @@
 }
 .wc-page-info__total { opacity: 0.7; }
 .wc-page-info--empty { opacity: 0.6; }
+
+/* ── Page intro ─────────────────────────────────────────────────────
+   Compact, dismissible one-line "what is this page" hint. Rendered by
+   pageIntro() (views/page-intro.ts); dismissal wired by PAGE_INTRO_JS. */
+.page-intro {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  margin-bottom: var(--space-4);
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+.page-intro__text { flex: 1; line-height: 1.5; }
+.page-intro__link { color: var(--color-primary); white-space: nowrap; text-decoration: none; }
+.page-intro__link:hover { text-decoration: underline; }
+.page-intro__dismiss {
+  flex-shrink: 0;
+  background: none;
+  border: 1px solid var(--color-border-strong);
+  color: var(--color-text-muted);
+  font: inherit;
+  font-size: var(--font-size-xs);
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+.page-intro__dismiss:hover { color: var(--color-text); border-color: var(--color-text-muted); }

--- a/packages/dashboard/src/routes/assets.ts
+++ b/packages/dashboard/src/routes/assets.ts
@@ -140,6 +140,7 @@ const GRAPH_RENDER_JS = `
   // viz blends with the rest of the dashboard chrome.
   var typeStyle = {
     shell:           { fill: '#dcfce7', border: '#15803d', text: '#166534' },
+    'llm-prompt':    { fill: '#dbeafe', border: '#2563eb', text: '#1d4ed8' },
     'claude-code':   { fill: '#dbeafe', border: '#2563eb', text: '#1d4ed8' },
     'conditional':   { fill: '#fef3c7', border: '#b45309', text: '#92400e' },
     'switch':        { fill: '#fef3c7', border: '#b45309', text: '#92400e' },

--- a/packages/dashboard/src/views/agent-add-node.ts
+++ b/packages/dashboard/src/views/agent-add-node.ts
@@ -37,7 +37,7 @@ function availableVariablesPanel(agent: Agent): SafeHtml {
           <thead>
             <tr>
               <th>Upstream</th>
-              <th>Claude-code template</th>
+              <th>llm-prompt template</th>
               <th>Shell env var</th>
             </tr>
           </thead>

--- a/packages/dashboard/src/views/agent-detail/config.ts
+++ b/packages/dashboard/src/views/agent-detail/config.ts
@@ -219,7 +219,7 @@ export async function renderAgentConfig(args: AgentDetailArgs): Promise<string> 
       <div style="display: flex; justify-content: flex-end;">
         <button type="submit" class="btn btn--sm">Save</button>
       </div>
-      <p class="dim" style="font-size: var(--font-size-xs); margin: 0;">Applies to all claude-code nodes. Individual nodes can override in YAML.</p>
+      <p class="dim" style="font-size: var(--font-size-xs); margin: 0;">Applies to all llm-prompt nodes. Individual nodes can override in YAML.</p>
     </form>
   `);
 

--- a/packages/dashboard/src/views/agent-detail/nodes.ts
+++ b/packages/dashboard/src/views/agent-detail/nodes.ts
@@ -12,7 +12,7 @@ export async function renderAgentNodes(args: AgentDetailArgs): Promise<string> {
     return html`
       <tr id="node-${n.id}">
         <td class="mono">${n.id}</td>
-        <td>${n.type === 'shell' ? html`<span class="badge badge--ok">shell</span>` : html`<span class="badge badge--info">claude-code</span>`}</td>
+        <td>${n.type === 'shell' ? html`<span class="badge badge--ok">shell</span>` : html`<span class="badge badge--info">${n.type === 'claude-code' ? 'llm-prompt' : n.type}</span>`}</td>
         <td class="mono">${deps}</td>
         <td class="mono">${secrets}</td>
         <td class="dim">${body}</td>

--- a/packages/dashboard/src/views/agent-detail/runs.ts
+++ b/packages/dashboard/src/views/agent-detail/runs.ts
@@ -18,7 +18,13 @@ export function renderAgentRuns(args: AgentDetailArgs): string {
   const content = html`
     <h2>Run history</h2>
     ${recentRuns.length === 0
-      ? html`<p class="dim">No runs yet.</p>`
+      ? html`
+        <div class="settings-empty">
+          <h3 style="margin-top: 0;">No runs yet</h3>
+          <p class="dim">Run this agent from the <a href="/agents/${agent.id}">Overview tab</a> with <strong>Run now</strong>, or from the CLI:</p>
+          <p class="mono dim" style="margin: 0;">sua agent run ${agent.id}</p>
+        </div>
+      `
       : html`
         <table class="table">
           <thead><tr><th>ID</th><th>Status</th><th>Started</th><th>Duration</th><th>Triggered</th></tr></thead>

--- a/packages/dashboard/src/views/components.ts
+++ b/packages/dashboard/src/views/components.ts
@@ -17,7 +17,9 @@ export function statusBadge(status: string): SafeHtml {
 
 export function typeBadge(type: string): SafeHtml {
   const kind = type === 'shell' ? 'badge--ok' : (type === 'claude-code' || type === 'llm-prompt') ? 'badge--info' : 'badge--muted';
-  return html`<span class="badge ${kind}">${type}</span>`;
+  // `claude-code` is the legacy alias of `llm-prompt`; show the canonical name.
+  const label = type === 'claude-code' ? 'llm-prompt' : type;
+  return html`<span class="badge ${kind}">${label}</span>`;
 }
 
 export function sourceBadge(source: string): SafeHtml {

--- a/packages/dashboard/src/views/controlflow-edit.ts
+++ b/packages/dashboard/src/views/controlflow-edit.ts
@@ -179,7 +179,7 @@ function renderGoesToDisplay(agent: Agent, node: AgentNode): SafeHtml {
             <span class="badge badge--info text-xs">if ${condition}</span>
             <span>\u2192</span>
             <a href="/agents/${agent.id}/nodes/${d.id}/edit" class="mono">${d.id}</a>
-            <span class="badge badge--${d.type === 'shell' ? 'ok' : (d.type === 'claude-code' || d.type === 'llm-prompt') ? 'info' : 'muted'}">${d.type}</span>
+            <span class="badge badge--${d.type === 'shell' ? 'ok' : (d.type === 'claude-code' || d.type === 'llm-prompt') ? 'info' : 'muted'}">${d.type === 'claude-code' ? 'llm-prompt' : d.type}</span>
           </div>
         `);
       } else {
@@ -206,7 +206,7 @@ function renderGoesToDisplay(agent: Agent, node: AgentNode): SafeHtml {
     <div style="display: flex; align-items: center; gap: var(--space-2); padding: var(--space-1) 0;">
       <span>\u2192</span>
       <a href="/agents/${agent.id}/nodes/${d.id}/edit" class="mono">${d.id}</a>
-      <span class="badge badge--${d.type === 'shell' ? 'ok' : (d.type === 'claude-code' || d.type === 'llm-prompt') ? 'info' : 'muted'}">${d.type}</span>
+      <span class="badge badge--${d.type === 'shell' ? 'ok' : (d.type === 'claude-code' || d.type === 'llm-prompt') ? 'info' : 'muted'}">${d.type === 'claude-code' ? 'llm-prompt' : d.type}</span>
     </div>
   `);
 

--- a/packages/dashboard/src/views/help.ts
+++ b/packages/dashboard/src/views/help.ts
@@ -140,14 +140,15 @@ export function renderHelp(): string {
         </li>
         <li>
           <strong>Pick your tools.</strong> Browse built-in tools (<code>http-get</code>,
-          <code>claude-code</code>, <code>csv-to-chart-json</code>, etc.) on
+          <code>file-read</code>, <code>csv-to-chart-json</code>, etc.) plus the
+          <code>llm-prompt</code> node type on
           <a href="/tools?tab=builtin">/tools \u2192 Built-in</a>.
           Need something third-party? Paste a Claude-Desktop <code>mcpServers</code> config at
           <a href="/tools/mcp/import">/tools/mcp/import</a> and pick which tools to import.
         </li>
         <li>
           <strong>Write the agent.</strong> Chain nodes with <code>dependsOn</code>. Pass upstream
-          data via <code>{{upstream.&lt;id&gt;.result}}</code> (claude-code) or
+          data via <code>{{upstream.&lt;id&gt;.result}}</code> (llm-prompt) or
           <code>$UPSTREAM_&lt;ID&gt;_RESULT</code> (shell). Edit nodes directly on
           <a href="/agents">agent detail \u2192 Nodes tab</a>, or author YAML and
           <code>sua workflow import-yaml</code>.

--- a/packages/dashboard/src/views/home.ts
+++ b/packages/dashboard/src/views/home.ts
@@ -10,6 +10,7 @@ import { layout } from './layout.js';
 import { buildHomeWidgets, renderHomeWidget } from './home-widgets.js';
 import type { HomeWidgetData } from './home-widgets.js';
 import { buildFromGoalButton, buildFromGoalModal } from './build-from-goal-modal.js';
+import { pageIntro } from './page-intro.js';
 
 export { type HomeWidgetData as HomePageInput } from './home-widgets.js';
 
@@ -18,6 +19,19 @@ export function renderHomePage(input: HomeWidgetData): string {
 
   const allTileIds = widgets.map((w) => w.id);
   const systemTileIds = allTileIds.slice(); // all are system widgets
+
+  const isEmpty = input.agents.length === 0;
+
+  const emptyState = html`
+    <div class="settings-empty" style="margin-top: var(--space-4);">
+      <h3 style="margin-top: 0;">No agents yet</h3>
+      <p class="dim">An agent is a named task sua can run \u2014 a shell command, an LLM prompt, or a chain of both. Describe what you want and let sua build it, or follow the guided tour.</p>
+      <p style="display: flex; gap: var(--space-3); justify-content: center; margin: 0;">
+        ${buildFromGoalButton({ variant: 'primary' })}
+        <a class="btn" href="/help/tutorial">Open tutorial</a>
+      </p>
+    </div>
+  `;
 
   const body = html`
     <div style="display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-6);">
@@ -32,6 +46,14 @@ export function renderHomePage(input: HomeWidgetData): string {
         <button type="button" class="btn btn--ghost btn--sm" id="home-add-container" style="display: none;">+ Add group</button>
       </div>
     </div>
+
+    ${pageIntro({
+      key: 'home',
+      text: 'Your at-a-glance home. Stat tiles summarize recent runs and scheduled work; rearrange them with Edit layout.',
+      learnMore: { href: 'https://github.com/gregmeyer/some-useful-agents/blob/main/docs/dashboard.md', label: 'Dashboard tour' },
+    })}
+
+    ${isEmpty ? emptyState : html``}
 
     <div id="home-containers">
       <section class="pulse-container" data-container-id="_default">

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -12,6 +12,7 @@ import { RUN_DETAIL_FILTER_JS } from './run-detail-filter.js.js';
 import { PULSE_CONFIGURE_JS } from './pulse-configure.js.js';
 import { PULSE_REFRESH_JS } from './pulse-refresh.js.js';
 import { WIDGET_REPLAY_INPLACE_JS } from './widget-replay.js.js';
+import { PAGE_INTRO_JS } from './page-intro.js.js';
 import { ADD_TILE_MODAL_JS } from './add-tile-modal.js.js';
 import { CSP_ALLOW_JS } from './csp-allow.js.js';
 import { footer } from './footer.js';
@@ -74,7 +75,7 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
   ${body}
 </main>
 ${footer()}
-<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + HOME_LAYOUT_JS + DASHBOARDS_LAYOUT_JS + BUILD_FROM_GOAL_JS + IMPROVE_LAYOUT_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS + WIDGET_REPLAY_INPLACE_JS + ADD_TILE_MODAL_JS + CSP_ALLOW_JS)}</script>
+<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + HOME_LAYOUT_JS + DASHBOARDS_LAYOUT_JS + BUILD_FROM_GOAL_JS + IMPROVE_LAYOUT_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS + WIDGET_REPLAY_INPLACE_JS + PAGE_INTRO_JS + ADD_TILE_MODAL_JS + CSP_ALLOW_JS)}</script>
 </body>
 </html>`;
 }

--- a/packages/dashboard/src/views/nodes.ts
+++ b/packages/dashboard/src/views/nodes.ts
@@ -24,7 +24,7 @@ const CATEGORIES: CategoryDef[] = [
     id: 'execution',
     label: 'Execution',
     blurb: 'Nodes that do work — run a command, call an LLM, write a file.',
-    types: ['shell', 'claude-code', 'file-write'],
+    types: ['shell', 'llm-prompt', 'file-write'],
   },
   {
     id: 'control-flow',

--- a/packages/dashboard/src/views/page-intro.js.ts
+++ b/packages/dashboard/src/views/page-intro.js.ts
@@ -1,0 +1,33 @@
+/**
+ * Client wiring for the dismissible page intros (see page-intro.ts).
+ *
+ * On load: hide any intro the user has already dismissed (localStorage key
+ * `sua-intro-<key>`), and wire each "Got it" button to hide + remember. If
+ * localStorage is unavailable the intro stays visible and dismiss is a no-op
+ * for that session — never throws.
+ *
+ * Inlined via layout.ts, same pattern as PULSE_REFRESH_JS / CSP_ALLOW_JS.
+ */
+export const PAGE_INTRO_JS = `
+  (function () {
+    var intros = document.querySelectorAll('.page-intro[data-intro-key]');
+    if (!intros.length) return;
+    for (var i = 0; i < intros.length; i++) {
+      (function (el) {
+        var key = el.getAttribute('data-intro-key');
+        var storeKey = key ? 'sua-intro-' + key : null;
+        try {
+          if (storeKey && localStorage.getItem(storeKey) === '1') {
+            el.style.display = 'none';
+            return;
+          }
+        } catch (e) { /* storage blocked — leave the intro visible */ }
+        var btn = el.querySelector('[data-intro-dismiss]');
+        if (btn) btn.addEventListener('click', function () {
+          el.style.display = 'none';
+          try { if (storeKey) localStorage.setItem(storeKey, '1'); } catch (e) { /* ignore */ }
+        });
+      })(intros[i]);
+    }
+  })();
+`;

--- a/packages/dashboard/src/views/page-intro.test.ts
+++ b/packages/dashboard/src/views/page-intro.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { pageIntro } from './page-intro.js';
+import { render } from './html.js';
+
+describe('pageIntro', () => {
+  it('renders the key, text, and a dismiss button', () => {
+    const out = render(pageIntro({ key: 'pulse', text: 'Live radiator of agent output.' }));
+    expect(out).toContain('class="page-intro"');
+    expect(out).toContain('data-intro-key="pulse"');
+    expect(out).toContain('Live radiator of agent output.');
+    expect(out).toContain('data-intro-dismiss');
+    expect(out).toContain('Got it');
+  });
+
+  it('omits the link when no learnMore is given', () => {
+    const out = render(pageIntro({ key: 'home', text: 'hi' }));
+    expect(out).not.toContain('page-intro__link');
+  });
+
+  it('renders a learnMore link with a default label and noopener', () => {
+    const out = render(pageIntro({ key: 'home', text: 'hi', learnMore: { href: 'https://example.com/docs' } }));
+    expect(out).toContain('href="https://example.com/docs"');
+    expect(out).toContain('rel="noopener"');
+    expect(out).toContain('Learn more');
+  });
+
+  it('honors a custom learnMore label', () => {
+    const out = render(pageIntro({ key: 'home', text: 'hi', learnMore: { href: 'https://example.com', label: 'Dashboard tour' } }));
+    expect(out).toContain('Dashboard tour');
+  });
+
+  it('escapes the text (no raw HTML injection)', () => {
+    const out = render(pageIntro({ key: 'x', text: '<script>alert(1)</script>' }));
+    expect(out).not.toContain('<script>alert(1)</script>');
+    expect(out).toContain('&lt;script&gt;');
+  });
+});

--- a/packages/dashboard/src/views/page-intro.ts
+++ b/packages/dashboard/src/views/page-intro.ts
@@ -1,0 +1,35 @@
+/**
+ * Compact, dismissible "what is this page" intro.
+ *
+ * Renders one line of context under a page title with an optional docs link
+ * and a "Got it" button. Dismissal persists per-key in localStorage (wired by
+ * PAGE_INTRO_JS), so daily users dismiss once and never see it again. Without
+ * JS the intro simply stays visible — progressive enhancement, not required.
+ *
+ * Keep the copy to a single sentence: DESIGN.md says typography and whitespace
+ * do the work, so this is a quiet hint, not a banner.
+ */
+
+import { html, type SafeHtml } from './html.js';
+
+export interface PageIntroOptions {
+  /** Stable key for localStorage dismissal, e.g. 'pulse', 'home', 'integrations'. */
+  key: string;
+  /** One-line explanation of what the page is for. */
+  text: string;
+  /** Optional link to the matching guide. */
+  learnMore?: { href: string; label?: string };
+}
+
+export function pageIntro(opts: PageIntroOptions): SafeHtml {
+  const link = opts.learnMore
+    ? html`<a class="page-intro__link" href="${opts.learnMore.href}" target="_blank" rel="noopener">${opts.learnMore.label ?? 'Learn more'} →</a>`
+    : html``;
+  return html`
+    <div class="page-intro" data-intro-key="${opts.key}">
+      <span class="page-intro__text">${opts.text}</span>
+      ${link}
+      <button type="button" class="page-intro__dismiss" data-intro-dismiss aria-label="Dismiss this hint">Got it</button>
+    </div>
+  `;
+}

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -16,6 +16,7 @@ import { esc } from './pulse-helpers.js';
 import { renderTile } from './pulse-renderers.js';
 import { buildDashboardOptions, renderDashboardsDropdown } from './dashboards-dropdown.js';
 import { improveLayoutButton, improveLayoutModal } from './improve-layout-modal.js';
+import { pageIntro } from './page-intro.js';
 export type { PulseTile, PulsePageInput, TileWrapFn } from './pulse-types.js';
 import type { PulseTile, PulsePageInput, TileWrapFn } from './pulse-types.js';
 
@@ -201,6 +202,12 @@ export function renderPulsePage(input: PulsePageInput): string {
         <button type="button" class="btn btn--ghost btn--sm" id="pulse-add-container" style="display: none;">+ Add group</button>
       </div>
     </div>
+
+    ${pageIntro({
+      key: 'pulse',
+      text: 'Pulse is your live information radiator — each tile shows an agent\'s latest output. Drag to reorder, or use Improve layout to curate what shows.',
+      learnMore: { href: 'https://github.com/gregmeyer/some-useful-agents/blob/main/docs/dashboard.md', label: 'Dashboard tour' },
+    })}
 
     <div id="pulse-containers">
       <section class="pulse-container" data-container-id="_default">

--- a/packages/dashboard/src/views/settings-integrations.ts
+++ b/packages/dashboard/src/views/settings-integrations.ts
@@ -35,9 +35,12 @@ export function renderSettingsIntegrations(args: SettingsIntegrationsArgs): Safe
     <div class="card">
       <p class="card__title">Integrations</p>
       <p class="dim">
-        Named external-service configurations. Agents reference these by
-        id in notify handlers (and later, connectors) instead of declaring
-        raw secret names per-agent.
+        Saved connections to outside systems, defined once and referenced by id
+        instead of repeating connection details per agent. <strong>Notify
+        destinations</strong> (Slack, webhook, file, MCP tool) are where an agent
+        sends a message when a run finishes. <strong>Data sources</strong> (CSV,
+        Postgres, SQLite) auto-generate query tools your nodes can call like a
+        built-in. <a href="https://github.com/gregmeyer/some-useful-agents/blob/main/docs/integrations.md" target="_blank" rel="noopener">Learn more →</a>
       </p>
       ${args.inlineNote ? html`<div class="flash flash--${args.inlineNote.kind} mb-3">${args.inlineNote.message}</div>` : unsafeHtml('')}
       ${renderTabStrip(tab, args.integrations)}

--- a/packages/dashboard/src/views/settings-variables.ts
+++ b/packages/dashboard/src/views/settings-variables.ts
@@ -25,7 +25,7 @@ export function renderSettingsVariables(args: SettingsVariablesArgs): SafeHtml {
       <p class="dim">
         Plain-text values available to every agent. Reference as
         <code>$NAME</code> in shell commands or <code>{{vars.NAME}}</code>
-        in claude-code prompts. For sensitive values, use
+        in llm-prompt nodes. For sensitive values, use
         <a href="/settings/secrets">Secrets</a> instead.
       </p>
       ${renderVariablesTable(args.variables)}

--- a/packages/dashboard/src/views/tools-list.ts
+++ b/packages/dashboard/src/views/tools-list.ts
@@ -61,8 +61,8 @@ export function renderToolsList(args: {
       <select name="type" style="padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm);">
         <option value="">All types</option>
         <option value="shell"${f.type === 'shell' ? ' selected' : ''}>shell</option>
-        <option value="claude-code"${f.type === 'claude-code' ? ' selected' : ''}>claude-code</option>
         <option value="llm-prompt"${f.type === 'llm-prompt' ? ' selected' : ''}>llm-prompt</option>
+        <option value="claude-code"${f.type === 'claude-code' ? ' selected' : ''}>claude-code (legacy)</option>
         <option value="builtin"${f.type === 'builtin' ? ' selected' : ''}>builtin</option>
         <option value="mcp"${f.type === 'mcp' ? ' selected' : ''}>mcp</option>
       </select>


### PR DESCRIPTION
## Summary

A targeted, high-signal pass to give dashboard users more context and fix terminology that lagged the `llm-prompt` unification.

**More in-app context**
- New reusable `pageIntro()` helper ([page-intro.ts](packages/dashboard/src/views/page-intro.ts)) — a compact, dismissible one-line hint with an optional "Learn more →" link. Dismissal persists per-page in localStorage ([PAGE_INTRO_JS](packages/dashboard/src/views/page-intro.js.ts), wired into the shared layout bundle), so power users dismiss once and never see it again. Progressive: still shows without JS.
- Intros added to **Home**, **Pulse**, and **Integrations** (Integrations strengthens its existing always-on blurb to match sibling settings tabs), each linking to the matching guide in `docs/`.
- **Home** now shows a guided empty state (Build from goal + tutorial CTAs) when there are no agents.
- The agent **Runs** tab "no runs yet" is now actionable (Run-now link + CLI hint).

**Cleanup: stale `claude-code` → `llm-prompt` in rendered UI**
- **Bug fix:** the Nodes-tab badge rendered *every* non-shell node as "claude-code", mislabeling real `llm-prompt` nodes ([nodes.ts](packages/dashboard/src/views/agent-detail/nodes.ts)).
- Normalized the canonical name in the shared `typeBadge` ([components.ts](packages/dashboard/src/views/components.ts)), control-flow "goes to" badges, the `/nodes` catalog grouping (canonical node was rendering *orphaned*), and DAG node coloring (`llm-prompt` had no color entry, so nodes rendered gray).
- Updated `/help`, settings → variables, and add-node copy.
- `claude-code` is still accepted as the legacy alias everywhere it's a functional value (stored `node.type`, form option values, conditionals).

DESIGN.md respected throughout — intros use existing tokens, no new colors/shadows.

## Testing
- `npm run build` clean; `npm run test` → **1523 passed, 3 skipped** (added [page-intro.test.ts](packages/dashboard/src/views/page-intro.test.ts), incl. an XSS-escaping case).
- View rendering is exercised by the existing dashboard suite (Home/Pulse/etc. render through the real view fns).
- Suggested manual check: dismiss an intro and reload (stays gone); open an agent with an `llm-prompt` node and confirm the Nodes badge + DAG color.

## Notes
- Separate from the docs PR (#352); rides into the already-staged **0.21.0** as a `patch`.
- Out of scope (deferred): feature-discoverability disclosures (interactive widgets, CSP rationale) and a full form-field helper audit.
- Flagged for later: `node-catalog.ts` (core) still ships both `llm-prompt` and `claude-code` as separate catalog entries, so `/nodes` shows the legacy alias as its own uncategorized card — a core data cleanup, not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)