### PR TITLE
fix(dashboard): show interactive output widgets on tiles regardless of signal.template

### DIFF
--- a/.changeset/pulse-interactive-widget-tile.md
+++ b/.changeset/pulse-interactive-widget-tile.md
@@ -1,0 +1,16 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Show interactive output widgets on Pulse/dashboard tiles even when `signal.template` isn't `widget`.
+
+Pulse dispatches tile rendering on `signal.template`, so an agent that declared
+an interactive `outputWidget` but left `signal.template` as e.g. `text-headline`
+(several shipped examples do) rendered an empty slot template instead of the
+widget on first view. Interactive widgets are tile-level mini-apps that render
+without a prior run, so they now always own the tile. Non-interactive widgets
+paired with a compact `signal.template` (e.g. a metric tile) are unchanged.

--- a/packages/dashboard/src/views/pulse-renderers.test.ts
+++ b/packages/dashboard/src/views/pulse-renderers.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import type { Agent } from '@some-useful-agents/core';
+import { renderTile } from './pulse-renderers.js';
+import type { PulseTile, TileWrapFn } from './pulse-types.js';
+import { render } from './html.js';
+
+const passThrough: TileWrapFn = (_tile, content) => content;
+
+function tileFor(agent: Partial<Agent>, signalTemplate: string): PulseTile {
+  return {
+    agent: { id: 'demo', name: 'demo', inputs: {}, ...agent } as unknown as Agent,
+    signal: { template: signalTemplate, mapping: {} } as PulseTile['signal'],
+    slots: {},
+  } as PulseTile;
+}
+
+describe('renderTile output-widget dispatch', () => {
+  it('renders an interactive outputWidget as the tile even when signal.template is not "widget"', () => {
+    // Mirrors the shipped mismatch (e.g. ashby-job-finder): interactive
+    // outputWidget but signal.template === 'text-headline'. The interactive
+    // widget must own the tile and show on first view (no run required).
+    const tile = tileFor(
+      { outputWidget: { type: 'ai-template', interactive: true } as Agent['outputWidget'] },
+      'text-headline',
+    );
+    const html = render(renderTile(tile, passThrough));
+    expect(html).toContain('data-iw'); // interactive widget shell
+  });
+
+  it('leaves a compact signal.template tile alone when the outputWidget is non-interactive', () => {
+    // e.g. churn-watcher: signal.template: metric + a non-interactive
+    // dashboard widget. The compact metric tile is intentional, so we must
+    // NOT hijack it into the full widget.
+    const tile = tileFor(
+      { outputWidget: { type: 'dashboard' } as Agent['outputWidget'] },
+      'metric',
+    );
+    const html = render(renderTile(tile, passThrough));
+    expect(html).not.toContain('data-iw');
+  });
+});

--- a/packages/dashboard/src/views/pulse-renderers.ts
+++ b/packages/dashboard/src/views/pulse-renderers.ts
@@ -325,6 +325,15 @@ function renderFunnel(tile: PulseTile, wrap: TileWrapFn): SafeHtml {
 // ── Dispatcher ───────────────────────────────────────────────────────────
 
 export function renderTile(tile: PulseTile, wrap: TileWrapFn): SafeHtml {
+  // An INTERACTIVE outputWidget is a tile-level mini-app (inputs form + run
+  // button) and renders without a prior run, so it must own the tile even when
+  // signal.template wasn't set to 'widget'. Pulse dispatches on signal.template,
+  // so an interactive-widget agent with e.g. signal.template: 'text-headline'
+  // would otherwise fall through to a slot template and render empty on first
+  // view — the mismatch build-plan-critic warns about. (Non-interactive widgets
+  // are left to signal.template so a compact metric/status tile paired with a
+  // richer widget, e.g. churn-watcher, keeps its intended compact tile.)
+  if (tile.agent.outputWidget?.interactive) return renderWidgetTile(tile, wrap);
   const { template } = normalizeSignal(tile.signal);
   switch (template as SignalTemplate) {
     case 'metric': return renderMetric(tile, wrap);


### PR DESCRIPTION
## What
On first view, an agent that declares an **interactive** `outputWidget` now renders that widget on its Pulse/dashboard tile, even if `signal.template` isn't `widget`.

## Why
Pulse dispatches tile rendering on `signal.template` ([pulse-renderers.ts `renderTile`](packages/dashboard/src/views/pulse-renderers.ts)). Several shipped example agents declare an interactive `outputWidget` but leave `signal.template` as a slot template (e.g. `ashby-job-finder`, `graphics-creator-mcp`, `ashby-discover` → `text-headline`/`text-image`). Those fell through to the slot renderer and showed an **empty tile** instead of the widget — exactly what `build-plan-critic` warns about. Interactive widgets render without a prior run, so the symptom shows up immediately ("on first run the agent is not set to the output widget").

## Change
- `renderTile` routes to the widget renderer whenever `agent.outputWidget?.interactive` is set, regardless of `signal.template`.
- **Scoped to interactive widgets on purpose:** non-interactive widgets paired with a compact `signal.template` (e.g. `churn-watcher` = `metric` + `dashboard` widget, `system-health`, `api-monitor`) are left as compact tiles — those pairings look intentional, so this avoids turning five unrelated tiles into full widgets.
- `build-plan-critic` still enforces `signal.template: widget` for newly built agents; this is a defensive fallback for hand-authored/interactive cases.

## Tests
- New `pulse-renderers.test.ts`: interactive widget + non-`widget` template → renders the widget shell (`data-iw`); non-interactive widget + `metric` → stays the compact tile.
- Full dashboard + cli suites green (395 tests).

## Note
Scoped per a design decision (interactive-only vs. widget-always) — see PR discussion. Changeset included (all five packages, patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)