### PR TITLE
fix(dashboard): DAG zoom + sticky Node execution header

### DIFF
--- a/.changeset/dag-zoom-and-node-exec-sticky.md
+++ b/.changeset/dag-zoom-and-node-exec-sticky.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+dashboard: DAG canvas zoom + sticky Node execution header.
+
+The DAG viewer on run detail now supports interactive zoom (wheel + drag-pan, plus a floating +/⧇/− toolbar in the bottom-right of the canvas) and renders the canvas a notch taller by default (380px standard, 240px for 1–2 node graphs) so labels and arrows read clearly without zooming.
+
+The Node execution panel below the DAG now has a sticky header — title, search, and status filter stay pinned at the top of the viewport while the user scrolls through long node-card lists. The sticky DAG/Result bar above is released automatically (via a small scroll observer) the moment the Node execution section reaches the release line, so the two sticky surfaces don't fight for the top of the screen.

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -86,18 +86,71 @@ main.main--wide {
   box-shadow: var(--shadow-sm);
 }
 
+/* Wrapper around the cytoscape canvas — the positioning context for the
+ * floating zoom toolbar. Cytoscape replaces the canvas's innerHTML on boot,
+ * so the toolbar must sit OUTSIDE the canvas as a sibling. */
+.dag-frame__wrap {
+  position: relative;
+}
+
 .dag-frame__canvas {
   width: 100%;
-  height: 320px;
+  height: 380px;
   background-color: var(--color-surface-raised);
   background-image: radial-gradient(circle, var(--color-border) 0.5px, transparent 0.5px);
   background-size: 16px 16px;
 }
 
-/* Trivial graphs (1–2 nodes) don't need the full canvas — a giant lone node
-   in 320px of empty grid is wasted space on single-node agents. */
+/* Trivial graphs (1–2 nodes) get a shorter canvas — still wasted space at the
+   full 380px on a single-node agent — but tall enough that the node + label
+   read clearly without forcing the user to zoom. */
 .dag-frame__canvas--compact {
-  height: 150px;
+  height: 240px;
+}
+
+/* Zoom controls overlay — bottom-right of the canvas. Buttons are small,
+ * touch-friendly, and stay out of the way of the graph. Wheel + drag also
+ * work on the canvas itself (Cytoscape user-zoom/user-pan enabled). */
+.dag-zoom-toolbar {
+  position: absolute;
+  right: var(--space-2);
+  bottom: var(--space-2);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  z-index: 2;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+
+.dag-zoom-toolbar__btn {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  font-weight: var(--weight-semibold);
+  line-height: 1;
+  padding: 6px 10px;
+  cursor: pointer;
+  min-width: 28px;
+}
+
+.dag-zoom-toolbar__btn + .dag-zoom-toolbar__btn {
+  border-top: 1px solid var(--color-border);
+}
+
+.dag-zoom-toolbar__btn:hover {
+  background: var(--color-surface-raised);
+}
+
+.dag-zoom-toolbar__btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: -2px;
 }
 
 /* Collapse/expand affordance for the DAG viewer. Reuses the design-system
@@ -226,6 +279,15 @@ main.main--wide {
   margin-bottom: var(--space-4);
 }
 
+/* Released when the Node execution section's sentinel crosses the viewport
+ * top. Dropping back to position:static lets the DAG bar scroll away cleanly
+ * so the (now-sticky) Node exec header isn't competing with a 60vh panel for
+ * the top of the screen. Toggled by run-detail-filter.js's IntersectionObserver. */
+.run-detail-grid--sticky.dag-released {
+  position: static;
+  max-height: none;
+}
+
 .run-detail-grid--sticky .run-detail-grid__dag,
 .run-detail-grid--sticky .run-detail-grid__result {
   position: static;
@@ -254,6 +316,65 @@ main.main--wide {
   max-height: 80vh;
   overflow-y: auto;
   padding-right: var(--space-2);
+}
+
+/* ---------- Node execution panel (full-width section below DAG/Result) ---------- */
+.run-detail-nodes {
+  margin-top: var(--space-6);
+}
+
+/* Sticky header — keeps the title + search + status filter pinned at the
+ * top of the viewport while the user scrolls through long node-card lists.
+ * z-index:6 sits above the DAG sticky bar (z-index:5); paired with the JS
+ * IntersectionObserver that releases the DAG bar (.dag-released) so we
+ * don't end up with two stacked sticky surfaces fighting for the top. */
+.run-detail-nodes__header {
+  position: sticky;
+  top: 0;
+  z-index: 6;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  background: var(--color-bg);
+  padding: var(--space-3) 0;
+  margin-bottom: var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.run-detail-nodes__title {
+  margin: 0;
+  flex: 0 0 auto;
+}
+
+.run-detail-nodes__search {
+  flex: 1 1 200px;
+  min-width: 120px;
+  max-width: 280px;
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.run-detail-nodes__status-filter {
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+@media (max-width: 900px) {
+  /* On narrow viewports the DAG bar isn't sticky anyway — keep the Node exec
+   * header inline so it doesn't eat scarce vertical space. */
+  .run-detail-nodes__header {
+    position: static;
+  }
 }
 
 /* ---------- Agent Config tab ----------

--- a/packages/dashboard/src/routes/assets.ts
+++ b/packages/dashboard/src/routes/assets.ts
@@ -240,12 +240,39 @@ window.renderDagViz = function () {
       grid: false,
     },
     autoungrabify: true,
-    userZoomingEnabled: false,
-    userPanningEnabled: false,
+    // Wheel-zoom + drag-pan enabled so users can inspect dense DAGs without
+    // a separate full-screen view. The toolbar buttons (data-dag-zoom) wrap
+    // these for keyboard/touch users; node taps still open the action dialog.
+    userZoomingEnabled: true,
+    userPanningEnabled: true,
+    minZoom: 0.25,
+    maxZoom: 3,
+    wheelSensitivity: 0.2,
     boxSelectionEnabled: false,
   });
   el.__cy = cy;
   cy.fit(undefined, 18);
+
+  // Toolbar wiring. Buttons are siblings of #dag-canvas (cytoscape replaces
+  // the canvas's innerHTML, so a button INSIDE it would be wiped). We attach
+  // a single delegated handler to the wrapper, which is stable across
+  // run-detail polls. __zoomBound flag avoids stacking listeners on re-render.
+  var wrap = el.parentElement;
+  if (wrap && !wrap.__zoomBound) {
+    wrap.__zoomBound = true;
+    wrap.addEventListener('click', function (evt) {
+      var t = evt.target;
+      if (!t || !t.getAttribute) return;
+      var action = t.getAttribute('data-dag-zoom');
+      if (!action || !el.__cy) return;
+      evt.preventDefault();
+      var cy = el.__cy;
+      var center = { x: el.clientWidth / 2, y: el.clientHeight / 2 };
+      if (action === 'in')  cy.zoom({ level: Math.min(cy.zoom() * 1.25, 3),    renderedPosition: center });
+      if (action === 'out') cy.zoom({ level: Math.max(cy.zoom() / 1.25, 0.25), renderedPosition: center });
+      if (action === 'fit') cy.fit(undefined, 18);
+    });
+  }
 
   // Cytoscape does NOT auto-resize. If the initial fit ran before the canvas
   // reached its final size (sticky grid settling, fonts loading, a parent

--- a/packages/dashboard/src/views/dag-view.ts
+++ b/packages/dashboard/src/views/dag-view.ts
@@ -66,7 +66,17 @@ export function renderDagView(args: {
         ${hint}
       </summary>
       <div class="dag-disclosure__body">
-        <div id="dag-canvas" class="dag-frame__canvas${agent.nodes.length <= 2 ? ' dag-frame__canvas--compact' : ''}"${unsafeHtml(navAttr)}${unsafeHtml(replayAttr)}${unsafeHtml(editAttr)}></div>
+        <!-- Wrapper hosts the cytoscape canvas + the floating zoom toolbar.
+             Cytoscape replaces #dag-canvas's innerHTML on boot, so the
+             toolbar lives as a SIBLING positioned over the canvas. -->
+        <div class="dag-frame__wrap${agent.nodes.length <= 2 ? ' dag-frame__wrap--compact' : ''}">
+          <div id="dag-canvas" class="dag-frame__canvas${agent.nodes.length <= 2 ? ' dag-frame__canvas--compact' : ''}"${unsafeHtml(navAttr)}${unsafeHtml(replayAttr)}${unsafeHtml(editAttr)}></div>
+          <div class="dag-zoom-toolbar" aria-label="DAG zoom controls">
+            <button type="button" class="dag-zoom-toolbar__btn" data-dag-zoom="in"  aria-label="Zoom in">+</button>
+            <button type="button" class="dag-zoom-toolbar__btn" data-dag-zoom="fit" aria-label="Fit to view" title="Fit to view">⧇</button>
+            <button type="button" class="dag-zoom-toolbar__btn" data-dag-zoom="out" aria-label="Zoom out">−</button>
+          </div>
+        </div>
         <script id="dag-data" type="application/json">${unsafeHtml(escapeScriptTag(payload))}</script>
 
         <!-- Dialog rendered BEFORE the scripts so the IIFE's initial

--- a/packages/dashboard/src/views/run-detail-filter.js.ts
+++ b/packages/dashboard/src/views/run-detail-filter.js.ts
@@ -47,5 +47,42 @@ export const RUN_DETAIL_FILTER_JS = `
     // these listeners survive a live poll. Expose the filter so the poll can
     // re-apply the active query/status to freshly-swapped cards.
     window.__suaApplyNodeFilter = filterNodes;
+
+    // ── Sticky DAG release ────────────────────────────────────────────
+    // The DAG/Result row is sticky at top:0 with max-height:60vh, and the
+    // cards-header below it is sticky too (z-index 6). Without intervention
+    // the DAG bar stays pinned and the cards-header sticky-pins UNDER it.
+    // Fix: as the sentinel approaches the DAG bar's bottom edge, add
+    // .dag-released so the DAG bar reverts to position:static and scrolls
+    // away — handing the top of the viewport to the cards-header alone.
+    var sentinel = document.querySelector('[data-dag-release-sentinel]');
+    var dagBar = document.querySelector('.run-detail-grid--sticky');
+    if (sentinel && dagBar) {
+      // Cache the DAG bar's stuck height once. Reading it after releasing
+      // would return the post-release (uncapped) value and cause hysteresis
+      // flapping right around the release line.
+      var dagH = Math.min(dagBar.offsetHeight, window.innerHeight * 0.6);
+      var ticking = false;
+      function check() {
+        ticking = false;
+        var rect = sentinel.getBoundingClientRect();
+        // Release when the sentinel has risen to within 8px of the DAG bar's
+        // bottom edge — i.e. overlap is about to start.
+        var shouldRelease = rect.top < dagH + 8;
+        if (shouldRelease) dagBar.classList.add('dag-released');
+        else dagBar.classList.remove('dag-released');
+      }
+      function onScroll() {
+        if (ticking) return;
+        ticking = true;
+        requestAnimationFrame(check);
+      }
+      window.addEventListener('scroll', onScroll, { passive: true });
+      window.addEventListener('resize', function () {
+        dagH = Math.min(dagBar.offsetHeight, window.innerHeight * 0.6);
+        onScroll();
+      }, { passive: true });
+      check();
+    }
   })();
 `;

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -217,14 +217,16 @@ export function renderRunDetail(opts: RunDetailOptions): string {
           </div>
         </div>
 
-        <!-- Bottom: Node execution (full width, searchable) -->
-        <section class="run-detail-nodes" style="margin-top: var(--space-6);">
-          <div style="display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-3); flex-wrap: wrap;">
-            <h2 style="margin: 0;">Node execution</h2>
-            <input type="text" class="run-detail-nodes__search" placeholder="Search nodes..."
-              style="padding: var(--space-1) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs); font-family: var(--font-mono); background: var(--color-surface); color: var(--color-text); flex: 1; min-width: 120px; max-width: 280px;">
-            <select class="run-detail-nodes__status-filter"
-              style="padding: var(--space-1) var(--space-2); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs); background: var(--color-surface); color: var(--color-text);">
+        <!-- Bottom: Node execution (full width, searchable). The header is
+             sticky so the search + filter stay reachable while the user
+             scrolls long node-card lists. A sibling IntersectionObserver
+             (run-detail-filter.js) releases the DAG sticky bar above so it
+             doesn't sit between the header and the cards. -->
+        <section class="run-detail-nodes" data-dag-release-sentinel>
+          <div class="run-detail-nodes__header">
+            <h2 class="run-detail-nodes__title">Node execution</h2>
+            <input type="text" class="run-detail-nodes__search" placeholder="Search nodes...">
+            <select class="run-detail-nodes__status-filter">
               <option value="">All statuses</option>
               <option value="completed">Completed</option>
               <option value="failed">Failed</option>


### PR DESCRIPTION
Two run-detail follow-ups queued in the latest handoff.

## DAG viewer

Bigger canvas + interactive zoom — the 150px compact canvas from [#360](https://github.com/gregmeyer/some-useful-agents/pull/360) made 2-node graphs almost unreadable, and there was no way to zoom in on dense DAGs.

- Default canvas height **320px → 380px**.
- Compact (1–2 nodes) **150px → 240px** — still smaller than default but legible.
- Wheel-zoom + drag-pan enabled in cytoscape config, clamped to `0.25..3` with a gentle wheel sensitivity.
- Floating **+ / ⧇ / −** toolbar in the bottom-right of the canvas. Buttons sit as siblings of `#dag-canvas` (cytoscape replaces the canvas's `innerHTML` on boot, so a button inside it would be wiped). Delegated click handler is idempotent across run-detail polls.

## Node execution panel

The header (title + search + status filter) was sliding under the sticky DAG/Result bar (z-index 5, max-height 60vh) as the user scrolled — the screenshot in the issue shows the bar covering the controls.

- Header is now `position: sticky; top: 0; z-index: 6` with a solid background. Inline styles promoted to `.run-detail-nodes__header*` classes.
- A small scroll observer (rAF-throttled) toggles `.dag-released` on the sticky DAG bar when the Node execution sentinel approaches the bar's bottom edge. Released, the bar drops to `position: static` and scrolls away — so the top of the viewport belongs to the cards header alone instead of two sticky surfaces fighting.
- DAG-bar height is cached on bind to avoid hysteresis flapping at the release line.
- On `<= 900px` viewports the header reverts to inline since the DAG bar isn't sticky there anyway.

## Visual verify

Screenshot pass on http://127.0.0.1:3000 at three scroll positions on a 2-node DAG run:

1. **Top of page** — DAG canvas at 240px with toolbar visible bottom-right, both nodes legible.
2. **Mid-scroll** — DAG bar still sticky-pinned, Node execution header approaching from below.
3. **Node-exec at top** — Node execution header docked at top:0, DAG bar released and scrolled away cleanly; cards readable below.

Programmatic checks:
- `cy.zoom()` cycles `1.04 → 1.30 → 0.83 → fit (1.04)` via toolbar clicks.
- `.dag-released` toggles `true / false` on scroll past / back; computed `position` flips `sticky / static`.

## Tests

`1585 pass / 3 skipped` — baseline unchanged. One pre-existing assertion (`/runs/run-v1` must not contain the literal `"Node execution"`) caught a leak from an inline-script comment; rephrased.

## Changeset

Patch bump across the workspace (`.changeset/dag-zoom-and-node-exec-sticky.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)