### PR TITLE
feat(dashboard): Improve-layout wireframe preview + layout-quality pills

### DIFF
--- a/.changeset/improve-layout-wireframe-and-quality-pills.md
+++ b/.changeset/improve-layout-wireframe-and-quality-pills.md
@@ -1,0 +1,23 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Improve-layout: wireframe preview + layout-quality pills.
+
+The plan view now renders a 4-column wireframe mockup above the Top
+agents list. Each cell shows the agent title, the planner's chosen
+size, tileFit indicator (↕ grow / ⇵ scroll), and pinned height when
+set. System tiles get a dashed border to distinguish them. The
+preview is a `<details open>` so users can collapse it.
+
+Suggestion pills gain three layout-quality intents — **Remove gaps**,
+**Make tables scrollable**, **Compact everything** — that drive the
+planner to use `suggestedSize` / `suggestedTileFit` /
+`suggestedHeight` aggressively. They appear ahead of the existing
+agent-curation pills (Group by topic, Rank by reliability, etc.).
+Max suggestions bumped from 5 to 6 so the new pills don't crowd out
+the popular ones.

--- a/packages/dashboard/src/lib/layout-suggestions.test.ts
+++ b/packages/dashboard/src/lib/layout-suggestions.test.ts
@@ -15,12 +15,19 @@ function agent(partial: Partial<LayoutSuggestionAgent> & { id: string }): Layout
 
 describe('computeLayoutSuggestions', () => {
   describe('static fillers', () => {
-    it('returns the four static pills when there are no agents', () => {
+    it('returns six static pills when there are no agents (layout-quality first, then agent-curation)', () => {
       const out = computeLayoutSuggestions([], null, NOW);
-      expect(out.length).toBe(4);
+      expect(out.length).toBe(6);
       expect(out.every((s) => s.dynamic === false)).toBe(true);
       const ids = out.map((s) => s.id);
-      expect(ids).toEqual(['group-by-topic', 'rank-by-reliability', 'surface-daily', 'pin-most-reliable']);
+      expect(ids).toEqual([
+        'remove-gaps',
+        'tables-scrollable',
+        'compact-everything',
+        'group-by-topic',
+        'rank-by-reliability',
+        'surface-daily',
+      ]);
     });
 
     it('returns static pills when no dynamic conditions trigger', () => {
@@ -30,7 +37,14 @@ describe('computeLayoutSuggestions', () => {
       const layout: CurrentLayout = { containers: [{ label: 'All', tiles: ['a1'] }] };
       const out = computeLayoutSuggestions(agents, layout, NOW);
       expect(out.every((s) => s.dynamic === false)).toBe(true);
-      expect(out.length).toBe(4);
+      expect(out.length).toBe(6);
+    });
+
+    it('includes layout-quality pills (remove gaps / tables scrollable / compact) ahead of agent-curation pills', () => {
+      const out = computeLayoutSuggestions([], null, NOW);
+      const idsInOrder = out.map((s) => s.id);
+      expect(idsInOrder.indexOf('remove-gaps')).toBeLessThan(idsInOrder.indexOf('group-by-topic'));
+      expect(idsInOrder.indexOf('tables-scrollable')).toBeLessThan(idsInOrder.indexOf('rank-by-reliability'));
     });
   });
 
@@ -171,7 +185,7 @@ describe('computeLayoutSuggestions', () => {
         agent({ id: 'api-monitor-b' }),
       ];
       const out = computeLayoutSuggestions(agents, null, NOW);
-      expect(out.length).toBeLessThanOrEqual(5);
+      expect(out.length).toBeLessThanOrEqual(6);
     });
 
     it('places dynamic pills before static fillers', () => {

--- a/packages/dashboard/src/lib/layout-suggestions.ts
+++ b/packages/dashboard/src/lib/layout-suggestions.ts
@@ -54,7 +54,7 @@ export interface LayoutSuggestion {
 
 const STALE_THRESHOLD_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 const FAIL_RATE_THRESHOLD = 0.5;
-const MAX_SUGGESTIONS = 5;
+const MAX_SUGGESTIONS = 6;
 const MAX_DYNAMIC = 3;
 
 /** Heuristic match for "this looks like a monitoring agent." */
@@ -155,6 +155,27 @@ function computeDynamicSuggestions(
 
 /** Always-on default suggestions. Order matters — first entries fill in if dynamic pills are scarce. */
 const STATIC_SUGGESTIONS: LayoutSuggestion[] = [
+  // Layout-quality intents first — they directly use suggestedSize /
+  // suggestedTileFit / suggestedHeight to tighten the visual grid.
+  {
+    id: 'remove-gaps',
+    label: 'Remove gaps',
+    prompt: 'Compact the grid: pick suggestedSize values that pack tiles tightly. Avoid leaving empty cells. Where a row has a tall tile next to a short one, shrink the tall one or grow the short one so the row reads as a single unit.',
+    dynamic: false,
+  },
+  {
+    id: 'tables-scrollable',
+    label: 'Make tables scrollable',
+    prompt: 'For every agent whose template is "table" / "story" / "widget" or whose output is a long list, set suggestedTileFit to "scroll" and a suggestedHeight around 240-320 pixels so feeds don\'t dominate their row.',
+    dynamic: false,
+  },
+  {
+    id: 'compact-everything',
+    label: 'Compact everything',
+    prompt: 'Prefer the smallest suggestedSize that still fits each agent\'s content. Default to 1x1 for metric/status templates and 2x1 only when text or comparison needs the width. Avoid 2x2 unless a widget genuinely requires it.',
+    dynamic: false,
+  },
+  // Agent-curation intents.
   {
     id: 'group-by-topic',
     label: 'Group by topic',

--- a/packages/dashboard/src/views/improve-layout.js.ts
+++ b/packages/dashboard/src/views/improve-layout.js.ts
@@ -679,7 +679,106 @@ export const IMPROVE_LAYOUT_JS = `
     });
   }
 
+  // Render a wireframe preview of the proposed layout: one labeled box
+  // per container, each containing a mock CSS grid of cells sized by the
+  // planner's suggestedSize (defaults 1x1). System tiles (leading "_")
+  // are drawn as compact metric cells. Cells also show tileFit (↕ grow /
+  // ⇅ scroll), pinned height when set, and the agent's human title (or
+  // id if missing). Wireframe is rendering-only — no DOM events.
+  function renderWireframe(plan, metaById, topAgentById) {
+    var containers = (plan.containers || []).filter(function (c) {
+      return c && Array.isArray(c.tiles) && c.tiles.length > 0;
+    });
+    if (containers.length === 0) return '';
+
+    function sizeToSpan(size) {
+      if (size === '2x1') return { cols: 2, rows: 1 };
+      if (size === '1x2') return { cols: 1, rows: 2 };
+      if (size === '2x2') return { cols: 2, rows: 2 };
+      return { cols: 1, rows: 1 };
+    }
+
+    var blocks = containers.map(function (c) {
+      var cells = c.tiles.map(function (tileId) {
+        var isSystem = typeof tileId === 'string' && tileId.charAt(0) === '_';
+        var meta = metaById[tileId] || null;
+        var top = topAgentById[tileId] || null;
+
+        // System tiles default to 1x1; named agents take the planner's
+        // suggestedSize, falling back to whatever the agent already has.
+        var rawSize = isSystem ? '1x1'
+          : (top && top.suggestedSize) || (meta && meta.size) || '1x1';
+        var span = sizeToSpan(rawSize);
+
+        var tileFit = top && top.suggestedTileFit ? top.suggestedTileFit : null;
+        var height = top && typeof top.suggestedHeight === 'number' ? top.suggestedHeight : null;
+
+        var titleText = meta && meta.title
+          ? meta.title
+          : (isSystem ? tileId.replace(/^_system-/, '').replace(/-/g, ' ') : tileId);
+
+        var fitIcon = '';
+        if (tileFit === 'scroll') fitIcon = '<span title="scroll" style="font-family:var(--font-mono);font-size:0.7rem;">⇵</span>';
+        else if (tileFit === 'grow') fitIcon = '<span title="grow" style="font-family:var(--font-mono);font-size:0.7rem;">↕</span>';
+
+        var heightLabel = height ? '<span class="dim" style="font-size:0.65rem;">' + height + 'px</span>' : '';
+
+        // Each cell. The minHeight gives 1-row cells a stable footprint;
+        // a tall content row stretches it further when grid-row is 2.
+        var minH = height ? height : (span.rows === 2 ? 88 : 42);
+        var bg = isSystem ? 'var(--color-surface-raised)' : 'var(--color-surface)';
+        var border = isSystem ? '1px dashed var(--color-border)' : '1px solid var(--color-border)';
+        return '<div style="' +
+          'grid-column: span ' + span.cols + ';' +
+          'grid-row: span ' + span.rows + ';' +
+          'min-height:' + minH + 'px;' +
+          'padding:var(--space-2);' +
+          'border:' + border + ';' +
+          'border-radius:var(--radius-sm);' +
+          'background:' + bg + ';' +
+          'display:flex;flex-direction:column;gap:2px;overflow:hidden;' +
+          '">' +
+          '<div style="display:flex;justify-content:space-between;align-items:center;gap:var(--space-1);">' +
+            '<div style="font-family:var(--font-mono);font-size:0.65rem;color:var(--color-text-muted);">' + esc(rawSize) + '</div>' +
+            '<div style="display:flex;gap:4px;align-items:center;">' + fitIcon + heightLabel + '</div>' +
+          '</div>' +
+          '<div style="font-size:var(--font-size-xs);font-weight:var(--weight-semibold);line-height:1.2;overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;">' +
+            esc(titleText) +
+          '</div>' +
+          '</div>';
+      }).join('');
+
+      return '<div style="margin-bottom:var(--space-3);">' +
+        '<div style="font-weight:var(--weight-semibold);font-size:var(--font-size-xs);text-transform:uppercase;letter-spacing:0.06em;color:var(--color-text-muted);margin-bottom:var(--space-1);">' + esc(c.label) + '</div>' +
+        '<div style="display:grid;grid-template-columns:repeat(4, 1fr);grid-auto-rows:minmax(0, auto);gap:var(--space-1);">' + cells + '</div>' +
+        '</div>';
+    }).join('');
+
+    return '<details open style="margin:0 0 var(--space-4) 0;padding:var(--space-3);border:1px solid var(--color-border);border-radius:var(--radius-sm);background:var(--color-surface-raised);">' +
+      '<summary style="cursor:pointer;font-size:var(--font-size-xs);color:var(--color-text-muted);font-weight:var(--weight-semibold);text-transform:uppercase;letter-spacing:0.06em;margin-bottom:var(--space-2);">Layout preview <span class="dim" style="font-weight:var(--weight-regular);text-transform:none;letter-spacing:0;font-size:0.7rem;">(4-column grid, tiles sized by the plan; ↕ grow / ⇵ scroll)</span></summary>' +
+      '<div style="margin-top:var(--space-2);">' + blocks + '</div>' +
+      '</details>';
+  }
+
   function renderPlan(plan) {
+    // Build a quick metadata lookup by agent id so the wireframe can
+    // show human titles + per-tile size/fit decisions. Missing ids are
+    // rendered with the bare id (rare — the planner is told to only
+    // emit ids that appear in AGENT_METADATA).
+    var metaById = {};
+    if (Array.isArray(cachedAgentMetadata)) {
+      for (var mi = 0; mi < cachedAgentMetadata.length; mi++) {
+        var mm = cachedAgentMetadata[mi];
+        if (mm && mm.id) metaById[mm.id] = mm;
+      }
+    }
+    var topAgentById = {};
+    (plan.topAgents || []).forEach(function (a) {
+      if (a && a.id) topAgentById[a.id] = a;
+    });
+
+    var wireframeHtml = renderWireframe(plan, metaById, topAgentById);
+
     var topRows = (plan.topAgents || []).map(function (a, i) {
       return '<div style="display:flex;gap:var(--space-3);padding:var(--space-2) 0;border-bottom:1px solid var(--color-border);">' +
         '<div class="dim" style="font-family:var(--font-mono);font-size:var(--font-size-xs);min-width:1.5rem;text-align:right;">' + (i + 1) + '.</div>' +
@@ -845,6 +944,7 @@ export const IMPROVE_LAYOUT_JS = `
       '<div style="padding:var(--space-4);">' +
       '<h3 style="margin:0 0 var(--space-2);">Proposed layout</h3>' +
       '<p class="dim" style="font-size:var(--font-size-xs);margin:0 0 var(--space-3);">' + esc(plan.summary || '') + '</p>' +
+      wireframeHtml +
       '<div style="font-size:var(--font-size-xs);color:var(--color-text-muted);font-weight:var(--weight-semibold);text-transform:uppercase;letter-spacing:0.06em;margin-bottom:var(--space-1);">Top agents</div>' +
       '<div style="margin-bottom:var(--space-4);">' + topRows + '</div>' +
       '<div style="font-size:var(--font-size-xs);color:var(--color-text-muted);font-weight:var(--weight-semibold);text-transform:uppercase;letter-spacing:0.06em;margin-bottom:var(--space-1);">Containers</div>' +


### PR DESCRIPTION
## Summary
- **Wireframe preview** above the Top agents list — 4-column CSS-grid mockup of the proposed layout. Each cell spans by `suggestedSize`, shows the agent title, size badge, tileFit indicator (↕ grow / ⇵ scroll), and pinned height when set. System tiles get a dashed border.
- **Three new layout-quality pills**: Remove gaps / Make tables scrollable / Compact everything. They drive the planner to use `suggestedSize`/`suggestedTileFit`/`suggestedHeight` aggressively, and sit ahead of the existing agent-curation pills.
- `MAX_SUGGESTIONS` bumped 5 → 6 so the new pills don't crowd out the popular ones.

## Why
Two real UX gaps surfaced during dogfooding the layout-planner (PR #369 / #371 / #372):
1. Users hit Apply without being able to visualize the proposed layout — they just saw a textual list of container labels + tile codes.
2. The pre-run pill set was all about *which agents to surface*, with no shortcut for *how the grid should look*. "Remove gaps" was a frequent ask that required typing it out.

The wireframe is a `<details open>` so users who don't want it can collapse and keep the textual list as before.

## Test plan
- [x] `npx vitest run packages/dashboard/src/lib/layout-suggestions.test.ts` — 20 tests, ordering and length updated for the new pill set
- [x] Full suite: `npx vitest run` → 1654 pass / 3 skipped
- [x] Clean build green
- [x] Manual: `/pulse` → Improve layout → 6 pills visible (3 quality + 3 curation by default)
- [x] Manual: click "Remove gaps" → textarea fills with the compaction prompt; click "Plan layout" → wireframe renders above Top agents with size badges visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)