### PR TITLE
docs: align builtin tool docs with builtin-tools.ts schemas

### DIFF
--- a/docs/tools/file-read.md
+++ b/docs/tools/file-read.md
@@ -13,7 +13,7 @@ Read a file from disk. Path is resolved relative to the project root and must st
 | Name | Type | Description |
 |---|---|---|
 | `content` | string | File contents as UTF-8 |
-| `size` | number | File size in bytes |
+| `bytes` | number | File size in bytes |
 | `result` | string | Alias for content |
 
 ## Example

--- a/docs/tools/file-write.md
+++ b/docs/tools/file-write.md
@@ -16,7 +16,8 @@ Write content to a file. Path is resolved relative to the project root; director
 |---|---|---|
 | `bytes` | number | Bytes written |
 | `path` | string | Absolute path of the written file |
-| `result` | string | Human-readable summary |
+| `append` | boolean | Whether the write was an append (mirrors the input) |
+| `result` | string | Alias for `path` — the resolved file path |
 
 ## Example
 

--- a/docs/tools/http-get.md
+++ b/docs/tools/http-get.md
@@ -15,9 +15,11 @@ HTTP GET with SSRF protection. Resolves the hostname to an IP, rejects private/l
 | Name | Type | Description |
 |---|---|---|
 | `status` | number | HTTP status code |
+| `body` | json | Response body — auto-parsed to JSON when the response is valid JSON, otherwise the raw string |
 | `headers` | object | Response headers |
-| `body` | string | Response body as text |
-| `result` | string | Alias for body |
+| `duration_ms` | number | Request duration in milliseconds |
+
+A `result` string alias is also emitted (the body stringified) for templates that expect text.
 
 ## Example
 

--- a/docs/tools/http-post.md
+++ b/docs/tools/http-post.md
@@ -7,8 +7,8 @@ HTTP POST with SSRF protection. Same safety guarantees as `http-get`.
 | Name | Type | Required | Description |
 |---|---|---|---|
 | `url` | string | yes | Full URL (http or https) |
-| `body` | string | no | Request body as text |
-| `headers` | object | no | Headers (default: `Content-Type: application/json` when body looks like JSON) |
+| `body` | json | no | Request body. JSON-encoded automatically — pass a structured value, not a pre-stringified string |
+| `headers` | object | no | Request headers. Merged on top of `Content-Type: application/json` (caller can override) |
 | `timeout` | number | no | Request timeout in seconds (default 30) |
 
 ## Outputs
@@ -16,9 +16,11 @@ HTTP POST with SSRF protection. Same safety guarantees as `http-get`.
 | Name | Type | Description |
 |---|---|---|
 | `status` | number | HTTP status code |
+| `body` | json | Response body — auto-parsed to JSON when the response is valid JSON, otherwise the raw string |
 | `headers` | object | Response headers |
-| `body` | string | Response body as text |
-| `result` | string | Alias for body |
+| `duration_ms` | number | Request duration in milliseconds |
+
+A `result` string alias is also emitted (the body stringified) for templates that expect text.
 
 ## Example
 
@@ -27,14 +29,13 @@ HTTP POST with SSRF protection. Same safety guarantees as `http-get`.
   tool: http-post
   toolInputs:
     url: "{{vars.SLACK_WEBHOOK}}"
-    headers:
-      Content-Type: "application/json"
-    body: |
-      {"text": "Agent finished: {{upstream.analyze.result}}"}
+    body:
+      text: "Agent finished: {{upstream.analyze.result}}"
 ```
 
 ## Notes
 
 - SSRF guardrails identical to [`http-get`](http-get.md).
-- `body` is sent as-is — no JSON auto-encoding. Stringify upstream.
+- `body` is JSON-encoded by the tool. Pass an object/array/scalar directly — do not stringify upstream.
+- When `body` is provided, `Content-Type: application/json` is set by default. Pass a different `Content-Type` in `headers` to override.
 - For webhook signing, compute the signature in a preceding shell node and pass it via `headers.X-Signature`.

--- a/docs/tools/json-parse.md
+++ b/docs/tools/json-parse.md
@@ -1,20 +1,21 @@
 # json-parse
 
-Parse a JSON string into structured fields downstream nodes can reference.
+Parse a JSON string into a structured value downstream nodes can reference.
 
 ## Inputs
 
 | Name | Type | Required | Description |
 |---|---|---|---|
-| `input` | string | yes | JSON text to parse |
+| `text` | string | yes | JSON text to parse |
 
 ## Outputs
 
-Every top-level key in the parsed JSON is exposed as an output field. Additionally:
-
 | Name | Type | Description |
 |---|---|---|
-| `result` | string | Pretty-printed re-serialization (for debugging) |
+| `value` | json | Parsed value (object, array, or scalar) |
+| `result` | string | Re-serialized JSON (for debugging or text-only consumers) |
+
+To pull a specific field out of `value`, chain into [`json-path`](json-path.md).
 
 ## Example
 
@@ -23,18 +24,18 @@ Every top-level key in the parsed JSON is exposed as an output field. Additional
   tool: json-parse
   dependsOn: [fetch]
   toolInputs:
-    input: "{{upstream.fetch.result}}"
+    text: "{{upstream.fetch.result}}"
 
-- id: use
-  type: shell
+- id: status
+  tool: json-path
   dependsOn: [parse]
-  command: echo "Status $UPSTREAM_PARSE_STATUS — $UPSTREAM_PARSE_COUNT items"
+  toolInputs:
+    data: "{{upstream.parse.value}}"
+    path: "status"
 ```
-
-If `fetch` emitted `{"status": "ok", "count": 42}`, the shell node sees `UPSTREAM_PARSE_STATUS=ok` and `UPSTREAM_PARSE_COUNT=42`.
 
 ## Notes
 
-- **Non-object roots** — if the JSON parses to an array or scalar, the whole value is exposed as `result` only (no per-key extraction).
 - **Malformed JSON** fails the node with a parse error.
-- For deep extraction, chain into [`json-path`](json-path.md).
+- `value` carries the parsed structure (any JSON type); `result` is its string form.
+- Most agents can skip this tool entirely — [`http-get`](http-get.md) and [`http-post`](http-post.md) auto-parse JSON response bodies into `body`, so chain straight into `json-path` against `{{upstream.fetch.body}}`.

--- a/docs/tools/json-path.md
+++ b/docs/tools/json-path.md
@@ -1,21 +1,20 @@
 # json-path
 
-Extract a value from a JSON string via a dot-path expression.
+Extract a value from a JSON value via a dot-path expression.
 
 ## Inputs
 
 | Name | Type | Required | Description |
 |---|---|---|---|
-| `input` | string | yes | JSON text |
-| `path` | string | yes | Dot-path with optional `[N]` indexes — e.g. `items[0].title` |
+| `data` | json | yes | Object, array, or scalar to walk |
+| `path` | string | yes | Dot-separated path — e.g. `items.0.title` (array indexes are bare numeric segments, no brackets) |
 
 ## Outputs
 
 | Name | Type | Description |
 |---|---|---|
-| `value` | string | The extracted value (JSON-stringified if not a primitive) |
-| `result` | string | Alias for value |
-| `found` | boolean | `true` if the path resolved, `false` if any step was undefined |
+| `value` | json | The extracted value, with its original type preserved |
+| `result` | string | The extracted value as a string (JSON-stringified if not already a string; empty string if the path didn't resolve) |
 
 ## Example
 
@@ -28,17 +27,18 @@ Extract a value from a JSON string via a dot-path expression.
   tool: json-path
   dependsOn: [fetch]
   toolInputs:
-    input: "{{upstream.fetch.body}}"
+    data: "{{upstream.fetch.body}}"
     path: "title"
 
 - id: announce
   type: shell
   dependsOn: [title]
-  command: echo "Got: $UPSTREAM_TITLE_VALUE"
+  command: echo "Got: {{upstream.title.result}}"
 ```
 
 ## Notes
 
-- Path syntax: `a.b[0].c` (dots + array indexes, no wildcards).
-- Missing paths return `found: false` and empty `value`, rather than failing.
-- For richer queries, shell out to `jq` in a shell node.
+- **Path syntax** is dots only. Use `items.0.title`, not `items[0].title`. No wildcards or filters.
+- **Missing paths** resolve `value` to `undefined` and `result` to an empty string. The node still succeeds.
+- `data` accepts a JSON value directly — pass `{{upstream.fetch.body}}` from `http-get`/`http-post`, or `{{upstream.parse.value}}` from [`json-parse`](json-parse.md). No need to re-stringify.
+- For richer queries (filters, wildcards), shell out to `jq` in a shell node.


### PR DESCRIPTION
Reconciles six tool docs in [docs/tools/](docs/tools/) against the authoritative \`def(...)\` schemas in [packages/core/src/builtin-tools.ts](packages/core/src/builtin-tools.ts). All of these were drifted enough to mislead an agent author building a flow.

## Fixes per file

- **[http-get.md](docs/tools/http-get.md)** — \`body\` is \`json\` (auto-parsed when valid JSON, else string); added \`duration_ms\`; removed the bogus standalone \`result\` row (kept as a string-alias note).
- **[http-post.md](docs/tools/http-post.md)** — input \`body\` is \`json\` and **JSON-encoded by the tool** (doc previously said \"no JSON auto-encoding; stringify upstream\" — wrong); response \`body\` is \`json\`; added \`duration_ms\`; example passes a body object, not a stringified blob.
- **[file-read.md](docs/tools/file-read.md)** — \`size\` → \`bytes\`.
- **[file-write.md](docs/tools/file-write.md)** — added \`append\` output (mirrors the input); \`result\` is the resolved file path (not a \"human-readable summary\").
- **[json-parse.md](docs/tools/json-parse.md)** — input \`input\` → \`text\`; outputs are \`value\` (json) + \`result\` only. Removed the incorrect \"every top-level key becomes an output field\" + \`UPSTREAM_PARSE_STATUS\` example (the tool never did this).
- **[json-path.md](docs/tools/json-path.md)** — input \`input\` → \`data\` (json); path is **dot-only** (\`items.0.title\`, NOT \`items[0].title\`); removed the nonexistent \`found\` output; \`value\` is json-typed.

## Why now

Followed [#360](https://github.com/gregmeyer/some-useful-agents/pull/360) (dashboard run-display + pulse-layout polish). This is the debt-audit doc cleanup queued in that handoff — strictly doc-only so no changeset per [CLAUDE.md](CLAUDE.md).

## Out of scope (intentional)

\`template.md\`, \`shell-exec.md\`, and \`csv-to-chart-json.md\` were checked against the source and left untouched — they're accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)