### PR TITLE
feat(dashboard): promote Scheduled to a top-level nav entry

### DIFF
--- a/.changeset/scheduled-top-nav.md
+++ b/.changeset/scheduled-top-nav.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Promote Scheduled to a top-level nav entry.
+
+The header now reads sua | Pulse | **Scheduled** | Agents | Settings |
+Help. `/scheduled` previously lived as a sub-tab under Agents, which
+made it hard to find — it carries cross-agent state (paused agents,
+next-run timing) that doesn't fit the per-building-block grouping.
+Dropping it from the Agents tab strip; promoting to global nav.

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -22,7 +22,7 @@ import { footer } from './footer.js';
 export interface LayoutOptions {
   title: string;
   /** Highlight in the nav (one of: agents, tools, runs, pulse, packs, settings, help). */
-  activeNav?: 'agents' | 'tools' | 'nodes' | 'runs' | 'pulse' | 'packs' | 'settings' | 'help';
+  activeNav?: 'agents' | 'tools' | 'nodes' | 'runs' | 'pulse' | 'packs' | 'scheduled' | 'settings' | 'help';
   /** Flash banner shown at the top of the body (errors from prior actions). */
   flash?: { kind: 'error' | 'info' | 'ok'; message: string };
   /** Widen the main column (for screens with 2-col layouts). */
@@ -60,6 +60,7 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
   <a class="topbar__brand" href="/">sua</a>
   <nav class="topbar__nav">
     <a href="/pulse" class="${opts.activeNav === 'pulse' ? 'is-active' : ''}">Pulse</a>
+    <a href="/scheduled" class="${opts.activeNav === 'scheduled' ? 'is-active' : ''}">Scheduled</a>
     <a href="/agents" class="${opts.activeNav === 'agents' || opts.activeNav === 'tools' || opts.activeNav === 'nodes' || opts.activeNav === 'runs' || opts.activeNav === 'packs' ? 'is-active' : ''}">Agents</a>
     <a href="/settings" class="${opts.activeNav === 'settings' ? 'is-active' : ''}">Settings</a>
     <a href="/help" class="${opts.activeNav === 'help' ? 'is-active' : ''}">Help</a>

--- a/packages/dashboard/src/views/scheduled.ts
+++ b/packages/dashboard/src/views/scheduled.ts
@@ -15,7 +15,6 @@ import type { Agent } from '@some-useful-agents/core';
 import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
-import { sectionTabs } from './section-tabs.js';
 import { cronToHuman, formatAge, statusBadge } from './components.js';
 
 export interface ScheduledRowInput {
@@ -56,7 +55,6 @@ export function renderScheduledPage(input: ScheduledViewInput): string {
 
   const body = html`
     ${pageHeader({ title: 'Scheduled', description })}
-    ${sectionTabs('scheduled')}
     ${renderEmptyState(rows)}
     ${rows.length > 0 ? renderTable(rows) : html``}
   `;
@@ -64,7 +62,7 @@ export function renderScheduledPage(input: ScheduledViewInput): string {
   return render(layout(
     {
       title: 'Scheduled agents',
-      activeNav: 'agents',
+      activeNav: 'scheduled',
       flash: flash ? { kind: 'info', message: flash } : undefined,
     },
     body,

--- a/packages/dashboard/src/views/section-tabs.ts
+++ b/packages/dashboard/src/views/section-tabs.ts
@@ -1,13 +1,17 @@
 import { html, type SafeHtml } from './html.js';
 
 /** The Agents section groups the building blocks + executions. */
-export type AgentsSection = 'agents' | 'tools' | 'nodes' | 'runs' | 'packs' | 'scheduled';
+export type AgentsSection = 'agents' | 'tools' | 'nodes' | 'runs' | 'packs';
 
 /**
  * In-page tab strip for the Agents section, mirroring the Settings shell's
  * `.tab-strip`. Rendered on each section landing page (not on deep detail
- * pages) so switching between Agents / Tools / Nodes / Runs / Packs /
- * Scheduled is a server-rendered click with no global subnav bar.
+ * pages) so switching between Agents / Tools / Nodes / Runs / Packs is a
+ * server-rendered click with no global subnav bar.
+ *
+ * Scheduled is a top-level nav entry instead of a sub-tab — it carries
+ * cross-agent context (paused agents, next-run timing) that doesn't fit
+ * the per-building-block grouping.
  */
 export function sectionTabs(active: AgentsSection): SafeHtml {
   const tab = (id: AgentsSection, href: string, label: string): SafeHtml => html`
@@ -20,7 +24,6 @@ export function sectionTabs(active: AgentsSection): SafeHtml {
       ${tab('nodes', '/nodes', 'Nodes')}
       ${tab('runs', '/runs', 'Runs')}
       ${tab('packs', '/packs', 'Packs')}
-      ${tab('scheduled', '/scheduled', 'Scheduled')}
     </nav>
   `;
 }


### PR DESCRIPTION
## Summary
- Header nav becomes: sua | Pulse | **Scheduled** | Agents | Settings | Help
- Removes Scheduled from the Agents sub-tab strip (it's now reachable directly)
- `activeNav: 'scheduled'` lights up the new entry
- Three-file change (layout.ts, scheduled.ts view, section-tabs.ts)

## Why
Dogfooding feedback: `/scheduled` carries cross-agent state (paused agents, next-run timing) that doesn't fit the per-building-block grouping under Agents. It was discoverability-hidden as a sub-tab. Promoting to top-level surfaces it in one click from anywhere.

## Test plan
- [x] `npx vitest run packages/dashboard/src` — 398 passed; scheduled subset (11 tests) still green
- [x] Clean build green
- [x] Manual: visit `/scheduled` — "Scheduled" nav entry highlights, no double tab strip below the header
- [ ] Manual: visit `/agents`, `/tools`, `/runs`, `/packs`, `/nodes` — Agents sub-tab strip no longer shows Scheduled

🤖 Generated with [Claude Code](https://claude.com/claude-code)