### PR TITLE
fix(dashboard): masonry-style Pulse grid eliminates undrop-targetable voids

### DIFF
--- a/.changeset/pulse-masonry-packing.md
+++ b/.changeset/pulse-masonry-packing.md
@@ -1,0 +1,30 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Pulse + dashboards: masonry-style packing eliminates grid voids.
+
+The 4-column Pulse grid used to lock every row's height to its tallest
+tile (with `align-items: start`), turning the space below shorter tiles
+into voids that belonged to the short tile's own grid cell —
+undrop-targetable, unfillable, visually ugly. Dragging a tile into a
+visual gap would either rearrange the layout or reject the drop.
+
+The grid now declares `grid-auto-rows: 8px` + `grid-auto-flow: dense`,
+and a small JS module (`pulse-masonry.js.ts`) computes `grid-row: span N`
+per tile from its rendered height. A 200px tile takes ~9 row-units, an
+1115px tile takes ~48. Columns pack independently (Pinterest-style),
+no voids. ResizeObserver re-packs on content height changes (image
+load, widget body swap, manual resize). MutationObserver re-packs when
+tiles are added/removed via drag-drop or planner Apply. Window resize
+also triggers a re-pack.
+
+`.pulse-tile--1x2` and `.pulse-tile--2x2` no longer declare
+`grid-row: span 2` — the row-span is computed. Their `max-height: 600px`
+cap is preserved so the planner's wide-and-tall intent still means a
+ceiling on height. Applies to named-dashboard `.pulse-grid` instances
+too — same packer, same triggers.

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -1056,20 +1056,26 @@ main.main--wide {
   background: var(--color-primary-soft, rgba(45,212,191,0.05));
 }
 
-/* -- Grid: fixed 4 columns -- */
+/* -- Grid: fixed 4 columns, masonry-style row packing --
+ * `grid-auto-rows: 8px` defines a small implicit row unit. Each tile then
+ * gets `grid-row: span N` computed in JS (see pulse-masonry.js.ts) from its
+ * rendered height, so a 200px tile occupies ~25 row-units while a 1115px
+ * tile occupies ~140. This eliminates the "void below a short tile in a
+ * tall row" problem with the old `align-items: start` row-major layout —
+ * voids belonged to the tile's grid cell and were undrop-targetable.
+ * `grid-auto-flow: dense` lets smaller tiles backfill earlier holes when
+ * the user explicitly drops or resizes. `align-items: start` is kept as a
+ * safety net for the brief moment before the JS snapper runs after load. */
 .pulse-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
+  grid-auto-rows: 8px;
+  grid-auto-flow: dense;
   gap: var(--space-4);
   min-height: 20px;
   border: 2px solid transparent;
   border-radius: var(--radius-md);
   transition: border-color 150ms ease, background 150ms ease;
-  /* Size each tile to its own content instead of stretching every tile in a
-     row to match the tallest one. Without this, a short metric tile next to a
-     tall widget renders as a near-empty card (the value stranded at the top of
-     a huge box). fit-grow tiles still grow with their content; explicitly
-     resized (.pulse-tile--fixed-h) tiles still win via their inline height. */
   align-items: start;
 }
 
@@ -1111,9 +1117,13 @@ main.main--wide {
 .pulse-tile--2x2 { max-height: 600px; }
 .pulse-tile--1x2 { max-height: 600px; }
 
+/* Column spans only — row span is computed by pulse-masonry.js.ts from
+ * each tile's rendered height so the grid packs without voids. The
+ * `1x2` / `2x2` classes used to declare `grid-row: span 2`; with the
+ * masonry packer that's now derived from content height + max-height
+ * (above), letting tiles take only the row-units they actually fill. */
 .pulse-tile--2x1 { grid-column: span 2; }
-.pulse-tile--1x2 { grid-row: span 2; }
-.pulse-tile--2x2 { grid-column: span 2; grid-row: span 2; }
+.pulse-tile--2x2 { grid-column: span 2; }
 
 /* ── Widget tile fit (outputWidget.tileFit) ───────────────────────────────
  * Controls a widget tile's HEIGHT when its content is taller than the slot.

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -3,6 +3,7 @@ import { DASHBOARD_JS } from './js.js';
 import { TEMPLATE_PALETTE_JS } from './template-palette.js.js';
 import { SUGGEST_IMPROVEMENTS_JS } from './suggest-improvements.js.js';
 import { PULSE_LAYOUT_JS } from './pulse-layout.js.js';
+import { PULSE_MASONRY_JS } from './pulse-masonry.js.js';
 import { HOME_LAYOUT_JS } from './home-layout.js.js';
 import { DASHBOARDS_LAYOUT_JS } from './dashboards-layout.js.js';
 import { BUILD_FROM_GOAL_JS } from './build-from-goal.js.js';
@@ -74,7 +75,7 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
   ${body}
 </main>
 ${footer()}
-<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + HOME_LAYOUT_JS + DASHBOARDS_LAYOUT_JS + BUILD_FROM_GOAL_JS + IMPROVE_LAYOUT_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS + WIDGET_REPLAY_INPLACE_JS + PAGE_INTRO_JS + ADD_TILE_MODAL_JS + CSP_ALLOW_JS + WIDGET_IMG_FALLBACK_JS + INSTALL_PACKS_MODAL_JS)}</script>
+<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + PULSE_MASONRY_JS + HOME_LAYOUT_JS + DASHBOARDS_LAYOUT_JS + BUILD_FROM_GOAL_JS + IMPROVE_LAYOUT_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS + WIDGET_REPLAY_INPLACE_JS + PAGE_INTRO_JS + ADD_TILE_MODAL_JS + CSP_ALLOW_JS + WIDGET_IMG_FALLBACK_JS + INSTALL_PACKS_MODAL_JS)}</script>
 </body>
 </html>`;
 }

--- a/packages/dashboard/src/views/pulse-masonry.js.ts
+++ b/packages/dashboard/src/views/pulse-masonry.js.ts
@@ -1,0 +1,106 @@
+/**
+ * Pulse masonry packer.
+ *
+ * Pulse + named dashboards declare a CSS grid with `grid-auto-rows: 8px`
+ * and `grid-auto-flow: dense`. Each tile's `grid-row: span N` is computed
+ * here from its rendered height so a 200px tile occupies ~25 row-units
+ * while a 1115px tile occupies ~140. The row-major default would lock
+ * every row's height to its tallest tile, turning the space below
+ * shorter tiles into voids that belong to the short tile's own grid
+ * cell — undrop-targetable and untunable. With per-tile row-spans + the
+ * `dense` auto-flow, columns pack independently and short tiles don't
+ * trap unusable space.
+ *
+ * Re-pack triggers:
+ *  - DOMContentLoaded (initial render)
+ *  - ResizeObserver per tile (content height changes — image load, widget
+ *    expand, "Run now" re-render that swaps the body, etc.)
+ *  - Window resize (column width changes → tile content may reflow taller)
+ *  - MutationObserver on `.pulse-grid` (tiles added/removed via drag-drop
+ *    or planner Apply)
+ *
+ * Coordinates with widget-layout.js.ts: that module owns `grid-column`
+ * + inline `height` for user-resized tiles. We own `grid-row`. The two
+ * never conflict — height changes from widget-layout fire ResizeObserver
+ * which re-snaps our row-span.
+ */
+
+export const PULSE_MASONRY_JS = `
+(function () {
+  var ROW_UNIT = 8;
+
+  function packGrid(grid) {
+    if (!grid) return;
+    var cs = window.getComputedStyle(grid);
+    var rowGap = parseInt(cs.rowGap || cs.gap || '16', 10) || 16;
+    var tiles = grid.querySelectorAll('.pulse-tile');
+    for (var i = 0; i < tiles.length; i++) {
+      var t = tiles[i];
+      var h = t.getBoundingClientRect().height;
+      if (h <= 0) continue;
+      var span = Math.max(1, Math.ceil((h + rowGap) / (ROW_UNIT + rowGap)));
+      t.style.gridRow = 'span ' + span;
+    }
+  }
+
+  function packAll() {
+    var grids = document.querySelectorAll('.pulse-grid');
+    for (var i = 0; i < grids.length; i++) packGrid(grids[i]);
+  }
+
+  var rafQueued = false;
+  function schedulePack() {
+    if (rafQueued) return;
+    rafQueued = true;
+    requestAnimationFrame(function () {
+      rafQueued = false;
+      packAll();
+    });
+  }
+
+  var ro = null;
+  if (typeof ResizeObserver !== 'undefined') {
+    ro = new ResizeObserver(function () { schedulePack(); });
+  }
+
+  function observeTiles() {
+    if (!ro) return;
+    var tiles = document.querySelectorAll('.pulse-tile');
+    for (var i = 0; i < tiles.length; i++) ro.observe(tiles[i]);
+  }
+
+  var mo = new MutationObserver(function (mutations) {
+    var dirty = false;
+    for (var i = 0; i < mutations.length; i++) {
+      var m = mutations[i];
+      if (m.type === 'childList' && (m.addedNodes.length || m.removedNodes.length)) {
+        dirty = true;
+        break;
+      }
+    }
+    if (dirty) {
+      observeTiles();
+      schedulePack();
+    }
+  });
+
+  function start() {
+    var grids = document.querySelectorAll('.pulse-grid');
+    for (var i = 0; i < grids.length; i++) {
+      mo.observe(grids[i], { childList: true, subtree: true });
+    }
+    observeTiles();
+    schedulePack();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
+  }
+
+  window.addEventListener('resize', schedulePack);
+
+  window.suaPackPulseGrid = packAll;
+})();
+`;


### PR DESCRIPTION
## Summary
- Pulse + named-dashboard 4-column grid switches to masonry-style packing
- `grid-auto-rows: 8px` + `grid-auto-flow: dense` + per-tile `grid-row: span N` computed from rendered height
- New `pulse-masonry.js.ts` runs on DOMContentLoaded, ResizeObserver per tile, MutationObserver on `.pulse-grid`, and window resize
- Columns pack independently (Pinterest-style); voids inside short tiles' cells are gone

## Why
Dogfooding bug: dragging a 1x1 tile (e.g. churn) into the visual space "under" ccusage-daily (which sat next to a 1115px astronomy tile, locking that row to 1115px) rearranged the layout or rejected the drop. The void belonged to ccusage's own grid cell — undrop-targetable.

Before/after for the same agent set (200px..1115px height variance):
| Tile | Before (1x1, row-major) | After (computed span) |
|---|---|---|
| astronomy-pic-of-the-day | row height = 1115px (locks row) | `grid-row: span 48` |
| churn-watcher | renders in 200px, 915px void below | `grid-row: span 9` |
| ccusage-daily | renders in 200px, 915px void below | `grid-row: span 9` |
| cocktail-of-the-day | renders in 710px | `grid-row: span 31` |

After: each column accumulates tiles top-to-bottom independently. No voids.

## Test plan
- [x] `npx vitest run` → 1654 pass / 3 skipped
- [x] Clean build green
- [x] Manual: `/pulse` renders with no voids; ccusage-daily and churn now sit next to astronomy with no 900px gap below
- [x] DOM probe: each tile carries an inline `grid-row: span N` proportional to its height
- [ ] Manual: drag a 1x1 tile under a shorter 1x1 next to a tall tile — should slot in the dragged tile's destination column without bouncing back

## Caveats
- Layout becomes more columnar (Pinterest-y) than the prior row-major flow. Tile *visual* order may diverge from source order when `dense` backfills holes; underlying tile/container ordering in `sua-pulse-layout` is unchanged.
- `.pulse-tile--1x2` / `.pulse-tile--2x2` no longer enforce a 2-row reservation. Their `max-height: 600px` cap is preserved.
- Browsers without ResizeObserver (very old Safari) skip the per-tile re-pack on content change. Initial pack still runs via DOMContentLoaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)