### PR TITLE
feat: agent wall-clock timeout + persist child PID + reaper kills orphan

### DIFF
--- a/.changeset/agent-timeout-and-pid-tracking.md
+++ b/.changeset/agent-timeout-and-pid-tracking.md
@@ -1,0 +1,23 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Belt-and-suspenders timeout enforcement: kill orphaned LLM processes on reboot + agent-level wall-clock ceiling.
+
+Follow-up to the orphan reaper (last release). The reaper closed the state-machine bleed but didn't stop the orphaned `claude`/`codex` CLI from continuing its current API call. This release adds the two pieces needed to make timeout enforcement actually stop the token burn:
+
+**Agent.timeoutSec — wall-clock ceiling for the whole run.** Per-node `timeout` protects against one node hanging; agent-level `timeoutSec` is the umbrella that catches "10 nodes at 60s each legitimately runs 10 minutes." When the run exceeds the ceiling, the executor aborts the in-flight node (SIGTERM, then SIGKILL after 5s via the cancel-path escalation shipped last release) and marks remaining nodes as cancelled. The run's `error` names the cap directly: `Agent wall-clock timeout (60s) exceeded.`
+
+`layout-planner.yaml` (the agent that revealed the orphan bug) now declares `timeoutSec: 60` — normal runtime is ~20s, the cap catches the dashboard-restart-orphan case without flagging legitimately-slow runs.
+
+**Persist child PID + start time on `node_executions`.** Two new nullable columns: `childPid` (the spawned process's OS pid) and `childStartedAtMs` (wall-clock ms at spawn time). The executor wires `spawnProcess`'s new `onSpawn(pid, startedAtMs)` callback to write both onto the in-flight node row the moment `spawn()` returns.
+
+**Reaper now kills the orphan.** When a `node_executions` row carries `childPid` + `childStartedAtMs`, the orphan reaper SIGKILLs the process before transitioning the row. To defend against PID reuse on long-uptime machines, it first parses `ps -p <pid> -o etime=` and compares the actual elapsed time against the stored start time; if they've drifted apart (PID reuse), the kill is skipped. Production callers get this automatically; tests inject a `killProcess` hook.
+
+`reapOrphanedRuns` now returns `pidsKilled` alongside `runsReaped` / `nodesReaped`. The dashboard boot log surfaces all three.
+
+Tests: +13 (4 for agent timeout, 1 round-trip, 3 for kill behavior, 5 for etime parsing). 1603 pass / 3 skipped.

--- a/agents/examples/layout-planner.yaml
+++ b/agents/examples/layout-planner.yaml
@@ -28,6 +28,11 @@ description: >
 status: active
 source: examples
 
+# Agent-level wall-clock ceiling. Normal runtime is ~20s; 60s catches the
+# orphaned-claude-burning-tokens case (run b48c0d25 ran 13m17s before the
+# user cancelled) without flagging legitimately-slow runs.
+timeoutSec: 60
+
 inputs:
   CURRENT_LAYOUT:
     type: string

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -170,6 +170,14 @@ export const agentV2Schema = z.object({
   stateMaxBytes: z.number().int().nonnegative().optional(),
 
   /**
+   * Agent-level wall-clock ceiling in seconds. Aborts the run when exceeded,
+   * even if no single node is over its own `timeout`. See Agent.timeoutSec
+   * doc on agent-v2-types.ts for semantics. Set to 0 to disable; unset =
+   * no ceiling.
+   */
+  timeoutSec: z.number().int().nonnegative().optional(),
+
+  /**
    * CSP allowlist contributions. Currently only `imgSrc` is honored —
    * each declared host (e.g. "images.unsplash.com" or "*.unsplash.com")
    * is merged into the dashboard's page-wide `img-src` directive on

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -319,6 +319,19 @@ export interface Agent {
   stateMaxBytes?: number;
 
   /**
+   * Agent-level wall-clock ceiling in seconds. When the run exceeds this
+   * the executor aborts the in-flight node (SIGTERM, then SIGKILL after 5s)
+   * and marks remaining nodes as cancelled with category `cancelled`.
+   * Independent of per-node `timeout` — covers the "10 nodes at 60s each
+   * legitimately runs 10 minutes" gap that per-node timeouts can't see.
+   *
+   * Unset = no agent-level ceiling (existing behavior). Set to 0 to disable
+   * explicitly. Authors typically pick something like 2-3× expected runtime
+   * (e.g. layout-planner normally runs ~20s → set 60 as the safety net).
+   */
+  timeoutSec?: number;
+
+  /**
    * CSP allowlist contributions, merged into the dashboard's page-wide
    * Content-Security-Policy on each request. Currently only `imgSrc` is
    * honored — declared hosts (e.g. "images.unsplash.com" or "*.unsplash.com")
@@ -576,6 +589,22 @@ export interface NodeExecutionRecord {
    * state by X bytes."
    */
   stateBytesAfter?: number;
+  /**
+   * PR C (orphan-kill): OS process id of the child spawned for this node.
+   * Set the moment `child_process.spawn()` returns (before any pipe wiring)
+   * so a dashboard restart can SIGKILL the orphan instead of just closing
+   * the state row. NULL on non-spawning paths (MCP, built-in tools, replay-
+   * copied prior outputs). PID is OS-scoped, not portable across machines.
+   */
+  childPid?: number;
+  /**
+   * Wall-clock ms-since-epoch when the child was spawned. Paired with
+   * `childPid` to defend against PID reuse: before killing, the reaper
+   * ps-cross-checks the running process's actual start time against this
+   * value and skips the kill if they've drifted apart (the original child
+   * died, PID got reassigned to something unrelated).
+   */
+  childStartedAtMs?: number;
 }
 
 /**

--- a/packages/core/src/dag-executor.test.ts
+++ b/packages/core/src/dag-executor.test.ts
@@ -2047,3 +2047,92 @@ describe('executeAgentDag — state-dir size cap (PR D.1)', () => {
     expect(ne.stateBytesAfter).toBeUndefined();
   });
 });
+
+describe('executeAgentDag — agent wall-clock timeout (Agent.timeoutSec)', () => {
+  it('fires when the run exceeds agent.timeoutSec; finalizes the run and remaining nodes', async () => {
+    // Two-node DAG: a slow first node that finishes after the agent
+    // timeout has tripped. The mock spawner doesn't honor abort signals
+    // (it just sleeps `delayMs`), so the first node still returns —
+    // exactly the case where an orphaned claude CLI would have finished
+    // its API call. The executor's loop sees `effectiveSignal.aborted=true`
+    // before the second node and marks it cancelled. The run's final
+    // error names the agent-level cap directly.
+    const agent = makeAgent({
+      timeoutSec: 1,
+      nodes: [
+        { id: 'slow', type: 'shell', command: 'sleep 0' },
+        { id: 'never', type: 'shell', command: 'echo never', dependsOn: ['slow'] },
+      ],
+    });
+    const run = await executeAgentDag(
+      agent,
+      { triggeredBy: 'cli' },
+      { runStore, spawnNode: cannedSpawner({ slow: { exitCode: 0, result: 'done', delayMs: 1100 } }) },
+    );
+
+    expect(run.status).toBe('failed');
+    expect(run.error).toMatch(/wall-clock timeout \(1s\)/);
+
+    const execs = runStore.listNodeExecutions(run.id);
+    const slow = execs.find((e) => e.nodeId === 'slow')!;
+    const never = execs.find((e) => e.nodeId === 'never')!;
+    // Slow node ran to completion under the mock (signal honoring is the
+    // spawner's job, not the executor's — the real spawnProcess does
+    // SIGTERM/SIGKILL). The executor still aborts the rest of the DAG.
+    expect(slow.status).toBe('completed');
+    expect(never.status).toBe('cancelled');
+    expect(never.errorCategory).toBe('cancelled');
+  });
+
+  it('does not fire when the run finishes under the ceiling', async () => {
+    const agent = makeAgent({ timeoutSec: 5 });
+    const run = await executeAgentDag(
+      agent,
+      { triggeredBy: 'cli' },
+      { runStore, spawnNode: cannedSpawner({ main: { exitCode: 0, result: 'fast', delayMs: 50 } }) },
+    );
+    expect(run.status).toBe('completed');
+    expect(run.error).toBeFalsy();
+  });
+
+  it('treats timeoutSec=0 as disabled (no ceiling)', async () => {
+    const agent = makeAgent({ timeoutSec: 0 });
+    const run = await executeAgentDag(
+      agent,
+      { triggeredBy: 'cli' },
+      { runStore, spawnNode: cannedSpawner({ main: { exitCode: 0, result: 'ok', delayMs: 50 } }) },
+    );
+    expect(run.status).toBe('completed');
+  });
+
+  it('respects a caller-supplied abort signal even when timeoutSec is set', async () => {
+    // Caller cancels BEFORE the agent timeout fires. The run should reflect
+    // a caller-driven cancellation, not a wall-clock-timeout error.
+    const controller = new AbortController();
+    const agent = makeAgent({
+      timeoutSec: 60,
+      nodes: [
+        { id: 'a', type: 'shell', command: 'echo a' },
+        { id: 'b', type: 'shell', command: 'echo b', dependsOn: ['a'] },
+      ],
+    });
+    const spawn: DagExecutorDeps['spawnNode'] = async (node) => {
+      if (node.id === 'a') {
+        controller.abort();
+        return { result: 'a-done', exitCode: 0 };
+      }
+      return { result: '', exitCode: 0 };
+    };
+    const run = await executeAgentDag(
+      agent,
+      { triggeredBy: 'cli', signal: controller.signal },
+      { runStore, spawnNode: spawn },
+    );
+    // The cancellation path tags firstFailure with category 'cancelled' —
+    // not the wall-clock-timeout error. The agent-timeout branch only
+    // overrides when agentTimedOut is true.
+    expect(run.error).not.toMatch(/wall-clock timeout/);
+    const execs = runStore.listNodeExecutions(run.id);
+    expect(execs.find((e) => e.nodeId === 'b')!.status).toBe('cancelled');
+  });
+});

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -242,6 +242,42 @@ export async function executeAgentDag(
   let flowEnded = false;
   const skippedNodes = new Set<string>();
 
+  // ── Agent wall-clock ceiling (Agent.timeoutSec) ──────────────────────
+  // Per-node timeouts protect against ONE node hanging, but a 10-node DAG
+  // at 60s each can legitimately burn 10 minutes on tokens before any
+  // single node trips. agent.timeoutSec is the umbrella that catches that
+  // case. Implementation: combine the caller's abort signal with an
+  // internal controller that fires on either the caller-abort OR the
+  // timeout, then pass the combined signal everywhere this loop previously
+  // passed `options.signal`. When the timeout itself fires we record
+  // `agentTimedOut=true` so the final run.error names the cap directly
+  // instead of looking like a generic cancel.
+  const internalAbort = new AbortController();
+  let agentTimedOut = false;
+  let agentTimeoutTimer: NodeJS.Timeout | undefined;
+  const forwardCallerAbort = () => internalAbort.abort();
+  if (options.signal) {
+    if (options.signal.aborted) internalAbort.abort();
+    else options.signal.addEventListener('abort', forwardCallerAbort, { once: true });
+  }
+  if (agent.timeoutSec && agent.timeoutSec > 0) {
+    agentTimeoutTimer = setTimeout(() => {
+      agentTimedOut = true;
+      internalAbort.abort();
+    }, agent.timeoutSec * 1000);
+  }
+  // Single point of cleanup for the wall-clock timer + caller-abort listener.
+  // Called once on every return path from this function (terminal status,
+  // replay early-exit, exception).
+  const cleanupAgentTimeout = () => {
+    if (agentTimeoutTimer) {
+      clearTimeout(agentTimeoutTimer);
+      agentTimeoutTimer = undefined;
+    }
+    if (options.signal) options.signal.removeEventListener('abort', forwardCallerAbort);
+  };
+  const effectiveSignal = internalAbort.signal;
+
   // Replay pre-load: copy prior node_executions for nodes before the pivot.
   // Their stored `result` feeds downstream outputs so re-execution starts
   // at `fromNodeId` with the exact snapshot the original run produced.
@@ -250,6 +286,7 @@ export async function executeAgentDag(
     const { priorRunId, fromNodeId } = options.replayFrom;
     const pivotIndex = order.findIndex((n) => n.id === fromNodeId);
     if (pivotIndex < 0) {
+      cleanupAgentTimeout();
       deps.runStore.updateRun(runId, {
         status: 'failed',
         completedAt: new Date().toISOString(),
@@ -271,6 +308,7 @@ export async function executeAgentDag(
       }
     }
     if (missing.length > 0) {
+      cleanupAgentTimeout();
       deps.runStore.updateRun(runId, {
         status: 'failed',
         completedAt: new Date().toISOString(),
@@ -303,7 +341,7 @@ export async function executeAgentDag(
 
     // Cancellation: abort signal was fired. Mark all remaining nodes
     // as cancelled and break out of the loop.
-    if (options.signal?.aborted) {
+    if (effectiveSignal.aborted) {
       deps.runStore.createNodeExecution({
         runId,
         nodeId: node.id,
@@ -700,6 +738,18 @@ export async function executeAgentDag(
       });
     };
 
+    // PR C (orphan-kill): persist the child's pid + wall-clock start time
+    // onto the in-flight node row the moment spawn() returns. A dashboard
+    // restart mid-run can then read these back, ps-cross-check, and SIGKILL
+    // the orphan instead of letting it burn tokens until the API call
+    // finishes naturally.
+    const onSpawn = (pid: number, startedAtMs: number) => {
+      deps.runStore.updateNodeExecution(runId, node.id, {
+        childPid: pid,
+        childStartedAtMs: startedAtMs,
+      });
+    };
+
     // v0.16 tool dispatch: if the node references a tool, resolve it and
     // call its execute() function. Built-in tools run in-process; user
     // tools that use shell/claude-code implementation types go through the
@@ -835,7 +885,7 @@ export async function executeAgentDag(
           };
           const toolInputs = resolveValue(rawInputs) as Record<string, unknown>;
 
-          structuredOutput = await callMcpTool(resolvedImpl, toolInputs, options.signal);
+          structuredOutput = await callMcpTool(resolvedImpl, toolInputs, effectiveSignal);
           const isError = Boolean(structuredOutput.isError);
           result = {
             result: structuredOutput.result ?? '',
@@ -856,7 +906,7 @@ export async function executeAgentDag(
           };
           const spawnOpts = { agentId: agent.id, agentSource: agent.source, allowUntrustedShell: deps.allowUntrustedShell };
           const spawnResult = spawnFn === spawnNodeReal
-            ? await spawnNodeReal(synthNode, env, spawnOpts, onProgress, options.signal)
+            ? await spawnNodeReal(synthNode, env, spawnOpts, onProgress, effectiveSignal, onSpawn)
             : await spawnFn(synthNode, env, spawnOpts);
           result = spawnResult;
           structuredOutput = buildToolOutput(spawnResult.result);
@@ -872,7 +922,7 @@ export async function executeAgentDag(
         const spawnFn = deps.spawnNode ?? spawnNodeReal;
         const spawnOpts = { agentId: agent.id, agentSource: agent.source, allowUntrustedShell: deps.allowUntrustedShell };
         const spawnResult = spawnFn === spawnNodeReal
-          ? await spawnNodeReal(nodeWithDefaults, env, spawnOpts, onProgress, options.signal)
+          ? await spawnNodeReal(nodeWithDefaults, env, spawnOpts, onProgress, effectiveSignal, onSpawn)
           : await spawnFn(nodeWithDefaults, env, spawnOpts);
         result = spawnResult;
         // Try to extract framed output from stdout even for legacy nodes,
@@ -966,6 +1016,18 @@ export async function executeAgentDag(
     }
   }
 
+  // Wall-clock ceiling tripped → name the cap directly in the run error so
+  // the dashboard shows "Agent wall-clock timeout (60s) exceeded" instead of
+  // a generic "Cancelled by user" that the abort plumbing would otherwise
+  // produce. The per-node row remains tagged with whatever category the
+  // spawn produced (typically 'timeout' on the in-flight node, 'cancelled'
+  // on the remaining ones).
+  if (agentTimedOut) {
+    finalStatus = 'failed';
+    finalError = `Agent wall-clock timeout (${agent.timeoutSec}s) exceeded.`;
+  }
+
+  cleanupAgentTimeout();
   deps.runStore.updateRun(runId, {
     status: finalStatus,
     completedAt: new Date().toISOString(),

--- a/packages/core/src/node-spawner.ts
+++ b/packages/core/src/node-spawner.ts
@@ -216,6 +216,7 @@ export async function spawnNodeReal(
   _opts: { agentId: string; agentSource: Agent['source']; allowUntrustedShell?: ReadonlySet<string> },
   onProgress?: (event: SpawnProgress) => void,
   signal?: AbortSignal,
+  onSpawn?: (pid: number, startedAtMs: number) => void,
 ): Promise<SpawnResult> {
   if (node.type === 'shell') {
     if (!node.command) {
@@ -226,6 +227,7 @@ export async function spawnNodeReal(
       env,
       timeoutSec: node.timeout ?? 300,
       signal,
+      onSpawn,
     });
   }
 
@@ -279,6 +281,7 @@ export async function spawnNodeReal(
     } : undefined,
     extractResult: (stdout) => spawner.extractResult(stdout),
     signal,
+    onSpawn,
   });
 }
 
@@ -302,6 +305,16 @@ export interface SpawnProcessOptions {
    * substitution exceeds that ceiling fails with `spawn E2BIG` otherwise.
    */
   stdinInput?: string;
+  /**
+   * PR C (orphan-kill): fires the moment `spawn()` returns a pid, BEFORE
+   * any pipe wiring or stdin writes. The executor persists pid + startedAtMs
+   * onto the in-flight `node_executions` row so a future dashboard restart
+   * can read it back and SIGKILL the orphan instead of letting it burn
+   * tokens until it finishes naturally. startedAtMs is `Date.now()` at
+   * spawn time; the reaper ps-cross-checks elapsed time against it to
+   * defend against PID reuse on long-uptime machines.
+   */
+  onSpawn?: (pid: number, startedAtMs: number) => void;
 }
 
 /**
@@ -370,6 +383,13 @@ export async function spawnProcess(
     } catch (err) {
       resolve({ result: '', exitCode: 127, error: (err as Error).message, category: 'spawn_failure' });
       return;
+    }
+    // Report the freshly-spawned pid + start time so the executor can persist
+    // them on the node_executions row. Fires before stdin write so a crash
+    // between spawn() and the first stdout chunk still leaves a kill handle.
+    // Wrapped in try/catch: the callback shouldn't kill the run if it throws.
+    if (opts.onSpawn && typeof child.pid === 'number') {
+      try { opts.onSpawn(child.pid, Date.now()); } catch { /* never let onSpawn break spawning */ }
     }
     if (opts.stdinInput !== undefined && child.stdin) {
       child.stdin.on('error', () => { /* child may close before we finish writing — swallow EPIPE */ });

--- a/packages/core/src/run-orphan-reaper.test.ts
+++ b/packages/core/src/run-orphan-reaper.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { RunStore } from './run-store.js';
-import { reapOrphanedRuns } from './run-orphan-reaper.js';
+import { reapOrphanedRuns, parseEtime } from './run-orphan-reaper.js';
 import type { NodeExecutionRecord } from './agent-v2-types.js';
 
 const TEST_DB = join(import.meta.dirname, '__test-data__', 'orphan-reaper.db');
@@ -105,5 +105,82 @@ describe('reapOrphanedRuns', () => {
 
     expect(result.runsReaped).toBe(1);
     expect(store.getRun('pre')?.status).toBe('failed');
+  });
+});
+
+describe('reapOrphanedRuns — PID kill (PR C)', () => {
+  it('persists childPid/childStartedAtMs through createNodeExecution/listNodeExecutions', () => {
+    // The DB plumbing has to round-trip these fields cleanly or the kill
+    // path can never see them. Sanity-check first.
+    store.createRun({ id: 'r-pid', agentName: 'x', status: 'running', startedAt: '2026-05-26T03:00:00Z', triggeredBy: 'cli' });
+    store.createNodeExecution(mkExec('r-pid', 'n', { childPid: 12345, childStartedAtMs: 1700000000000 }));
+    const fetched = store.getNodeExecution('r-pid', 'n');
+    expect(fetched?.childPid).toBe(12345);
+    expect(fetched?.childStartedAtMs).toBe(1700000000000);
+  });
+
+  it('calls killProcess for rows that carry a pid, and counts the kills', () => {
+    const killed: Array<{ pid: number; startedAtMs: number }> = [];
+    store.createRun({ id: 'r-k', agentName: 'x', status: 'running', startedAt: '2026-05-26T03:00:00Z', triggeredBy: 'cli' });
+    store.createNodeExecution(mkExec('r-k', 'a', { childPid: 1111, childStartedAtMs: 1_700_000_000_000 }));
+    store.createNodeExecution(mkExec('r-k', 'b', { childPid: 2222, childStartedAtMs: 1_700_000_010_000 }));
+
+    const result = reapOrphanedRuns(store, {
+      killProcess: (pid, startedAtMs) => { killed.push({ pid, startedAtMs }); return true; },
+    });
+
+    expect(killed).toEqual([
+      { pid: 1111, startedAtMs: 1_700_000_000_000 },
+      { pid: 2222, startedAtMs: 1_700_000_010_000 },
+    ]);
+    expect(result.pidsKilled).toBe(2);
+    expect(result.nodesReaped).toBe(2);
+  });
+
+  it('does NOT call killProcess for rows without a pid (non-spawning paths)', () => {
+    const killed: number[] = [];
+    store.createRun({ id: 'r-mcp', agentName: 'x', status: 'running', startedAt: '2026-05-26T03:00:00Z', triggeredBy: 'cli' });
+    // MCP / built-in tool nodes don't spawn a child process.
+    store.createNodeExecution(mkExec('r-mcp', 'mcp-call'));
+
+    const result = reapOrphanedRuns(store, {
+      killProcess: (pid) => { killed.push(pid); return true; },
+    });
+
+    expect(killed).toEqual([]);
+    expect(result.pidsKilled).toBe(0);
+    expect(result.nodesReaped).toBe(1); // row still finalized
+  });
+
+  it('does not increment pidsKilled when killProcess declines (PID reuse)', () => {
+    store.createRun({ id: 'r-skip', agentName: 'x', status: 'running', startedAt: '2026-05-26T03:00:00Z', triggeredBy: 'cli' });
+    store.createNodeExecution(mkExec('r-skip', 'a', { childPid: 9999, childStartedAtMs: 1_700_000_000_000 }));
+
+    const result = reapOrphanedRuns(store, { killProcess: () => false });
+
+    expect(result.pidsKilled).toBe(0);
+    expect(result.nodesReaped).toBe(1); // row still finalized
+    expect(store.getNodeExecution('r-skip', 'a')?.errorCategory).toBe('abandoned');
+  });
+});
+
+describe('parseEtime', () => {
+  it('parses MM:SS', () => {
+    expect(parseEtime('00:30')).toBe(30);
+    expect(parseEtime('02:15')).toBe(135);
+  });
+  it('parses HH:MM:SS', () => {
+    expect(parseEtime('01:02:03')).toBe(3723);
+  });
+  it('parses DD-HH:MM:SS', () => {
+    expect(parseEtime('2-03:04:05')).toBe(2 * 86400 + 3 * 3600 + 4 * 60 + 5);
+  });
+  it('tolerates surrounding whitespace', () => {
+    expect(parseEtime('  00:42  ')).toBe(42);
+  });
+  it('returns null on garbage', () => {
+    expect(parseEtime('not-a-time')).toBeNull();
+    expect(parseEtime('')).toBeNull();
+    expect(parseEtime('00:99:00:00')).toBeNull();
   });
 });

--- a/packages/core/src/run-orphan-reaper.ts
+++ b/packages/core/src/run-orphan-reaper.ts
@@ -17,11 +17,13 @@
  * notify logic doesn't fire forever, and the audit trail explains the
  * gap.
  *
- * This DOES NOT kill the orphaned child process — that requires the
- * child PID, which isn't persisted yet (followup C). Tokens already
- * spent are gone; what this stops is the state-machine bleed.
+ * PR C (this file): when the node row carries a persisted `childPid` +
+ * `childStartedAtMs`, the reaper additionally SIGKILLs the orphan after
+ * a ps-cross-check defends against PID reuse. This actually stops the
+ * token burn instead of just closing the state-machine bleed.
  */
 
+import { execSync } from 'node:child_process';
 import type { RunStore } from './run-store.js';
 import type { RunStatus } from './types.js';
 import type { NodeExecutionRecord } from './agent-v2-types.js';
@@ -31,6 +33,8 @@ export interface ReapResult {
   runsReaped: number;
   /** Number of `node_executions` rows transitioned to `failed`. */
   nodesReaped: number;
+  /** Number of orphaned child processes the reaper actually SIGKILLed. */
+  pidsKilled: number;
   /** Run IDs that were reaped, in case the caller wants to log them. */
   reapedRunIds: string[];
 }
@@ -43,12 +47,107 @@ export interface ReapOptions {
    * message that names the daemon-restart race as the typical cause.
    */
   reason?: string;
+  /**
+   * `Date.now()` reference for the ps cross-check. Tests inject a fixed
+   * clock so they can verify drift detection deterministically. Defaults
+   * to the live wall clock.
+   */
+  nowMs?: number;
+  /**
+   * Hook the kill + ps subprocess for tests. Returns true iff the process
+   * was killed (or didn't need to be). Production callers leave this
+   * unset and get the real `killIfStillOurs`.
+   */
+  killProcess?: (pid: number, startedAtMs: number, nowMs: number) => boolean;
 }
 
 const DEFAULT_REASON =
   'Run abandoned: dashboard restarted while this run was in flight. ' +
-  'The child process was reparented and may have continued briefly; ' +
-  'the run record is being finalized so dashboards stop polling.';
+  'The orphaned child process has been killed (if still running); the ' +
+  'run record is being finalized so dashboards stop polling.';
+
+/**
+ * Kill an orphaned child process if we can verify it's still the one we
+ * spawned. Defends against PID reuse on long-uptime machines by parsing
+ * `ps -p <pid> -o etime=` and comparing the elapsed time against the
+ * stored `startedAtMs`. Drift > max(5s, 10% of expected) → skip the kill.
+ *
+ * Returns true when the process was SIGKILLed (or already gone — which is
+ * the desired end state anyway). Returns false when we declined to kill
+ * because the PID belongs to something else now, or `ps` failed.
+ */
+export function killIfStillOurs(pid: number, startedAtMs: number, nowMs: number = Date.now()): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+
+  let etimeRaw: string;
+  try {
+    // `ps -p <pid> -o etime=` works on macOS + Linux. Empty trailing `=`
+    // suppresses the header. The format is `[[DD-]HH:]MM:SS`.
+    etimeRaw = execSync(`ps -p ${pid} -o etime=`, {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 2000,
+    }).trim();
+  } catch {
+    // ps returned non-zero (pid not found) or hung past timeout. Either way
+    // the orphan is already gone — desired end state.
+    return true;
+  }
+
+  const actualEtimeSec = parseEtime(etimeRaw);
+  if (actualEtimeSec === null) {
+    // Unparseable output — be conservative and skip the kill.
+    return false;
+  }
+
+  const expectedSec = Math.max(0, (nowMs - startedAtMs) / 1000);
+  const tolerance = Math.max(5, expectedSec * 0.1);
+  if (Math.abs(actualEtimeSec - expectedSec) > tolerance) {
+    // PID reuse: a different process is wearing this pid now. Do not kill.
+    return false;
+  }
+
+  try {
+    process.kill(pid, 'SIGKILL');
+    return true;
+  } catch {
+    // ESRCH (already dead) or EPERM (not ours). Either way we're done.
+    return true;
+  }
+}
+
+/**
+ * Parse `ps -o etime=` output into seconds.
+ *
+ * Accepted forms (any whitespace allowed around):
+ *   `MM:SS`          →  MM * 60 + SS
+ *   `HH:MM:SS`       →  HH * 3600 + MM * 60 + SS
+ *   `DD-HH:MM:SS`    →  DD * 86400 + HH * 3600 + MM * 60 + SS
+ *
+ * Returns null on anything that doesn't match.
+ */
+export function parseEtime(raw: string): number | null {
+  const s = raw.trim();
+  // Day-prefixed form: `DD-HH:MM:SS`
+  const dayMatch = s.match(/^(\d+)-(\d+):(\d+):(\d+)$/);
+  if (dayMatch) {
+    const [, d, h, m, sec] = dayMatch;
+    return +d * 86400 + +h * 3600 + +m * 60 + +sec;
+  }
+  // Hour-prefixed form: `HH:MM:SS`
+  const hourMatch = s.match(/^(\d+):(\d+):(\d+)$/);
+  if (hourMatch) {
+    const [, h, m, sec] = hourMatch;
+    return +h * 3600 + +m * 60 + +sec;
+  }
+  // Bare minutes: `MM:SS`
+  const minMatch = s.match(/^(\d+):(\d+)$/);
+  if (minMatch) {
+    const [, m, sec] = minMatch;
+    return +m * 60 + +sec;
+  }
+  return null;
+}
 
 /**
  * Find every run in a non-terminal status (`running` or `pending`) and
@@ -61,7 +160,9 @@ const DEFAULT_REASON =
  */
 export function reapOrphanedRuns(runStore: RunStore, options: ReapOptions = {}): ReapResult {
   const completedAt = options.now ?? new Date().toISOString();
+  const nowMs = options.nowMs ?? Date.now();
   const reason = options.reason ?? DEFAULT_REASON;
+  const killFn = options.killProcess ?? killIfStillOurs;
 
   // Pull every non-terminal run. `queryRuns` with statuses=['running','pending']
   // captures both the actively-executing case and the rare "DB row written
@@ -74,6 +175,7 @@ export function reapOrphanedRuns(runStore: RunStore, options: ReapOptions = {}):
 
   let runsReaped = 0;
   let nodesReaped = 0;
+  let pidsKilled = 0;
   const reapedRunIds: string[] = [];
 
   for (const run of rows) {
@@ -88,9 +190,22 @@ export function reapOrphanedRuns(runStore: RunStore, options: ReapOptions = {}):
 
     // Finalize any still-running node executions. Skip terminal-status
     // node rows so a partially-completed run keeps its earlier history.
+    // For each row that carries a persisted childPid + childStartedAtMs,
+    // try to SIGKILL the orphan before transitioning the row — this is
+    // what actually stops the token bleed (vs just closing the state-
+    // machine bleed). PR-C addition.
     const nodeExecs: NodeExecutionRecord[] = runStore.listNodeExecutions(run.id);
     for (const exec of nodeExecs) {
       if (exec.status === 'running' || exec.status === 'pending') {
+        if (typeof exec.childPid === 'number' && typeof exec.childStartedAtMs === 'number') {
+          // killFn returns true when the process was killed OR was already
+          // gone (both desired end states). False means PID reuse drift
+          // declined the kill — orphan continues until it finishes
+          // naturally, but the state machine is still closed.
+          if (killFn(exec.childPid, exec.childStartedAtMs, nowMs)) {
+            pidsKilled++;
+          }
+        }
         runStore.updateNodeExecution(run.id, exec.nodeId, {
           status: 'failed',
           errorCategory: 'abandoned',
@@ -102,5 +217,5 @@ export function reapOrphanedRuns(runStore: RunStore, options: ReapOptions = {}):
     }
   }
 
-  return { runsReaped, nodesReaped, reapedRunIds };
+  return { runsReaped, nodesReaped, pidsKilled, reapedRunIds };
 }

--- a/packages/core/src/run-store.ts
+++ b/packages/core/src/run-store.ts
@@ -205,6 +205,18 @@ export class RunStore {
     if (!execCols.has('statebytesafter')) {
       this.db.exec(`ALTER TABLE node_executions ADD COLUMN stateBytesAfter INTEGER`);
     }
+
+    // PR C (orphan-kill): persist the spawned child process's PID + wall-clock
+    // start time. The orphan reaper reads both — `childStartedAtMs` lets it
+    // ps-cross-check before SIGKILL'ing, defending against PID reuse on
+    // long-uptime machines. NULL on rows from non-spawning code paths (MCP
+    // tool calls, built-in tools, replay-copied prior outputs) by design.
+    if (!execCols.has('childpid')) {
+      this.db.exec(`ALTER TABLE node_executions ADD COLUMN childPid INTEGER`);
+    }
+    if (!execCols.has('childstartedatms')) {
+      this.db.exec(`ALTER TABLE node_executions ADD COLUMN childStartedAtMs INTEGER`);
+    }
   }
 
   /**
@@ -388,8 +400,8 @@ export class RunStore {
         runId, nodeId, workflowVersion, status, errorCategory,
         startedAt, completedAt, result, exitCode, error,
         inputsJson, upstreamInputsJson, outputsJson, progressJson,
-        stateBytesBefore, stateBytesAfter
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        stateBytesBefore, stateBytesAfter, childPid, childStartedAtMs
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     stmt.run(
       record.runId, record.nodeId, record.workflowVersion, record.status,
@@ -399,6 +411,7 @@ export class RunStore {
       record.inputsJson ?? null, record.upstreamInputsJson ?? null,
       record.outputsJson ?? null, record.progressJson ?? null,
       record.stateBytesBefore ?? null, record.stateBytesAfter ?? null,
+      record.childPid ?? null, record.childStartedAtMs ?? null,
     );
   }
 
@@ -406,7 +419,7 @@ export class RunStore {
     runId: string,
     nodeId: string,
     updates: Partial<Pick<NodeExecutionRecord,
-      'status' | 'errorCategory' | 'completedAt' | 'result' | 'exitCode' | 'error' | 'inputsJson' | 'upstreamInputsJson' | 'outputsJson' | 'progressJson' | 'stateBytesBefore' | 'stateBytesAfter'
+      'status' | 'errorCategory' | 'completedAt' | 'result' | 'exitCode' | 'error' | 'inputsJson' | 'upstreamInputsJson' | 'outputsJson' | 'progressJson' | 'stateBytesBefore' | 'stateBytesAfter' | 'childPid' | 'childStartedAtMs'
     >>,
   ): void {
     const fields: string[] = [];
@@ -423,6 +436,8 @@ export class RunStore {
     if (updates.progressJson !== undefined) { fields.push('progressJson = ?'); values.push(updates.progressJson); }
     if (updates.stateBytesBefore !== undefined) { fields.push('stateBytesBefore = ?'); values.push(updates.stateBytesBefore); }
     if (updates.stateBytesAfter !== undefined) { fields.push('stateBytesAfter = ?'); values.push(updates.stateBytesAfter); }
+    if (updates.childPid !== undefined) { fields.push('childPid = ?'); values.push(updates.childPid); }
+    if (updates.childStartedAtMs !== undefined) { fields.push('childStartedAtMs = ?'); values.push(updates.childStartedAtMs); }
     if (fields.length === 0) return;
 
     values.push(runId, nodeId);
@@ -515,6 +530,8 @@ export class RunStore {
       progressJson: (row.progressJson as string | null) ?? undefined,
       stateBytesBefore: (row.stateBytesBefore as number | null) ?? undefined,
       stateBytesAfter: (row.stateBytesAfter as number | null) ?? undefined,
+      childPid: (row.childPid as number | null) ?? undefined,
+      childStartedAtMs: (row.childStartedAtMs as number | null) ?? undefined,
     };
   }
 }

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -305,14 +305,15 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
   // the cancel route's activeRuns Map is empty. Finalize those rows so
   // dashboards stop polling and downstream notify/retry don't hang.
   //
-  // Caveat: the orphaned child process (claude / codex CLI) may keep running
-  // briefly until it finishes its current HTTP call — this reaper closes the
-  // state-machine bleed but cannot kill the process without a persisted PID
-  // (see followup C: persist child pid on node_executions row).
+  // PR C: when the node row carries a persisted childPid + childStartedAtMs,
+  // the reaper additionally SIGKILLs the orphaned process after a ps-cross-
+  // check defends against PID reuse. This stops the token bleed for orphans
+  // still streaming to the Anthropic API at boot time.
   const reapResult = reapOrphanedRuns(runStore);
   if (reapResult.runsReaped > 0) {
     console.warn(
       `[orphan-reaper] Finalized ${reapResult.runsReaped} run(s) and ${reapResult.nodesReaped} node execution(s) ` +
+      `(killed ${reapResult.pidsKilled} orphaned process(es)) ` +
       `left in non-terminal state by a prior dashboard exit. Run ids: ${reapResult.reapedRunIds.slice(0, 10).join(', ')}` +
       `${reapResult.reapedRunIds.length > 10 ? ` (+${reapResult.reapedRunIds.length - 10} more)` : ''}`,
     );


### PR DESCRIPTION
Follow-up to [#363](https://github.com/gregmeyer/some-useful-agents/pull/363) (orphan reaper). The reaper closed the state-machine bleed but couldn't stop the orphaned \`claude\`/\`codex\` CLI from finishing its in-flight API call. This PR adds the two missing pieces, plus the agent-level wall-clock ceiling we were missing entirely.

## E — \`Agent.timeoutSec\`: wall-clock ceiling for the whole run

Per-node \`timeout\` protects against one node hanging. Agent-level \`timeoutSec\` is the umbrella that catches the case where a 10-node DAG at 60s each can legitimately burn 10 minutes — and no single node's setTimeout fires to stop it.

- New optional field on [Agent](packages/core/src/agent-v2-types.ts) (yaml + zod + type).
- [executeAgentDag](packages/core/src/dag-executor.ts) arms an internal \`AbortController\` that fires on **either** the caller's abort signal **OR** a \`setTimeout(timeoutSec * 1000)\`. The combined signal is passed everywhere \`options.signal\` previously was — MCP calls, both \`spawnNodeReal\` sites.
- When the timeout itself fires, the run finalizes with \`status='failed'\` and the error names the cap directly: \`Agent wall-clock timeout (60s) exceeded.\`
- [agents/examples/layout-planner.yaml](agents/examples/layout-planner.yaml) gets \`timeoutSec: 60\` (normal runtime ~20s — catches the run b48c0d25 case without flagging legitimately-slow runs).

## C — persist child PID + kill orphan on reap

Two new nullable columns on \`node_executions\`: \`childPid\` and \`childStartedAtMs\`. The reaper now SIGKILLs orphans whose row carries them.

- [RunStore](packages/core/src/run-store.ts) idempotent migration via \`PRAGMA table_info\`. [NodeExecutionRecord](packages/core/src/agent-v2-types.ts) + create/update/row functions threaded through.
- [spawnProcess](packages/core/src/node-spawner.ts) gains \`onSpawn(pid, startedAtMs)\` fired the moment \`spawn()\` returns, BEFORE any pipe wiring. Wrapped in try/catch — the callback never breaks spawning.
- [executeAgentDag](packages/core/src/dag-executor.ts) wires \`onSpawn\` → \`runStore.updateNodeExecution(runId, nodeId, { childPid, childStartedAtMs })\`.
- [reapOrphanedRuns](packages/core/src/run-orphan-reaper.ts) calls \`killIfStillOurs(pid, startedAtMs, nowMs)\` for every abandoned row that carries the new fields. The helper:
  - Runs \`ps -p <pid> -o etime=\` (works on macOS + Linux).
  - Parses \`[[DD-]HH:]MM:SS\` to seconds.
  - Compares against \`(nowMs - startedAtMs) / 1000\`.
  - Tolerates drift up to \`max(5s, expected * 0.1)\`.
  - If within tolerance → \`process.kill(pid, 'SIGKILL')\`.
  - Otherwise (PID reuse, process gone, ps unavailable) → skip silently.
- \`ReapResult\` gains \`pidsKilled\`; dashboard boot log includes it: \`Finalized 1 run(s) and 1 node execution(s) (killed 1 orphaned process(es))\`.

## Tests

\`1603 pass / 3 skipped\` (was 1590, +13). No regressions.

- **E** (4): timeout fires + finalizes, no-op when under cap, \`timeoutSec=0\` disables, caller-abort wins over wall-clock.
- **C** (9): DB round-trip of pid/startedAtMs, killProcess called only on pid-bearing rows, pidsKilled tracks decline-to-kill, parseEtime handles all four formats + garbage.

## Files

11 changed (+464 / -18). Changeset bumps all five workspace packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)