### PR TITLE
feat(dashboard,cli): crash logging — stack traces + signal names in dashboard.log

### DIFF
--- a/.changeset/dashboard-crash-logging.md
+++ b/.changeset/dashboard-crash-logging.md
@@ -1,0 +1,28 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Dashboard crash logging: stack traces + signal names in `dashboard.log`.
+
+Before this PR, `dashboard.log` only contained the startup banner. If
+the dashboard hit an uncaught exception, an unhandled promise rejection,
+or any route threw, the process died with no trace — operators saw
+"daemon status: stopped" and an empty log.
+
+Now:
+- A 4-arg Express error middleware (`error-middleware.ts`) catches any
+  route that throws synchronously or via `next(err)`, writes a
+  timestamped line to stderr (`[ts] ERROR METHOD PATH → STATUS: msg`
+  + full stack), and responds with a 500 that points at the log
+- The CLI `dashboard start` command registers
+  `process.on('uncaughtException')` and `process.on('unhandledRejection')`
+  handlers that write `FATAL ...` lines before exiting 1
+- Shutdown signals name themselves: `dashboard shutting down (SIGTERM)` /
+  `(SIGINT)` so the log distinguishes graceful stops from crashes
+
+The daemon supervisor already pipes stderr to `dashboard.log`, so
+nothing changes operationally — the contents just become useful.

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -123,11 +123,46 @@ of scope for this release — wrap in launchd / systemd if you need it.
     );
     console.log(ui.dim('Press Ctrl+C to stop.\n'));
 
-    const shutdown = async () => {
-      console.log('\nShutting down dashboard...');
-      await handle.close();
-      process.exit(0);
+    // Crash-logging contract. The daemon supervisor pipes stderr to
+    // dashboard.log; previously the only thing that ever reached it
+    // was the startup banner. Now signal-triggered shutdowns name
+    // their signal, uncaught exceptions write the full stack before
+    // exit, and unhandled rejections do the same. Without these the
+    // dashboard would die mid-request and the operator would see an
+    // empty log + no PID — exactly the symptom that prompted this.
+    const ts = (): string => new Date().toISOString();
+    const shutdown = async (reason: string) => {
+      process.stderr.write(`[${ts()}] dashboard shutting down (${reason})\n`);
+      try {
+        await handle.close();
+        process.exit(0);
+      } catch (err) {
+        process.stderr.write(
+          `[${ts()}] dashboard shutdown error: ${(err as Error)?.message ?? String(err)}\n` +
+          `${(err as Error)?.stack ?? ''}\n`,
+        );
+        process.exit(1);
+      }
     };
-    process.on('SIGINT', () => { void shutdown(); });
-    process.on('SIGTERM', () => { void shutdown(); });
+
+    process.on('SIGINT', () => { void shutdown('SIGINT'); });
+    process.on('SIGTERM', () => { void shutdown('SIGTERM'); });
+
+    process.on('uncaughtException', (err) => {
+      process.stderr.write(
+        `[${ts()}] FATAL uncaughtException: ${err?.message ?? String(err)}\n${err?.stack ?? ''}\n`,
+      );
+      // Exit with 1 so the supervisor knows this wasn't a clean stop
+      // and can decide whether to restart. Don't await handle.close()
+      // — the process state is corrupt; leave the OS to reclaim fds.
+      process.exit(1);
+    });
+
+    process.on('unhandledRejection', (reason) => {
+      const err = reason instanceof Error ? reason : new Error(String(reason));
+      process.stderr.write(
+        `[${ts()}] FATAL unhandledRejection: ${err.message}\n${err.stack ?? ''}\n`,
+      );
+      process.exit(1);
+    });
   });

--- a/packages/dashboard/src/error-middleware.test.ts
+++ b/packages/dashboard/src/error-middleware.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Verifies the dashboard's Express error middleware writes a structured
+ * line to stderr (the daemon supervisor pipes it to dashboard.log) and
+ * responds with a meaningful 500 instead of Node's default. The whole
+ * point: "dashboard crashed, log was empty" must never happen again —
+ * if this test passes, the operator always has a stack trace.
+ *
+ * Standalone Express app to keep the test focused; the integration
+ * surface (buildDashboardApp registers this middleware as the last
+ * 4-arg handler) is verified by inspection.
+ */
+
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import express, { type Request, type Response, type NextFunction } from 'express';
+import { buildDashboardErrorHandler } from './error-middleware.js';
+
+function makeApp() {
+  const app = express();
+  app.get('/throw-sync', (_req: Request, _res: Response) => {
+    throw new Error('synthetic sync explosion');
+  });
+  app.get('/throw-async', async (_req: Request, _res: Response, next: NextFunction) => {
+    try {
+      await Promise.reject(new Error('synthetic async explosion'));
+    } catch (e) {
+      next(e);
+    }
+  });
+  app.get('/throw-with-status', (_req: Request, _res: Response) => {
+    const err = new Error('forbidden by policy') as Error & { status: number };
+    err.status = 403;
+    throw err;
+  });
+  app.use(buildDashboardErrorHandler());
+  return app;
+}
+
+function captureStderr<T>(fn: () => Promise<T>): Promise<{ result: T; logged: string }> {
+  const writes: string[] = [];
+  const orig = process.stderr.write.bind(process.stderr);
+  (process.stderr.write as unknown as (s: string | Uint8Array) => boolean) = ((chunk: string | Uint8Array) => {
+    writes.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
+    return true;
+  }) as unknown as typeof process.stderr.write;
+  return fn().then(
+    (result) => { process.stderr.write = orig; return { result, logged: writes.join('') }; },
+    (err) => { process.stderr.write = orig; throw err; },
+  );
+}
+
+describe('buildDashboardErrorHandler', () => {
+  it('catches synchronous throws, writes a stack to stderr, sends 500', async () => {
+    const app = makeApp();
+    const { result: res, logged } = await captureStderr(() =>
+      request(app).get('/throw-sync'),
+    );
+    expect(res.status).toBe(500);
+    expect(res.text).toContain('Internal Server Error');
+    expect(res.text).toContain('GET /throw-sync');
+    expect(logged).toMatch(/ERROR GET \/throw-sync .*→ 500: synthetic sync explosion/);
+    expect(logged).toContain('Error: synthetic sync explosion');
+    expect(logged).toMatch(/at \w+/); // stack frame present
+  });
+
+  it('catches errors forwarded via next(err)', async () => {
+    const app = makeApp();
+    const { result: res, logged } = await captureStderr(() =>
+      request(app).get('/throw-async'),
+    );
+    expect(res.status).toBe(500);
+    expect(logged).toMatch(/ERROR GET \/throw-async .*→ 500: synthetic async explosion/);
+  });
+
+  it('honours err.status when set (e.g. 403 instead of 500)', async () => {
+    const app = makeApp();
+    const { result: res, logged } = await captureStderr(() =>
+      request(app).get('/throw-with-status'),
+    );
+    expect(res.status).toBe(403);
+    expect(logged).toMatch(/→ 403: forbidden by policy/);
+  });
+
+});

--- a/packages/dashboard/src/error-middleware.ts
+++ b/packages/dashboard/src/error-middleware.ts
@@ -1,0 +1,36 @@
+/**
+ * Express error-handling middleware for the dashboard.
+ *
+ * Must be the LAST middleware registered on the app (4-arg signature is
+ * what Express uses to recognise it as an error handler). Without this,
+ * any route that throws synchronously or rejects without handling
+ * propagates to Node's default error handler — which writes a generic
+ * 500 to the response and leaves NOTHING in the dashboard log. Operators
+ * end up with the symptom "dashboard crashed, log is empty" and no way
+ * to diagnose.
+ *
+ * Writes the method, path, status, message, and stack to `process.stderr`
+ * so the daemon supervisor pipes it to `dashboard.log`, then sends a
+ * minimal-but-informative 500 to the client.
+ */
+
+import type { ErrorRequestHandler } from 'express';
+
+export function buildDashboardErrorHandler(): ErrorRequestHandler {
+  return (err, req, res, _next) => {
+    const ts = new Date().toISOString();
+    const status = (typeof (err as { status?: unknown }).status === 'number')
+      ? (err as { status: number }).status
+      : 500;
+    const message = err instanceof Error ? err.message : String(err);
+    const stack = err instanceof Error && err.stack ? err.stack : '';
+    process.stderr.write(
+      `[${ts}] ERROR ${req.method} ${req.originalUrl} → ${status}: ${message}\n${stack}\n`,
+    );
+    if (res.headersSent) return;
+    res.status(status).type('text/plain').send(
+      `Internal Server Error\n\nThe dashboard hit an unhandled error on ${req.method} ${req.originalUrl}. ` +
+      `Check the dashboard log for the stack trace.`,
+    );
+  };
+}

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -33,6 +33,7 @@ import type { DashboardContext } from './context.js';
 import { getContext } from './context.js';
 import { EncryptedFileSecretsSession } from './secrets-session.js';
 import { requireAuth } from './auth-middleware.js';
+import { buildDashboardErrorHandler } from './error-middleware.js';
 import { healthRouter } from './routes/health.js';
 import { authRouter } from './routes/auth.js';
 import { agentsRouter } from './routes/agents.js';
@@ -267,6 +268,10 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
     const { renderNotFoundPage } = await import('./views/not-found.js');
     res.status(404).type('html').send(renderNotFoundPage({ path: req.originalUrl }));
   });
+
+  // Express error handler — see error-middleware.ts for the contract.
+  // Must be the LAST middleware registered.
+  app.use(buildDashboardErrorHandler());
 
   return app;
 }


### PR DESCRIPTION
## Why
Dogfooding: user reported "dashboard crashed" and the log was empty — just the startup banner. Turns out the dashboard hadn't actually crashed (PID alive, port responding), but it COULD have, and we'd have had nothing to work from.

Before this PR, `dashboard.log` only ever contained the startup banner. Any uncaught exception, unhandled promise rejection, or thrown route killed the process with no trace. Operators saw "daemon status: stopped" + empty log → no way to diagnose.

## Summary
- [error-middleware.ts](packages/dashboard/src/error-middleware.ts): new 4-arg Express error handler. Catches any route that throws sync or via `next(err)`; writes `[ts] ERROR METHOD PATH → STATUS: msg` + full stack to stderr; responds 500 with a hint to check the log
- [cli/commands/dashboard.ts](packages/cli/src/commands/dashboard.ts): adds `process.on('uncaughtException')` and `process.on('unhandledRejection')` — write `FATAL ...` lines before `exit(1)`
- Shutdown signals name themselves in the log: `dashboard shutting down (SIGTERM)` / `(SIGINT)` so graceful stops are distinguishable from crashes

The daemon supervisor already pipes stderr to `dashboard.log` — nothing changes operationally; the contents just become useful.

## Test plan
- [x] `npx vitest run packages/dashboard/src/error-middleware.test.ts` — 3 tests: sync throw, async-next throw, honours `err.status` (403 etc)
- [x] Full suite: `npx vitest run` → 1686 pass / 3 skipped (was 1683; +3)
- [x] Clean build green
- [x] Live verification: `kill -TERM <pid>` → log now ends with `[2026-05-27T21:45:07.293Z] dashboard shutting down (SIGTERM)`
- [ ] Manual: trigger a route that throws to confirm the 500 page includes the path

🤖 Generated with [Claude Code](https://claude.com/claude-code)