### PR TITLE
fix(dashboard): run-display + pulse-layout polish

### DIFF
--- a/.changeset/dashboard-display-debt.md
+++ b/.changeset/dashboard-display-debt.md
@@ -1,0 +1,24 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Dashboard run-display and Pulse-layout polish.
+
+- Run detail no longer shows the literal "exit null" for DAG/multi-node runs
+  (the run-level exit code is null by design); it shows a muted "—" instead.
+- Node stdout strips a single enclosing Markdown code fence, so llm-prompt
+  output wrapped in ```json … ``` renders clean instead of showing the backticks.
+- Trivial graphs (1–2 nodes) use a compact DAG canvas instead of the full-height
+  one, so single-node agents don't render a giant lone node in empty space.
+- The Pulse grid sizes each tile to its own content instead of stretching every
+  tile in a row to the tallest one, so short metric/status tiles no longer
+  render as near-empty cards.
+- Broken widget images cap their placeholder height so a failed hero image
+  doesn't leave an oversized box.
+- The named-dashboard header (`/dashboards/:id`) now mirrors Pulse: the dashboard
+  name is the prominent heading with tile-count/source meta beside it, and the
+  dashboards dropdown plus actions move into the right-aligned group.

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -94,6 +94,12 @@ main.main--wide {
   background-size: 16px 16px;
 }
 
+/* Trivial graphs (1–2 nodes) don't need the full canvas — a giant lone node
+   in 320px of empty grid is wasted space on single-node agents. */
+.dag-frame__canvas--compact {
+  height: 150px;
+}
+
 /* Collapse/expand affordance for the DAG viewer. Reuses the design-system
  * `.dag-frame` card chrome but adds a summary row on top. */
 .dag-disclosure {
@@ -938,6 +944,12 @@ main.main--wide {
   border: 2px solid transparent;
   border-radius: var(--radius-md);
   transition: border-color 150ms ease, background 150ms ease;
+  /* Size each tile to its own content instead of stretching every tile in a
+     row to match the tallest one. Without this, a short metric tile next to a
+     tall widget renders as a near-empty card (the value stranded at the top of
+     a huge box). fit-grow tiles still grow with their content; explicitly
+     resized (.pulse-tile--fixed-h) tiles still win via their inline height. */
+  align-items: start;
 }
 
 @media (max-width: 900px) {

--- a/packages/dashboard/src/views/components.test.ts
+++ b/packages/dashboard/src/views/components.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { formatExitCode, stripEnclosingCodeFence } from './components.js';
+
+describe('formatExitCode', () => {
+  it('renders a plain exit code', () => {
+    expect(formatExitCode(0)).toBe('exit 0 (success)');
+    expect(formatExitCode(2)).toBe('exit 2 (misuse of shell command)');
+  });
+
+  it('renders an unlabelled code without a paren', () => {
+    expect(formatExitCode(42)).toBe('exit 42');
+  });
+
+  it('decodes signal exit codes', () => {
+    expect(formatExitCode(137)).toBe('exit 137 (killed (SIGKILL / out of memory))');
+    expect(formatExitCode(140)).toBe('exit 140 (signal 12)');
+  });
+
+  it('returns empty for no exit code — undefined OR null (DAG/multi-node runs)', () => {
+    // DAG/multi-node runs carry no run-level exit code; the store returns null.
+    // Regression: this used to render the literal "exit null".
+    expect(formatExitCode(undefined)).toBe('');
+    expect(formatExitCode(null)).toBe('');
+  });
+});
+
+describe('stripEnclosingCodeFence', () => {
+  it('strips a ```json … ``` wrapper', () => {
+    expect(stripEnclosingCodeFence('```json\n{"a":1}\n```')).toBe('{"a":1}');
+  });
+
+  it('strips a bare ``` … ``` wrapper', () => {
+    expect(stripEnclosingCodeFence('```\nhello\nworld\n```')).toBe('hello\nworld');
+  });
+
+  it('leaves un-fenced text untouched', () => {
+    expect(stripEnclosingCodeFence('just some output')).toBe('just some output');
+  });
+
+  it('leaves text with an inline (non-enclosing) fence untouched', () => {
+    const mixed = 'Here is code:\n```js\nx()\n```\nand more prose';
+    expect(stripEnclosingCodeFence(mixed)).toBe(mixed);
+  });
+});

--- a/packages/dashboard/src/views/components.ts
+++ b/packages/dashboard/src/views/components.ts
@@ -27,8 +27,20 @@ export function sourceBadge(source: string): SafeHtml {
   return html`<span class="badge ${kind}">${source}</span>`;
 }
 
+/**
+ * Strip a single enclosing Markdown code fence. LLM nodes routinely wrap their
+ * whole output in ```json … ``` (or ```), which renders as literal backticks in
+ * the stdout frame. When the entire (trimmed) text is one fenced block, return
+ * its inner content; otherwise leave the text untouched.
+ */
+export function stripEnclosingCodeFence(text: string): string {
+  const trimmed = text.trim();
+  const match = /^```[a-zA-Z0-9_-]*\n([\s\S]*?)\n?```$/.exec(trimmed);
+  return match ? match[1] : text;
+}
+
 export function outputFrame(text: string): SafeHtml {
-  return html`<div class="output-frame">${text}</div>`;
+  return html`<div class="output-frame">${stripEnclosingCodeFence(text)}</div>`;
 }
 
 export function kv(key: string, value: SafeHtml | string): SafeHtml {
@@ -71,8 +83,10 @@ const EXIT_CODE_LABELS: Record<number, string> = {
   143: 'terminated (SIGTERM)',
 };
 
-export function formatExitCode(code: number | undefined): string {
-  if (code === undefined) return '';
+export function formatExitCode(code: number | null | undefined): string {
+  // DAG/multi-node runs (and some legacy v1 runs) have no run-level exit code —
+  // the store returns null, which must render as "no exit code", not "exit null".
+  if (code == null) return '';
   const label = EXIT_CODE_LABELS[code];
   if (code >= 129 && code <= 165 && !label) {
     const signal = code - 128;

--- a/packages/dashboard/src/views/dag-view.ts
+++ b/packages/dashboard/src/views/dag-view.ts
@@ -66,7 +66,7 @@ export function renderDagView(args: {
         ${hint}
       </summary>
       <div class="dag-disclosure__body">
-        <div id="dag-canvas" class="dag-frame__canvas"${unsafeHtml(navAttr)}${unsafeHtml(replayAttr)}${unsafeHtml(editAttr)}></div>
+        <div id="dag-canvas" class="dag-frame__canvas${agent.nodes.length <= 2 ? ' dag-frame__canvas--compact' : ''}"${unsafeHtml(navAttr)}${unsafeHtml(replayAttr)}${unsafeHtml(editAttr)}></div>
         <script id="dag-data" type="application/json">${unsafeHtml(escapeScriptTag(payload))}</script>
 
         <!-- Dialog rendered BEFORE the scripts so the IIFE's initial

--- a/packages/dashboard/src/views/dashboards.ts
+++ b/packages/dashboard/src/views/dashboards.ts
@@ -11,7 +11,6 @@
 import type { Dashboard } from '@some-useful-agents/core';
 import { html, render, unsafeHtml, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
-import { pageHeader } from './page-header.js';
 import { renderTile } from './pulse-renderers.js';
 import { tileWrap, type PulseTile } from './pulse.js';
 import { TEMPLATE_REGISTRY } from './pulse-templates.js';
@@ -76,14 +75,15 @@ export function renderDashboardPage(input: RenderDashboardPageInput): string {
   const sourceLabel = input.dashboard.packId ? `from pack: ${input.dashboard.packId}` : 'user-created';
 
   const body = html`
-    <div style="display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-4);">
-      ${dropdown}
+    <div style="display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-6);">
+      <h1 style="margin: 0;">${input.dashboard.name}</h1>
       <span class="dim" style="font-size: var(--font-size-sm);">
         ${String(totalTiles)} tile${totalTiles === 1 ? '' : 's'}
         ${totalMissing > 0 ? html`, ${String(totalMissing)} missing` : html``}
         · ${sourceLabel}
       </span>
-      <div style="margin-left: auto; display: flex; gap: var(--space-2);">
+      <div style="margin-left: auto; display: flex; align-items: center; gap: var(--space-2);">
+        ${dropdown}
         <button type="button" class="btn btn--primary btn--sm add-tile-btn"
           data-dashboard-id="${input.dashboard.id}"
           data-section-idx="0"
@@ -95,11 +95,6 @@ export function renderDashboardPage(input: RenderDashboardPageInput): string {
         <a class="btn btn--ghost btn--sm" href="/dashboards/${encodeURIComponent(input.dashboard.id)}/export" title="Download as a pack manifest YAML">Save as pack</a>
       </div>
     </div>
-
-    ${pageHeader({
-      title: input.dashboard.name,
-      back: { href: '/packs', label: 'All packs' },
-    })}
 
     ${input.sections.length === 0
       ? html`<p class="dim" style="padding: var(--space-4); text-align: center;">No sections in this dashboard.</p>`

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -173,7 +173,7 @@ export function renderRunDetail(opts: RunDetailOptions): string {
           <dt>Started</dt><dd class="mono">${run.startedAt}</dd>
           <dt>Completed</dt><dd class="mono">${run.completedAt ?? html`<span class="dim">in progress</span>`}</dd>
           <dt>Duration</dt><dd>${formatDuration(run.startedAt, run.completedAt)}</dd>
-          <dt>Exit code</dt><dd class="mono">${formatExitCode(run.exitCode)}</dd>
+          <dt>Exit code</dt><dd class="mono">${formatExitCode(run.exitCode) || html`<span class="dim">—</span>`}</dd>
           <dt>Triggered by</dt><dd>${run.triggeredBy}</dd>
           ${replayedFrom}
           ${retryOf}

--- a/packages/dashboard/src/views/widget-img-fallback.js.ts
+++ b/packages/dashboard/src/views/widget-img-fallback.js.ts
@@ -47,6 +47,9 @@ export const WIDGET_IMG_FALLBACK_JS = `
     img.removeAttribute('srcset');
     img.src = PLACEHOLDER;
     img.style.objectFit = 'contain';
+    // Keep the broken-image state compact: a tall hero <img> shouldn't leave a
+    // giant placeholder box. Cap the height; the SVG stays centered via contain.
+    img.style.maxHeight = '200px';
     img.title = failed ? ('Image failed to load: ' + failed) : 'Image failed to load';
   }, true);
 })();


### PR DESCRIPTION
## Summary

Dashboard debt cleanup from a read-only audit of Pulse layout and agent run/display. All server-rendered, URLs unchanged, low-risk.

**Run / display**
- **`exit null` bug fixed.** `formatExitCode` only guarded `undefined`, so DAG/multi-node runs (whose run-level exit code is `null` by design) rendered the literal `exit null` in the run summary — directly contradicting the per-node row that said "exit 0 (success)". Now guards `null` too; the summary shows a muted `—` when there's no run-level code.
- **stdout strips an enclosing code fence.** `llm-prompt` nodes wrap output in ` ```json … ``` `, which showed as literal backticks. A single enclosing fence is now stripped; inline/mid-text fences are left alone.
- **Compact DAG for trivial graphs.** 1–2 node agents used the full 320px canvas, rendering one giant lone node in empty space. They now use a 150px canvas.

**Pulse / dashboard layout**
- **Grid sizes tiles to content.** The grid used the default `align-items: stretch`, so a short metric tile next to a tall widget stretched to match and rendered as a near-empty card (value stranded at the top). `align-items: start` fixes it — short cards stay short; `fit-grow` tiles still grow; explicitly resized tiles still win. (e.g. the Churn tile went from a stretched empty box to a compact 170px card.)
- **Broken-image placeholder capped** at 200px so a failed hero image doesn't leave an oversized box.
- **Named-dashboard header mirrors Pulse.** `/dashboards/:id` led with the dropdown and buried the name in a separate row below. Now the dashboard name is the prominent heading with tile-count/source meta beside it, dropdown + actions in the right group, no orphan back link (Pulse has none; "← All packs" was also wrong for user-created dashboards).

## Out of scope (flagged)
The dim trivia-widget headline is AI-generated widget HTML stored in the DB, not dashboard CSS — not fixed here (would mean editing one agent's stored content).

## Test Coverage
New `components.test.ts`: `formatExitCode` (incl. the `null` regression + signal codes) and the code-fence stripper. Visual fixes verified in-browser (run detail, Pulse grid via DOM height check, named-dashboard header).

Full suite: **1585 passed, 3 skipped** (104 files). Clean `tsc --build` + `tsc --noEmit`.

## Test plan
- [x] `tsc --build` + `tsc --noEmit` clean
- [x] `npx vitest run` — 1585 passed / 3 skipped
- [x] Browser-verified: exit code shows `—`; compact single-node DAG; Pulse short tiles compact (170px); named-dashboard header parallel to Pulse

🤖 Generated with [Claude Code](https://claude.com/claude-code)