### PR TITLE
fix(dashboard): start fails gracefully when the port is in use

### DIFF
--- a/.changeset/dashboard-port-in-use-message.md
+++ b/.changeset/dashboard-port-in-use-message.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Fix `sua dashboard start` crashing / mis-starting when the port is in use.
+
+Express's `app.listen(port, host, cb)` invokes its callback even when the bind
+fails, so a busy port (EADDRINUSE) could resolve an unbound server — printing a
+bogus "running" banner — or leak as an uncaught error and crash on startup.
+Binding now keys off the `listening` event so a port conflict reliably rejects.
+The CLI then reports it clearly: if a dashboard is already running it prints the
+sign-in URL and exits 0; otherwise it explains the port is taken and suggests
+`--port <port>`.

--- a/packages/cli/src/commands/dashboard.test.ts
+++ b/packages/cli/src/commands/dashboard.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { dialableHost, isDashboardServing } from './dashboard.js';
+
+/** Spin up a throwaway HTTP server returning `body` (JSON) for any request. */
+async function serveJson(body: unknown, status = 200): Promise<{ port: number; close: () => Promise<void> }> {
+  const server: Server = createServer((_req, res) => {
+    res.statusCode = status;
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify(body));
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const addr = server.address();
+  if (addr === null || typeof addr === 'string') throw new Error('no port');
+  return {
+    port: addr.port,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+describe('dialableHost', () => {
+  it('maps wildcard bind hosts to loopback', () => {
+    expect(dialableHost('0.0.0.0')).toBe('127.0.0.1');
+    expect(dialableHost('::')).toBe('127.0.0.1');
+  });
+  it('leaves real hosts untouched', () => {
+    expect(dialableHost('127.0.0.1')).toBe('127.0.0.1');
+    expect(dialableHost('localhost')).toBe('localhost');
+  });
+});
+
+describe('isDashboardServing', () => {
+  let close: (() => Promise<void>) | undefined;
+  afterEach(async () => {
+    await close?.();
+    close = undefined;
+  });
+
+  it('returns true for a sua-dashboard /health signature', async () => {
+    const s = await serveJson({ status: 'ok', scheduler: { status: 'running' }, commit: 'abc' });
+    close = s.close;
+    expect(await isDashboardServing('127.0.0.1', s.port)).toBe(true);
+  });
+
+  it('returns false when the port is held by something else', async () => {
+    const s = await serveJson({ hello: 'world' });
+    close = s.close;
+    expect(await isDashboardServing('127.0.0.1', s.port)).toBe(false);
+  });
+
+  it('returns false on a non-200 response', async () => {
+    const s = await serveJson({ status: 'ok', scheduler: {} }, 503);
+    close = s.close;
+    expect(await isDashboardServing('127.0.0.1', s.port)).toBe(false);
+  });
+
+  it('returns false when nothing is listening', async () => {
+    // Bind then immediately release to get a port that is (almost certainly) free.
+    const s = await serveJson({});
+    const deadPort = s.port;
+    await s.close();
+    expect(await isDashboardServing('127.0.0.1', deadPort)).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -1,10 +1,34 @@
 import { Command } from 'commander';
 import { startDashboardServer } from '@some-useful-agents/dashboard';
+import { getMcpTokenPath, readMcpToken } from '@some-useful-agents/core';
 import { loadConfig, getAgentDirs, getDbPath, getSecretsPath, getVariablesPath, getRetentionDays, getDashboardBaseUrl } from '../config.js';
 import * as ui from '../ui.js';
 
 function collectName(value: string, previous: string[]): string[] {
   return [...previous, value];
+}
+
+/** Wildcard bind hosts aren't dialable — map them to loopback for probe/print. */
+export function dialableHost(host: string): string {
+  return host === '0.0.0.0' || host === '::' ? '127.0.0.1' : host;
+}
+
+/**
+ * Probe a port that refused to bind, to tell "our dashboard is already running"
+ * apart from "the port is taken by something else". Returns true only when
+ * /health answers with the sua-dashboard signature.
+ */
+export async function isDashboardServing(host: string, port: number): Promise<boolean> {
+  try {
+    const res = await fetch(`http://${dialableHost(host)}:${port}/health`, {
+      signal: AbortSignal.timeout(1500),
+    });
+    if (!res.ok) return false;
+    const body = (await res.json()) as { status?: string; scheduler?: unknown };
+    return body.status === 'ok' && 'scheduler' in body;
+  } catch {
+    return false;
+  }
 }
 
 export const dashboardCommand = new Command('dashboard')
@@ -61,6 +85,29 @@ of scope for this release — wrap in launchd / systemd if you need it.
         dashboardBaseUrl: getDashboardBaseUrl(config),
       });
     } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'EADDRINUSE') {
+        const urlHost = dialableHost(options.host);
+        if (await isDashboardServing(options.host, port)) {
+          const token = readMcpToken(getMcpTokenPath());
+          ui.banner(
+            `Dashboard already running on ${urlHost}:${port}`,
+            [
+              `Another dashboard is already serving this port — no need to start a second one.`,
+              ``,
+              ...(token
+                ? [`Sign-in URL:`, `http://${urlHost}:${port}/auth#token=${token}`, ``]
+                : []),
+              `Open http://${urlHost}:${port}/`,
+            ],
+          );
+          process.exit(0);
+        }
+        ui.fail(
+          `Port ${port} is already in use by another process. Stop it, or start on a ` +
+            `different port: sua dashboard start --port <port>.`,
+        );
+        process.exit(1);
+      }
       ui.fail((err as Error).message);
       process.exit(1);
     }

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -260,6 +260,28 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   return app;
 }
 
+/**
+ * Bind an Express app, resolving only on a genuinely successful listen.
+ *
+ * Express's `app.listen(port, host, cb)` invokes the callback even when the
+ * underlying bind fails (e.g. EADDRINUSE) — the returned server is left
+ * unbound (`listening === false`, `address() === null`), and depending on
+ * timing the failure can also surface as an uncaught `error` event. Keying
+ * off the `listening` event instead means a port conflict reliably rejects,
+ * so callers can handle it (see the EADDRINUSE branch in the CLI) rather than
+ * appearing to start against a server that never bound.
+ */
+export function listenWithErrors(app: Application, port: number, host: string): Promise<Server> {
+  return new Promise<Server>((resolve, reject) => {
+    const s = app.listen(port, host);
+    s.once('error', reject);
+    s.once('listening', () => {
+      s.removeListener('error', reject);
+      resolve(s);
+    });
+  });
+}
+
 export async function startDashboardServer(opts: StartDashboardOptions): Promise<DashboardHandle> {
   const host = opts.host ?? '127.0.0.1';
   const tokenPath = opts.tokenPath ?? getMcpTokenPath();
@@ -401,16 +423,7 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     );
   }
 
-  const server = await new Promise<Server>((resolve, reject) => {
-    const s = app.listen(opts.port, host, () => {
-      s.removeListener('error', reject);
-      resolve(s);
-    });
-    // Without this, EADDRINUSE (and other listen failures) emit on the
-    // server but never reach the awaiter — the promise hangs and the
-    // caller prints its banner against a server that didn't actually bind.
-    s.once('error', (err) => reject(err));
-  });
+  const server = await listenWithErrors(app, opts.port, host);
 
   const authUrl = `http://${host}:${opts.port}/auth#token=${token}`;
 

--- a/packages/dashboard/src/listen.test.ts
+++ b/packages/dashboard/src/listen.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import type { AddressInfo } from 'node:net';
+import { listenWithErrors } from './index.js';
+
+describe('listenWithErrors', () => {
+  it('resolves a genuinely listening server on a free port', async () => {
+    const server = await listenWithErrors(express(), 0, '127.0.0.1');
+    try {
+      expect(server.listening).toBe(true);
+      expect(server.address()).not.toBeNull();
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+
+  it('rejects with EADDRINUSE on a busy port instead of resolving an unbound server', async () => {
+    // Grab an ephemeral port, then try to bind it again.
+    const first = await listenWithErrors(express(), 0, '127.0.0.1');
+    const port = (first.address() as AddressInfo).port;
+    try {
+      await expect(listenWithErrors(express(), port, '127.0.0.1')).rejects.toMatchObject({
+        code: 'EADDRINUSE',
+      });
+    } finally {
+      await new Promise<void>((r) => first.close(() => r()));
+    }
+  });
+});


### PR DESCRIPTION
## What
`sua dashboard start` now behaves sanely when the port is already in use.

## Why
Reported as "dashboard crashed on startup." Root cause: Express's `app.listen(port, host, cb)` **invokes its callback even when the bind fails** (e.g. `EADDRINUSE`). The old promise resolved off that callback, so a busy port either:
- resolved an **unbound** server (`listening: false`, `address(): null`) → printed a bogus "Dashboard running" banner, or
- (depending on timing) leaked the failure as an **uncaught `error` event** → the EADDRINUSE crash.

## Change
- **`packages/dashboard/src/index.ts`** — extract `listenWithErrors()` and bind via the `listening` event, so a port conflict **reliably rejects** instead of resolving a dead server.
- **`packages/cli/src/commands/dashboard.ts`** — handle `EADDRINUSE`: probe `/health`, and
  - if a sua dashboard is already serving → print the sign-in URL and exit **0**;
  - otherwise → "Port N is already in use by another process. … `--port <port>`" and exit **1**.
- Tests: `listen.test.ts` (busy → rejects EADDRINUSE, free → resolves a listening server) and `dashboard.test.ts` (probe discrimination + host mapping).
- Changeset included (all five packages, `patch`).

## Verification
- Clean rebuild; **401 cli+dashboard tests pass** (8 new).
- Local end-to-end under a PTY:
  - busy port w/ live dashboard → "already running" + sign-in URL, exit 0
  - busy port w/ non-sua process → "in use by another process", exit 1
  - free port → binds, `/health` 200, releases on stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)