### PR TITLE
feat(dashboard): /scheduled Activate one-click on drafts + explanatory hints

### DIFF
--- a/.changeset/scheduled-activate-drafts.md
+++ b/.changeset/scheduled-activate-drafts.md
@@ -1,0 +1,21 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+dashboard/scheduled: Activate one-click on draft rows + explanatory hint for non-firing statuses.
+
+Follow-up to the new /scheduled page. The page listed drafts with a `schedule:` declared but offered no row action — leaving the user with `Every day at 7:00 AM` next to `—` in Next fire and a "why didn't this run?" question. The answer is that the scheduler only fires `status='active'` agents.
+
+Now:
+
+- **Draft rows get an `Activate` button.** Posts to a new `POST /scheduled/:id/activate` route that flips status `draft → active`. Same shape as Pause/Resume; 303 redirect with a flash; idempotent guards.
+
+- **Non-active rows get an explanatory Next-fire hint.** Drafts render `won't fire — status is draft` (with a tooltip explaining the scheduler-only-fires-active rule). Archived render `won't fire — archived`. Paused continues to show `—` (the cron is paused-by-intent and one click away from firing on Resume).
+
+- **`never` in Last fire gets a tooltip.** Clarifies that the column counts only scheduler-triggered runs — manual runs via dashboard / CLI / MCP don't count, so an agent that's been run manually but never by the scheduler shows `never` here by design.
+
+Tests: 1614 pass / 3 skipped (+4 new: draft renders Activate + hint, activate flips status, idempotent on already-active, archived hint with no row action).

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -3700,4 +3700,79 @@ describe('/scheduled — scheduled-agents page (and pause/resume)', () => {
     expect(decodeURIComponent(res.headers.location)).toMatch(/flash=.*already paused/);
     expect(agentStore.getAgent('already-paused')?.status).toBe('paused');
   });
+
+  it('renders an Activate button + draft hint on rows with status=draft', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'cron-draft', name: 'Cron Draft', status: 'draft', source: 'local', mcp: false,
+      schedule: '0 7 * * *',
+      nodes: [{ id: 'main', type: 'shell', command: 'echo hi' }],
+    }, 'cli');
+
+    const res = await request(app).get('/scheduled')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    expect(res.status).toBe(200);
+    // Activate form points at the new route.
+    expect(res.text).toMatch(/\/scheduled\/cron-draft\/activate/);
+    // Inline hint replaces the bare em-dash in the Next-fire cell.
+    expect(res.text).toMatch(/won't fire — status is draft/);
+    // No pause/resume button on a draft row.
+    expect(res.text).not.toMatch(/\/scheduled\/cron-draft\/pause/);
+    expect(res.text).not.toMatch(/\/scheduled\/cron-draft\/resume/);
+  });
+
+  it('POST /scheduled/:id/activate flips a draft to active and redirects', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'to-activate', name: 'To Activate', status: 'draft', source: 'local', mcp: false,
+      schedule: '0 8 * * *',
+      nodes: [{ id: 'main', type: 'shell', command: 'echo hi' }],
+    }, 'cli');
+
+    const res = await request(app).post('/scheduled/to-activate/activate')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/^\/scheduled\?flash=/);
+    expect(decodeURIComponent(res.headers.location)).toMatch(/flash=Activated/);
+    expect(agentStore.getAgent('to-activate')?.status).toBe('active');
+    expect(agentStore.getAgent('to-activate')?.schedule).toBe('0 8 * * *');
+  });
+
+  it('POST /scheduled/:id/activate on an already-active agent is a no-op with a flash', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'already-active', name: 'Already', status: 'active', source: 'local', mcp: false,
+      schedule: '0 8 * * *',
+      nodes: [{ id: 'main', type: 'shell', command: 'echo hi' }],
+    }, 'cli');
+
+    const res = await request(app).post('/scheduled/already-active/activate')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    expect(res.status).toBe(303);
+    expect(decodeURIComponent(res.headers.location)).toMatch(/flash=.*already active/);
+    expect(agentStore.getAgent('already-active')?.status).toBe('active');
+  });
+
+  it('archived rows render the archived hint, no pause/resume/activate button', async () => {
+    const app = await makeApp();
+    agentStore.createAgent({
+      id: 'cron-archived', name: 'Cron Archived', status: 'archived', source: 'local', mcp: false,
+      schedule: '0 9 * * *',
+      nodes: [{ id: 'main', type: 'shell', command: 'echo hi' }],
+    }, 'cli');
+
+    const res = await request(app).get('/scheduled')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+    expect(res.status).toBe(200);
+    expect(res.text).toMatch(/won't fire — archived/);
+    expect(res.text).not.toMatch(/\/scheduled\/cron-archived\/(pause|resume|activate)/);
+  });
 });

--- a/packages/dashboard/src/routes/scheduled.ts
+++ b/packages/dashboard/src/routes/scheduled.ts
@@ -62,10 +62,29 @@ scheduledRouter.get('/scheduled', (req: Request, res: Response) => {
 });
 
 /**
- * Set status to a target value and redirect to /scheduled with a flash.
- * Used by both /pause and /resume so the error/flash paths stay consistent.
+ * Verb metadata for each row-action route. `noun` is the user-facing label
+ * (gerund + past tense both derive from the route name); `past` is the
+ * "Did X" form used in the success flash. Centralised so the flash copy
+ * stays consistent across pause / resume / activate.
  */
-function flipStatus(req: Request, res: Response, nextStatus: 'paused' | 'active'): void {
+interface VerbCopy {
+  /** Imperative + present-progressive form, used in error flashes ("Pause failed"). */
+  imperative: 'Pause' | 'Resume' | 'Activate';
+  /** Past tense form, used in success flashes ("Paused \"X\""). */
+  past: 'Paused' | 'Resumed' | 'Activated';
+}
+
+/**
+ * Flip an agent's status to `nextStatus` and redirect to /scheduled with a
+ * flash. Used by /pause, /resume, and /activate. Guards: missing agent,
+ * missing schedule, already-in-target-state all return 303 + flash, not 5xx.
+ */
+function flipStatus(
+  req: Request,
+  res: Response,
+  nextStatus: 'paused' | 'active',
+  verb: VerbCopy,
+): void {
   const ctx = getContext(req.app.locals);
   const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
 
@@ -75,7 +94,7 @@ function flipStatus(req: Request, res: Response, nextStatus: 'paused' | 'active'
     return;
   }
   if (!agent.schedule) {
-    res.redirect(303, `/scheduled?flash=${encodeURIComponent(`Agent "${id}" has no schedule to ${nextStatus === 'paused' ? 'pause' : 'resume'}.`)}`);
+    res.redirect(303, `/scheduled?flash=${encodeURIComponent(`Agent "${id}" has no schedule to ${verb.imperative.toLowerCase()}.`)}`);
     return;
   }
   if (agent.status === nextStatus) {
@@ -85,13 +104,19 @@ function flipStatus(req: Request, res: Response, nextStatus: 'paused' | 'active'
 
   try {
     ctx.agentStore.updateAgentMeta(id, { status: nextStatus });
-    const verb = nextStatus === 'paused' ? 'Paused' : 'Resumed';
-    res.redirect(303, `/scheduled?flash=${encodeURIComponent(`${verb} "${id}".`)}`);
+    res.redirect(303, `/scheduled?flash=${encodeURIComponent(`${verb.past} "${id}".`)}`);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    res.redirect(303, `/scheduled?flash=${encodeURIComponent(`${nextStatus === 'paused' ? 'Pause' : 'Resume'} failed: ${msg}`)}`);
+    res.redirect(303, `/scheduled?flash=${encodeURIComponent(`${verb.imperative} failed: ${msg}`)}`);
   }
 }
 
-scheduledRouter.post('/scheduled/:id/pause', (req, res) => flipStatus(req, res, 'paused'));
-scheduledRouter.post('/scheduled/:id/resume', (req, res) => flipStatus(req, res, 'active'));
+scheduledRouter.post('/scheduled/:id/pause', (req, res) =>
+  flipStatus(req, res, 'paused', { imperative: 'Pause', past: 'Paused' }));
+scheduledRouter.post('/scheduled/:id/resume', (req, res) =>
+  flipStatus(req, res, 'active', { imperative: 'Resume', past: 'Resumed' }));
+// /activate is /resume's twin for status='draft' agents — same end state
+// (active), different copy. The scheduler ignores drafts, so a scheduled
+// draft is "scheduled-in-intent but never fires" until the user activates.
+scheduledRouter.post('/scheduled/:id/activate', (req, res) =>
+  flipStatus(req, res, 'active', { imperative: 'Activate', past: 'Activated' }));

--- a/packages/dashboard/src/views/scheduled.ts
+++ b/packages/dashboard/src/views/scheduled.ts
@@ -118,14 +118,34 @@ function renderRow(row: ScheduledRowInput): SafeHtml {
   const { agent, lastFireAt, nextFireAt } = row;
   const isActive = agent.status === 'active';
   const isPaused = agent.status === 'paused';
+  const isDraft = agent.status === 'draft';
+  const isArchived = agent.status === 'archived';
 
-  // Next-fire is only meaningful when the agent is active (paused agents
-  // have nextFireAt computed by the scheduler-heartbeat as "what it WOULD
-  // be" — but rendering that confuses users). For non-active rows, show "—".
-  const nextStr = isActive && nextFireAt
-    ? formatRelative(nextFireAt, true)
-    : html`<span class="dim">—</span>`;
-  const lastStr = lastFireAt ? formatAge(lastFireAt) : html`<span class="dim">never</span>`;
+  // Next-fire rendering, three cases:
+  //   active  -> formatted relative time ("9h")
+  //   draft / archived  -> explanatory hint, since the scheduler skips
+  //                        these statuses entirely. The cron is on record
+  //                        but never fires until you activate (drafts) or
+  //                        change status (archived). Without this hint
+  //                        the user sees a cron next to "—" and reasonably
+  //                        wonders why it never ran.
+  //   paused  -> "—" (the cron is paused-by-intent; resume is one click)
+  let nextCell: SafeHtml;
+  if (isActive && nextFireAt) {
+    nextCell = html`<span>${formatRelative(nextFireAt, true)}</span>`;
+  } else if (isDraft) {
+    nextCell = html`<span class="dim" style="font-size: var(--font-size-xs); cursor: help;" title="The scheduler only fires status='active' agents. Activate to start firing on the declared cron.">won't fire — status is draft</span>`;
+  } else if (isArchived) {
+    nextCell = html`<span class="dim" style="font-size: var(--font-size-xs); cursor: help;" title="Archived agents don't fire. Restore via /agents/:id/config.">won't fire — archived</span>`;
+  } else {
+    nextCell = html`<span class="dim">—</span>`;
+  }
+
+  // Last fire: filtered to scheduler-triggered runs (triggeredBy='schedule').
+  // Manual runs via dashboard / CLI / MCP don't count here; the page is about
+  // scheduling, not all execution. "never" here means "scheduler has never
+  // fired this", not "this agent has never run."
+  const lastStr = lastFireAt ? formatAge(lastFireAt) : html`<span class="dim" title="Last scheduler-triggered run. Manual runs (dashboard, CLI, MCP) do not count.">never</span>`;
 
   return html`
     <tr>
@@ -138,10 +158,11 @@ function renderRow(row: ScheduledRowInput): SafeHtml {
         <span title="${agent.schedule ?? ''}">${cronToHuman(agent.schedule ?? '')}</span>
       </td>
       <td>${lastStr}</td>
-      <td>${nextStr}</td>
+      <td>${nextCell}</td>
       <td style="text-align: right; white-space: nowrap;">
         ${isActive ? renderPauseForm(agent.id) : html``}
         ${isPaused ? renderResumeForm(agent.id) : html``}
+        ${isDraft ? renderActivateForm(agent.id) : html``}
         <a href="/agents/${agent.id}/config" class="btn btn--sm btn--ghost" style="margin-left: var(--space-2);">Edit</a>
       </td>
     </tr>
@@ -160,6 +181,14 @@ function renderResumeForm(agentId: string): SafeHtml {
   return html`
     <form method="POST" action="/scheduled/${agentId}/resume" style="display: inline;">
       <button type="submit" class="btn btn--sm btn--primary" title="Resume this agent. Scheduler will fire on its declared cron.">Resume</button>
+    </form>
+  `;
+}
+
+function renderActivateForm(agentId: string): SafeHtml {
+  return html`
+    <form method="POST" action="/scheduled/${agentId}/activate" style="display: inline;">
+      <button type="submit" class="btn btn--sm btn--primary" title="Activate this draft. The scheduler will start firing on its declared cron.">Activate</button>
     </form>
   `;
 }


### PR DESCRIPTION
Follow-up to [#365](https://github.com/gregmeyer/some-useful-agents/pull/365). After landing the /scheduled page, you asked: \"how can some of these have a schedule but have never run?\" — the answer was that the scheduler only fires \`status='active'\` agents, and 10 of the 16 rows were drafts. The page showed the cron next to a bare \`—\` in Next fire with no row action, which made that invisible.

Two fixes close the gap.

## Activate one-click on draft rows

\`POST /scheduled/:id/activate\` — flips status \`draft → active\`. Mirrors the shape of Pause / Resume; 303 redirect with a flash; idempotent guards. The \`flipStatus\` helper now takes a \`VerbCopy\` so pause / resume / activate share guards but produce correct copy (\`Activated\` vs \`Resumed\`).

Renders an **Activate** button on draft rows alongside the existing Edit link. Pause / Resume only appear for active / paused respectively. Archived rows have no row action (use Edit).

## Explanatory hints for non-firing statuses

Next-fire cell — three cases now:

| Status | Renders |
|---|---|
| \`active\` | formatted relative time (\`9h\`) |
| \`draft\` | \`won't fire — status is draft\` (cursor: help; tooltip explains the active-only rule) |
| \`archived\` | \`won't fire — archived\` |
| \`paused\` | \`—\` (cron is paused-by-intent; one click away from firing on Resume) |

\`never\` in Last fire gets a tooltip clarifying that the column counts only \`triggeredBy='schedule'\` runs — manual runs via dashboard / CLI / MCP don't count here. An agent run manually but not by the scheduler shows \`never\` by design.

## Visual

Draft rows now read top-to-bottom as: id + description, \`draft\` badge, cron, \`never\`, \`won't fire — status is draft\`, **Activate**, Edit. The why-isn't-this-firing question is answered inline.

## Tests

\`1614 pass / 3 skipped\` (+4 new):

- draft row renders Activate form + the inline hint; no pause/resume forms
- activate flips status, keeps schedule, 303 redirect with flash
- already-active activate is no-op + flash
- archived row renders the archived hint with no row action

🤖 Generated with [Claude Code](https://claude.com/claude-code)