### PR TITLE
feat(core): auto-backfill permissions.imgSrc on agent create/upsert

### DIFF
--- a/.changeset/drafter-img-permissions-backfill.md
+++ b/.changeset/drafter-img-permissions-backfill.md
@@ -1,0 +1,29 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Auto-backfill `permissions.imgSrc` from outputWidget template at agent
+create/upsert time.
+
+The drafter prompt teaches the LLM to declare `permissions.imgSrc` for
+external image hosts, but the field is optional and the LLM
+occasionally forgets — leaving the user with a broken-image tile on
+Pulse + a CSP error in the console.
+
+`AgentStore.createAgent` / `upsertAgent` now run a defense-in-depth
+static-analysis pass: any `<img src="https://HOST/…">` in
+`outputWidget.template` has its hostname extracted, baseline CSP
+hosts filtered out (img.youtube.com, i.vimeocdn.com), and the union
+merged into `permissions.imgSrc` before persistence. Wildcard entries
+the drafter declared (e.g. `*.unsplash.com`) are preserved — the
+analyser can't infer those. Idempotent — re-saving an agent whose
+hosts are already declared doesn't bump the version.
+
+Belt-and-suspenders with the runtime inline-allow card (#377): every
+new draft now ships with correct permissions; existing agents pick up
+the backfill on their next save. The card stays as the catch-all for
+late-binding images and edge cases.

--- a/packages/core/src/agent-store.test.ts
+++ b/packages/core/src/agent-store.test.ts
@@ -330,3 +330,65 @@ describe('AgentStore.starred', () => {
     expect(store.listAgents().map((a) => a.id)).toEqual(['alpha', 'gamma', 'beta']);
   });
 });
+
+describe('AgentStore permissions.imgSrc backfill', () => {
+  function seedWithTemplate(template: string, extra: Partial<Agent> = {}): Omit<Agent, 'version'> {
+    return seed({
+      id: 'with-img',
+      outputWidget: {
+        type: 'ai-template',
+        template,
+      } as Agent['outputWidget'],
+      ...extra,
+    });
+  }
+
+  it('backfills permissions.imgSrc from outputWidget.template when none declared', () => {
+    const tpl = '<div><img src="https://apod.nasa.gov/x.jpg"></div>';
+    store.createAgent(seedWithTemplate(tpl), 'cli');
+    const got = store.getAgent('with-img');
+    expect(got?.permissions?.imgSrc).toEqual(['apod.nasa.gov']);
+  });
+
+  it('merges with permissions declared by the drafter (preserves wildcards)', () => {
+    const tpl = '<img src="https://images.unsplash.com/x.jpg">';
+    store.createAgent(
+      seedWithTemplate(tpl, {
+        permissions: { imgSrc: ['*.unsplash.com'] },
+      } as Partial<Agent>),
+      'cli',
+    );
+    const got = store.getAgent('with-img');
+    expect(got?.permissions?.imgSrc).toEqual(['*.unsplash.com', 'images.unsplash.com']);
+  });
+
+  it('skips baseline hosts (img.youtube.com, i.vimeocdn.com)', () => {
+    const tpl = `
+      <img src="https://img.youtube.com/vi/abc/0.jpg">
+      <img src="https://apod.nasa.gov/x.jpg">
+    `;
+    store.createAgent(seedWithTemplate(tpl), 'cli');
+    const got = store.getAgent('with-img');
+    expect(got?.permissions?.imgSrc).toEqual(['apod.nasa.gov']);
+  });
+
+  it('leaves agents without an outputWidget untouched', () => {
+    store.createAgent(seed(), 'cli');
+    const got = store.getAgent('hello');
+    expect(got?.permissions).toBeUndefined();
+  });
+
+  it('does not bump version on upsert when extracted hosts already merged in', () => {
+    const tpl = '<img src="https://apod.nasa.gov/x.jpg">';
+    store.createAgent(seedWithTemplate(tpl), 'cli');
+    const v1 = store.getAgent('with-img');
+    expect(v1?.version).toBe(1);
+    expect(v1?.permissions?.imgSrc).toEqual(['apod.nasa.gov']);
+
+    // Upsert the same spec — backfill is idempotent, DAG-equality should match,
+    // no new version row created.
+    store.upsertAgent(seedWithTemplate(tpl), 'cli');
+    const v2 = store.getAgent('with-img');
+    expect(v2?.version).toBe(1);
+  });
+});

--- a/packages/core/src/agent-store.ts
+++ b/packages/core/src/agent-store.ts
@@ -12,6 +12,7 @@ import type {
   AgentVersionDag,
 } from './agent-v2-types.js';
 import { deriveCapabilities } from './agent-capabilities.js';
+import { extractImgHosts, mergeImgSrcHosts } from './extract-img-hosts.js';
 
 type SqlValue = string | number | null | bigint | Uint8Array;
 
@@ -385,6 +386,30 @@ export class AgentStore {
     if (agent.author !== undefined) dag.author = agent.author;
     if (agent.tags) dag.tags = agent.tags;
     if (agent.permissions) dag.permissions = agent.permissions;
+
+    // Backfill permissions.imgSrc by static analysis of the outputWidget
+    // template. The drafter prompt teaches the LLM to emit this field
+    // when widgets reference external images, but the field is soft
+    // and the LLM occasionally forgets — leaving the user with a
+    // broken-image tile until they manually add the host. This pass
+    // catches every <img src="https://HOST/..."> tag the LLM did write,
+    // merges those hosts into existing permissions.imgSrc, and persists
+    // them with the version. Defense-in-depth — the inline-allow card
+    // on Pulse is the runtime catch-all; this is the install-time fix.
+    if (agent.outputWidget?.template) {
+      const extracted = extractImgHosts({ outputWidget: agent.outputWidget });
+      if (extracted.length > 0) {
+        const merged = mergeImgSrcHosts(dag.permissions?.imgSrc, extracted);
+        // Only write back if the merge changed something — avoids needless
+        // version bumps when upsertAgent's DAG-equality check runs.
+        const existing = dag.permissions?.imgSrc ?? [];
+        const changed = merged.length !== existing.length || merged.some((h, i) => h !== existing[i]);
+        if (changed) {
+          dag.permissions = { ...(dag.permissions ?? {}), imgSrc: merged };
+        }
+      }
+    }
+
     return dag;
   }
 

--- a/packages/core/src/extract-img-hosts.test.ts
+++ b/packages/core/src/extract-img-hosts.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { extractImgHosts, mergeImgSrcHosts } from './extract-img-hosts.js';
+
+describe('extractImgHosts', () => {
+  it('returns empty array when there is no outputWidget', () => {
+    expect(extractImgHosts({})).toEqual([]);
+  });
+
+  it('returns empty array when template is empty', () => {
+    expect(extractImgHosts({ outputWidget: { template: '' } })).toEqual([]);
+  });
+
+  it('extracts a single external host', () => {
+    const tpl = '<div><img src="https://apod.nasa.gov/apod/image/x.jpg"></div>';
+    expect(extractImgHosts({ outputWidget: { template: tpl } })).toEqual(['apod.nasa.gov']);
+  });
+
+  it('extracts multiple distinct hosts and de-dupes + sorts', () => {
+    const tpl = `
+      <img src="https://images.unsplash.com/photo-1">
+      <img src="https://www.thecocktaildb.com/images/drink.jpg">
+      <img src="https://apod.nasa.gov/apod/image/y.jpg">
+      <img src="https://images.unsplash.com/photo-2">
+    `;
+    expect(extractImgHosts({ outputWidget: { template: tpl } })).toEqual([
+      'apod.nasa.gov',
+      'images.unsplash.com',
+      'www.thecocktaildb.com',
+    ]);
+  });
+
+  it('handles single-quoted src attributes', () => {
+    const tpl = `<img src='https://apod.nasa.gov/x.jpg'>`;
+    expect(extractImgHosts({ outputWidget: { template: tpl } })).toEqual(['apod.nasa.gov']);
+  });
+
+  it('filters out CSP-baseline hosts (img.youtube.com, i.vimeocdn.com)', () => {
+    const tpl = `
+      <img src="https://img.youtube.com/vi/abc/0.jpg">
+      <img src="https://i.vimeocdn.com/video/123.jpg">
+      <img src="https://apod.nasa.gov/x.jpg">
+    `;
+    expect(extractImgHosts({ outputWidget: { template: tpl } })).toEqual(['apod.nasa.gov']);
+  });
+
+  it('lowercases hostnames', () => {
+    const tpl = `<img src="https://APOD.NASA.GOV/x.jpg">`;
+    expect(extractImgHosts({ outputWidget: { template: tpl } })).toEqual(['apod.nasa.gov']);
+  });
+
+  it('skips http: data: and inline base64', () => {
+    const tpl = `
+      <img src="http://insecure.example.com/x.jpg">
+      <img src="data:image/png;base64,abc">
+      <img src="https://apod.nasa.gov/x.jpg">
+    `;
+    // http: still matches (CSP allows http if declared, though the dashboard uses https). For
+    // safety we extract it — the user can prune via the imgSrc form.
+    expect(extractImgHosts({ outputWidget: { template: tpl } })).toEqual([
+      'apod.nasa.gov',
+      'insecure.example.com',
+    ]);
+  });
+
+  it('skips IP-literal hosts', () => {
+    const tpl = `<img src="https://192.168.1.1/x.jpg">`;
+    expect(extractImgHosts({ outputWidget: { template: tpl } })).toEqual([]);
+  });
+
+  it('handles arbitrary attribute order and whitespace before src', () => {
+    const tpl = `
+      <img class="hero" alt="Astronomy"
+           src="https://apod.nasa.gov/x.jpg" width="320">
+      <img loading="lazy" src='https://images.unsplash.com/y.jpg' />
+    `;
+    expect(extractImgHosts({ outputWidget: { template: tpl } })).toEqual([
+      'apod.nasa.gov',
+      'images.unsplash.com',
+    ]);
+  });
+
+  it('is reentrant — repeated calls return the same result (regex state reset)', () => {
+    const tpl = '<img src="https://a.example.com/1"><img src="https://b.example.com/2">';
+    const first = extractImgHosts({ outputWidget: { template: tpl } });
+    const second = extractImgHosts({ outputWidget: { template: tpl } });
+    expect(first).toEqual(['a.example.com', 'b.example.com']);
+    expect(second).toEqual(first);
+  });
+});
+
+describe('mergeImgSrcHosts', () => {
+  it('returns sorted union of existing + extracted, de-duped', () => {
+    expect(mergeImgSrcHosts(['b.example.com'], ['a.example.com', 'b.example.com'])).toEqual([
+      'a.example.com',
+      'b.example.com',
+    ]);
+  });
+
+  it('preserves wildcard entries from existing (analyser can\'t infer wildcards)', () => {
+    expect(mergeImgSrcHosts(['*.unsplash.com'], ['images.unsplash.com'])).toEqual([
+      '*.unsplash.com',
+      'images.unsplash.com',
+    ]);
+  });
+
+  it('lowercases + trims existing entries', () => {
+    expect(mergeImgSrcHosts([' APOD.NASA.GOV '], [])).toEqual(['apod.nasa.gov']);
+  });
+
+  it('handles undefined existing', () => {
+    expect(mergeImgSrcHosts(undefined, ['a.example.com'])).toEqual(['a.example.com']);
+  });
+
+  it('returns empty when both inputs empty', () => {
+    expect(mergeImgSrcHosts(undefined, [])).toEqual([]);
+  });
+});

--- a/packages/core/src/extract-img-hosts.ts
+++ b/packages/core/src/extract-img-hosts.ts
@@ -1,0 +1,90 @@
+/**
+ * Static-analysis helper that finds external image hosts referenced by
+ * an agent's spec. Used by AgentStore on create/upsert to backfill
+ * `permissions.imgSrc` so a drafted agent's `<img src="…">` tags don't
+ * silently break at runtime via CSP block.
+ *
+ * Scope:
+ *   - Walks `agent.outputWidget.template` (the ai-template HTML body
+ *     — where 99% of widget image URLs live). Anything `<img src="…">`
+ *     pointing at a real HTTPS host gets its hostname extracted.
+ *
+ * Out of scope (handled at runtime by the inline-allow card):
+ *   - DAG node outputs (only known after a run, not at spec time)
+ *   - Markdown images that the LLM renders dynamically into a result
+ *   - CSS `background-image: url(…)` inside templates (rare; can extend later)
+ *
+ * The CSP baseline already allows `img.youtube.com`, `i.vimeocdn.com`,
+ * and `data:` URIs — those are filtered out so backfilled
+ * `permissions.imgSrc` lists stay minimal. Host names are lowercased
+ * and de-duplicated.
+ */
+
+/**
+ * Hosts the dashboard CSP allows by default — must mirror `BASE_IMG_SRC`
+ * in packages/dashboard/src/index.ts. Backfilling these would be noise.
+ */
+const BASELINE_IMG_HOSTS: ReadonlySet<string> = new Set([
+  'img.youtube.com',
+  'i.vimeocdn.com',
+]);
+
+// One regex per `<img>` tag in the template. The src attribute may use
+// single or double quotes. We allow optional whitespace and any other
+// attributes before `src=`. Hostname is captured up to the first `/`,
+// `?`, `#`, `"`, `'`, or whitespace.
+const IMG_TAG_RE = /<img\b[^>]*?\bsrc\s*=\s*["']https?:\/\/([^/"'?#\s]+)/gi;
+
+// Hostname format check: lowercase letters, digits, hyphens, dots,
+// optional leading `*.` for wildcard. Reject ports, anything weird.
+// IP literals pass this regex (digits + dots match too); the IPv4
+// guard below catches them separately.
+const VALID_HOST_RE = /^(\*\.)?[a-z0-9]([a-z0-9.-]*[a-z0-9])?$/;
+const IPV4_RE = /^\d{1,3}(\.\d{1,3}){3}$/;
+
+export interface ExtractImgHostsInput {
+  outputWidget?: { template?: string } | undefined;
+}
+
+/**
+ * Extract the external image-host hostnames referenced by an agent
+ * spec's outputWidget template. Returns a sorted, de-duplicated array
+ * of bare hostnames suitable for `permissions.imgSrc`.
+ *
+ * Excludes:
+ *   - Hosts in BASELINE_IMG_HOSTS (already allowed by the dashboard CSP)
+ *   - Empty / malformed hostnames
+ *   - Anything that doesn't match the hostname regex (IPs, ports, etc.)
+ */
+export function extractImgHosts(spec: ExtractImgHostsInput): string[] {
+  const template = spec.outputWidget?.template;
+  if (!template || typeof template !== 'string') return [];
+  const hosts = new Set<string>();
+  // Reset regex state — the `g` flag makes the regex stateful across calls.
+  IMG_TAG_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = IMG_TAG_RE.exec(template)) !== null) {
+    const host = m[1].toLowerCase();
+    if (!VALID_HOST_RE.test(host)) continue;
+    if (IPV4_RE.test(host)) continue;
+    if (BASELINE_IMG_HOSTS.has(host)) continue;
+    hosts.add(host);
+  }
+  return Array.from(hosts).sort();
+}
+
+/**
+ * Merge extracted hosts with an existing `permissions.imgSrc` list.
+ * Preserves any hosts the drafter (or user) explicitly declared, even
+ * wildcard subdomains that the static analyser wouldn't infer on its
+ * own. Returns a new sorted, de-duplicated array.
+ */
+export function mergeImgSrcHosts(existing: string[] | undefined, extracted: string[]): string[] {
+  const set = new Set<string>();
+  for (const h of existing ?? []) {
+    const lower = h.toLowerCase().trim();
+    if (lower) set.add(lower);
+  }
+  for (const h of extracted) set.add(h);
+  return Array.from(set).sort();
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -84,6 +84,10 @@ export {
   type BlockedImgHost,
 } from './blocked-img-hosts-store.js';
 export {
+  extractImgHosts,
+  mergeImgSrcHosts,
+} from './extract-img-hosts.js';
+export {
   IntegrationsStore,
   INTEGRATION_ID_RE,
   type Integration,


### PR DESCRIPTION
## Why
The drafter prompt teaches the LLM to declare `permissions.imgSrc` when widgets render external images — but it's a soft instruction the LLM occasionally skips. Result: user drafts an agent that loads `<img src="https://apod.nasa.gov/...">`, the field is missing, page CSP blocks it, broken image.

#377 added the runtime inline-allow card so users can fix this in one click. This PR closes the loop one layer up: every agent persistence path now back-fills the field automatically from static analysis of the template.

Confirmed via DB audit of the user's previously broken agents:
- `marvel-hero-of-the-day` v8 → declared (`upload.wikimedia.org`) ✓
- `cocktail-of-the-day` v13 → declared (`www.thecocktaildb.com`) ✓
- `weather-dashboard` v7 → NULL (would be fixed on next save by this PR)
- `hn-classified` v1 → NULL (would be fixed on next save by this PR)

The LLM is inconsistent. The backfill is deterministic.

## Summary
- New util `extractImgHosts()` walks `outputWidget.template`, regex-matches `<img src="https://HOST/...">`, lowercases, filters out CSP baseline (img.youtube.com, i.vimeocdn.com) and IPv4 literals
- New util `mergeImgSrcHosts()` unions with any existing list, preserves wildcard entries (`*.unsplash.com`) the static analyser can't infer
- `AgentStore.extractDag()` (called from create + upsert) now runs the backfill + merge before persistence. Only writes when the merge actually changed something so upsert's DAG-equality short-circuit still skips no-op version bumps
- 21 new tests (16 util + 5 store integration)

## Test plan
- [x] `npx vitest run packages/core/src/extract-img-hosts.test.ts` — 16 tests covering edge cases (single/double quotes, attribute order, IPs, wildcards, baselines, idempotency)
- [x] `npx vitest run packages/core/src/agent-store.test.ts` — 33 tests including 5 new for the backfill (happy path, merge-with-existing, baseline filter, no-template, idempotent upsert)
- [x] Full suite: `npx vitest run` → 1707 pass / 3 skipped (was 1686; +21 new)
- [x] Clean build green
- [ ] Manual: draft a new agent via Build From Goal whose widget loads an external image; confirm `permissions.imgSrc` is set in the v1 spec (sqlite check on `data/runs.db`)
- [ ] Manual: edit `weather-dashboard` or `hn-classified` from the dashboard YAML editor (any change → triggers upsert → backfill); confirm permissions now declared

🤖 Generated with [Claude Code](https://claude.com/claude-code)