### PR TITLE
fix: reap orphaned runs on dashboard boot + SIGKILL escalation on cancel

### DIFF
--- a/.changeset/orphan-run-reaper.md
+++ b/.changeset/orphan-run-reaper.md
@@ -1,0 +1,21 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Fix: orphaned runs after dashboard restart no longer burn tokens silently.
+
+When the dashboard process died mid-run (a `daemon restart`, a crash, an OOM), any in-flight LLM child process was reparented to launchd/init and kept running. The 180-second per-node timeout was an in-memory `setTimeout` inside the dashboard process — it died with the parent. The new dashboard had no `activeRuns` entry for the run and couldn't abort it, and the `runs` row sat at `status='running'` indefinitely. The user-cancel route's fallback path force-updated the `runs` row but left every `node_executions` row stuck on a spinner forever.
+
+This release ships three fixes that close the bleed:
+
+- **Orphan reaper on boot.** Any run still flagged `running` or `pending` when the dashboard starts is, by definition, an orphan — the only process that could be executing it is the dashboard, and it just started. The reaper transitions the run to `failed` and every still-`running`/`pending` node execution to `failed` with new `errorCategory='abandoned'` so dashboards stop polling, notify logic doesn't fire forever, and the audit trail explains the gap. Idempotent; safe to call repeatedly.
+
+- **SIGKILL escalation on the cancel path.** When the abort signal fires, the spawner now SIGTERMs the child and escalates to SIGKILL after 5 seconds — matching the timeout path. A claude/codex CLI stuck in a slow HTTP read can no longer ignore SIGTERM indefinitely.
+
+- **Cancel route finalizes node rows.** `POST /runs/:id/cancel`'s fallback (used when activeRuns is empty because the dashboard restarted between kickoff and cancel) now walks every `running`/`pending` node execution for the run and transitions it to `cancelled` alongside the run-level update.
+
+Note: this release does NOT yet kill the orphaned child process itself — that requires persisting the child PID on the `node_executions` row (followup). What this stops is the state-machine bleed: rows stop sitting at `running` forever, and the run row gets a coherent terminal status.

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -323,7 +323,7 @@ export const agentV2Schema = z.object({
     delaySeconds: z.number().int().min(1).max(3600).optional(),
     categories: z.array(z.enum([
       'setup', 'input_resolution', 'spawn_failure', 'exit_nonzero',
-      'timeout', 'cancelled', 'upstream_failed', 'condition_not_met', 'flow_ended',
+      'timeout', 'cancelled', 'abandoned', 'upstream_failed', 'condition_not_met', 'flow_ended',
     ])).optional(),
   }).optional(),
 

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -65,6 +65,11 @@ export type NodeExecutionStatus = 'pending' | 'running' | 'completed' | 'failed'
  *   a non-zero exit code
  * - `timeout`: node exceeded its timeout
  * - `cancelled`: explicitly cancelled (provider shutdown, user abort)
+ * - `abandoned`: the run was in flight when the dashboard restarted (or
+ *   crashed); the orphaned child process kept running but the in-memory
+ *   timeout/state died with the parent. Reaped on next boot. Distinct
+ *   from `cancelled` (deliberate) so retry-policy and dashboards can
+ *   distinguish a user action from infrastructure churn.
  * - `upstream_failed`: this node never ran because an upstream failed;
  *   error text names the failing upstream for coherent top-to-bottom logs
  */
@@ -75,6 +80,7 @@ export type NodeErrorCategory =
   | 'exit_nonzero'
   | 'timeout'
   | 'cancelled'
+  | 'abandoned'
   | 'upstream_failed'
   | 'condition_not_met'
   | 'flow_ended'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export * from './types.js';
 export * from './schema.js';
 export * from './agent-loader.js';
 export * from './run-store.js';
+export * from './run-orphan-reaper.js';
 export * from './agent-executor.js';
 export * from './local-provider.js';
 export * from './chain-resolver.js';

--- a/packages/core/src/node-spawner.ts
+++ b/packages/core/src/node-spawner.ts
@@ -404,9 +404,18 @@ export async function spawnProcess(
       setTimeout(() => { if (!child.killed) child.kill('SIGKILL'); }, 5000);
     }, opts.timeoutSec * 1000);
 
-    // Cancellation signal: SIGTERM the child when the signal fires.
+    // Cancellation signal: SIGTERM the child when the signal fires, then
+    // escalate to SIGKILL after 5s if the child is still alive. Mirrors the
+    // timeout path above. Without escalation, a claude/codex CLI stuck in a
+    // slow HTTP read could ignore SIGTERM indefinitely, leaving the executor
+    // await pending forever and the run/node rows in `running` until the
+    // next dashboard restart (which reaps them via reapOrphanedRuns).
     if (opts.signal) {
-      const onAbort = () => { killed = true; child.kill('SIGTERM'); };
+      const onAbort = () => {
+        killed = true;
+        child.kill('SIGTERM');
+        setTimeout(() => { if (!child.killed) child.kill('SIGKILL'); }, 5000);
+      };
       if (opts.signal.aborted) {
         onAbort();
       } else {

--- a/packages/core/src/run-orphan-reaper.test.ts
+++ b/packages/core/src/run-orphan-reaper.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { RunStore } from './run-store.js';
+import { reapOrphanedRuns } from './run-orphan-reaper.js';
+import type { NodeExecutionRecord } from './agent-v2-types.js';
+
+const TEST_DB = join(import.meta.dirname, '__test-data__', 'orphan-reaper.db');
+
+let store: RunStore;
+
+beforeEach(() => {
+  store = new RunStore(TEST_DB);
+});
+
+afterEach(() => {
+  store.close();
+  rmSync(join(import.meta.dirname, '__test-data__'), { recursive: true, force: true });
+});
+
+function mkExec(runId: string, nodeId: string, overrides?: Partial<NodeExecutionRecord>): NodeExecutionRecord {
+  return {
+    runId,
+    nodeId,
+    workflowVersion: 1,
+    status: 'running',
+    startedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('reapOrphanedRuns', () => {
+  it('transitions a single running run + its running node to failed/abandoned', () => {
+    store.createRun({ id: 'orphan-1', agentName: 'planner', status: 'running', startedAt: '2026-05-26T03:29:13.760Z', triggeredBy: 'dashboard' });
+    store.createNodeExecution(mkExec('orphan-1', 'plan'));
+
+    const result = reapOrphanedRuns(store, { now: '2026-05-26T03:42:30.777Z' });
+
+    expect(result.runsReaped).toBe(1);
+    expect(result.nodesReaped).toBe(1);
+    expect(result.reapedRunIds).toEqual(['orphan-1']);
+
+    const run = store.getRun('orphan-1');
+    expect(run?.status).toBe('failed');
+    expect(run?.completedAt).toBe('2026-05-26T03:42:30.777Z');
+    expect(run?.error).toMatch(/abandoned/i);
+
+    const node = store.getNodeExecution('orphan-1', 'plan');
+    expect(node?.status).toBe('failed');
+    expect(node?.errorCategory).toBe('abandoned');
+    expect(node?.completedAt).toBe('2026-05-26T03:42:30.777Z');
+  });
+
+  it('leaves terminal-status runs untouched', () => {
+    store.createRun({ id: 'done-1',     agentName: 'x', status: 'completed', startedAt: '2026-05-26T01:00:00Z', completedAt: '2026-05-26T01:01:00Z', triggeredBy: 'cli' });
+    store.createRun({ id: 'failed-1',   agentName: 'x', status: 'failed',    startedAt: '2026-05-26T01:00:00Z', completedAt: '2026-05-26T01:01:00Z', error: 'real failure', triggeredBy: 'cli' });
+    store.createRun({ id: 'cancel-1',   agentName: 'x', status: 'cancelled', startedAt: '2026-05-26T01:00:00Z', completedAt: '2026-05-26T01:01:00Z', error: 'user cancelled', triggeredBy: 'cli' });
+
+    const result = reapOrphanedRuns(store);
+
+    expect(result.runsReaped).toBe(0);
+    expect(store.getRun('done-1')?.status).toBe('completed');
+    expect(store.getRun('failed-1')?.error).toBe('real failure');
+    expect(store.getRun('cancel-1')?.error).toBe('user cancelled');
+  });
+
+  it('finalizes only running/pending node executions; preserves completed ones', () => {
+    // Multi-node run that died mid-DAG: one completed, one was running, one was queued.
+    store.createRun({ id: 'multi', agentName: 'p', status: 'running', startedAt: '2026-05-26T03:00:00Z', triggeredBy: 'dashboard' });
+    store.createNodeExecution(mkExec('multi', 'a', { status: 'completed', completedAt: '2026-05-26T03:01:00Z', result: 'ok', exitCode: 0 }));
+    store.createNodeExecution(mkExec('multi', 'b', { status: 'running' }));
+    store.createNodeExecution(mkExec('multi', 'c', { status: 'pending' }));
+
+    const result = reapOrphanedRuns(store);
+
+    expect(result.runsReaped).toBe(1);
+    expect(result.nodesReaped).toBe(2); // b + c
+
+    expect(store.getNodeExecution('multi', 'a')?.status).toBe('completed'); // untouched
+    expect(store.getNodeExecution('multi', 'a')?.result).toBe('ok');
+    expect(store.getNodeExecution('multi', 'b')?.status).toBe('failed');
+    expect(store.getNodeExecution('multi', 'b')?.errorCategory).toBe('abandoned');
+    expect(store.getNodeExecution('multi', 'c')?.status).toBe('failed');
+    expect(store.getNodeExecution('multi', 'c')?.errorCategory).toBe('abandoned');
+  });
+
+  it('idempotent: a second call after reaping is a no-op', () => {
+    store.createRun({ id: 'orphan-2', agentName: 'x', status: 'running', startedAt: '2026-05-26T03:00:00Z', triggeredBy: 'cli' });
+    store.createNodeExecution(mkExec('orphan-2', 'plan'));
+
+    const first = reapOrphanedRuns(store);
+    expect(first.runsReaped).toBe(1);
+
+    const second = reapOrphanedRuns(store);
+    expect(second.runsReaped).toBe(0);
+    expect(second.nodesReaped).toBe(0);
+  });
+
+  it('reaps pending runs the same way as running runs', () => {
+    // A `pending` run was created (DB write) but the executor never picked it up
+    // because the dashboard died between createRun and the first node spawn.
+    store.createRun({ id: 'pre', agentName: 'x', status: 'pending', startedAt: '2026-05-26T03:00:00Z', triggeredBy: 'schedule' });
+
+    const result = reapOrphanedRuns(store);
+
+    expect(result.runsReaped).toBe(1);
+    expect(store.getRun('pre')?.status).toBe('failed');
+  });
+});

--- a/packages/core/src/run-orphan-reaper.ts
+++ b/packages/core/src/run-orphan-reaper.ts
@@ -1,0 +1,106 @@
+/**
+ * Reap orphaned runs on dashboard boot.
+ *
+ * Symptom this protects against: when the dashboard process dies mid-run
+ * (`daemon restart`, crash, OOM), any in-flight LLM child processes are
+ * reparented to launchd/init and keep running — burning tokens — while
+ * the in-memory `setTimeout(SIGTERM)` that node-spawner armed dies with
+ * the parent. The new dashboard process has no `activeRuns` entry for
+ * them and cannot abort them. The run row sits at `status='running'`
+ * indefinitely; the node row never finalizes.
+ *
+ * Semantic this enforces: any run still flagged `running` (or `pending`)
+ * at dashboard startup is, by definition, an orphan — the only process
+ * that could be executing it is the dashboard, and the dashboard just
+ * started fresh. Mark the run + every still-`running` node execution
+ * as `failed` with category `abandoned` so dashboards stop polling them,
+ * notify logic doesn't fire forever, and the audit trail explains the
+ * gap.
+ *
+ * This DOES NOT kill the orphaned child process — that requires the
+ * child PID, which isn't persisted yet (followup C). Tokens already
+ * spent are gone; what this stops is the state-machine bleed.
+ */
+
+import type { RunStore } from './run-store.js';
+import type { RunStatus } from './types.js';
+import type { NodeExecutionRecord } from './agent-v2-types.js';
+
+export interface ReapResult {
+  /** Number of `runs` rows transitioned to `failed`. */
+  runsReaped: number;
+  /** Number of `node_executions` rows transitioned to `failed`. */
+  nodesReaped: number;
+  /** Run IDs that were reaped, in case the caller wants to log them. */
+  reapedRunIds: string[];
+}
+
+export interface ReapOptions {
+  /** ISO timestamp to record as `completedAt`. Defaults to `now`. Tests override. */
+  now?: string;
+  /**
+   * Free-form reason recorded on the run/node `error` column. Defaults to a
+   * message that names the daemon-restart race as the typical cause.
+   */
+  reason?: string;
+}
+
+const DEFAULT_REASON =
+  'Run abandoned: dashboard restarted while this run was in flight. ' +
+  'The child process was reparented and may have continued briefly; ' +
+  'the run record is being finalized so dashboards stop polling.';
+
+/**
+ * Find every run in a non-terminal status (`running` or `pending`) and
+ * transition it to `failed` with `errorCategory='abandoned'`. For each
+ * such run, also transition any `running` node_execution rows so the
+ * per-node table doesn't show a spinner forever.
+ *
+ * Returns counts for telemetry / boot-log surface. Safe to call multiple
+ * times: a row already in a terminal status is left alone.
+ */
+export function reapOrphanedRuns(runStore: RunStore, options: ReapOptions = {}): ReapResult {
+  const completedAt = options.now ?? new Date().toISOString();
+  const reason = options.reason ?? DEFAULT_REASON;
+
+  // Pull every non-terminal run. `queryRuns` with statuses=['running','pending']
+  // captures both the actively-executing case and the rare "DB row written
+  // but child not yet spawned" case the executor briefly produces.
+  const { rows } = runStore.queryRuns({
+    statuses: ['running', 'pending'] as RunStatus[],
+    limit: 10_000,
+    offset: 0,
+  });
+
+  let runsReaped = 0;
+  let nodesReaped = 0;
+  const reapedRunIds: string[] = [];
+
+  for (const run of rows) {
+    // Finalize the run row.
+    runStore.updateRun(run.id, {
+      status: 'failed' as RunStatus,
+      completedAt,
+      error: reason,
+    });
+    runsReaped++;
+    reapedRunIds.push(run.id);
+
+    // Finalize any still-running node executions. Skip terminal-status
+    // node rows so a partially-completed run keeps its earlier history.
+    const nodeExecs: NodeExecutionRecord[] = runStore.listNodeExecutions(run.id);
+    for (const exec of nodeExecs) {
+      if (exec.status === 'running' || exec.status === 'pending') {
+        runStore.updateNodeExecution(run.id, exec.nodeId, {
+          status: 'failed',
+          errorCategory: 'abandoned',
+          completedAt,
+          error: reason,
+        });
+        nodesReaped++;
+      }
+    }
+  }
+
+  return { runsReaped, nodesReaped, reapedRunIds };
+}

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -22,6 +22,7 @@ import {
   getMcpTokenPath,
   rotateMcpToken,
   buildLoopbackAllowlist,
+  reapOrphanedRuns,
   type SecretsStore,
   type RunStatus,
   getSchedulerStatus,
@@ -295,6 +296,28 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
   }
 
   const runStore = opts.runStore ?? new RunStore(opts.dbPath);
+
+  // Orphan reap. Any run still flagged `running` or `pending` at boot is, by
+  // definition, an orphan — the only process that could be executing it is
+  // this dashboard, and we just started fresh. A daemon restart / crash mid-
+  // run leaves the row in non-terminal state forever; the in-memory
+  // setTimeout(SIGTERM) armed inside the previous process died with it, and
+  // the cancel route's activeRuns Map is empty. Finalize those rows so
+  // dashboards stop polling and downstream notify/retry don't hang.
+  //
+  // Caveat: the orphaned child process (claude / codex CLI) may keep running
+  // briefly until it finishes its current HTTP call — this reaper closes the
+  // state-machine bleed but cannot kill the process without a persisted PID
+  // (see followup C: persist child pid on node_executions row).
+  const reapResult = reapOrphanedRuns(runStore);
+  if (reapResult.runsReaped > 0) {
+    console.warn(
+      `[orphan-reaper] Finalized ${reapResult.runsReaped} run(s) and ${reapResult.nodesReaped} node execution(s) ` +
+      `left in non-terminal state by a prior dashboard exit. Run ids: ${reapResult.reapedRunIds.slice(0, 10).join(', ')}` +
+      `${reapResult.reapedRunIds.length > 10 ? ` (+${reapResult.reapedRunIds.length - 10} more)` : ''}`,
+    );
+  }
+
   // AgentStore reads v2 DAG agents from the same runs.db file. Uses its own
   // DatabaseSync — avoids changing RunStore's constructor signature. WAL
   // mode makes concurrent handles safe.

--- a/packages/dashboard/src/routes/run-mutations.ts
+++ b/packages/dashboard/src/routes/run-mutations.ts
@@ -355,15 +355,34 @@ runMutationsRouter.post('/runs/:id/cancel', async (req: Request, res: Response) 
     // Provider may not have this run — that's fine if the abort above worked.
   }
 
-  // If neither path updated the status (e.g. run finished between the
-  // check and the cancel), force-update as a fallback.
+  // If neither path updated the status (e.g. run finished between the check
+  // and the cancel, OR — more commonly — the dashboard was restarted mid-run
+  // so activeRuns is empty and provider.cancelRun is a no-op), force-update
+  // as a fallback. We also finalize any node_executions still flagged
+  // `running` for this run: the old fallback only touched the `runs` row,
+  // leaving node rows stuck on a spinner forever even though the run was
+  // marked cancelled. This is the symptom of run b48c0d25 (layout-planner,
+  // 2026-05-26) where the user-cancel path left the node row in `running`
+  // until the next dashboard boot's orphan reaper finalized it.
   const updated = ctx.runStore.getRun(id);
   if (updated && updated.status === 'running') {
+    const completedAt = new Date().toISOString();
     ctx.runStore.updateRun(id, {
       status: 'cancelled' as RunStatus,
-      completedAt: new Date().toISOString(),
+      completedAt,
       error: 'Cancelled by user.',
     });
+    const nodeExecs = ctx.runStore.listNodeExecutions(id);
+    for (const exec of nodeExecs) {
+      if (exec.status === 'running' || exec.status === 'pending') {
+        ctx.runStore.updateNodeExecution(id, exec.nodeId, {
+          status: 'cancelled',
+          errorCategory: 'cancelled',
+          completedAt,
+          error: 'Cancelled by user.',
+        });
+      }
+    }
   }
 
   res.redirect(303, `/runs/${encodeURIComponent(id)}?flash=${encodeURIComponent('Run cancelled.')}`);


### PR DESCRIPTION
## Symptom

Run [`b48c0d25` (layout-planner, 2026-05-26)](runs/b48c0d25-b5f1-4f54-97ed-2a71d7c5e9c6) ran for **13m17s** and burned tokens, normal runtime ~20s. Node status sat at \`running\` even after the run was force-cancelled. No 180s per-node timeout fired.

## Root cause

\`daemon restart --service dashboard\` 6s after kickoff. The 180s \`setTimeout(SIGTERM)\` armed in [node-spawner.ts:401](packages/core/src/node-spawner.ts#L401) lived inside the dashboard process and died with the parent. The claude child was reparented to launchd and kept calling the Anthropic API for the full 13 minutes. The new dashboard's in-memory \`activeRuns\` Map was empty; user-cancel found nothing to abort. The fallback at [run-mutations.ts:358-366](packages/dashboard/src/routes/run-mutations.ts#L358-L366) force-updated only the \`runs\` row, never \`node_executions\`.

DB state at end:
- \`runs.status='cancelled'\`, \`completedAt='03:42:30'\`, \`error='Cancelled by user.'\`
- \`node_executions.status='running'\`, \`completedAt=NULL\`, \`progressJson=NULL\`, \`result=NULL\`

## Three fixes in this PR

### A. Orphan reaper on dashboard boot
[New: packages/core/src/run-orphan-reaper.ts](packages/core/src/run-orphan-reaper.ts) — \`reapOrphanedRuns(runStore)\`. Any run still flagged \`running\` or \`pending\` at startup is, by definition, an orphan (the only process that could be executing it is the dashboard, and we just started). Transitions the run to \`failed\` and every still-running/pending node execution to \`failed\` with new \`errorCategory='abandoned'\`. Idempotent. Wired into [startDashboardServer](packages/dashboard/src/index.ts) right after RunStore construction.

### B. SIGKILL escalation on the cancel path
[node-spawner.ts](packages/core/src/node-spawner.ts) — the abort handler now mirrors the timeout path: \`SIGTERM\` → wait 5s → \`SIGKILL\`. A claude/codex CLI stuck in a slow HTTP read can no longer ignore SIGTERM indefinitely.

### D. \`POST /runs/:id/cancel\` fallback finalizes node rows
[run-mutations.ts](packages/dashboard/src/routes/run-mutations.ts) — when the in-memory abort controller is gone, the fallback now walks \`listNodeExecutions(runId)\` and transitions any \`running\`/\`pending\` node to \`cancelled\` alongside the run-level update.

## New type: \`NodeErrorCategory.abandoned\`

Distinct from \`cancelled\` (user deliberate) so retry policies and dashboards can tell apart user action from infrastructure churn. Added to the retry-policy validator allowance.

## Tests

\`1590 pass / 3 skipped\` — baseline 1585 + 5 new reaper tests (single-orphan, terminal rows untouched, multi-node mixed states, idempotency, pending-only runs). No regressions.

## Not in this PR (queued)

- **C** — persist child PID on \`node_executions\` so the reaper can \`kill -9\` the orphaned process itself, not just close the state-machine bleed.
- **E** — agent-level wall-clock ceiling, independent of any single node's setTimeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)