### PR TITLE
feat(dashboard): widget rendering robustness + image safety

### DIFF
--- a/.changeset/build-eval-dead-image-links.md
+++ b/.changeset/build-eval-dead-image-links.md
@@ -1,0 +1,33 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Build eval now catches dead image links the drafter LLM hand-writes into agents.
+
+Drafter LLMs frequently bake literal asset URLs into generated agents (e.g. a
+shell node with an array of Wikimedia portrait URLs) and hallucinate the path.
+These pass the structural critic — the host *is* declared in
+`permissions.imgSrc`, so the page CSP allows it — but the URL 404s and the
+widget renders a broken image. Observed in the wild: ~1/3 of the Wikimedia URLs
+in a drafted "Marvel hero of the day" agent were dead links.
+
+The build evaluation now extracts every hardcoded `http(s)` image URL from each
+generated agent and HEAD-checks it. Definitively-gone links (HTTP 404/410) are
+fed back to the planner/drafter as critic-style feedback so the next attempt
+fixes the source (or drops the image) instead of committing an agent that
+renders broken. Inconclusive results — network errors, timeouts, 401/403
+(hotlink), 429 (rate-limit), 5xx — are never flagged, so an offline or
+rate-limited build host can't produce false failures. Template placeholders
+(`{{outputs.image_url}}`) and data URIs are skipped (not statically verifiable
+/ can't 404). The check runs in both the multi-agent `PlannerLoopRunner` eval
+phase and the single-agent drafter critic-retry loop.
+
+New `@some-useful-agents/core` exports: `extractImageUrls`, `findDeadImageUrls`,
+`checkPlanImageUrls`, `defaultCheckImageUrl`, `formatDeadImageFeedback`,
+`formatImageCheckFeedback`. `PlannerLoopRunnerDeps` gains an optional
+`checkImageUrl` dependency; omitting it skips the check (keeps tests/offline
+builds network-free).

--- a/.changeset/csp-blocked-widget-image-run-fail.md
+++ b/.changeset/csp-blocked-widget-image-run-fail.md
@@ -1,0 +1,37 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Fail runs whose widget output references CSP-blocked image hosts (root-cause fix).
+
+When an ai-template widget rendered an `<img>` from a host not in the agent's
+`permissions.imgSrc`, the browser silently blocked it and the run-detail auto-poll
+re-fired the CSP violation on every 2s refresh — filling the console with repeating
+"Loading the image '…' violates the following Content Security Policy directive"
+errors.
+
+Fixed at the source: the executor now checks a finished run's widget output against
+the agent's `permissions.imgSrc` and, if it references an un-allowlisted image host,
+marks the run **failed** with an actionable error naming the host(s)
+(`unallowedWidgetImageHosts` / `formatBlockedImageError`, new in
+`@some-useful-agents/core`). The run-detail view hides the broken widget for such a
+run (so the blocked image never renders or re-fires the violation) and renders a
+**server-side** one-click "Allow host" form per blocked host — robust because the
+hidden widget fires no CSP violation, so a client-JS banner would have nothing to
+react to. The `allow-host` endpoint accepts that form POST and redirects back to the
+run (same-origin redirects only); allow the host, then Retry run. As a safety net,
+the live poll also pauses when any CSP img-src violation is detected
+(`window.__suaCspPaused`), so residual cases on rendered widgets can't spam the
+console either.
+
+Separately, widget images that load from an *allowlisted* host but still 404 (an
+LLM hand-wrote a Wikimedia path with the wrong hash, so the run completes but the
+image is dead) no longer show a broken-image glyph. A capture-phase image-error
+listener swaps any failed widget `<img>` for an inline SVG "Image unavailable"
+placeholder (`data:` URI, permitted by the CSP `img-src` allowlist), preserving
+the failed URL in a tooltip. This is the graceful fallback for hallucinated image
+URLs that slip past the host-level checks.

--- a/.changeset/dag-live-render-blank-fix.md
+++ b/.changeset/dag-live-render-blank-fix.md
@@ -1,0 +1,43 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Fix: run-detail live updates no longer wipe the DAG graph or the CSP "Allow" banner.
+
+The run page auto-polls every 2s and swaps in a fresh `[data-run-container]`
+fragment via `innerHTML` + `replaceWith`. Two pieces of client UI didn't survive
+the swap:
+
+- **DAG graph went blank.** Scripts inserted via `innerHTML` never execute
+  (HTML5), so the cytoscape bootstrap stopped running after the first poll and the
+  new `#dag-canvas` rendered blank for the rest of the run. The bootstrap is now a
+  re-callable, per-canvas-idempotent global (`window.renderDagViz`) that the poll
+  re-invokes after each swap, so the graph stays visible and node colors update
+  live as the run progresses.
+- **CSP "Allow host" banner disappeared mid-run.** The banner for CSP-blocked
+  widget images was mounted *inside* `[data-run-container]`, so the poll destroyed
+  it; the violation listener's host-dedupe then suppressed re-rendering, so the
+  "Allow" button vanished on the first poll and never came back. It's now mounted
+  as a sibling in the container's stable parent, surviving every swap.
+
+The root cause behind both was that the poll replaced the entire
+`[data-run-container]` every 2s. The poll now **reconciles only the regions that
+changed** (`data-poll-region` markers: status, meta, error, result, nodes) instead
+of nuking the container — so the DAG canvas (kept via a `data-poll-preserve`
+region), focused inputs, the node search/filter, and scroll position all survive a
+live update. The DAG bootstrap re-renders only when its data actually changed
+(signature check), reusing the same `#dag-canvas` element. Finally, the
+currently-running DAG node now **pulses** (glowing halo + breathing border) so
+it's obvious at a glance which step is live.
+
+Also fixed: the DAG sometimes rendered only the middle node. Cytoscape doesn't
+auto-resize, so if the initial `fit()` ran before the canvas reached its final
+size (sticky grid settling, fonts loading), the viewport stayed zoomed to a
+stale box and the outer nodes were clipped. The bootstrap now attaches a
+`ResizeObserver` that re-fits on any canvas resize. And `graph-render.js` is now
+served `no-cache` (it was `max-age=300`), so DAG fixes land on refresh instead of
+being masked by a 5-minute stale cache.

--- a/.changeset/widget-tile-fit-and-resize-height.md
+++ b/.changeset/widget-tile-fit-and-resize-height.md
@@ -1,0 +1,26 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Widget tiles grow to fit their content, with a resize handle to pin height + scroll.
+
+Tall output widgets used to get an internal scrollbar inside a capped tile. Now:
+
+- **Tiles grow vertically by default.** A widget tile is as tall as its content
+  (readable, no scrollbar); width stays the dashboard-defined grid column. New
+  `outputWidget.tileFit` controls this per widget: `grow` (default) or `scroll`
+  (cap height + scroll). The output-widget editor exposes the choice. The full
+  run/agent detail view always renders at natural height regardless.
+- **Resize handle pins a height.** Dragging a tile's resize handle in layout-edit
+  mode now sets an explicit height, snapped to a short grid unit, and the tile
+  body scrolls anything taller — so you can shorten a tall tile and it scrolls
+  instead of growing. Width still snaps to dashboard columns. Persisted per tile
+  in the existing layout localStorage.
+
+Also: the dashboard CSS is served `no-cache` (was `max-age=300`) so style/layout
+fixes land on refresh instead of being masked by a 5-minute stale cache — the
+same trap that made an earlier tile change look broken until a hard reload.

--- a/docs/adr/0025-build-eval-image-link-verification.md
+++ b/docs/adr/0025-build-eval-image-link-verification.md
@@ -1,0 +1,114 @@
+# ADR-0025: Verify hardcoded image links during build evaluation
+
+## Status
+Accepted
+
+## Context
+
+Generated agents frequently render images — a Pulse tile with a portrait, a
+dashboard card with a logo. Two layers already guard the image path:
+
+1. **CSP host allowlist** — an agent declares `permissions.imgSrc: [host]`, which
+   the dashboard merges into the page-wide `img-src` directive so the browser
+   won't block the load (ADR-0021, the HTML sanitizer + CSP).
+2. **Structural critic** — `build-plan-critic.ts` scans each ai-template for
+   hardcoded `<img src="https://HOST/...">` and fails the build if `HOST` isn't
+   declared in `permissions.imgSrc`.
+
+Both check whether a host is *allowed*. Neither checks whether the specific URL
+*resolves*. That gap produced a real broken widget: a drafted
+"Marvel hero of the day" agent baked an array of ~30 Wikimedia portrait URLs
+into a `pick-hero` shell node, and the drafter LLM hallucinated the
+hash-prefixed paths (`/wikipedia/en/1/14/Rogue_%28Marvel_Comics%29.jpg`).
+`upload.wikimedia.org` was correctly allowlisted, so CSP passed and the critic
+was happy — but ~1/3 of the URLs returned HTTP 404, and the widget rendered
+broken images. The dashboard was behaving correctly; the data was wrong.
+
+Crucially, these URLs are **literals in the generated agent definition**, not
+runtime output. So they can be extracted and verified at build-eval time —
+before the agent is ever committed — rather than only failing when a user views
+a run.
+
+## Decision
+
+Add an **image-link verifier** to the build evaluation
+(`packages/core/src/build-plan-image-check.ts`):
+
+- Extract every `http(s)` URL ending in a known image extension from each
+  generated agent's YAML (covers shell commands and ai-template HTML alike).
+- HEAD-check each unique URL (1-byte ranged GET fallback for hosts that reject
+  HEAD), with a real User-Agent and a hard timeout.
+- Flag a URL as dead **only** on a definitively-gone status (HTTP 404/410).
+  Feed dead links back to the planner/drafter as critic-style feedback for a
+  retry, on the same footing as structural critic errors.
+
+Wired into both evaluation surfaces:
+- `PlannerLoopRunner` evaluate phase (multi-agent plans) — via an optional
+  injected `checkImageUrl` dependency.
+- The single-agent drafter critic-retry loop in `build-orchestrator.ts`.
+
+### Why 404/410 only
+
+Failing a build for an inconclusive result would be worse than the broken image
+it prevents:
+- **Network error / timeout** — the build host may be offline or sandboxed.
+- **403** — hotlink protection; the image usually exists and renders in-browser.
+- **429** — rate-limiting from our own rapid checks, not a dead resource.
+- **5xx** — transient server fault.
+
+All of these are treated as inconclusive and never flagged. Only "the resource
+is gone" (404/410) is actionable and unambiguous.
+
+### Why inject the checker
+
+The per-URL checker is a constructor/dependency parameter, not a hardcoded
+`fetch`. The planner loop stays deterministic and network-free by default, so
+unit tests (and offline builds) skip the network entirely; the dashboard wires
+the real `defaultCheckImageUrl`.
+
+### Why not verify template placeholders
+
+`<img src="{{outputs.image_url}}">` binds to a runtime value that doesn't exist
+at build time, so it can't be statically verified. Data URIs can't 404. Both are
+skipped; this ADR addresses only literal asset URLs the LLM hand-wrote.
+
+## Consequences
+
+**Positive:**
+- Catches hallucinated asset URLs at generation time, with the exact dead URL +
+  status in the retry feedback, so the LLM fixes the source instead of shipping
+  broken images.
+- Reuses the existing critic-retry machinery — no new loop, no new UI.
+- Conservative flagging keeps false-positive build failures near zero.
+
+**Negative:**
+- The build eval now makes outbound network requests (bounded: only literal
+  image URLs, deduped, concurrency-capped, with a timeout). The dependency is
+  opt-in, so any caller that wants a hermetic build omits `checkImageUrl`.
+- A URL that 404s only intermittently (or after the build) still slips through —
+  this is a generation-time gate, not a runtime monitor. Graceful runtime
+  fallback for broken widget images remains future work.
+
+## Alternatives considered
+
+- **Pure static heuristic (no network)** — flag *any* hardcoded external image
+  URL as risky and tell the planner to resolve images at runtime. Rejected as
+  the primary mechanism: it can't tell a good URL from a dead one, so it would
+  flag working agents (noisy) while still not proving the bad ones are bad.
+  Its guidance ("prefer runtime resolution over baked URLs") is folded into the
+  dead-link feedback message instead.
+- **Dynamic verification by executing the agent** — run the drafted agent, then
+  HTTP-check the URLs it emits. Rejected: far more expensive and nondeterministic
+  than checking the literals already present in the definition, and unnecessary
+  here because the bad URLs are static.
+- **Runtime broken-image fallback only** — degrade gracefully in the widget when
+  an `<img>` 404s. Complementary, not a substitute: it hides the symptom but
+  still ships an agent with dead links. Tracked separately.
+
+## References
+
+- ADR-0021 (HTML allowlist sanitizer) — the CSP `img-src` allowlist this
+  verifier complements.
+- ADR-0024 (build-planner split) — the drafter critic-retry loop this check
+  plugs into.
+- [docs/build-from-goal.md](../build-from-goal.md) — user-facing guide.

--- a/docs/build-from-goal.md
+++ b/docs/build-from-goal.md
@@ -71,6 +71,14 @@ saved. Current checks include:
   template grammar only resolves one level, so nested paths render blank.
 - **img-src hosts** — external `<img>` hosts must be declared in
   `permissions.imgSrc`; the critic prompts to allow the host.
+- **dead image links** — every hardcoded `http(s)` image URL baked into an agent
+  (in a shell command or an ai-template) is HEAD-checked
+  (`build-plan-image-check.ts`). URLs returning HTTP 404/410 are fed back to the
+  drafter for a retry — a host can be allowlisted *and* still 404 because the LLM
+  hallucinated the path. Inconclusive results (network error, 403, 429, 5xx) are
+  never flagged, and template placeholders (`{{outputs.image_url}}`) and data
+  URIs are skipped. This check makes outbound requests, so it's a no-op when the
+  planner runs without the `checkImageUrl` dependency (e.g. tests, offline).
 - **signal.template = widget** — an agent that declares an `outputWidget` must use
   `signal.template: widget` so its Pulse tile mirrors the widget. A mismatch
   (e.g. `text-image`) produces a broken tile, so the critic flags it.

--- a/packages/core/src/build-plan-image-check.test.ts
+++ b/packages/core/src/build-plan-image-check.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractImageUrls,
+  findDeadImageUrls,
+  checkPlanImageUrls,
+  formatDeadImageFeedback,
+  formatImageCheckFeedback,
+  type CheckUrlFn,
+} from './build-plan-image-check.js';
+import { buildPlanSchema, type BuildPlanInput } from './build-plan-schema.js';
+
+/** A shell agent whose command bakes in the given image URLs. */
+const yamlWithImages = (id: string, urls: string[]) => {
+  const arr = urls.map((u) => `{\\"image\\":\\"${u}\\"}`).join(',');
+  return `id: ${id}\nname: ${id} agent\nnodes:\n  - id: n1\n    type: shell\n    command: echo '[${arr}]'\n`;
+};
+
+function planFor(overrides: Partial<BuildPlanInput> = {}): ReturnType<typeof buildPlanSchema.parse> {
+  return buildPlanSchema.parse({
+    intent: 'agent',
+    summary: 'A test plan',
+    survey: { matchedAgents: [], missingFor: [], existingDashboards: [] },
+    newAgents: [{ id: 'one', purpose: 'p', yaml: yamlWithImages('one', []) }],
+    dashboard: null,
+    questions: [],
+    ...overrides,
+  });
+}
+
+/** Build a checkUrl stub from a {url: status} map. Unlisted URLs → null. */
+const stubChecker = (statuses: Record<string, number | null>): CheckUrlFn =>
+  async (url: string) => (url in statuses ? statuses[url] : null);
+
+describe('extractImageUrls', () => {
+  it('extracts http(s) URLs by image extension', () => {
+    const text =
+      'see https://cdn.example.com/a.png and http://x.io/b.JPG and https://y.org/c.webp?w=1';
+    expect(extractImageUrls(text)).toEqual([
+      'https://cdn.example.com/a.png',
+      'http://x.io/b.JPG',
+      'https://y.org/c.webp?w=1',
+    ]);
+  });
+
+  it('keeps URL-encoded segments intact', () => {
+    const url = 'https://upload.wikimedia.org/wikipedia/en/1/14/Rogue_%28Marvel_Comics%29.jpg';
+    expect(extractImageUrls(`img: "${url}"`)).toEqual([url]);
+  });
+
+  it('de-dups while preserving first-seen order', () => {
+    const text = 'a.png? no: https://h/a.png then https://h/b.gif then https://h/a.png';
+    expect(extractImageUrls(text)).toEqual(['https://h/a.png', 'https://h/b.gif']);
+  });
+
+  it('ignores non-image URLs, data URIs, and template placeholders', () => {
+    const text =
+      'page https://h/index.html data:image/png;base64,AAAA src="{{outputs.image_url}}"';
+    expect(extractImageUrls(text)).toEqual([]);
+  });
+});
+
+describe('findDeadImageUrls', () => {
+  it('flags only 404/410, not 200/3xx/403/429/5xx/network-error', async () => {
+    const statuses: Record<string, number | null> = {
+      'https://h/ok.png': 200,
+      'https://h/redir.png': 301,
+      'https://h/gone.png': 410,
+      'https://h/missing.png': 404,
+      'https://h/forbidden.png': 403,
+      'https://h/ratelimited.png': 429,
+      'https://h/server.png': 500,
+      'https://h/neterr.png': null,
+    };
+    const dead = await findDeadImageUrls(Object.keys(statuses), { checkUrl: stubChecker(statuses) });
+    expect(dead.map((d) => d.url)).toEqual(['https://h/gone.png', 'https://h/missing.png']);
+    expect(dead).toContainEqual({ url: 'https://h/missing.png', status: 404 });
+  });
+
+  it('treats a throwing checker as inconclusive (not dead)', async () => {
+    const throwing: CheckUrlFn = async () => { throw new Error('boom'); };
+    const dead = await findDeadImageUrls(['https://h/x.png'], { checkUrl: throwing });
+    expect(dead).toEqual([]);
+  });
+
+  it('de-dups URLs before checking', async () => {
+    let calls = 0;
+    const counting: CheckUrlFn = async () => { calls++; return 404; };
+    const dead = await findDeadImageUrls(['https://h/x.png', 'https://h/x.png'], { checkUrl: counting });
+    expect(calls).toBe(1);
+    expect(dead).toHaveLength(1);
+  });
+});
+
+describe('checkPlanImageUrls', () => {
+  it('passes when every image URL resolves', async () => {
+    const plan = planFor({
+      newAgents: [{ id: 'one', purpose: 'p', yaml: yamlWithImages('one', ['https://h/ok.png']) }],
+    });
+    const result = await checkPlanImageUrls(plan, { checkUrl: stubChecker({ 'https://h/ok.png': 200 }) });
+    expect(result.ok).toBe(true);
+    expect(result.perAgent).toEqual([]);
+  });
+
+  it('groups dead links per newAgent', async () => {
+    const plan = planFor({
+      intent: 'dashboard-new',
+      newAgents: [
+        { id: 'one', purpose: 'p', yaml: yamlWithImages('one', ['https://h/dead.png', 'https://h/ok.png']) },
+        { id: 'two', purpose: 'p', yaml: yamlWithImages('two', ['https://h/ok.png']) },
+      ],
+      dashboard: { id: 'user:d', name: 'D', sections: [{ title: 'T', agentIds: ['one', 'two'] }] },
+    });
+    const result = await checkPlanImageUrls(plan, {
+      checkUrl: stubChecker({ 'https://h/dead.png': 404, 'https://h/ok.png': 200 }),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.perAgent).toHaveLength(1);
+    expect(result.perAgent[0].agentId).toBe('one');
+    expect(result.perAgent[0].dead.map((d) => d.url)).toEqual(['https://h/dead.png']);
+  });
+
+  it('fetches a URL shared across agents only once', async () => {
+    let calls = 0;
+    const counting: CheckUrlFn = async () => { calls++; return 404; };
+    const plan = planFor({
+      intent: 'dashboard-new',
+      newAgents: [
+        { id: 'one', purpose: 'p', yaml: yamlWithImages('one', ['https://h/shared.png']) },
+        { id: 'two', purpose: 'p', yaml: yamlWithImages('two', ['https://h/shared.png']) },
+      ],
+      dashboard: { id: 'user:d', name: 'D', sections: [{ title: 'T', agentIds: ['one', 'two'] }] },
+    });
+    const result = await checkPlanImageUrls(plan, { checkUrl: counting });
+    expect(calls).toBe(1);
+    expect(result.perAgent.map((a) => a.agentId)).toEqual(['one', 'two']);
+  });
+});
+
+describe('feedback formatters', () => {
+  it('formatDeadImageFeedback lists each URL with its status', () => {
+    const fb = formatDeadImageFeedback([{ url: 'https://h/x.png', status: 404 }]);
+    expect(fb).toMatch(/Critic feedback/);
+    expect(fb).toMatch(/https:\/\/h\/x\.png → HTTP 404/);
+  });
+
+  it('formatDeadImageFeedback is empty when nothing is dead', () => {
+    expect(formatDeadImageFeedback([])).toBe('');
+  });
+
+  it('formatImageCheckFeedback groups per agent and is empty when ok', () => {
+    expect(formatImageCheckFeedback({ ok: true, perAgent: [] })).toBe('');
+    const fb = formatImageCheckFeedback({
+      ok: false,
+      perAgent: [{ agentId: 'one', dead: [{ url: 'https://h/x.png', status: 410 }] }],
+    });
+    expect(fb).toMatch(/newAgent "one"/);
+    expect(fb).toMatch(/HTTP 410/);
+  });
+});

--- a/packages/core/src/build-plan-image-check.ts
+++ b/packages/core/src/build-plan-image-check.ts
@@ -1,0 +1,222 @@
+/**
+ * Image-link verifier for build-planner output.
+ *
+ * The structural critic (`build-plan-critic.ts`) checks that every external
+ * `<img src="https://HOST/...">` host hardcoded in an ai-template is declared
+ * in `permissions.imgSrc` so the page CSP won't block it. That keeps the
+ * allowlist honest — but a host being *allowed* says nothing about whether
+ * the specific URL actually resolves.
+ *
+ * The failure this module exists for: a drafter LLM hand-writes image URLs
+ * into a generated agent (e.g. a `pick-hero` shell node with a baked-in array
+ * of Wikimedia portrait URLs) and hallucinates the path. The host is real and
+ * allowlisted, so CSP passes and the critic is happy, but the URL 404s and the
+ * widget renders a broken image. Observed in the wild: ~1/3 of the Wikimedia
+ * URLs in a drafted "Marvel hero of the day" agent were dead links.
+ *
+ * Because these URLs are *literals in the generated agent definition* (not
+ * runtime output), we can extract and HEAD-check them at build-eval time —
+ * before the agent is ever committed — and feed the dead ones back to the
+ * planner/drafter as critic-style feedback for a retry.
+ *
+ * Design choices:
+ *  - Only HTTP(S) image URLs (by file extension) are checked. Data URIs and
+ *    template placeholders (`{{outputs.image_url}}`) are skipped — the former
+ *    can't 404, the latter is a runtime value we can't verify statically.
+ *  - "Dead" means a *definitively gone* status (404 or 410). Network errors,
+ *    timeouts, 401/403 (auth/hotlink), 429 (rate-limit) and 5xx are treated as
+ *    inconclusive and NOT flagged — failing a build because the build host is
+ *    offline or rate-limited would be worse than the broken image it prevents.
+ *  - The per-URL checker is injected so the planner loop stays testable and
+ *    offline by default; the dashboard wires `defaultCheckImageUrl`.
+ */
+
+import type { BuildPlan } from './build-plan-schema.js';
+
+/** A URL the checker decided is gone, with the status that decided it. */
+export interface DeadImageUrl {
+  url: string;
+  /** The HTTP status that marked it dead (404 or 410). */
+  status: number;
+}
+
+export interface ImageCheckAgentResult {
+  agentId: string;
+  dead: DeadImageUrl[];
+}
+
+export interface ImageCheckResult {
+  ok: boolean;
+  /** One entry per newAgent with at least one dead link. Empty when ok. */
+  perAgent: ImageCheckAgentResult[];
+}
+
+/** Signature of the injectable per-URL checker. Returns the HTTP status, or
+ *  `null` when the request couldn't conclude (network error / timeout). */
+export type CheckUrlFn = (url: string) => Promise<number | null>;
+
+/** Statuses that mean "this resource is gone" — the only ones we flag. */
+const DEAD_STATUSES = new Set([404, 410]);
+
+/**
+ * Match http(s) URLs that end in a known image extension (optionally followed
+ * by a query string). The character class stops at whitespace and the
+ * delimiters that commonly wrap a URL in YAML / shell / HTML (quotes, angle
+ * brackets, backticks, backslashes, parens). URL-encoded segments like
+ * `%28...%29` stay inside the match because `%` and digits aren't excluded.
+ */
+const IMG_URL_RE =
+  /https?:\/\/[^\s"'`<>\\)]+\.(?:png|jpe?g|gif|svg|webp|bmp|avif|ico)(?:\?[^\s"'`<>\\)]*)?/gi;
+
+/**
+ * Extract unique image URLs from arbitrary text (a newAgent YAML document,
+ * which embeds shell commands and ai-template HTML alike). Order-preserving
+ * de-dup so feedback reads in the order a human would scan the file.
+ */
+export function extractImageUrls(text: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const m of text.matchAll(IMG_URL_RE)) {
+    const url = m[0];
+    if (!seen.has(url)) {
+      seen.add(url);
+      out.push(url);
+    }
+  }
+  return out;
+}
+
+/**
+ * Run a checker over a list of URLs with bounded concurrency and return the
+ * subset that came back definitively dead (404/410). Inconclusive results
+ * (null / other statuses) are dropped.
+ */
+export async function findDeadImageUrls(
+  urls: string[],
+  opts: { checkUrl: CheckUrlFn; concurrency?: number },
+): Promise<DeadImageUrl[]> {
+  const unique = Array.from(new Set(urls));
+  const concurrency = Math.max(1, opts.concurrency ?? 6);
+  const dead: DeadImageUrl[] = [];
+  let next = 0;
+
+  async function worker(): Promise<void> {
+    while (next < unique.length) {
+      const url = unique[next++];
+      let status: number | null = null;
+      try {
+        status = await opts.checkUrl(url);
+      } catch {
+        status = null; // a throwing checker is "inconclusive", not "dead"
+      }
+      if (status !== null && DEAD_STATUSES.has(status)) {
+        dead.push({ url, status });
+      }
+    }
+  }
+
+  const pool = Array.from({ length: Math.min(concurrency, unique.length) }, () => worker());
+  await Promise.all(pool);
+  // Restore input order (workers race; the result set shouldn't be arbitrary).
+  const order = new Map(unique.map((u, i) => [u, i]));
+  dead.sort((a, b) => (order.get(a.url) ?? 0) - (order.get(b.url) ?? 0));
+  return dead;
+}
+
+/**
+ * Plan-level convenience: extract + check every newAgent's image URLs and
+ * group the dead ones per agent. Used by the multi-agent PlannerLoopRunner.
+ */
+export async function checkPlanImageUrls(
+  plan: BuildPlan,
+  opts: { checkUrl: CheckUrlFn; concurrency?: number },
+): Promise<ImageCheckResult> {
+  // De-dup across agents so a URL shared by several drafts is fetched once,
+  // then fan the verdict back out to each agent that referenced it.
+  const perAgentUrls = plan.newAgents.map((a) => ({ agentId: a.id, urls: extractImageUrls(a.yaml) }));
+  const allUrls = perAgentUrls.flatMap((a) => a.urls);
+  const dead = await findDeadImageUrls(allUrls, opts);
+  const deadByUrl = new Map(dead.map((d) => [d.url, d]));
+
+  const perAgent: ImageCheckAgentResult[] = [];
+  for (const { agentId, urls } of perAgentUrls) {
+    const agentDead = urls.map((u) => deadByUrl.get(u)).filter((d): d is DeadImageUrl => d !== undefined);
+    if (agentDead.length > 0) perAgent.push({ agentId, dead: agentDead });
+  }
+  return { ok: perAgent.length === 0, perAgent };
+}
+
+const DEAD_LINK_GUIDANCE =
+  'These image URLs were hand-written into the agent and return 404/410 — the widget will render broken images. ' +
+  'Replace each with a URL you can verify resolves, or drop the image field. ' +
+  'Hand-written CDN paths (especially Wikimedia upload.wikimedia.org hash paths) are frequently wrong — ' +
+  'prefer resolving images at runtime from a stable API/endpoint over baking literal asset URLs into the agent.';
+
+/**
+ * Format per-agent dead links as a critic-style feedback block (used by the
+ * single-agent drafter loop in build-orchestrator).
+ */
+export function formatDeadImageFeedback(dead: DeadImageUrl[]): string {
+  if (dead.length === 0) return '';
+  const lines = dead.map((d) => `  - ${d.url} → HTTP ${d.status}`);
+  return [
+    'Critic feedback — dead image links in your previous draft (fix every item below):',
+    ...lines,
+    `  ${DEAD_LINK_GUIDANCE}`,
+  ].join('\n');
+}
+
+/**
+ * Format a plan-level image-check result as planner feedback. Mirrors
+ * `formatCriticFeedback` / `formatSmokeFeedback` so the reflect step can hand
+ * all three to the next compose invocation in one combined block.
+ */
+export function formatImageCheckFeedback(result: ImageCheckResult): string {
+  if (result.ok) return '';
+  const lines: string[] = [];
+  lines.push('Image-link feedback on your previous plan (each URL below is a dead link — fix every item):');
+  for (const a of result.perAgent) {
+    lines.push(`- newAgent "${a.agentId}":`);
+    for (const d of a.dead) lines.push(`  - ${d.url} → HTTP ${d.status}`);
+  }
+  lines.push(`  ${DEAD_LINK_GUIDANCE}`);
+  return lines.join('\n');
+}
+
+/** User-Agent for link checks. Wikimedia (and others) reject requests with no
+ *  descriptive UA, which would otherwise turn live images into false 403s. */
+const IMG_CHECK_UA = 'some-useful-agents/image-link-check (+https://github.com/some-useful-agents)';
+
+/**
+ * Default per-URL checker: a HEAD request with a real User-Agent and a hard
+ * timeout, falling back to a 1-byte ranged GET for hosts that reject HEAD
+ * (405/501). Returns the HTTP status, or `null` on any network/timeout error
+ * so the caller treats it as inconclusive rather than dead.
+ */
+export async function defaultCheckImageUrl(url: string, timeoutMs = 5000): Promise<number | null> {
+  const attempt = async (method: 'HEAD' | 'GET'): Promise<number> => {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      const res = await fetch(url, {
+        method,
+        redirect: 'follow',
+        signal: ctrl.signal,
+        headers: method === 'GET'
+          ? { 'User-Agent': IMG_CHECK_UA, Range: 'bytes=0-0' }
+          : { 'User-Agent': IMG_CHECK_UA },
+      });
+      return res.status;
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+
+  try {
+    const headStatus = await attempt('HEAD');
+    if (headStatus === 405 || headStatus === 501) return await attempt('GET');
+    return headStatus;
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/src/dag-executor.test.ts
+++ b/packages/core/src/dag-executor.test.ts
@@ -186,6 +186,55 @@ describe('executeAgentDag — single node', () => {
   });
 });
 
+describe('executeAgentDag — widget image-host guard', () => {
+  const tmpl = '<div><img src="{{outputs.image_url}}" alt="x"></div>';
+
+  it('fails a completed run whose ai-template image host is not allowlisted', async () => {
+    const agent = makeAgent({
+      outputWidget: { type: 'ai-template', template: tmpl },
+      permissions: { imgSrc: ['allowed.example'] },
+    });
+    const run = await executeAgentDag(
+      agent,
+      { triggeredBy: 'cli' },
+      { runStore, spawnNode: cannedSpawner({ main: { exitCode: 0, result: JSON.stringify({ image_url: 'https://blocked.example/p.jpg' }) } }) },
+    );
+    expect(run.status).toBe('failed');
+    expect(run.error).toMatch(/blocked\.example/);
+    expect(run.error).toMatch(/permissions\.imgSrc/);
+    // Result is still persisted so the dashboard can offer one-click "Allow".
+    expect(run.result).toContain('blocked.example');
+  });
+
+  it('keeps a run completed when the image host IS allowlisted', async () => {
+    const agent = makeAgent({
+      outputWidget: { type: 'ai-template', template: tmpl },
+      permissions: { imgSrc: ['ok.example'] },
+    });
+    const run = await executeAgentDag(
+      agent,
+      { triggeredBy: 'cli' },
+      { runStore, spawnNode: cannedSpawner({ main: { exitCode: 0, result: JSON.stringify({ image_url: 'https://ok.example/p.jpg' }) } }) },
+    );
+    expect(run.status).toBe('completed');
+    expect(run.error).toBeFalsy();
+  });
+
+  it('does not second-guess a run that already failed at a node', async () => {
+    const agent = makeAgent({
+      outputWidget: { type: 'ai-template', template: tmpl },
+      permissions: { imgSrc: [] },
+    });
+    const run = await executeAgentDag(
+      agent,
+      { triggeredBy: 'cli' },
+      { runStore, spawnNode: cannedSpawner({ main: { exitCode: 2, error: 'boom' } }) },
+    );
+    expect(run.status).toBe('failed');
+    expect(run.error).toContain('exit_nonzero'); // node failure wins, not the image guard
+  });
+});
+
 describe('executeAgentDag — multi-node DAG', () => {
   const threeNodeAgent: Agent = {
     id: 'news', name: 'News', status: 'active', source: 'local', mcp: false, version: 1,

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -39,6 +39,7 @@ import { substituteInputs } from './input-resolver.js';
 import { stateDirFor, stateDirSize, formatBytes, DEFAULT_STATE_MAX_BYTES } from './agent-state.js';
 import { UntrustedCommunityShellError } from './agent-executor.js';
 import { buildNodeEnv, buildUpstreamSnapshot, filterEnvForLog } from './node-env.js';
+import { unallowedWidgetImageHosts, formatBlockedImageError } from './widget-image-hosts.js';
 import { type SpawnResult, type SpawnNodeFn, type SpawnProgress, spawnNodeReal } from './node-spawner.js';
 import { resolveToolId, resolveToolInputs } from './tool-dispatch.js';
 import { dispatchNotify, type NotifyLogger } from './notify-dispatcher.js';
@@ -938,14 +939,33 @@ export async function executeAgentDag(
     }
   }
 
-  const finalStatus: RunStatus = firstFailure ? 'failed' : 'completed';
+  let finalStatus: RunStatus = firstFailure ? 'failed' : 'completed';
   // Final result = last completed node's output. Keeps `sua agent status`
   // readable for single-node agents where "the run's result" is obvious,
   // and gives multi-node agents a meaningful summary string.
   const lastCompleted = [...outputs.values()].pop();
-  const finalError = firstFailure
+  let finalError = firstFailure
     ? `Failed at node "${firstFailure.nodeId}" (${firstFailure.category})`
     : undefined;
+
+  // Root-cause guard for CSP-blocked widget images: an agent whose ai-template
+  // widget renders an image from a host not in permissions.imgSrc produces
+  // output the browser will refuse to render (and the run-detail poll re-fires
+  // the violation on every refresh). Fail the run here with an actionable
+  // error instead of shipping un-renderable output. Result is still persisted
+  // so the dashboard can name the blocked host(s) and offer one-click "Allow".
+  if (finalStatus === 'completed') {
+    const blockedHosts = unallowedWidgetImageHosts({
+      outputWidget: agent.outputWidget,
+      permissions: agent.permissions,
+      result: lastCompleted?.result,
+    });
+    if (blockedHosts.length > 0) {
+      finalStatus = 'failed';
+      finalError = formatBlockedImageError(blockedHosts);
+    }
+  }
+
   deps.runStore.updateRun(runId, {
     status: finalStatus,
     completedAt: new Date().toISOString(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -181,6 +181,24 @@ export {
   type PlanCriticContext,
 } from './build-plan-critic.js';
 export {
+  extractImageUrls,
+  findDeadImageUrls,
+  checkPlanImageUrls,
+  defaultCheckImageUrl,
+  formatDeadImageFeedback,
+  formatImageCheckFeedback,
+  type CheckUrlFn,
+  type DeadImageUrl,
+  type ImageCheckAgentResult,
+  type ImageCheckResult,
+} from './build-plan-image-check.js';
+export {
+  extractImgTagHosts,
+  unallowedWidgetImageHosts,
+  formatBlockedImageError,
+  type WidgetImageHostInput,
+} from './widget-image-hosts.js';
+export {
   PlannerLoopRunner,
   type PlannerLoopRunnerDeps,
   autofixPlanYamls,

--- a/packages/core/src/output-widget-schema.ts
+++ b/packages/core/src/output-widget-schema.ts
@@ -161,6 +161,13 @@ export const outputWidgetSchema = z.object({
    * named views. State is URL-driven (no client JS) so refresh = default view.
    */
   controls: z.array(widgetControlSchema).optional(),
+  /**
+   * Tile HEIGHT behavior when the widget is taller than its Pulse/dashboard
+   * slot (width is always the dashboard-defined column). Tiles only — the full
+   * run/agent view always renders at natural height. `grow` (default) grows the
+   * tile vertically; `scroll` caps + scrolls. Unset = grow.
+   */
+  tileFit: z.enum(['grow', 'scroll']).optional(),
 }).superRefine((schema, ctx) => {
   if (schema.type === 'ai-template') {
     if (!schema.template || schema.template.trim() === '') {

--- a/packages/core/src/output-widget-types.ts
+++ b/packages/core/src/output-widget-types.ts
@@ -94,6 +94,16 @@ export interface OutputWidgetSchema {
    * named views. State is URL-driven (no client JS).
    */
   controls?: WidgetControl[];
+  /**
+   * How the widget tile's HEIGHT behaves on a Pulse/dashboard when its content
+   * is taller than the slot. Width is always the dashboard-defined grid column.
+   * Only affects tiles — the full run/agent view always renders at natural
+   * height.
+   *   - `grow` (default): the tile grows vertically to the widget's height — no
+   *     scroll, fully readable; the grid row sizes to it.
+   *   - `scroll`: cap the tile height and scroll the overflow.
+   */
+  tileFit?: 'grow' | 'scroll';
 }
 
 /** A named subset of widget fields used by `view-switch` controls. */

--- a/packages/core/src/planner-loop/runner.ts
+++ b/packages/core/src/planner-loop/runner.ts
@@ -1,4 +1,5 @@
 import { formatCriticFeedback, type PlanCriticError } from '../build-plan-critic.js';
+import { checkPlanImageUrls, formatImageCheckFeedback, type CheckUrlFn, type ImageCheckResult } from '../build-plan-image-check.js';
 import type { BuildPlan } from '../build-plan-schema.js';
 import type { PlannerTelemetryStore } from '../planner-telemetry-store.js';
 import { formatSmokeFeedback, smokeRunNewAgents, type SmokeRunContext, type SmokeRunResult } from './eval-smoke-run.js';
@@ -13,10 +14,11 @@ import type { LoopOutcome, LoopStepRecord } from './types.js';
  * The planner prompt is already trained to handle critic feedback, so
  * smoke feedback follows the same prefix-line convention.
  */
-function combinedFeedback(criticErrors: PlanCriticError[], smoke: SmokeRunResult): string {
+function combinedFeedback(criticErrors: PlanCriticError[], smoke: SmokeRunResult, imageCheck?: ImageCheckResult): string {
   const parts: string[] = [];
   if (criticErrors.length > 0) parts.push(formatCriticFeedback(criticErrors));
   if (!smoke.ok) parts.push(formatSmokeFeedback(smoke));
+  if (imageCheck && !imageCheck.ok) parts.push(formatImageCheckFeedback(imageCheck));
   return parts.join('\n\n');
 }
 
@@ -53,6 +55,16 @@ export interface PlannerLoopRunnerDeps {
    * the smoke eval skips its tool-id check.
    */
   loadKnownToolIds?: () => Set<string>;
+  /**
+   * Per-URL image-link checker. When supplied, the evaluate phase extracts
+   * every hardcoded http(s) image URL from each newAgent and HEAD-checks it;
+   * dead links (404/410) become retry feedback so the planner fixes the
+   * source instead of committing an agent that renders broken images.
+   * Returns the HTTP status or `null` on a network/timeout error (treated as
+   * inconclusive, never as dead). Optional — omitting it skips the check, so
+   * tests and offline builds stay deterministic and network-free.
+   */
+  checkImageUrl?: CheckUrlFn;
   /**
    * Cross-run planner memory (PR 3). When supplied, the runner's compose
    * step re-retrieves similar prior plans for the retry — now that the
@@ -160,8 +172,29 @@ export class PlannerLoopRunner {
       });
     } catch { /* swallow */ }
 
+    // Image-link check: HEAD every hardcoded image URL baked into a newAgent
+    // and flag dead ones (404/410). Drafter LLMs hand-write asset URLs that
+    // pass the CSP host check but 404 at render time; this catches them before
+    // commit. Skipped entirely when no checker dep was supplied (tests/offline).
+    let imageCheck: ImageCheckResult | undefined;
+    if (this.deps.checkImageUrl) {
+      const imgStart = Date.now();
+      imageCheck = await checkPlanImageUrls(plan, { checkUrl: this.deps.checkImageUrl });
+      const deadCount = imageCheck.perAgent.reduce((n, a) => n + a.dead.length, 0);
+      steps.push(step({
+        phase: 'evaluate',
+        primitive: 'checkPlanImageUrls',
+        runId: input.runId,
+        ok: imageCheck.ok,
+        summary: imageCheck.ok
+          ? 'image links ok'
+          : `${deadCount} dead image link(s) across ${imageCheck.perAgent.length} newAgent(s)`,
+        tookMs: Date.now() - imgStart,
+      }));
+    }
+
     // ── reflect (decide) ─────────────────────────────────────────────
-    const evalOk = critic.ok && smoke.ok;
+    const evalOk = critic.ok && smoke.ok && (imageCheck?.ok ?? true);
     const rootRunId = this.deps.telemetryStore?.resolveOriginalRunId(input.runId) ?? input.runId;
     const rootRow = this.deps.telemetryStore?.get(rootRunId) ?? null;
     const attemptsSoFar = rootRow?.planAttempts ?? 1;
@@ -181,7 +214,7 @@ export class PlannerLoopRunner {
     if (decision.kind === 'retry') {
       try { this.deps.telemetryStore?.incrementAttempts(input.runId); } catch { /* swallow */ }
       const goal = rootRow?.goal ?? '';
-      const feedback = combinedFeedback(critic.errors, smoke);
+      const feedback = combinedFeedback(critic.errors, smoke, imageCheck);
 
       // understand: pull prior committed plans for the *now-known* intent
       // and inject them on the retry. Skipped silently when memory store
@@ -227,6 +260,7 @@ export class PlannerLoopRunner {
           plan,
           criticErrors: critic.errors,
           smoke,
+          imageCheck,
           criticWarning: 'Plan has unresolved structural issues; retry could not be started. You can commit anyway or dismiss.',
           steps,
         };
@@ -237,6 +271,7 @@ export class PlannerLoopRunner {
         attempt: attemptsSoFar + 1,
         criticErrors: critic.errors,
         smoke,
+        imageCheck,
         phase: `Refining plan (attempt ${attemptsSoFar + 1})...`,
         steps,
       };
@@ -253,6 +288,7 @@ export class PlannerLoopRunner {
       plan,
       criticErrors: critic.errors,
       smoke,
+      imageCheck,
       criticWarning: `Planner could not produce a clean plan after ${attemptsSoFar} attempts. Review the issues below and either fix the YAML inline or commit anyway.`,
       steps,
     };

--- a/packages/core/src/planner-loop/types.ts
+++ b/packages/core/src/planner-loop/types.ts
@@ -1,4 +1,5 @@
 import type { BuildPlan, PlanCriticError } from '../index.js';
+import type { ImageCheckResult } from '../build-plan-image-check.js';
 import type { SmokeRunResult } from './eval-smoke-run.js';
 
 /**
@@ -41,6 +42,7 @@ export type LoopOutcome =
       criticErrors?: PlanCriticError[];
       criticWarning?: string;
       smoke?: SmokeRunResult;
+      imageCheck?: ImageCheckResult;
       steps: LoopStepRecord[];
     }
   | {
@@ -55,6 +57,7 @@ export type LoopOutcome =
       attempt: number;
       criticErrors: PlanCriticError[];
       smoke?: SmokeRunResult;
+      imageCheck?: ImageCheckResult;
       phase: string;
       steps: LoopStepRecord[];
     };

--- a/packages/core/src/widget-image-hosts.test.ts
+++ b/packages/core/src/widget-image-hosts.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractImgTagHosts,
+  unallowedWidgetImageHosts,
+  formatBlockedImageError,
+} from './widget-image-hosts.js';
+
+describe('extractImgTagHosts', () => {
+  it('pulls lowercased hosts from http(s) <img> srcs', () => {
+    const html =
+      '<img src="https://CDN.Example.com/a.png"> text <img src=\'http://other.io/b\'>';
+    expect(extractImgTagHosts(html).sort()).toEqual(['cdn.example.com', 'other.io']);
+  });
+
+  it('ignores data URIs and relative (same-origin) srcs', () => {
+    const html =
+      '<img src="data:image/png;base64,AAAA"><img src="/output-file?path=/x.png">';
+    expect(extractImgTagHosts(html)).toEqual([]);
+  });
+
+  it('de-dups repeated hosts', () => {
+    const html = '<img src="https://h/a.png"><img src="https://h/b.png">';
+    expect(extractImgTagHosts(html)).toEqual(['h']);
+  });
+});
+
+describe('unallowedWidgetImageHosts', () => {
+  const template = '<div><img src="{{outputs.image_url}}" alt="x"></div>';
+
+  it('returns [] when there is no ai-template widget', () => {
+    expect(unallowedWidgetImageHosts({
+      outputWidget: { type: 'dashboard', template },
+      permissions: { imgSrc: [] },
+      result: JSON.stringify({ image_url: 'https://blocked.example/x.png' }),
+    })).toEqual([]);
+  });
+
+  it('returns [] when there is no result', () => {
+    expect(unallowedWidgetImageHosts({
+      outputWidget: { type: 'ai-template', template },
+      permissions: { imgSrc: [] },
+      result: undefined,
+    })).toEqual([]);
+  });
+
+  it('flags a runtime image host not in permissions.imgSrc', () => {
+    const bad = unallowedWidgetImageHosts({
+      outputWidget: { type: 'ai-template', template },
+      permissions: { imgSrc: ['allowed.example'] },
+      result: JSON.stringify({ image_url: 'https://blocked.example/portrait.jpg' }),
+    });
+    expect(bad).toEqual(['blocked.example']);
+  });
+
+  it('passes when the runtime host IS allowlisted', () => {
+    expect(unallowedWidgetImageHosts({
+      outputWidget: { type: 'ai-template', template },
+      permissions: { imgSrc: ['upload.wikimedia.org'] },
+      result: JSON.stringify({ image_url: 'https://upload.wikimedia.org/a/b/x.jpg' }),
+    })).toEqual([]);
+  });
+
+  it('honours wildcard allowlist entries', () => {
+    expect(unallowedWidgetImageHosts({
+      outputWidget: { type: 'ai-template', template },
+      permissions: { imgSrc: ['*.wikimedia.org'] },
+      result: JSON.stringify({ image_url: 'https://upload.wikimedia.org/a/b/x.jpg' }),
+    })).toEqual([]);
+  });
+
+  it('returns [] when the rendered template has no external image', () => {
+    expect(unallowedWidgetImageHosts({
+      outputWidget: { type: 'ai-template', template: '<p>{{outputs.title}}</p>' },
+      permissions: {},
+      result: JSON.stringify({ title: 'hi' }),
+    })).toEqual([]);
+  });
+
+  it('recovers JSON from markdown-fenced output', () => {
+    const bad = unallowedWidgetImageHosts({
+      outputWidget: { type: 'ai-template', template },
+      permissions: {},
+      result: '```json\n{"image_url":"https://blocked.example/x.png"}\n```',
+    });
+    expect(bad).toEqual(['blocked.example']);
+  });
+
+  it('catches a hardcoded blocked host in the template itself', () => {
+    expect(unallowedWidgetImageHosts({
+      outputWidget: { type: 'ai-template', template: '<img src="https://hard.example/logo.png">' },
+      permissions: { imgSrc: [] },
+      result: '{}',
+    })).toEqual(['hard.example']);
+  });
+});
+
+describe('formatBlockedImageError', () => {
+  it('names a single host with singular phrasing', () => {
+    const msg = formatBlockedImageError(['blocked.example']);
+    expect(msg).toMatch(/image host not allowed/);
+    expect(msg).toMatch(/blocked\.example/);
+    expect(msg).toMatch(/permissions\.imgSrc/);
+  });
+
+  it('names multiple hosts with plural phrasing', () => {
+    const msg = formatBlockedImageError(['a.example', 'b.example']);
+    expect(msg).toMatch(/image hosts not allowed/);
+    expect(msg).toMatch(/a\.example, b\.example/);
+  });
+});

--- a/packages/core/src/widget-image-hosts.ts
+++ b/packages/core/src/widget-image-hosts.ts
@@ -1,0 +1,120 @@
+/**
+ * Runtime image-host guard for ai-template output widgets.
+ *
+ * The page CSP only permits `<img>` loads from hosts an agent declares in
+ * `permissions.imgSrc` (merged into the dashboard's `img-src` directive). The
+ * build-time critic (`build-plan-critic.ts`) checks *hardcoded* template hosts,
+ * but an ai-template usually pulls its image URL from a runtime output value
+ * (`<img src="{{outputs.image_url}}">`). If that value resolves to a host the
+ * agent never allowlisted, the browser silently blocks the image and the
+ * run-detail auto-poll re-fires the violation on every refresh.
+ *
+ * This module computes — from the finished run's result + the agent's template —
+ * exactly which image hosts the rendered widget will reference, and which of
+ * those aren't allowlisted. The executor uses it to fail such a run with an
+ * actionable error (rather than ship output that can't render safely); the
+ * run-detail view uses it to suppress the broken widget and offer one-click
+ * "Allow host".
+ */
+
+import { substitutePlaceholders } from './html-sanitizer.js';
+
+/**
+ * Extract the lowercased host of every `<img src="http(s)://...">` in rendered
+ * HTML. Mirrors what the browser's CSP `img-src` check sees. Data URIs and
+ * same-origin (relative) srcs are ignored — they don't hit an external host.
+ */
+export function extractImgTagHosts(html: string): string[] {
+  const hosts = new Set<string>();
+  const re = /<img\b[^>]*\bsrc\s*=\s*["']\s*(https?:\/\/[^"'\s>]+)/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html)) !== null) {
+    try {
+      hosts.add(new URL(m[1]).hostname.toLowerCase());
+    } catch {
+      /* unparseable URL — skip */
+    }
+  }
+  return [...hosts];
+}
+
+/** Does `host` match an allowlist entry, honouring `*.example.com` wildcards? */
+function hostAllowed(host: string, allow: Set<string>): boolean {
+  if (allow.has(host)) return true;
+  for (const d of allow) {
+    if (d.startsWith('*.') && host.endsWith(d.slice(1))) return true;
+  }
+  return false;
+}
+
+/**
+ * Best-effort parse of an agent's output as a JSON object so `{{outputs.X}}`
+ * placeholders resolve. Tolerates markdown fences and prose-wrapped JSON, the
+ * same recovery the widget renderer applies. Returns `{}` when nothing parses.
+ */
+function parseOutputObject(output: string): Record<string, unknown> {
+  const tryParse = (s: string): Record<string, unknown> | undefined => {
+    try {
+      const v = JSON.parse(s);
+      return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : undefined;
+    } catch {
+      return undefined;
+    }
+  };
+  const direct = tryParse(output.trim());
+  if (direct) return direct;
+  const fence = output.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fence) {
+    const fenced = tryParse(fence[1].trim());
+    if (fenced) return fenced;
+  }
+  const brace = output.match(/\{[\s\S]*\}/);
+  if (brace) {
+    const braced = tryParse(brace[0]);
+    if (braced) return braced;
+  }
+  return {};
+}
+
+export interface WidgetImageHostInput {
+  outputWidget?: { type?: string; template?: string };
+  permissions?: { imgSrc?: string[] };
+  result: string | null | undefined;
+}
+
+/**
+ * Return the image hosts an ai-template widget would render that are NOT
+ * covered by `permissions.imgSrc`. Empty when there's no ai-template widget,
+ * no result, the template references no external images, or every referenced
+ * host is already allowlisted.
+ */
+export function unallowedWidgetImageHosts(input: WidgetImageHostInput): string[] {
+  const { outputWidget, permissions, result } = input;
+  if (!outputWidget || outputWidget.type !== 'ai-template' || !outputWidget.template) return [];
+  if (!result) return [];
+
+  const outputs = parseOutputObject(result);
+  const rendered = substitutePlaceholders(outputWidget.template, { outputs, result });
+  const hosts = extractImgTagHosts(rendered);
+  if (hosts.length === 0) return [];
+
+  const allow = new Set((permissions?.imgSrc ?? []).map((h) => h.toLowerCase()));
+  const bad: string[] = [];
+  for (const h of hosts) {
+    if (!hostAllowed(h, allow)) bad.push(h);
+  }
+  return bad;
+}
+
+/**
+ * The run-error string for a run whose widget output references blocked image
+ * hosts. Written to be actionable in the dashboard's Error block.
+ */
+export function formatBlockedImageError(hosts: string[]): string {
+  const list = hosts.join(', ');
+  const one = hosts.length === 1;
+  return (
+    `Widget output references image host${one ? '' : 's'} not allowed by the page security policy: ${list}. ` +
+    `Add ${one ? 'it' : 'them'} to the agent's permissions.imgSrc (or click "Allow" on the run page), then re-run.`
+  );
+}

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -982,6 +982,24 @@ main.main--wide {
 .pulse-tile--1x2 { grid-row: span 2; }
 .pulse-tile--2x2 { grid-column: span 2; grid-row: span 2; }
 
+/* ── Widget tile fit (outputWidget.tileFit) ───────────────────────────────
+ * Controls a widget tile's HEIGHT when its content is taller than the slot.
+ * Width is always the dashboard-defined grid column. The full run/agent view
+ * is unaffected (it never gets these classes). */
+
+/* grow (default): the tile is as tall as its widget — no cap, no scroll. */
+.pulse-tile--fit-grow { max-height: none; }
+.pulse-tile--fit-grow .pulse-tile__body { overflow: visible; }
+
+/* scroll: cap the tile height and scroll the overflow — the base .pulse-tile
+ * (max-height + .pulse-tile__body overflow-y:auto) already does this, so no
+ * extra rules are needed. */
+
+/* fixed-h: the tile was given an explicit dragged height (snapped to a grid
+ * unit) via the resize handle. The inline height/max-height pins it and the
+ * body scrolls anything taller. Overrides the grow body's overflow:visible. */
+.pulse-tile--fixed-h .pulse-tile__body { overflow-y: auto; }
+
 .pulse-tile__header {
   display: flex;
   align-items: center;

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -375,6 +375,117 @@ describe('Dashboard /runs/:id per-node table', () => {
     expect(res.text).toContain('Non-zero exit code');
     // The DAG viz should render here too
     expect(res.text).toContain('id="dag-canvas"');
+    // Poll-reconciliation regions: the live poll updates these by name instead
+    // of replacing the whole container. The DAG is a preserve region (canvas
+    // kept across polls); the node cards are their own region so the search
+    // controls (outside it) keep their listeners.
+    expect(res.text).toContain('data-poll-region="dag"');
+    expect(res.text).toContain('data-poll-preserve');
+    expect(res.text).toContain('data-poll-region="nodes"');
+    expect(res.text).toContain('data-poll-region="meta"');
+    expect(res.text).toContain('data-poll-region="status"');
+  });
+
+  it('wires the live poll to re-render the DAG for a running run', async () => {
+    // Regression: the DAG canvas went blank ~2s into a run because the poll
+    // swaps in a fresh fragment via innerHTML (whose <script> tags never
+    // execute), so the cytoscape bootstrap never re-ran. The page must (a)
+    // arm the poll and (b) re-invoke the persisted renderDagViz after the swap.
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'live', name: 'Live', status: 'active', source: 'local', mcp: false,
+      nodes: [
+        { id: 'a', type: 'shell', command: 'echo 1' },
+        { id: 'b', type: 'shell', command: 'echo 2', dependsOn: ['a'] },
+      ],
+    }, 'cli');
+    const now = new Date().toISOString();
+    runStore.createRun({
+      id: 'run-live', agentName: 'live', status: 'running', startedAt: now, triggeredBy: 'cli',
+      workflowId: 'live', workflowVersion: 1,
+    });
+
+    const res = await request(app).get('/runs/run-live')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('id="dag-canvas"');
+    // Poll is armed for the in-progress run.
+    expect(res.text).toContain('data-run-in-progress="run-live"');
+    // The poll re-invokes the persisted bootstrap after replacing the container.
+    expect(res.text).toContain('window.renderDagViz()');
+    // The CSP-allow banner must mount OUTSIDE [data-run-container] (a sibling in
+    // the stable parent), so the poll's replaceWith doesn't destroy the "Allow"
+    // button mid-run. Guards against re-introducing the inside-container mount.
+    expect(res.text).toContain('data-csp-agent="live"');
+    expect(res.text).toContain('container.parentNode.insertBefore(banner, container)');
+  });
+
+  it('hides the widget and renders a server-side Allow form when output references a blocked image host', async () => {
+    // Root-cause path: the executor fails such a run; the view must hide the
+    // widget (so the blocked <img> never renders / re-fires the CSP violation)
+    // and render a server-side one-click Allow form for the known host — not
+    // relying on client JS, since the hidden widget fires no CSP violation.
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'blocked', name: 'Blocked', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'main', type: 'shell', command: 'echo hi' }],
+      outputWidget: { type: 'ai-template', template: '<div><img src="{{outputs.image_url}}"></div>' },
+      permissions: { imgSrc: ['allowed.example'] },
+    }, 'cli');
+    const now = new Date().toISOString();
+    runStore.createRun({
+      id: 'run-blocked', agentName: 'blocked', status: 'failed', startedAt: now, completedAt: now,
+      triggeredBy: 'cli', workflowId: 'blocked', workflowVersion: 1,
+      result: JSON.stringify({ image_url: 'https://blocked.example/portrait.jpg' }),
+      error: 'Widget output references image host not allowed by the page security policy: blocked.example.',
+    });
+
+    const res = await request(app).get('/runs/run-blocked')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    // The widget (and its blocked <img>) must NOT be rendered.
+    expect(res.text).not.toContain('blocked.example/portrait.jpg');
+    expect(res.text).toContain('Output widget hidden');
+    // A server-rendered Allow form targets the allow-host endpoint with the host.
+    expect(res.text).toContain('action="/agents/blocked/permissions/allow-host"');
+    expect(res.text).toContain('value="blocked.example"');
+    expect(res.text).toContain('Allow blocked.example');
+  });
+
+  it('allow-host form POST adds the host and redirects back to the run', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'allowme', name: 'AllowMe', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'main', type: 'shell', command: 'echo hi' }],
+      outputWidget: { type: 'ai-template', template: '<img src="{{outputs.u}}">' },
+    }, 'cli');
+    const res = await request(app).post('/agents/allowme/permissions/allow-host')
+      .type('form')
+      .send({ host: 'apod.nasa.gov', redirect: '/runs/whatever' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toBe('/runs/whatever');
+    const updated = agentStore.getAgent('allowme');
+    expect(updated?.permissions?.imgSrc).toContain('apod.nasa.gov');
+  });
+
+  it('allow-host form POST refuses an off-site redirect', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'allowme2', name: 'AllowMe2', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'main', type: 'shell', command: 'echo hi' }],
+    }, 'cli');
+    const res = await request(app).post('/agents/allowme2/permissions/allow-host')
+      .type('form')
+      .send({ host: 'apod.nasa.gov', redirect: 'https://evil.example/' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    // Non-`/` redirect is ignored → falls back to the JSON contract.
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
   });
 
   it('does not render the per-node table for a v1 run', async () => {
@@ -424,6 +535,11 @@ describe('Dashboard static assets', () => {
     expect(res.headers['content-type']).toMatch(/javascript/);
     expect(res.text).toContain('cytoscape');
     expect(res.text).toContain('dag-canvas');
+    // The bootstrap must be a re-callable global (not a bare IIFE) and invoke
+    // itself once on load, so the run-detail auto-poll can re-render the DAG
+    // after each DOM swap. Regression guard for the "blank DAG mid-run" bug.
+    expect(res.text).toContain('window.renderDagViz = function');
+    expect(res.text).toContain('window.renderDagViz();');
   });
 
   it('serves /assets/cytoscape.min.js', async () => {

--- a/packages/dashboard/src/routes/agent-inputs.ts
+++ b/packages/dashboard/src/routes/agent-inputs.ts
@@ -458,6 +458,11 @@ agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res:
     ? parsedActions
     : actionsEdited ? [] : prevActions;
 
+  // Tile fit: how the widget tile's height behaves when taller than its slot.
+  // `grow` is the default, so only persist `scroll` to keep the YAML clean.
+  const tileFit: 'grow' | 'scroll' = body.widget_tileFit === 'scroll' ? 'scroll' : 'grow';
+  const tileFitField = tileFit !== 'grow' ? { tileFit } : {};
+
   let outputWidget: OutputWidgetSchema;
   if (widgetType === 'ai-template') {
     const rawTemplate = typeof body.template === 'string' ? body.template : '';
@@ -478,6 +483,7 @@ agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res:
       ...(interactive && replayLabel ? { replayLabel } : {}),
       ...(controls?.length ? { controls } : {}),
       ...(actions?.length ? { actions } : {}),
+      ...tileFitField,
     };
   } else {
     // Typed widgets (dashboard / key-value / diff-apply / raw) are
@@ -511,6 +517,7 @@ agentInputsRouter.post('/agents/:name/output-widget/update', (req: Request, res:
       ...(interactive && replayLabel ? { replayLabel } : {}),
       ...(controls?.length ? { controls } : {}),
       ...(actions?.length ? { actions } : {}),
+      ...tileFitField,
     };
   }
 

--- a/packages/dashboard/src/routes/assets.ts
+++ b/packages/dashboard/src/routes/assets.ts
@@ -117,13 +117,28 @@ const DASHBOARD_CSS = loadDashboardCss();
  *     pattern, status colors override type.
  */
 const GRAPH_RENDER_JS = `
-(function () {
+// Exposed as a named global (not a bare IIFE) so the run-detail auto-poll can
+// re-run it after it swaps in a fresh [data-run-container] fragment. Scripts
+// injected via innerHTML never execute, so without an explicit re-invocation
+// the freshly-swapped #dag-canvas would stay blank for the rest of the run.
+window.renderDagViz = function () {
   var el = document.getElementById('dag-canvas');
   var dataEl = document.getElementById('dag-data');
   if (!el || !dataEl || typeof window.cytoscape !== 'function') return;
 
+  // Re-render only when the data actually changed. The run-detail poll keeps
+  // the SAME #dag-canvas element across updates and just refreshes #dag-data,
+  // so we signature-check the data: identical → no-op (no flicker), changed →
+  // tear down the prior cytoscape instance and re-render into the same element.
+  var sig = dataEl.textContent || '';
+  if (el.__dagSig === sig) return;
+  el.__dagSig = sig;
+  if (el.__pulseTimer) { clearInterval(el.__pulseTimer); el.__pulseTimer = null; }
+  if (el.__ro) { try { el.__ro.disconnect(); } catch (e) { /* ignore */ } el.__ro = null; }
+  if (el.__cy) { try { el.__cy.destroy(); } catch (e) { /* ignore */ } el.__cy = null; }
+
   var payload;
-  try { payload = JSON.parse(dataEl.textContent); } catch (e) { return; }
+  try { payload = JSON.parse(sig); } catch (e) { return; }
 
   // Status tints — mirror tokens.css (--color-*-soft for fill, --color-*
   // for border + text). Run-detail nodes use these.
@@ -229,7 +244,42 @@ const GRAPH_RENDER_JS = `
     userPanningEnabled: false,
     boxSelectionEnabled: false,
   });
+  el.__cy = cy;
   cy.fit(undefined, 18);
+
+  // Cytoscape does NOT auto-resize. If the initial fit ran before the canvas
+  // reached its final size (sticky grid settling, fonts loading, a parent
+  // <details> opening, window resize), the viewport stays zoomed to a stale box
+  // and the outer nodes get clipped — the classic "only the middle node shows"
+  // symptom. Re-fit whenever the canvas resizes. The observer fires once on
+  // observe(), which also corrects a too-early initial fit.
+  if (typeof ResizeObserver === 'function') {
+    el.__ro = new ResizeObserver(function () {
+      if (!el.__cy || (el.__cy.destroyed && el.__cy.destroyed())) return;
+      el.__cy.resize();
+      el.__cy.fit(undefined, 18);
+    });
+    el.__ro.observe(el);
+  }
+
+  // Pulse any node that's currently running so it's obvious at a glance which
+  // step is live. A glowing halo (underlay) + breathing border loops via an
+  // interval owned by this canvas; it's cleared when renderDagViz re-renders
+  // (e.g. when the node finishes and the run-detail poll refreshes #dag-data),
+  // so the pulse always tracks the node that's actually running right now.
+  var runningNodes = cy.nodes().filter(function (n) { return n.data('status') === 'running'; });
+  if (runningNodes.length > 0) {
+    runningNodes.style({ 'underlay-color': '#2563eb', 'underlay-padding': 6, 'underlay-opacity': 0.15 });
+    var pulseBig = false;
+    el.__pulseTimer = setInterval(function () {
+      if (!el.__cy || (el.__cy.destroyed && el.__cy.destroyed())) { clearInterval(el.__pulseTimer); el.__pulseTimer = null; return; }
+      pulseBig = !pulseBig;
+      runningNodes.animate(
+        { style: { 'underlay-opacity': pulseBig ? 0.4 : 0.12, 'border-width': pulseBig ? 4 : 1 } },
+        { duration: 600, easing: 'ease-in-out-sine' },
+      );
+    }, 700);
+  }
 
   // Click a node → open the node-action dialog with Edit + Replay buttons
   // and metadata pulled from the same Cytoscape payload. When no dialog
@@ -530,7 +580,11 @@ const GRAPH_RENDER_JS = `
       if (navBase) window.location.hash = 'node-' + encodeURIComponent(data.id);
     }
   });
-})();
+};
+
+// Render once on initial page load. On the auto-polled run-detail page the
+// poll calls window.renderDagViz() again after each DOM swap (see js.ts).
+window.renderDagViz();
 `;
 
 export const assetsRouter: Router = Router();
@@ -545,14 +599,19 @@ assetsRouter.get('/assets/cytoscape.min.js', (_req: Request, res: Response) => {
 });
 
 assetsRouter.get('/assets/graph-render.js', (_req: Request, res: Response) => {
-  // Short cache (5m) for our own bootstrap — during local dev we tweak
-  // node styling and want changes visible on refresh without a hard
-  // reload. Cytoscape itself stays on immutable since it's vendored.
-  res.setHeader('Cache-Control', 'public, max-age=300');
+  // `no-cache` = revalidate on every load (Express still sends an ETag, so an
+  // unchanged file 304s — cheap). max-age=300 previously served a stale copy
+  // for up to 5 minutes after a deploy, so DAG behaviour fixes appeared not to
+  // land without a hard reload. The file is tiny; correctness beats caching it.
+  res.setHeader('Cache-Control', 'no-cache');
   res.type('application/javascript').send(GRAPH_RENDER_JS);
 });
 
 assetsRouter.get('/assets/dashboard.css', (_req: Request, res: Response) => {
-  res.setHeader('Cache-Control', 'public, max-age=300');
+  // `no-cache` (revalidate every load; Express sends an ETag so unchanged = 304).
+  // max-age=300 served stale CSS for up to 5 min after a deploy, so layout
+  // fixes appeared not to land — and a stale stylesheet against fresh markup
+  // (e.g. new tile-fit classes without their rules) can break the grid.
+  res.setHeader('Cache-Control', 'no-cache');
   res.type('text/css').send(DASHBOARD_CSS);
 });

--- a/packages/dashboard/src/routes/build-orchestrator.ts
+++ b/packages/dashboard/src/routes/build-orchestrator.ts
@@ -31,6 +31,10 @@ import {
   buildPlanSchema,
   critiquePlan,
   formatCriticFeedback,
+  extractImageUrls,
+  findDeadImageUrls,
+  defaultCheckImageUrl,
+  formatDeadImageFeedback,
   type Agent,
   type BuildPlan,
   type Draft,
@@ -541,14 +545,28 @@ async function advanceDrafting(ctx: Ctx, session: BuildSession): Promise<void> {
     });
     if (synthetic.success) {
       const critique = critiquePlan(synthetic.data, { existingAgentIds: existingAgentIds(ctx) });
-      if (!critique.ok) {
+      // Image-link check: HEAD every hardcoded image URL the drafter baked
+      // into this agent. Dead links (404/410) sail past the structural critic
+      // — the host is CSP-allowlisted — but render broken images at runtime,
+      // so they retry on the same footing as structural errors. Inconclusive
+      // results (network error / 403 / 429) are not flagged.
+      const deadImages = await findDeadImageUrls(extractImageUrls(fixedYaml), { checkUrl: defaultCheckImageUrl });
+      if (!critique.ok || deadImages.length > 0) {
         const attempts = session.drafterAttempts.get(key) ?? 1;
         if (attempts < MAX_DRAFT_ATTEMPTS) {
-          retries.push({ key, feedback: formatCriticFeedback(critique.errors) });
+          const feedback = [
+            critique.ok ? '' : formatCriticFeedback(critique.errors),
+            deadImages.length > 0 ? formatDeadImageFeedback(deadImages) : '',
+          ].filter(Boolean).join('\n\n');
+          retries.push({ key, feedback });
           continue;
         }
-        // Exhausted budget — surface the critic errors as the failure.
-        failedFragments.push(`${key}: critic (after ${attempts} attempts) — ${critique.errors.map((e) => e.message).join(' | ')}`);
+        // Exhausted budget — surface whatever rejected the draft.
+        const reasons = [
+          ...(critique.ok ? [] : critique.errors.map((e) => e.message)),
+          ...deadImages.map((d) => `dead image ${d.url} (HTTP ${d.status})`),
+        ];
+        failedFragments.push(`${key}: critic (after ${attempts} attempts) — ${reasons.join(' | ')}`);
         continue;
       }
     }

--- a/packages/dashboard/src/routes/run-now-build.ts
+++ b/packages/dashboard/src/routes/run-now-build.ts
@@ -14,6 +14,7 @@ import {
   buildDiscoveryCatalog,
   buildPlanSchema,
   PlannerLoopRunner,
+  defaultCheckImageUrl,
   findSimilarCommittedPlans,
   formatPriorPlansBlock,
   type PriorPlanCandidate,
@@ -938,6 +939,7 @@ buildRouter.get('/agents/build/:runId', async (req: Request, res: Response) => {
         } catch { /* tool store unavailable */ }
         return builtinIds;
       },
+      checkImageUrl: defaultCheckImageUrl,
       memoryStore: ctx.plannerMemoryStore,
       maxRetries: MAX_CRITIC_RETRIES,
     });

--- a/packages/dashboard/src/routes/versions.ts
+++ b/packages/dashboard/src/routes/versions.ts
@@ -415,9 +415,20 @@ versionsRouter.post('/agents/:id/permissions/allow-host', (req: Request, res: Re
   const body = (req.body ?? {}) as Record<string, unknown>;
   const raw = typeof body.host === 'string' ? body.host : '';
 
+  // Two callers: the client banner's `fetch` (wants JSON) and the
+  // server-rendered Allow form on a failed run (a plain POST that needs a
+  // redirect back). When the form supplies a same-origin `redirect` path we
+  // answer with a 303; otherwise we keep the JSON contract. Only `/`-relative
+  // paths are honoured (no open redirect).
+  const redirectTo = typeof body.redirect === 'string' && body.redirect.startsWith('/') ? body.redirect : null;
+  const fail = (status: number, error: string): void => {
+    if (redirectTo) { res.redirect(303, redirectTo); return; }
+    res.status(status).json({ ok: false, error });
+  };
+
   const agent = ctx.agentStore.getAgent(id);
   if (!agent) {
-    res.status(404).json({ ok: false, error: 'Agent not found.' });
+    fail(404, 'Agent not found.');
     return;
   }
 
@@ -426,12 +437,13 @@ versionsRouter.post('/agents/:id/permissions/allow-host', (req: Request, res: Re
   const host = raw.trim().toLowerCase()
     .replace(/^https?:\/\//, '').replace(/\/.*$/, '').replace(/:\d+$/, '');
   if (!host || !IMG_SRC_HOST_RE.test(host)) {
-    res.status(400).json({ ok: false, error: `Invalid host: ${raw || '(empty)'}` });
+    fail(400, `Invalid host: ${raw || '(empty)'}`);
     return;
   }
 
   const current = agent.permissions?.imgSrc ?? [];
   if (current.includes(host)) {
+    if (redirectTo) { res.redirect(303, redirectTo); return; }
     res.json({ ok: true, host, imgSrc: current, unchanged: true });
     return;
   }
@@ -439,8 +451,9 @@ versionsRouter.post('/agents/:id/permissions/allow-host', (req: Request, res: Re
   try {
     const updated = { ...agent, permissions: { ...agent.permissions, imgSrc } };
     ctx.agentStore.upsertAgent(updated, 'dashboard', `Allowed img-src host ${host}`);
+    if (redirectTo) { res.redirect(303, redirectTo); return; }
     res.json({ ok: true, host, imgSrc });
   } catch (err) {
-    res.status(500).json({ ok: false, error: err instanceof Error ? err.message : String(err) });
+    fail(500, err instanceof Error ? err.message : String(err));
   }
 });

--- a/packages/dashboard/src/views/agent-detail-helpers.ts
+++ b/packages/dashboard/src/views/agent-detail-helpers.ts
@@ -460,6 +460,17 @@ export function renderOutputWidgetEditor(agent: Agent): SafeHtml {
             </label>
           </div>
         </div>
+
+        <div style="margin-top: var(--space-3); padding-top: var(--space-3); border-top: 1px solid var(--color-border);">
+          <label style="font-size: var(--font-size-xs); display: flex; flex-direction: column; gap: 2px; max-width: 30rem;">
+            <strong>Tile fit</strong>
+            <span class="dim">How this widget fits a Pulse/dashboard tile when it's taller than the slot. The full run/agent view always shows it at 100%.</span>
+            <select name="widget_tileFit" style="${FIELD} width: 22rem; margin-top: 4px;">
+              <option value="grow" ${(widget?.tileFit ?? 'grow') === 'grow' ? 'selected' : ''}>Grow (default) — tile grows vertically to the widget's height</option>
+              <option value="scroll" ${widget?.tileFit === 'scroll' ? 'selected' : ''}>Scroll — cap tile height, scroll the overflow</option>
+            </select>
+          </label>
+        </div>
       </div>
 
       <div style="display: flex; gap: var(--space-2); justify-content: space-between; align-items: center; flex-wrap: wrap; margin-bottom: var(--space-3);">

--- a/packages/dashboard/src/views/csp-allow.js.ts
+++ b/packages/dashboard/src/views/csp-allow.js.ts
@@ -42,9 +42,19 @@ export const CSP_ALLOW_JS = `
       banner = document.createElement('div');
       banner.className = 'flash flash--info';
       banner.style.cssText = 'margin: var(--space-3) 0; display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-3); flex-wrap: wrap;';
-      // Mount just above the run container so it's visible near the result.
-      var anchor = document.querySelector('[data-run-container]') || document.body;
-      anchor.insertBefore(banner, anchor.firstChild);
+      // Mount just ABOVE the run container, as a sibling in its stable parent
+      // — NOT inside it. The run-detail auto-poll replaces the entire
+      // [data-run-container] every ~2s (replaceWith); a banner mounted inside
+      // would be destroyed on the first poll, and the violation listener's
+      // host-dedupe (blockedHosts) then suppresses re-rendering — so the Allow
+      // button would vanish mid-run and never return. Mounting outside the
+      // swapped subtree keeps it alive across polls.
+      var container = document.querySelector('[data-run-container]');
+      if (container && container.parentNode) {
+        container.parentNode.insertBefore(banner, container);
+      } else {
+        document.body.insertBefore(banner, document.body.firstChild);
+      }
     }
     var chips = hosts.map(function (h) {
       return '<code style="font-size:var(--font-size-xs);background:var(--color-surface-raised);padding:0 var(--space-1);border-radius:var(--radius-sm);">' + esc(h) + '</code>';
@@ -104,7 +114,16 @@ export const CSP_ALLOW_JS = `
     var host = hostFromUri(e.blockedURI);
     if (!host || blockedHosts[host]) return;
     blockedHosts[host] = true;
+    // Signal the run-detail auto-poll to pause — re-rendering won't help until
+    // the host is allowed (a reload), and continuing would re-fire this
+    // violation on every 2s refresh (the "recursive content fail" spam).
+    window.__suaCspPaused = true;
     renderBanner();
   });
+
+  // NOTE: when a run is *failed* because its widget references blocked image
+  // hosts, the widget is hidden server-side (so no violation fires here) and
+  // the run-detail view renders its own one-click "Allow host" form. This
+  // listener handles only live violations on rendered widgets (residual cases).
 })();
 `;

--- a/packages/dashboard/src/views/js.ts
+++ b/packages/dashboard/src/views/js.ts
@@ -242,6 +242,51 @@ export const DASHBOARD_JS = `
   if (runDetail) {
     var runId = runDetail.getAttribute('data-run-in-progress');
     var finalPollCount = 0;
+
+    // Reconcile only the regions that changed instead of replacing the whole
+    // [data-run-container]. Replacing the container nuked transient client
+    // state every 2s — the cytoscape canvas, focused inputs, the node filter,
+    // scroll position. Each updatable area is tagged data-poll-region="<name>";
+    // we swap a region only when its content actually changed, skip any region
+    // the user is interacting with, and special-case the DAG (data-poll-preserve)
+    // so its canvas element is kept and only its #dag-data is refreshed.
+    var reconcileRun = function (current, fresh) {
+      var regions = fresh.querySelectorAll('[data-poll-region]');
+      for (var i = 0; i < regions.length; i++) {
+        var fr = regions[i];
+        var name = fr.getAttribute('data-poll-region');
+        var cur = current.querySelector('[data-poll-region="' + name + '"]');
+        if (!cur) continue;
+        if (cur.hasAttribute('data-poll-preserve')) {
+          // DAG: keep the canvas (and its cytoscape instance); just refresh the
+          // embedded #dag-data and let renderDagViz re-render on data change.
+          var curData = cur.querySelector('#dag-data');
+          var frData = fr.querySelector('#dag-data');
+          if (curData && frData && curData.textContent !== frData.textContent) {
+            curData.textContent = frData.textContent;
+          }
+          if (typeof window.renderDagViz === 'function') window.renderDagViz();
+          continue;
+        }
+        // Don't disrupt a region the user is actively interacting with (e.g.
+        // typing in the node search box that lives next to the cards).
+        if (document.activeElement && cur.contains(document.activeElement)) continue;
+        if (cur.isEqualNode(fr)) continue; // unchanged — preserve the DOM
+        cur.replaceWith(fr);
+        // The node filter's listeners live on the (non-swapped) controls; after
+        // swapping in new cards, re-apply the active filter so they obey it.
+        if (name === 'nodes' && typeof window.__suaApplyNodeFilter === 'function') {
+          window.__suaApplyNodeFilter();
+        }
+      }
+      // Keep the container's own in-progress marker current for the next tick.
+      if (fresh.hasAttribute('data-run-in-progress')) {
+        current.setAttribute('data-run-in-progress', fresh.getAttribute('data-run-in-progress'));
+      } else {
+        current.removeAttribute('data-run-in-progress');
+      }
+    };
+
     var poll = function () {
       fetch('/runs/' + encodeURIComponent(runId) + '?partial=1', { credentials: 'same-origin' })
         .then(function (r) { return r.ok ? r.text() : Promise.reject(r.status); })
@@ -251,8 +296,12 @@ export const DASHBOARD_JS = `
           var fresh = placeholder.querySelector('[data-run-container]');
           var current = document.querySelector('[data-run-container]');
           if (fresh && current) {
-            current.replaceWith(fresh);
-            if (fresh.querySelector('[data-run-in-progress]')) {
+            reconcileRun(current, fresh);
+            // Pause live updates once a CSP image violation has been detected:
+            // re-rendering can't fix it (needs an Allow + reload) and would just
+            // re-fire the violation every 2s.
+            if (window.__suaCspPaused) return;
+            if (fresh.hasAttribute('data-run-in-progress')) {
               // Still in progress — keep polling.
               finalPollCount = 0;
               setTimeout(poll, 2000);

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -15,6 +15,7 @@ import { WIDGET_REPLAY_INPLACE_JS } from './widget-replay.js.js';
 import { PAGE_INTRO_JS } from './page-intro.js.js';
 import { ADD_TILE_MODAL_JS } from './add-tile-modal.js.js';
 import { CSP_ALLOW_JS } from './csp-allow.js.js';
+import { WIDGET_IMG_FALLBACK_JS } from './widget-img-fallback.js.js';
 import { footer } from './footer.js';
 
 export interface LayoutOptions {
@@ -75,7 +76,7 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
   ${body}
 </main>
 ${footer()}
-<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + HOME_LAYOUT_JS + DASHBOARDS_LAYOUT_JS + BUILD_FROM_GOAL_JS + IMPROVE_LAYOUT_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS + WIDGET_REPLAY_INPLACE_JS + PAGE_INTRO_JS + ADD_TILE_MODAL_JS + CSP_ALLOW_JS)}</script>
+<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + HOME_LAYOUT_JS + DASHBOARDS_LAYOUT_JS + BUILD_FROM_GOAL_JS + IMPROVE_LAYOUT_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS + WIDGET_REPLAY_INPLACE_JS + PAGE_INTRO_JS + ADD_TILE_MODAL_JS + CSP_ALLOW_JS + WIDGET_IMG_FALLBACK_JS)}</script>
 </body>
 </html>`;
 }

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -53,8 +53,15 @@ export function tileWrap(
   // visible bottom edge. The `pulse-tile__body` wrapper is the same
   // class the home widgets already use; the CSS lets it `flex: 1` and
   // own the overflow.
+  // Tile fit: how a widget taller than its slot behaves. Width is always the
+  // dashboard-defined grid column; tileFit only controls height.
+  //   `grow` (default) — the tile grows vertically to the widget's height.
+  //   `scroll` — cap the tile height and scroll the overflow.
+  const fit = tile.agent.outputWidget ? (tile.agent.outputWidget.tileFit ?? 'grow') : null;
+  const fitClass = fit ? ` pulse-tile--fit-${fit}` : '';
+
   return unsafeHtml(
-    `<div class="pulse-tile ${sizeClass(sizeAttr)}" data-agent-id="${esc(tile.agent.id)}" data-tile-size="${esc(sizeAttr)}"${paletteAttr}${accentAttr}>` +
+    `<div class="pulse-tile ${sizeClass(sizeAttr)}${fitClass}" data-agent-id="${esc(tile.agent.id)}" data-tile-size="${esc(sizeAttr)}"${paletteAttr}${accentAttr}>` +
     tileHeader(tile, isSystem, ctx).toString() +
     `<div class="pulse-tile__body">` +
     content.toString() +

--- a/packages/dashboard/src/views/run-detail-filter.js.ts
+++ b/packages/dashboard/src/views/run-detail-filter.js.ts
@@ -42,5 +42,10 @@ export const RUN_DETAIL_FILTER_JS = `
 
     if (searchInput) searchInput.addEventListener('input', filterNodes);
     if (statusSelect) statusSelect.addEventListener('change', filterNodes);
+
+    // The search/select controls live OUTSIDE the swapped node-cards region, so
+    // these listeners survive a live poll. Expose the filter so the poll can
+    // re-apply the active query/status to freshly-swapped cards.
+    window.__suaApplyNodeFilter = filterNodes;
   })();
 `;

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -1,4 +1,5 @@
 import type { Agent, NodeExecutionRecord, Run } from '@some-useful-agents/core';
+import { unallowedWidgetImageHosts } from '@some-useful-agents/core';
 import { html, render, unsafeHtml, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader, type PageHeaderBack } from './page-header.js';
@@ -30,6 +31,41 @@ export function renderRunDetail(opts: RunDetailOptions): string {
   const pollAttr = inProgress ? unsafeHtml(` data-run-in-progress="${run.id}"`) : unsafeHtml('');
 
   const isDagRun = run.workflowId && nodeExecutions && agent;
+
+  // Image hosts the widget would render that aren't in permissions.imgSrc.
+  // When non-empty, the executor failed the run for exactly this reason. We
+  // hide the widget here so the blocked <img> never renders (and never
+  // re-fires the CSP violation the poll would otherwise spam), and render a
+  // server-side one-click "Allow" form per host. Server-rendered (not the
+  // client CSP banner) so it works even though the hidden widget fires no
+  // violation — the failed run already knows the exact hosts.
+  const blockedImageHosts = agent
+    ? unallowedWidgetImageHosts({
+        outputWidget: agent.outputWidget,
+        permissions: agent.permissions,
+        result: run.result,
+      })
+    : [];
+  const widgetBlocked = blockedImageHosts.length > 0;
+  const allowForms = blockedImageHosts.map((host) => html`
+    <form method="POST" action="/agents/${run.agentName}/permissions/allow-host" style="display: inline; margin: 0;">
+      <input type="hidden" name="host" value="${host}">
+      <input type="hidden" name="redirect" value="/runs/${run.id}">
+      <button type="submit" class="btn btn--sm btn--primary">Allow ${host}</button>
+    </form>
+  `);
+  const widgetHiddenNotice = html`
+    <div class="flash flash--error">
+      <div style="font-size: var(--font-size-xs); margin-bottom: var(--space-2);">
+        Output widget hidden — it references ${String(blockedImageHosts.length)} image host${blockedImageHosts.length === 1 ? '' : 's'}
+        not allowed by the page security policy. Allow ${blockedImageHosts.length === 1 ? 'it' : 'them'}
+        (adds to the agent's <code>permissions.imgSrc</code> as a new version), then <strong>Retry run</strong>.
+      </div>
+      <div style="display: flex; gap: var(--space-2); flex-wrap: wrap;">
+        ${allowForms as unknown as SafeHtml[]}
+      </div>
+    </div>
+  `;
 
   const replayedFrom = run.replayedFromRunId ? html`
     <dt>Replayed from</dt>
@@ -110,12 +146,17 @@ export function renderRunDetail(opts: RunDetailOptions): string {
     ? html`<span class="badge badge--muted" title="This run is a retry of an earlier attempt">attempt ${String(run.attempt)}</span>`
     : html``;
 
+  // The live poll reconciles by `data-poll-region`, replacing only changed
+  // regions instead of nuking the whole container — so the DAG canvas, focused
+  // inputs, the node filter, and scroll position survive an update. The status
+  // badge is wrapped identically in both header shapes so the poll can swap it
+  // in place regardless of full-page vs partial chrome.
+  const statusRegion = html`<span data-poll-region="status">${statusBadge(run.status)} ${cancelButton}</span>`;
   const header = partial
-    ? html`<h1>Run <span class="mono">${run.id.slice(0, 8)}</span> ${statusBadge(run.status)} ${attemptBadge} ${cancelButton}</h1>`
+    ? html`<h1>Run <span class="mono">${run.id.slice(0, 8)}</span> ${statusRegion} ${attemptBadge}</h1>`
     : pageHeader({
         title: `Run ${run.id.slice(0, 8)}`,
-        meta: [statusBadge(run.status), attemptBadge],
-        cta: cancelButton,
+        meta: [statusRegion, attemptBadge],
         back,
       });
 
@@ -126,7 +167,7 @@ export function renderRunDetail(opts: RunDetailOptions): string {
     <div data-run-container${pollAttr}${cspAttr}>
       ${header}
 
-      <div class="card" style="margin-bottom: var(--space-6);">
+      <div class="card" data-poll-region="meta" style="margin-bottom: var(--space-6);">
         <dl class="kv">
           <dt>Agent</dt><dd><a href="/agents/${run.agentName}">${run.agentName}</a>${run.workflowVersion ? html` <span class="dim">v${String(run.workflowVersion)}</span>` : html``}</dd>
           <dt>Started</dt><dd class="mono">${run.startedAt}</dd>
@@ -139,7 +180,7 @@ export function renderRunDetail(opts: RunDetailOptions): string {
         </dl>
       </div>
 
-      ${run.error ? html`
+      <div data-poll-region="error">${run.error ? html`
         <h2>Error</h2>
         <div class="flash flash--error" style="display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-3);">
           <span>${run.error}</span>
@@ -153,21 +194,23 @@ export function renderRunDetail(opts: RunDetailOptions): string {
               class="btn btn--sm btn--ghost">Suggest improvements</a>
           </span>
         </div>
-      ` : html``}
+      ` : html``}</div>
 
       ${isDagRun ? html`
         <!-- Top: DAG + Result side-by-side, sticky while node logs scroll. -->
         <div class="run-detail-grid run-detail-grid--sticky">
-          <div class="run-detail-grid__dag">
+          <div class="run-detail-grid__dag" data-poll-region="dag" data-poll-preserve>
             ${dagSection}
             ${canReplay ? renderReplayFallback(run, agent!) : html``}
           </div>
-          <div class="run-detail-grid__result">
+          <div class="run-detail-grid__result" data-poll-region="result">
             <h2 style="margin-top: 0;">Result</h2>
             ${!inProgress && run.result
-              ? (agent?.outputWidget
-                  ? renderOutputWidget(agent.outputWidget, run.result, agent.id, widgetControls, agent.inputs) ?? outputFrame(run.result)
-                  : outputFrame(run.result))
+              ? (widgetBlocked
+                  ? widgetHiddenNotice
+                  : agent?.outputWidget
+                    ? renderOutputWidget(agent.outputWidget, run.result, agent.id, widgetControls, agent.inputs) ?? outputFrame(run.result)
+                    : outputFrame(run.result))
               : inProgress
                 ? html`<p class="dim" style="font-size: var(--font-size-xs);">Run in progress...</p>`
                 : html`<p class="dim" style="font-size: var(--font-size-xs);">No output yet.</p>`}
@@ -189,13 +232,15 @@ export function renderRunDetail(opts: RunDetailOptions): string {
               <option value="skipped">Skipped</option>
             </select>
           </div>
-          ${renderNodeCards(nodeExecutions!, run.id, canReplay)}
+          <div data-poll-region="nodes">${renderNodeCards(nodeExecutions!, run.id, canReplay)}</div>
         </section>
       ` : html`
         <h2>Output</h2>
-        ${run.result
-          ? (agent?.outputWidget ? renderOutputWidget(agent.outputWidget, run.result, agent.id, widgetControls, agent.inputs) ?? outputFrame(run.result) : outputFrame(run.result))
-          : html`<p class="dim">No output yet.</p>`}
+        <div data-poll-region="result">${run.result
+          ? (widgetBlocked
+              ? widgetHiddenNotice
+              : agent?.outputWidget ? renderOutputWidget(agent.outputWidget, run.result, agent.id, widgetControls, agent.inputs) ?? outputFrame(run.result) : outputFrame(run.result))
+          : html`<p class="dim">No output yet.</p>`}</div>
       `}
       ${cancelModal}
     </div>

--- a/packages/dashboard/src/views/widget-img-fallback.js.ts
+++ b/packages/dashboard/src/views/widget-img-fallback.js.ts
@@ -1,0 +1,53 @@
+/**
+ * Broken-image fallback for widget output.
+ *
+ * Agents frequently emit image URLs that resolve to a 404 — e.g. an LLM
+ * hand-writes a Wikimedia path with the wrong hash. When the host IS in
+ * `permissions.imgSrc` (so CSP allows the request) the run completes and the
+ * widget renders an `<img>` that the browser then fails to load, leaving an
+ * ugly broken-image glyph with no explanation.
+ *
+ * We can't use an inline `onerror=` attribute — the HTML sanitizer strips event
+ * handlers and the page CSP forbids inline handlers anyway. Instead we listen
+ * for image load errors in the CAPTURE phase (error events don't bubble) and
+ * swap the failed `<img>` for an inline SVG placeholder (a `data:` URI, which
+ * the CSP `img-src` allowlist permits). The original URL is preserved in a
+ * tooltip + data attribute so the cause stays debuggable.
+ *
+ * Scoped to widget/result output so we never touch unrelated chrome images.
+ */
+export const WIDGET_IMG_FALLBACK_JS = `
+(function () {
+  var PLACEHOLDER = 'data:image/svg+xml,' + encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="200">' +
+      '<rect width="100%" height="100%" fill="#1f2430"/>' +
+      '<g fill="none" stroke="#5b6275" stroke-width="2">' +
+        '<rect x="120" y="74" width="80" height="60" rx="6"/>' +
+        '<circle cx="142" cy="96" r="7"/>' +
+        '<path d="M124 130l24-22 14 12 16-16 22 26"/>' +
+      '</g>' +
+      '<text x="50%" y="168" fill="#8b93a7" font-family="system-ui,sans-serif" font-size="13" text-anchor="middle">Image unavailable</text>' +
+    '</svg>'
+  );
+
+  function isWidgetImage(el) {
+    return el && el.tagName === 'IMG' && typeof el.closest === 'function' &&
+      el.closest('.ai-template-widget, [data-poll-region="result"], .pulse-tile, [data-widget]');
+  }
+
+  // Capture phase: error events from <img> don't bubble, so a non-capturing
+  // document listener would never see them.
+  window.addEventListener('error', function (e) {
+    var img = e.target;
+    if (!isWidgetImage(img)) return;
+    if (img.getAttribute('data-img-fallback') === '1') return; // already swapped — avoid loops
+    var failed = img.currentSrc || img.src || '';
+    img.setAttribute('data-img-fallback', '1');
+    img.setAttribute('data-failed-src', failed);
+    img.removeAttribute('srcset');
+    img.src = PLACEHOLDER;
+    img.style.objectFit = 'contain';
+    img.title = failed ? ('Image failed to load: ' + failed) : 'Image failed to load';
+  }, true);
+})();
+`;

--- a/packages/dashboard/src/views/widget-layout.js.ts
+++ b/packages/dashboard/src/views/widget-layout.js.ts
@@ -735,9 +735,22 @@ export function widgetLayoutJS(config: WidgetLayoutConfig): string {
         var s = sizes[id];
         if (s) {
           allT[i].style.gridColumn = 'span ' + (s.cols || 1);
-          allT[i].style.gridRow = 'span ' + (s.rows || 1);
           // Remove preset size classes — inline style takes over.
           allT[i].classList.remove('pulse-tile--2x1', 'pulse-tile--1x2', 'pulse-tile--2x2');
+          // Height: an explicit dragged height pins the tile and scrolls any
+          // overflow (so dragging it shorter than the widget = scroll). With no
+          // explicit height the tile keeps growing to its content. Width stays
+          // the dashboard-defined column span above.
+          if (s.h) {
+            allT[i].style.height = s.h + 'px';
+            allT[i].style.maxHeight = s.h + 'px';
+            allT[i].classList.add('pulse-tile--fixed-h');
+            var b = allT[i].querySelector('.pulse-tile__body');
+            if (b) b.style.overflowY = 'auto';   // scroll content taller than the set height
+          } else if (s.rows) {
+            // Legacy {cols,rows} entries — keep the row span for back-compat.
+            allT[i].style.gridRow = 'span ' + s.rows;
+          }
         }
       }
     }
@@ -767,22 +780,25 @@ export function widgetLayoutJS(config: WidgetLayoutConfig): string {
 
       var tileRect = tile.getBoundingClientRect();
       var currentCols = Math.round(tileRect.width / (gridCellW + gap)) || 1;
-      var currentRows = Math.max(1, Math.round(tileRect.height / (gridCellH + gap)));
 
       tile.classList.add('pulse-tile--resizing');
 
       resizing = {
         tile: tile,
+        body: tile.querySelector('.pulse-tile__body'),
         agentId: tile.getAttribute('data-agent-id'),
         startX: e.clientX,
         startY: e.clientY,
         startCols: currentCols,
-        startRows: currentRows,
+        startHeight: tileRect.height,
         gridCellW: gridCellW,
-        gridCellH: gridCellH,
         gap: gap
       };
     });
+
+    // Vertical snap unit — the "grid height". Shorter than a full grid cell so
+    // height can be tuned finely. Width still snaps to dashboard columns.
+    var ROW_UNIT = 80;
 
     document.addEventListener('mousemove', function(e) {
       if (!resizing) return;
@@ -792,12 +808,16 @@ export function widgetLayoutJS(config: WidgetLayoutConfig): string {
       var dy = e.clientY - resizing.startY;
 
       var newCols = Math.max(1, Math.min(4, resizing.startCols + Math.round(dx / (resizing.gridCellW + resizing.gap))));
-      var newRows = Math.max(1, Math.min(4, resizing.startRows + Math.round(dy / (resizing.gridCellH + resizing.gap))));
+      // Height snaps to the nearest ROW_UNIT; min one unit.
+      var newH = Math.max(ROW_UNIT, Math.round((resizing.startHeight + dy) / ROW_UNIT) * ROW_UNIT);
 
       resizing.tile.style.gridColumn = 'span ' + newCols;
-      resizing.tile.style.gridRow = 'span ' + newRows;
+      resizing.tile.style.gridRow = '';
+      resizing.tile.style.height = newH + 'px';
+      resizing.tile.style.maxHeight = newH + 'px';
+      if (resizing.body) resizing.body.style.overflowY = 'auto';
       resizing.newCols = newCols;
-      resizing.newRows = newRows;
+      resizing.newH = newH;
     });
 
     document.addEventListener('mouseup', function() {
@@ -807,15 +827,17 @@ export function widgetLayoutJS(config: WidgetLayoutConfig): string {
       resizing.tile.classList.remove('pulse-tile--2x1', 'pulse-tile--1x2', 'pulse-tile--2x2');
 
       var newCols = resizing.newCols || resizing.startCols;
-      var newRows = resizing.newRows || resizing.startRows;
+      var newH = resizing.newH || 0;
 
       var sizes = getSizes();
-      if (newCols === 1 && newRows === 1) {
+      if (newCols === 1 && !newH) {
         delete sizes[resizing.agentId];
         resizing.tile.style.gridColumn = '';
-        resizing.tile.style.gridRow = '';
+        resizing.tile.style.height = '';
+        resizing.tile.style.maxHeight = '';
       } else {
-        sizes[resizing.agentId] = { cols: newCols, rows: newRows };
+        sizes[resizing.agentId] = { cols: newCols };
+        if (newH) { sizes[resizing.agentId].h = newH; resizing.tile.classList.add('pulse-tile--fixed-h'); }
       }
       saveSizes(sizes);
       resizing = null;


### PR DESCRIPTION
## Summary

Hardens dashboard widget rendering and agent image output. Three layers:

**Image safety (core + dashboard)**
- **Build-eval dead-link check** — generated agents get their hardcoded `http(s)` image URLs HEAD-checked; dead links (404/410) feed back to the planner/drafter for a retry (`build-plan-image-check.ts`).
- **Run-time CSP guard** — a run whose ai-template output references an image host not in `permissions.imgSrc` now **fails** with an actionable error, and the run page renders a server-side one-click **Allow host** form (`widget-image-hosts.ts`, `versions.ts` allow-host accepts a form POST + safe redirect).
- **Broken-image fallback** — any widget `<img>` that fails to load (e.g. an allowlisted host with a hallucinated 404 path) swaps to an inline "Image unavailable" placeholder (`widget-img-fallback.js.ts`), CSP-safe (`data:` URI, no inline `onerror`).

**Run-detail live rendering (dashboard)**
- The 2s poll now **reconciles only changed regions** (`data-poll-region`) instead of replacing the whole `[data-run-container]`. The DAG canvas, focused inputs, the node search/filter, and scroll position survive an update.
- The **DAG bootstrap** is a re-callable global with a `ResizeObserver` (fixes both the "blank DAG" and "only the middle node shows" bugs) and the currently-running node **pulses**.
- The **CSP "Allow" banner** mounts outside the swapped subtree so it survives polls; the poll pauses on a CSP image violation.

**Widget tile sizing (Pulse / dashboards)**
- Tiles **grow vertically** to their content; width stays the dashboard-defined grid column. `outputWidget.tileFit` (`grow` default | `scroll`) is exposed in the output-widget editor.
- The **resize handle** pins a snapped height and scrolls overflow.

**Caching** — `graph-render.js` and `dashboard.css` are served `no-cache` so layout/behavior fixes land on refresh instead of behind a 5-minute stale cache (the trap behind the tile-overlap regression).

## Tests
- Full suite: **1566 passed, 3 skipped**. `npm run build` + `npm run lint` clean.
- New: `build-plan-image-check.test.ts`, `widget-image-hosts.test.ts`, executor image-host-guard cases, dashboard tests for poll regions / failed-run Allow form / allow-host redirect.
- Browser-verified on Pulse + run detail: DAG renders all nodes + pulses, tiles grow with no overlap, resize pins+scrolls, image fallback renders.

## Notes
- Changesets included for all five workspace packages (4 changesets) + ADR-0025.
- The `marvel-hero-of-the-day` agent's `pick-hero` node was separately fixed (DB import, v8) to resolve live Wikipedia image URLs instead of stale hardcoded paths — not part of this diff (agent data, not packages).
- Branch bundles several related concerns into one PR per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)