### PR TITLE
feat(core,dashboard): per-section placement overrides for named dashboards (PR 3/3)

### DIFF
--- a/.changeset/layout-hints-dashboard-placements.md
+++ b/.changeset/layout-hints-dashboard-placements.md
@@ -1,0 +1,21 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Named dashboards: per-placement layout overrides.
+
+`DashboardSection` gains an optional `placements` map keyed by agent id —
+`{ size?, tileFit?, height? }`. The dashboard Improve-layout commit
+endpoint reads the planner's `topAgents` entries and writes per-section
+placements on the new layout, so two dashboards can size the same agent
+differently. The renderer applies placement on top of the agent-global
+`LayoutHintsStore` entry; any undefined placement field falls through to
+the hint, then to the agent's `signal.size` / `outputWidget.tileFit`,
+then to the renderer defaults.
+
+Backwards-compatible: existing dashboards without `placements` render
+exactly as before. Round-trips through the dashboard store.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -66,6 +66,7 @@ export {
   type PackAgentRef,
   type PackDashboardManifest,
   type DashboardSection,
+  type DashboardSectionPlacement,
 } from './packs-store.js';
 export {
   DashboardsStore,

--- a/packages/core/src/packs-store.ts
+++ b/packages/core/src/packs-store.ts
@@ -6,10 +6,26 @@ import { chmod600Safe } from './fs-utils.js';
 /**
  * One section within a dashboard layout — a titled, ordered list of agent
  * IDs to render as tiles. A dashboard is just an ordered list of these.
+ *
+ * `placements` is an optional per-agent override map keyed by agent id.
+ * When set, it overrides the agent-global LayoutHintsStore entry FOR THIS
+ * SECTION ONLY — so two dashboards can size the same agent differently.
+ * Absent / missing keys fall through to the agent-global hint, then to
+ * the agent's declared signal.size / outputWidget.tileFit, then to the
+ * renderer defaults. Width is still grid-column-based; placements only
+ * touch height-related fields.
  */
+export interface DashboardSectionPlacement {
+  size?: '1x1' | '2x1' | '1x2' | '2x2';
+  tileFit?: 'grow' | 'scroll';
+  /** Pinned height in CSS pixels. Bounded 80..1200 to match LayoutHintsStore. */
+  height?: number;
+}
+
 export interface DashboardSection {
   title: string;
   agentIds: string[];
+  placements?: Record<string, DashboardSectionPlacement>;
 }
 
 /**

--- a/packages/dashboard/src/routes/dashboard-layout-plan-commit.test.ts
+++ b/packages/dashboard/src/routes/dashboard-layout-plan-commit.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for POST /dashboards/:id/layout-plan/commit — the dashboard-side
+ * Improve-layout apply. Two responsibilities:
+ *
+ *  1. Replace section membership from the plan's containers (pre-existing).
+ *  2. Persist per-placement size/tileFit/height overrides on each section
+ *     from the planner's topAgents entries.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import request from 'supertest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AgentStore,
+  DashboardsStore,
+  LayoutHintsStore,
+  LocalProvider,
+  MemorySecretsStore,
+  PacksStore,
+  RunStore,
+  buildLoopbackAllowlist,
+  loadAgents,
+} from '@some-useful-agents/core';
+import { buildDashboardApp } from '../index.js';
+import type { DashboardContext } from '../context.js';
+import { SESSION_COOKIE } from '../auth-middleware.js';
+import { MemorySecretsSession } from '../secrets-session.js';
+
+const TOKEN = 'a'.repeat(64);
+const PORT = 3996;
+const COOKIE = `${SESSION_COOKIE}=${TOKEN}`;
+const DASHBOARD_ID = 'user:test-dash';
+
+let dir: string;
+let provider: LocalProvider;
+let runStore: RunStore;
+let agentStore: AgentStore;
+let packsStore: PacksStore;
+let dashboardsStore: DashboardsStore;
+let layoutHintsStore: LayoutHintsStore;
+
+async function makeApp() {
+  dir = mkdtempSync(join(tmpdir(), 'sua-dash-commit-'));
+  const dbPath = join(dir, 'runs.db');
+  const agentsDir = join(dir, 'agents', 'local');
+  mkdirSync(agentsDir, { recursive: true });
+
+  const secretsStore = new MemorySecretsStore();
+  runStore = new RunStore(dbPath);
+  agentStore = new AgentStore(dbPath);
+  packsStore = new PacksStore(dbPath);
+  dashboardsStore = new DashboardsStore(dbPath);
+  layoutHintsStore = new LayoutHintsStore(dbPath);
+  provider = new LocalProvider(dbPath, secretsStore);
+  await provider.initialize();
+
+  for (const id of ['api-monitor', 'hn-top-3', 'weather']) {
+    agentStore.createAgent({
+      id,
+      name: id,
+      status: 'active',
+      source: 'local',
+      mcp: false,
+      nodes: [{ id: 'n', type: 'shell', command: 'echo hi', dependsOn: [] }],
+      signal: { title: id, template: 'text-headline', mapping: { headline: 'result' } },
+    }, 'cli');
+  }
+
+  dashboardsStore.upsertDashboard({
+    id: DASHBOARD_ID,
+    packId: null,
+    name: 'Test',
+    layout: { sections: [{ title: 'Misc', agentIds: ['weather'] }] },
+  });
+
+  const ctx: DashboardContext = {
+    token: TOKEN,
+    allowlist: buildLoopbackAllowlist(PORT),
+    port: PORT,
+    provider,
+    runStore,
+    agentStore,
+    loadAgents: () => loadAgents({ directories: [agentsDir] }),
+    secretsStore,
+    secretsSession: new MemorySecretsSession({ backing: secretsStore }),
+    tokenPath: join(dir, 'mcp-token'),
+    retentionDays: 30,
+    dbPath,
+    secretsPath: join(dir, 'secrets.enc'),
+    rotateToken: () => 'r'.repeat(64),
+    packsStore,
+    dashboardsStore,
+    layoutHintsStore,
+    allowUntrustedShell: new Set(),
+    activeRuns: new Map(),
+    dataDir: dir,
+    dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
+  };
+
+  return buildDashboardApp(ctx);
+}
+
+afterEach(async () => {
+  if (provider) {
+    const start = Date.now();
+    while ((provider as unknown as { running?: { size: number } }).running?.size && Date.now() - start < 2000) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    await provider.shutdown();
+  }
+  try { runStore?.close(); } catch { /* ignore */ }
+  try { agentStore?.close(); } catch { /* ignore */ }
+  try { packsStore?.close(); } catch { /* ignore */ }
+  try { dashboardsStore?.close(); } catch { /* ignore */ }
+  try { layoutHintsStore?.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('POST /dashboards/:id/layout-plan/commit', () => {
+  it('writes per-placement overrides on the new section from topAgents', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post(`/dashboards/${encodeURIComponent(DASHBOARD_ID)}/layout-plan/commit`)
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE)
+      .send({
+        containers: [{ label: 'Monitoring', tiles: ['api-monitor', 'hn-top-3'] }],
+        topAgents: [
+          { id: 'api-monitor', rationale: 'a', suggestedSize: '2x1' },
+          { id: 'hn-top-3', rationale: 'b', suggestedTileFit: 'scroll', suggestedHeight: 320 },
+        ],
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.placementsWritten).toBe(2);
+
+    const after = dashboardsStore.getDashboard(DASHBOARD_ID)!;
+    expect(after.layout.sections).toHaveLength(1);
+    const section = after.layout.sections[0];
+    expect(section.placements).toBeDefined();
+    expect(section.placements!['api-monitor'].size).toBe('2x1');
+    expect(section.placements!['hn-top-3'].tileFit).toBe('scroll');
+    expect(section.placements!['hn-top-3'].height).toBe(320);
+  });
+
+  it('omits placements when no topAgents are provided', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post(`/dashboards/${encodeURIComponent(DASHBOARD_ID)}/layout-plan/commit`)
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE)
+      .send({ containers: [{ label: 'Monitoring', tiles: ['api-monitor'] }] });
+    expect(res.status).toBe(200);
+    expect(res.body.placementsWritten).toBe(0);
+    const after = dashboardsStore.getDashboard(DASHBOARD_ID)!;
+    expect(after.layout.sections[0].placements).toBeUndefined();
+  });
+
+  it('skips invalid field values silently', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post(`/dashboards/${encodeURIComponent(DASHBOARD_ID)}/layout-plan/commit`)
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE)
+      .send({
+        containers: [{ label: 'Group', tiles: ['api-monitor'] }],
+        topAgents: [
+          { id: 'api-monitor', rationale: 'x', suggestedSize: '5x5', suggestedTileFit: 'shrink', suggestedHeight: 50 },
+        ],
+      });
+    expect(res.status).toBe(200);
+    // All fields invalid → no placement entry created at all.
+    expect(res.body.placementsWritten).toBe(0);
+    const after = dashboardsStore.getDashboard(DASHBOARD_ID)!;
+    expect(after.layout.sections[0].placements).toBeUndefined();
+  });
+
+  it('groups placements per section by container membership', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post(`/dashboards/${encodeURIComponent(DASHBOARD_ID)}/layout-plan/commit`)
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE)
+      .send({
+        containers: [
+          { label: 'Monitoring', tiles: ['api-monitor'] },
+          { label: 'News', tiles: ['hn-top-3'] },
+        ],
+        topAgents: [
+          { id: 'api-monitor', rationale: 'a', suggestedSize: '2x1' },
+          { id: 'hn-top-3', rationale: 'b', suggestedTileFit: 'scroll' },
+        ],
+      });
+    expect(res.status).toBe(200);
+    const after = dashboardsStore.getDashboard(DASHBOARD_ID)!;
+    const [monitoring, news] = after.layout.sections;
+    expect(monitoring.title).toBe('Monitoring');
+    expect(monitoring.placements!['api-monitor'].size).toBe('2x1');
+    expect(monitoring.placements!['hn-top-3']).toBeUndefined();
+    expect(news.title).toBe('News');
+    expect(news.placements!['hn-top-3'].tileFit).toBe('scroll');
+  });
+
+  it('skips an agent placement that ended up not assigned to any section', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post(`/dashboards/${encodeURIComponent(DASHBOARD_ID)}/layout-plan/commit`)
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE)
+      .send({
+        containers: [{ label: 'Group', tiles: ['api-monitor'] }],
+        topAgents: [
+          { id: 'api-monitor', rationale: 'a', suggestedSize: '2x1' },
+          { id: 'hn-top-3', rationale: 'b', suggestedSize: '2x2' }, // not placed
+        ],
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.placementsWritten).toBe(1);
+    const after = dashboardsStore.getDashboard(DASHBOARD_ID)!;
+    expect(after.layout.sections[0].placements!['api-monitor']).toBeDefined();
+    expect(after.layout.sections[0].placements!['hn-top-3']).toBeUndefined();
+  });
+});

--- a/packages/dashboard/src/routes/dashboard-layout-plan.ts
+++ b/packages/dashboard/src/routes/dashboard-layout-plan.ts
@@ -351,6 +351,31 @@ dashboardLayoutPlanRouter.post('/dashboards/:id/layout-plan/commit', (req: Reque
   const ctx = getContext(req.app.locals);
   const body = (req.body ?? {}) as Record<string, unknown>;
   const containersRaw = Array.isArray(body.containers) ? body.containers : [];
+  const topAgentsRaw = Array.isArray(body.topAgents) ? body.topAgents : [];
+
+  // Build a per-agent placement map from the planner's topAgents entries.
+  // These become per-section overrides on the new layout — dashboard-scoped,
+  // unlike LayoutHintsStore which is agent-global. Invalid field values
+  // are silently dropped (the renderer falls through to the next link in
+  // the chain).
+  const placementByAgentId = new Map<string, { size?: '1x1' | '2x1' | '1x2' | '2x2'; tileFit?: 'grow' | 'scroll'; height?: number }>();
+  for (const entry of topAgentsRaw) {
+    if (!entry || typeof entry !== 'object') continue;
+    const e = entry as Record<string, unknown>;
+    const id = typeof e.id === 'string' ? e.id : '';
+    if (!id || id.startsWith('_')) continue;
+    const placement: { size?: '1x1' | '2x1' | '1x2' | '2x2'; tileFit?: 'grow' | 'scroll'; height?: number } = {};
+    if (typeof e.suggestedSize === 'string' && (e.suggestedSize === '1x1' || e.suggestedSize === '2x1' || e.suggestedSize === '1x2' || e.suggestedSize === '2x2')) {
+      placement.size = e.suggestedSize;
+    }
+    if (typeof e.suggestedTileFit === 'string' && (e.suggestedTileFit === 'grow' || e.suggestedTileFit === 'scroll')) {
+      placement.tileFit = e.suggestedTileFit;
+    }
+    if (typeof e.suggestedHeight === 'number' && Number.isInteger(e.suggestedHeight) && e.suggestedHeight >= 80 && e.suggestedHeight <= 1200) {
+      placement.height = e.suggestedHeight;
+    }
+    if (Object.keys(placement).length > 0) placementByAgentId.set(id, placement);
+  }
 
   // Build the new section list from the plan's containers, filtering
   // out system tiles, de-duplicating ids, and dropping ids that don't
@@ -362,7 +387,7 @@ dashboardLayoutPlanRouter.post('/dashboards/:id/layout-plan/commit', (req: Reque
   // where the planner kept a prior session's container).
   const seenIds = new Set<string>();
   const skippedUnknown: string[] = [];
-  const sectionsByTitle = new Map<string, { title: string; agentIds: string[] }>();
+  const sectionsByTitle = new Map<string, { title: string; agentIds: string[]; placements?: Record<string, { size?: '1x1' | '2x1' | '1x2' | '2x2'; tileFit?: 'grow' | 'scroll'; height?: number }> }>();
   const sectionOrder: string[] = [];
   for (const c of containersRaw) {
     if (!c || typeof c !== 'object') continue;
@@ -387,17 +412,31 @@ dashboardLayoutPlanRouter.post('/dashboards/:id/layout-plan/commit', (req: Reque
       ids.push(t);
     }
     if (ids.length === 0) continue;
+    // Assemble placements for THIS section: only ids that ended up in
+    // this section's agentIds AND had a placement entry from topAgents.
+    const placementsHere: Record<string, { size?: '1x1' | '2x1' | '1x2' | '2x2'; tileFit?: 'grow' | 'scroll'; height?: number }> = {};
+    let hasPlacement = false;
+    for (const id of ids) {
+      const p = placementByAgentId.get(id);
+      if (p) { placementsHere[id] = p; hasPlacement = true; }
+    }
+
     const existing = sectionsByTitle.get(titleKey);
     if (existing) {
       for (const id of ids) {
         if (!existing.agentIds.includes(id)) existing.agentIds.push(id);
       }
+      if (hasPlacement) {
+        existing.placements = { ...(existing.placements ?? {}), ...placementsHere };
+      }
     } else {
-      sectionsByTitle.set(titleKey, { title: label, agentIds: ids });
+      const section: { title: string; agentIds: string[]; placements?: Record<string, { size?: '1x1' | '2x1' | '1x2' | '2x2'; tileFit?: 'grow' | 'scroll'; height?: number }> } = { title: label, agentIds: ids };
+      if (hasPlacement) section.placements = placementsHere;
+      sectionsByTitle.set(titleKey, section);
       sectionOrder.push(titleKey);
     }
   }
-  const newSections: Array<{ title: string; agentIds: string[] }> = sectionOrder.map((k) => sectionsByTitle.get(k)!);
+  const newSections = sectionOrder.map((k) => sectionsByTitle.get(k)!);
 
   // Compute removed/retained/added vs the prior membership for the
   // response. `added` is the newly-surfaced delta (installed agents
@@ -434,7 +473,14 @@ dashboardLayoutPlanRouter.post('/dashboards/:id/layout-plan/commit', (req: Reque
     return;
   }
 
-  res.json({ ok: true, removed, retained, added, skippedUnknown });
+  // Count placements written for the response (UI surfaces this as
+  // "Applied N tile sizes" — a signal that the planner's hints landed).
+  let placementsWritten = 0;
+  for (const s of newSections) {
+    if (s.placements) placementsWritten += Object.keys(s.placements).length;
+  }
+
+  res.json({ ok: true, removed, retained, added, skippedUnknown, placementsWritten });
 });
 
 // Reference unused imports defensively to keep tsc-clean if a future

--- a/packages/dashboard/src/routes/dashboards.test.ts
+++ b/packages/dashboard/src/routes/dashboards.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import {
   AgentStore,
   DashboardsStore,
+  LayoutHintsStore,
   LocalProvider,
   MemorySecretsStore,
   PacksStore,
@@ -27,6 +28,7 @@ let runStore: RunStore;
 let agentStore: AgentStore;
 let packsStore: PacksStore;
 let dashboardsStore: DashboardsStore;
+let layoutHintsStore: LayoutHintsStore;
 
 async function makeApp() {
   dir = mkdtempSync(join(tmpdir(), 'sua-dashboards-routes-'));
@@ -39,6 +41,7 @@ async function makeApp() {
   agentStore = new AgentStore(dbPath);
   packsStore = new PacksStore(dbPath);
   dashboardsStore = new DashboardsStore(dbPath);
+  layoutHintsStore = new LayoutHintsStore(dbPath);
   provider = new LocalProvider(dbPath, secretsStore);
   await provider.initialize();
 
@@ -70,6 +73,7 @@ async function makeApp() {
     rotateToken: () => 'r'.repeat(64),
     packsStore,
     dashboardsStore,
+    layoutHintsStore,
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
     dataDir: dir,
@@ -91,6 +95,7 @@ afterEach(async () => {
   try { agentStore?.close(); } catch { /* ignore */ }
   try { packsStore?.close(); } catch { /* ignore */ }
   try { dashboardsStore?.close(); } catch { /* ignore */ }
+  try { layoutHintsStore?.close(); } catch { /* ignore */ }
   if (dir) rmSync(dir, { recursive: true, force: true });
 });
 
@@ -255,5 +260,61 @@ describe('dashboards routes', () => {
       .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
     expect(res.status).toBe(200);
     expect(res.text).not.toContain('class="dashboards-dropdown"');
+  });
+
+  it('per-section placement overrides the agent-global LayoutHintsStore entry', async () => {
+    const app = await makeApp();
+    // Agent-global hint: 1x1 / grow / no height (what Pulse would see).
+    layoutHintsStore.setHint('hello', { size: '1x1', tileFit: 'grow' });
+    // Dashboard places the same agent with 2x2 / scroll / pinned 240px.
+    dashboardsStore.upsertDashboard({
+      id: 'user:big-card',
+      packId: null,
+      name: 'Big Card',
+      layout: {
+        sections: [{
+          title: 'Hero',
+          agentIds: ['hello'],
+          placements: { hello: { size: '2x2', tileFit: 'scroll', height: 240 } },
+        }],
+      },
+    });
+
+    const res = await request(app)
+      .get('/dashboards/user%3Abig-card')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    // Per-placement wins on every axis.
+    expect(res.text).toMatch(/data-tile-size="2x2"/);
+    expect(res.text).toMatch(/pulse-tile--fit-scroll/);
+    expect(res.text).toMatch(/style="height: 240px"/);
+  });
+
+  it('falls through to agent-global hint when a placement field is undefined', async () => {
+    const app = await makeApp();
+    layoutHintsStore.setHint('hello', { size: '2x1', tileFit: 'scroll' });
+    dashboardsStore.upsertDashboard({
+      id: 'user:partial',
+      packId: null,
+      name: 'Partial',
+      layout: {
+        sections: [{
+          title: 'Hero',
+          agentIds: ['hello'],
+          // Only override height; size + tileFit should fall through to the hint.
+          placements: { hello: { height: 180 } },
+        }],
+      },
+    });
+
+    const res = await request(app)
+      .get('/dashboards/user%3Apartial')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toMatch(/data-tile-size="2x1"/);
+    expect(res.text).toMatch(/pulse-tile--fit-scroll/);
+    expect(res.text).toMatch(/style="height: 180px"/);
   });
 });

--- a/packages/dashboard/src/routes/dashboards.ts
+++ b/packages/dashboard/src/routes/dashboards.ts
@@ -54,10 +54,25 @@ dashboardsRouter.get('/dashboards/:id', (req: Request, res: Response) => {
       }
       tiles.push(buildPulseTile(agent as Agent & { signal: AgentSignal }, { runStore: ctx.runStore }));
     }
-    // Decorate with any agent-global layout hints from LayoutHintsStore.
-    // Per-placement overrides land in PR 3; for now dashboards share the
-    // same hint as Pulse for a given agent.
+    // Decorate with the agent-global hint first, then layer this
+    // section's per-placement overrides on top. Each defined placement
+    // field wins; undefined fields fall through to the hint, signal,
+    // or default — same precedence as Pulse, plus a dashboard-scoped
+    // layer above it.
     attachLayoutHints(tiles, ctx.layoutHintsStore);
+    if (s.placements) {
+      for (const tile of tiles) {
+        const placement = s.placements[tile.agent.id];
+        if (!placement) continue;
+        const base = tile.layoutHint ?? { agentId: tile.agent.id, updatedAt: 0 };
+        tile.layoutHint = {
+          ...base,
+          ...(placement.size !== undefined ? { size: placement.size } : {}),
+          ...(placement.tileFit !== undefined ? { tileFit: placement.tileFit } : {}),
+          ...(placement.height !== undefined ? { height: placement.height } : {}),
+        };
+      }
+    }
     return { title: s.title, tiles, missingAgentIds, agentIds: [...s.agentIds] };
   });
 


### PR DESCRIPTION
## Summary
- `DashboardSection` gains an optional `placements: Record<agentId, { size?, tileFit?, height? }>` map. Additive — existing dashboards render identically
- `/dashboards/:id/layout-plan/commit` reads `plan.topAgents`, validates each field, and writes per-section placements (only ids actually placed in that section). Response includes `placementsWritten`
- Dashboard renderer merges placement onto the agent-global hint field-by-field: defined wins, undefined falls through to the hint → signal/outputWidget → defaults
- Round-trips through the store — `JSON.stringify(layout)` preserves the new map shape

## Why
Final of 3 PRs implementing the layout-planner tileFit/height follow-up ([plan](~/.claude/plans/improve-layout-tilefit-followup.md)). PR 1 wired the foundation; PR 2 made Pulse persist. This PR closes the cross-surface bleed concern: running Improve layout on dashboard X no longer changes how the same agent looks on Pulse or dashboard Y — the dashboard now owns its placement.

## Test plan
- [x] `npx vitest run packages/dashboard/src/routes/dashboard-layout-plan-commit.test.ts` — 5 tests: happy path, no-topAgents, invalid fields, per-section grouping, unplaced-skip
- [x] `npx vitest run packages/dashboard/src/routes/dashboards.test.ts` — 10 tests (added 2 renderer precedence tests: placement-wins, undefined-falls-through)
- [x] Full suite: `npx vitest run` → 1653 pass / 3 skipped (was 1646 on main; +7 new tests)
- [x] Clean build: `rm -rf packages/*/dist packages/*/*.tsbuildinfo && npm run build` — green
- [ ] Manual: create two dashboards containing the same agent; run Improve layout on each with different focus; confirm sizes differ across dashboards and Pulse is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)