### PR TITLE
feat(dashboard): Inbox MVP — top-nav surface + list + detail (PR 2/2 of MVP)

### DIFF
--- a/.changeset/inbox-dashboard-ui.md
+++ b/.changeset/inbox-dashboard-ui.md
@@ -1,0 +1,30 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox MVP — dashboard surface (PR 2/2 of the Inbox MVP).
+
+Wires the `InboxStore` from PR 1 into the dashboard:
+
+- Top nav gains an **Inbox** entry between Scheduled and Agents
+  (`activeNav: 'inbox'`)
+- `GET /inbox` renders a priority-grouped list (High / Medium / Low
+  sections) with row columns: agent, title, source, age, status.
+  Mirrors the runs-list table pattern.
+- `GET /inbox/:id` renders a detail page with priority/source/age/status
+  badges, the message body, a collapsible Context payload, and a
+  placeholder for the conversation thread + recommendation that
+  arrive in PR 4
+- `inboxStore` wired into `DashboardContext` (optional — booting
+  without it renders the empty state)
+- New `SUA_INBOX_DEMO=1` env flag seeds one message per priority on
+  boot so the UI is visible before producers are wired in PR 3.
+  Disappears when PR 3 lands.
+
+The MVP is read-only. Producer hooks (failed runs, CSP-block
+escalation, cadence agent), mutation routes (dismiss / respond /
+triage), CLI verbs, and verification all ship in follow-up PRs.

--- a/.changeset/inbox-store-foundation.md
+++ b/.changeset/inbox-store-foundation.md
@@ -1,0 +1,33 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox store foundation — SQLite-backed queue for "needs your attention".
+
+First of a 5-PR sequence (this is the MVP base; the dashboard UI lands
+in PR 2). Adds `InboxStore` in core with:
+
+- `inbox_messages` table keyed by id, with priority (high/medium/low),
+  source (run-failure / permission-request / cadence / manual),
+  status (open → triaged → awaiting_user → verifying → resolved, plus
+  `dismissed` as terminal), and a `dedupe_key` UNIQUE column so
+  producers can fire-and-forget without state
+- `inbox_responses` table for per-message conversation threads
+  (role: user / triage / system), used by later PRs
+- Public API: `add`, `list`, `get`, `findByDedupeKey`, `updateStatus`,
+  `dismiss`, `addResponse`, `listResponses`, `clear` — mirrors the
+  canonical pattern from `BlockedImgHostsStore` / `LayoutHintsStore`
+
+`list()` default-orders by priority (high first via CASE expression,
+since alphabetical sort would put low before medium) then created_at
+DESC, and default-excludes `dismissed` and `resolved` so the queue
+shows only active work.
+
+Producers, dashboard UI, top-nav entry, triage system agent, CLI verbs,
+and verification loop all ship in follow-up PRs. The schema is locked
+now (including unused-in-MVP columns like `triage_run_id` and
+`recommendation`) to avoid migrations.

--- a/packages/core/src/inbox-store.test.ts
+++ b/packages/core/src/inbox-store.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { InboxStore, type InboxMessage } from './inbox-store.js';
+
+let dir: string;
+let store: InboxStore;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'sua-inbox-store-'));
+  store = new InboxStore(join(dir, 'runs.db'));
+});
+
+afterEach(() => {
+  try { store.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+function addMinimal(overrides: Partial<Parameters<InboxStore['add']>[0]> = {}): InboxMessage {
+  return store.add({
+    priority: 'medium',
+    source: 'manual',
+    title: 'Hello',
+    body: 'World',
+    ...overrides,
+  });
+}
+
+describe('InboxStore.add + get', () => {
+  it('writes a row, get round-trips it, default status is open', () => {
+    const msg = addMinimal();
+    expect(msg.id).toBeTruthy();
+    expect(msg.status).toBe('open');
+    expect(msg.createdAt).toBeGreaterThan(0);
+    expect(msg.resolvedAt).toBeUndefined();
+
+    const got = store.get(msg.id);
+    expect(got).not.toBeNull();
+    expect(got!.id).toBe(msg.id);
+    expect(got!.title).toBe('Hello');
+    expect(got!.body).toBe('World');
+  });
+
+  it('persists optional fields', () => {
+    const msg = addMinimal({
+      priority: 'high',
+      source: 'run-failure',
+      agentId: 'astro',
+      runId: 'run-123',
+      contextJson: JSON.stringify({ exit: 1 }),
+    });
+    const got = store.get(msg.id)!;
+    expect(got.priority).toBe('high');
+    expect(got.source).toBe('run-failure');
+    expect(got.agentId).toBe('astro');
+    expect(got.runId).toBe('run-123');
+    expect(got.contextJson).toBe('{"exit":1}');
+  });
+
+  it('add with same dedupeKey is idempotent — returns existing row', () => {
+    const first = addMinimal({ dedupeKey: 'run-failure:abc' });
+    const second = addMinimal({ dedupeKey: 'run-failure:abc', title: 'Different' });
+    expect(second.id).toBe(first.id);
+    expect(second.title).toBe('Hello'); // original preserved
+    expect(store.list({ status: 'open' })).toHaveLength(1);
+  });
+
+  it('add without dedupeKey always creates a new row even with identical content', () => {
+    const a = addMinimal();
+    const b = addMinimal();
+    expect(a.id).not.toBe(b.id);
+  });
+});
+
+describe('InboxStore.list', () => {
+  it('orders by priority (high → low) then created_at DESC within each priority', async () => {
+    addMinimal({ priority: 'low', title: 'L1' });
+    await new Promise((r) => setTimeout(r, 3));
+    addMinimal({ priority: 'high', title: 'H1' });
+    await new Promise((r) => setTimeout(r, 3));
+    addMinimal({ priority: 'medium', title: 'M1' });
+    await new Promise((r) => setTimeout(r, 3));
+    addMinimal({ priority: 'high', title: 'H2' });
+    const titles = store.list().map((m) => m.title);
+    expect(titles).toEqual(['H2', 'H1', 'M1', 'L1']);
+  });
+
+  it('default filter excludes dismissed and resolved', () => {
+    const a = addMinimal({ title: 'keep' });
+    const b = addMinimal({ title: 'dismiss-me' });
+    const c = addMinimal({ title: 'resolve-me' });
+    store.dismiss(b.id);
+    store.updateStatus(c.id, 'resolved');
+    expect(store.list().map((m) => m.title)).toEqual(['keep']);
+    expect(a.id).toBeTruthy();
+  });
+
+  it('status filter overrides the default exclusion', () => {
+    const a = addMinimal({ title: 'dismissed-one' });
+    store.dismiss(a.id);
+    expect(store.list({ status: 'dismissed' }).map((m) => m.title)).toEqual(['dismissed-one']);
+  });
+
+  it('priority filter narrows the result', () => {
+    addMinimal({ priority: 'high', title: 'h' });
+    addMinimal({ priority: 'low', title: 'l' });
+    expect(store.list({ priority: 'high' }).map((m) => m.title)).toEqual(['h']);
+  });
+
+  it('respects limit', () => {
+    for (let i = 0; i < 5; i++) addMinimal({ title: `m${i}` });
+    expect(store.list({ limit: 2 })).toHaveLength(2);
+  });
+});
+
+describe('InboxStore.updateStatus / dismiss', () => {
+  it('transitions open → triaged → resolved and sets resolved_at on resolve', () => {
+    const m = addMinimal();
+    store.updateStatus(m.id, 'triaged', { triageRunId: 'run-xyz', recommendation: 'check log' });
+    let got = store.get(m.id)!;
+    expect(got.status).toBe('triaged');
+    expect(got.triageRunId).toBe('run-xyz');
+    expect(got.recommendation).toBe('check log');
+    expect(got.resolvedAt).toBeUndefined();
+
+    store.updateStatus(m.id, 'resolved');
+    got = store.get(m.id)!;
+    expect(got.status).toBe('resolved');
+    expect(got.resolvedAt).toBeGreaterThan(0);
+  });
+
+  it('dismiss sets status + resolved_at', () => {
+    const m = addMinimal();
+    store.dismiss(m.id);
+    const got = store.get(m.id)!;
+    expect(got.status).toBe('dismissed');
+    expect(got.resolvedAt).toBeGreaterThan(0);
+  });
+
+  it('throws when updating a missing id', () => {
+    expect(() => store.updateStatus('nope', 'resolved')).toThrow(/no message with id/);
+  });
+});
+
+describe('InboxStore.addResponse + listResponses', () => {
+  it('round-trips responses in chronological order', async () => {
+    const m = addMinimal();
+    store.addResponse(m.id, 'user', 'first reply');
+    await new Promise((r) => setTimeout(r, 3));
+    store.addResponse(m.id, 'triage', 'recommendation');
+    await new Promise((r) => setTimeout(r, 3));
+    store.addResponse(m.id, 'system', 'state change');
+    const responses = store.listResponses(m.id);
+    expect(responses.map((r) => r.role)).toEqual(['user', 'triage', 'system']);
+    expect(responses.map((r) => r.body)).toEqual(['first reply', 'recommendation', 'state change']);
+  });
+
+  it('rejects responses for unknown messages', () => {
+    expect(() => store.addResponse('nope', 'user', 'x')).toThrow(/no message with id/);
+  });
+
+  it('persists metaJson', () => {
+    const m = addMinimal();
+    store.addResponse(m.id, 'system', 'allowed apod.nasa.gov', JSON.stringify({ host: 'apod.nasa.gov' }));
+    const responses = store.listResponses(m.id);
+    expect(responses[0].metaJson).toBe('{"host":"apod.nasa.gov"}');
+  });
+});
+
+describe('InboxStore.findByDedupeKey', () => {
+  it('returns the matching row', () => {
+    const m = addMinimal({ dedupeKey: 'csp-block:astro:apod.nasa.gov' });
+    expect(store.findByDedupeKey('csp-block:astro:apod.nasa.gov')?.id).toBe(m.id);
+  });
+  it('returns null for unknown keys', () => {
+    expect(store.findByDedupeKey('nope')).toBeNull();
+  });
+});
+
+describe('InboxStore.clear', () => {
+  it('empties both tables', () => {
+    const m = addMinimal();
+    store.addResponse(m.id, 'user', 'x');
+    store.clear();
+    expect(store.list()).toEqual([]);
+    expect(store.listResponses(m.id)).toEqual([]);
+  });
+});
+
+describe('InboxStore validation', () => {
+  it('rejects invalid priority', () => {
+    expect(() => addMinimal({ priority: 'urgent' as never })).toThrow(/invalid priority/);
+  });
+  it('rejects invalid source', () => {
+    expect(() => addMinimal({ source: 'mystery' as never })).toThrow(/invalid source/);
+  });
+  it('rejects invalid status on updateStatus', () => {
+    const m = addMinimal();
+    expect(() => store.updateStatus(m.id, 'snoozed' as never)).toThrow(/invalid status/);
+  });
+  it('rejects invalid response role', () => {
+    const m = addMinimal();
+    expect(() => store.addResponse(m.id, 'admin' as never, 'x')).toThrow(/invalid response role/);
+  });
+  it('requires title and body on add', () => {
+    expect(() => store.add({ priority: 'low', source: 'manual', title: '', body: 'x' })).toThrow(/title/);
+    expect(() => store.add({ priority: 'low', source: 'manual', title: 'x', body: '' })).toThrow(/body/);
+  });
+});

--- a/packages/core/src/inbox-store.ts
+++ b/packages/core/src/inbox-store.ts
@@ -1,0 +1,402 @@
+import { DatabaseSync } from 'node:sqlite';
+import { mkdirSync, existsSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { chmod600Safe } from './fs-utils.js';
+
+/**
+ * Inbox store — a unified "needs your attention" queue for the
+ * dashboard.
+ *
+ * Producers (PR 3+) drop rows here from disconnected signals:
+ *   - failed runs (high)        — hooked from run-store.updateRun
+ *   - permission requests (med) — currently CSP-blocked image hosts
+ *   - cadence reminders  (low)  — emitted by a scheduled system agent
+ *
+ * Consumers: the dashboard `/inbox` views, future `sua inbox …` CLI,
+ * and a future triage system agent that classifies messages + emits a
+ * structured <plan>{ messageId, recommendation, verifyHint }</plan>
+ * parsed by the route.
+ *
+ * The MVP only writes/displays `open` and `dismissed`; the full
+ * lifecycle enum (`triaged`, `awaiting_user`, `verifying`, `resolved`)
+ * is defined now so PR 3+ doesn't require a migration.
+ */
+
+export const INBOX_PRIORITIES = ['high', 'medium', 'low'] as const;
+export type InboxPriority = typeof INBOX_PRIORITIES[number];
+
+export const INBOX_STATUSES = [
+  'open',
+  'triaged',
+  'awaiting_user',
+  'verifying',
+  'resolved',
+  'dismissed',
+] as const;
+export type InboxStatus = typeof INBOX_STATUSES[number];
+
+export const INBOX_SOURCES = ['run-failure', 'permission-request', 'cadence', 'manual'] as const;
+export type InboxSource = typeof INBOX_SOURCES[number];
+
+export const INBOX_RESPONSE_ROLES = ['user', 'triage', 'system'] as const;
+export type InboxResponseRole = typeof INBOX_RESPONSE_ROLES[number];
+
+export interface InboxMessage {
+  id: string;
+  createdAt: number;
+  priority: InboxPriority;
+  source: InboxSource;
+  agentId?: string;
+  runId?: string;
+  title: string;
+  body: string;
+  contextJson?: string;
+  status: InboxStatus;
+  triageRunId?: string;
+  recommendation?: string;
+  resolvedAt?: number;
+  dedupeKey?: string;
+}
+
+export interface InboxResponse {
+  id: string;
+  messageId: string;
+  createdAt: number;
+  role: InboxResponseRole;
+  body: string;
+  metaJson?: string;
+}
+
+export interface AddMessageInput {
+  priority: InboxPriority;
+  source: InboxSource;
+  title: string;
+  body: string;
+  agentId?: string;
+  runId?: string;
+  contextJson?: string;
+  /**
+   * Idempotency key. If a row with this dedupeKey already exists, `add`
+   * returns the existing row unchanged. Suggested formats:
+   *   `run-failure:<runId>` — each failed run is its own incident
+   *   `csp-block:<agentId>:<host>` — collapses repeated CSP blocks
+   *   `cadence:<topic>:<yyyy-mm-dd>` — one reminder per topic per day
+   */
+  dedupeKey?: string;
+}
+
+export interface ListMessagesOpts {
+  status?: InboxStatus;
+  priority?: InboxPriority;
+  limit?: number;
+}
+
+/**
+ * Priority ranking for ORDER BY — `high` first. SQLite sorts strings
+ * alphabetically by default which would put `low` before `medium`
+ * before `high`; we inject a CASE expression to fix the ordering
+ * without storing a numeric column.
+ */
+const PRIORITY_RANK_CASE = `
+  CASE priority
+    WHEN 'high' THEN 0
+    WHEN 'medium' THEN 1
+    WHEN 'low' THEN 2
+    ELSE 3
+  END
+`;
+
+/**
+ * SQLite-backed Inbox. One row per message in `inbox_messages`; an
+ * optional conversation thread per message in `inbox_responses`. The
+ * full schema lands in the MVP even though `triage_run_id`,
+ * `recommendation`, and `inbox_responses` are unused until PR 4 —
+ * adding nullable columns later means migrations, and the schema is
+ * small enough to define once.
+ */
+export class InboxStore {
+  private db: DatabaseSync;
+  private readonly ownsConnection: boolean;
+  public readonly dataRoot: string;
+
+  constructor(dbPath: string) {
+    const dir = dirname(dbPath);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    this.db = new DatabaseSync(dbPath);
+    this.ownsConnection = true;
+    chmod600Safe(dbPath);
+    this.dataRoot = dir;
+    this.ensureSchema();
+  }
+
+  static fromHandle(db: DatabaseSync): InboxStore {
+    const store = Object.create(InboxStore.prototype) as InboxStore;
+    (store as unknown as { db: DatabaseSync }).db = db;
+    (store as unknown as { ownsConnection: boolean }).ownsConnection = false;
+    (store as unknown as { dataRoot: string }).dataRoot = '';
+    store.ensureSchema();
+    return store;
+  }
+
+  private ensureSchema(): void {
+    this.db.exec('PRAGMA journal_mode = WAL');
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS inbox_messages (
+        id TEXT PRIMARY KEY,
+        created_at INTEGER NOT NULL,
+        priority TEXT NOT NULL,
+        source TEXT NOT NULL,
+        agent_id TEXT,
+        run_id TEXT,
+        title TEXT NOT NULL,
+        body TEXT NOT NULL,
+        context_json TEXT,
+        status TEXT NOT NULL,
+        triage_run_id TEXT,
+        recommendation TEXT,
+        resolved_at INTEGER,
+        dedupe_key TEXT UNIQUE
+      )
+    `);
+    this.db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_inbox_open
+        ON inbox_messages(status, priority, created_at DESC)
+    `);
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS inbox_responses (
+        id TEXT PRIMARY KEY,
+        message_id TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        role TEXT NOT NULL,
+        body TEXT NOT NULL,
+        meta_json TEXT
+      )
+    `);
+    this.db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_inbox_responses_msg
+        ON inbox_responses(message_id, created_at)
+    `);
+  }
+
+  /**
+   * Insert a new message. When `dedupeKey` is set and a row already
+   * exists with the same key, returns the existing row unchanged
+   * (idempotent — producers can fire-and-forget without state).
+   * Returns the resulting row in either case.
+   */
+  add(input: AddMessageInput): InboxMessage {
+    this.validatePriority(input.priority);
+    this.validateSource(input.source);
+    if (!input.title) throw new Error('InboxStore.add: title is required');
+    if (!input.body) throw new Error('InboxStore.add: body is required');
+
+    if (input.dedupeKey) {
+      const existing = this.findByDedupeKey(input.dedupeKey);
+      if (existing) return existing;
+    }
+
+    const id = randomUUID();
+    const now = Date.now();
+    this.db.prepare(`
+      INSERT INTO inbox_messages (
+        id, created_at, priority, source, agent_id, run_id,
+        title, body, context_json, status, dedupe_key
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?)
+    `).run(
+      id,
+      now,
+      input.priority,
+      input.source,
+      input.agentId ?? null,
+      input.runId ?? null,
+      input.title,
+      input.body,
+      input.contextJson ?? null,
+      input.dedupeKey ?? null,
+    );
+    return this.get(id)!;
+  }
+
+  /**
+   * List messages newest-first within each priority. Default filter
+   * excludes `dismissed` + `resolved` (the queue is for active items
+   * only); pass `status` to override.
+   */
+  list(opts: ListMessagesOpts = {}): InboxMessage[] {
+    const where: string[] = [];
+    const params: (string | number | null)[] = [];
+    if (opts.status !== undefined) {
+      this.validateStatus(opts.status);
+      where.push('status = ?');
+      params.push(opts.status);
+    } else {
+      where.push("status NOT IN ('dismissed', 'resolved')");
+    }
+    if (opts.priority !== undefined) {
+      this.validatePriority(opts.priority);
+      where.push('priority = ?');
+      params.push(opts.priority);
+    }
+    const limit = typeof opts.limit === 'number' && opts.limit > 0 ? opts.limit : 200;
+    const rows = this.db.prepare(`
+      SELECT * FROM inbox_messages
+      WHERE ${where.join(' AND ')}
+      ORDER BY ${PRIORITY_RANK_CASE}, created_at DESC
+      LIMIT ?
+    `).all(...params, limit) as Array<Record<string, unknown>>;
+    return rows.map((r) => this.rowToMessage(r));
+  }
+
+  get(id: string): InboxMessage | null {
+    const row = this.db.prepare(`SELECT * FROM inbox_messages WHERE id = ?`)
+      .get(id) as Record<string, unknown> | undefined;
+    return row ? this.rowToMessage(row) : null;
+  }
+
+  findByDedupeKey(dedupeKey: string): InboxMessage | null {
+    const row = this.db.prepare(`SELECT * FROM inbox_messages WHERE dedupe_key = ?`)
+      .get(dedupeKey) as Record<string, unknown> | undefined;
+    return row ? this.rowToMessage(row) : null;
+  }
+
+  /**
+   * Transition a message to a new status. `triageRunId` and
+   * `recommendation` are set when present (used by PR 4's triage
+   * route). Transitioning to `resolved` or `dismissed` also writes
+   * `resolved_at`.
+   */
+  updateStatus(
+    id: string,
+    status: InboxStatus,
+    opts: { triageRunId?: string; recommendation?: string } = {},
+  ): void {
+    this.validateStatus(status);
+    const fields: string[] = ['status = ?'];
+    const params: (string | number | null)[] = [status];
+    if (opts.triageRunId !== undefined) {
+      fields.push('triage_run_id = ?');
+      params.push(opts.triageRunId);
+    }
+    if (opts.recommendation !== undefined) {
+      fields.push('recommendation = ?');
+      params.push(opts.recommendation);
+    }
+    if (status === 'resolved' || status === 'dismissed') {
+      fields.push('resolved_at = ?');
+      params.push(Date.now());
+    }
+    params.push(id);
+    const result = this.db.prepare(
+      `UPDATE inbox_messages SET ${fields.join(', ')} WHERE id = ?`,
+    ).run(...params);
+    if (result.changes === 0) throw new Error(`InboxStore.updateStatus: no message with id "${id}"`);
+  }
+
+  /** Convenience for the common `updateStatus(id, 'dismissed')` path. */
+  dismiss(id: string): void {
+    this.updateStatus(id, 'dismissed');
+  }
+
+  /**
+   * Append a conversation entry to a message. Roles:
+   *   `user`   — operator reply via the dashboard or CLI
+   *   `triage` — triage agent recommendation / follow-up
+   *   `system` — automated state-transition note (e.g. "host added to allowlist")
+   */
+  addResponse(
+    messageId: string,
+    role: InboxResponseRole,
+    body: string,
+    metaJson?: string,
+  ): InboxResponse {
+    this.validateResponseRole(role);
+    if (!body) throw new Error('InboxStore.addResponse: body is required');
+    // Ensure the parent message exists — fail loudly rather than orphan a row.
+    if (!this.get(messageId)) {
+      throw new Error(`InboxStore.addResponse: no message with id "${messageId}"`);
+    }
+    const id = randomUUID();
+    const now = Date.now();
+    this.db.prepare(`
+      INSERT INTO inbox_responses (id, message_id, created_at, role, body, meta_json)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(id, messageId, now, role, body, metaJson ?? null);
+    return { id, messageId, createdAt: now, role, body, metaJson };
+  }
+
+  listResponses(messageId: string): InboxResponse[] {
+    const rows = this.db.prepare(`
+      SELECT id, message_id, created_at, role, body, meta_json
+        FROM inbox_responses
+        WHERE message_id = ?
+        ORDER BY created_at ASC
+    `).all(messageId) as Array<Record<string, unknown>>;
+    return rows.map((r) => this.rowToResponse(r));
+  }
+
+  /** Drop every row from both tables. Test + dev tooling. */
+  clear(): void {
+    this.db.exec(`DELETE FROM inbox_responses`);
+    this.db.exec(`DELETE FROM inbox_messages`);
+  }
+
+  close(): void {
+    if (this.ownsConnection) this.db.close();
+  }
+
+  // ── validation ─────────────────────────────────────────────────────
+
+  private validatePriority(p: string): void {
+    if (!(INBOX_PRIORITIES as readonly string[]).includes(p)) {
+      throw new Error(`InboxStore: invalid priority "${p}" — must be one of ${INBOX_PRIORITIES.join(', ')}`);
+    }
+  }
+  private validateStatus(s: string): void {
+    if (!(INBOX_STATUSES as readonly string[]).includes(s)) {
+      throw new Error(`InboxStore: invalid status "${s}" — must be one of ${INBOX_STATUSES.join(', ')}`);
+    }
+  }
+  private validateSource(s: string): void {
+    if (!(INBOX_SOURCES as readonly string[]).includes(s)) {
+      throw new Error(`InboxStore: invalid source "${s}" — must be one of ${INBOX_SOURCES.join(', ')}`);
+    }
+  }
+  private validateResponseRole(r: string): void {
+    if (!(INBOX_RESPONSE_ROLES as readonly string[]).includes(r)) {
+      throw new Error(`InboxStore: invalid response role "${r}" — must be one of ${INBOX_RESPONSE_ROLES.join(', ')}`);
+    }
+  }
+
+  // ── row marshalling ────────────────────────────────────────────────
+
+  private rowToMessage(row: Record<string, unknown>): InboxMessage {
+    return {
+      id: row.id as string,
+      createdAt: row.created_at as number,
+      priority: row.priority as InboxPriority,
+      source: row.source as InboxSource,
+      agentId: (row.agent_id as string | null) ?? undefined,
+      runId: (row.run_id as string | null) ?? undefined,
+      title: row.title as string,
+      body: row.body as string,
+      contextJson: (row.context_json as string | null) ?? undefined,
+      status: row.status as InboxStatus,
+      triageRunId: (row.triage_run_id as string | null) ?? undefined,
+      recommendation: (row.recommendation as string | null) ?? undefined,
+      resolvedAt: (row.resolved_at as number | null) ?? undefined,
+      dedupeKey: (row.dedupe_key as string | null) ?? undefined,
+    };
+  }
+
+  private rowToResponse(row: Record<string, unknown>): InboxResponse {
+    return {
+      id: row.id as string,
+      messageId: row.message_id as string,
+      createdAt: row.created_at as number,
+      role: row.role as InboxResponseRole,
+      body: row.body as string,
+      metaJson: (row.meta_json as string | null) ?? undefined,
+    };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,6 +88,21 @@ export {
   mergeImgSrcHosts,
 } from './extract-img-hosts.js';
 export {
+  InboxStore,
+  INBOX_PRIORITIES,
+  INBOX_STATUSES,
+  INBOX_SOURCES,
+  INBOX_RESPONSE_ROLES,
+  type InboxMessage,
+  type InboxResponse,
+  type InboxPriority,
+  type InboxStatus,
+  type InboxSource,
+  type InboxResponseRole,
+  type AddMessageInput,
+  type ListMessagesOpts,
+} from './inbox-store.js';
+export {
   IntegrationsStore,
   INTEGRATION_ID_RE,
   type Integration,

--- a/packages/dashboard/src/context.ts
+++ b/packages/dashboard/src/context.ts
@@ -1,4 +1,4 @@
-import type { LocalProvider, RunStore, SecretsStore, AgentDefinition, AgentStore, ToolStore, VariablesStore, PacksStore, DashboardsStore, LayoutHintsStore, BlockedImgHostsStore, IntegrationsStore, PlannerTelemetryStore, PlannerLoopStepLogStore, PlannerMemoryStore, AgentMemoryStore } from '@some-useful-agents/core';
+import type { LocalProvider, RunStore, SecretsStore, AgentDefinition, AgentStore, ToolStore, VariablesStore, PacksStore, DashboardsStore, LayoutHintsStore, BlockedImgHostsStore, InboxStore, IntegrationsStore, PlannerTelemetryStore, PlannerLoopStepLogStore, PlannerMemoryStore, AgentMemoryStore } from '@some-useful-agents/core';
 import type { SecretsSession } from './secrets-session.js';
 
 /**
@@ -100,6 +100,13 @@ export interface DashboardContext {
    * — booting without it just disables the suggestion UI.
    */
   blockedImgHostsStore?: BlockedImgHostsStore;
+  /**
+   * Unified "needs your attention" queue (PR 1 of the Inbox feature
+   * series). The dashboard's `/inbox` views read from this; producer
+   * hooks + a triage system agent are wired in follow-up PRs.
+   * Optional — booting without it just disables the Inbox surface.
+   */
+  inboxStore?: InboxStore;
   /**
    * Integrations store. Holds project-scoped named external-service configs
    * (slack, webhook, file, …) that agents and notify handlers reference by

--- a/packages/dashboard/src/inbox-demo-seed.ts
+++ b/packages/dashboard/src/inbox-demo-seed.ts
@@ -1,0 +1,58 @@
+/**
+ * Demo seed for the Inbox MVP. When `SUA_INBOX_DEMO=1` is set at boot
+ * and the inbox is empty, seeds one row at each priority so the UI
+ * surface is visible before real producers (failed-run hook,
+ * CSP-block escalation, cadence agent) ship.
+ *
+ * This file disappears when PR 3 lands and real producers populate the
+ * inbox. Intentionally tiny + non-magical: no scheduler, no random
+ * data, no recurring inserts.
+ */
+
+import type { InboxStore } from '@some-useful-agents/core';
+
+export function seedInboxDemoIfRequested(store: InboxStore | undefined): void {
+  if (!store) return;
+  if (process.env.SUA_INBOX_DEMO !== '1') return;
+  // Only seed if empty so daemon restarts don't accumulate duplicates
+  // (dedupe_key would catch them anyway, but the empty-check makes
+  // the intent explicit).
+  if (store.list().length > 0) return;
+
+  try {
+    store.add({
+      priority: 'high',
+      source: 'run-failure',
+      agentId: 'demo-failing-agent',
+      runId: 'demo-run-1',
+      title: 'demo-failing-agent failed: exit code 1',
+      body: 'The most recent run of demo-failing-agent terminated with a non-zero exit code. Diagnose the failure and either fix the agent or mark this resolved.',
+      contextJson: JSON.stringify({ exitCode: 1, durationMs: 4321, lastErrorLine: 'shell-exec: command not found' }),
+      dedupeKey: 'demo:run-failure',
+    });
+    store.add({
+      priority: 'medium',
+      source: 'permission-request',
+      agentId: 'demo-astro-tile',
+      title: 'demo-astro-tile wants to load images from apod.nasa.gov',
+      body: 'A widget on demo-astro-tile has tried to load images from apod.nasa.gov 4 times in the last hour and been blocked by the page CSP. Add the host to its allowlist or dismiss to hide this reminder.',
+      contextJson: JSON.stringify({ host: 'apod.nasa.gov', blockedCount: 4 }),
+      dedupeKey: 'demo:csp-block',
+    });
+    store.add({
+      priority: 'low',
+      source: 'cadence',
+      title: '3 agents have not run in 30+ days',
+      body: 'Housekeeping reminder: stock-ticker, weather-archive, and cron-test-old have not produced runs in the last 30 days. Archive them or trigger a fresh run to confirm they still work.',
+      contextJson: JSON.stringify({ staleAgents: ['stock-ticker', 'weather-archive', 'cron-test-old'] }),
+      dedupeKey: 'demo:cadence',
+    });
+  } catch (err) {
+    // Demo seed failures are non-fatal — the page will just render
+    // an empty state. Log to stderr so an operator inspecting
+    // dashboard.log knows the seed ran but skipped.
+    process.stderr.write(
+      `[inbox-demo-seed] failed: ${(err as Error)?.message ?? String(err)}\n`,
+    );
+  }
+}

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -10,6 +10,7 @@ import {
   DashboardsStore,
   LayoutHintsStore,
   BlockedImgHostsStore,
+  InboxStore,
   IntegrationsStore,
   PlannerTelemetryStore,
   PlannerLoopStepLogStore,
@@ -55,6 +56,8 @@ import { settingsMcpRouter } from './routes/settings-mcp.js';
 import { helpRouter } from './routes/help.js';
 import { versionsRouter } from './routes/versions.js';
 import { imgBlockReportRouter } from './routes/img-block-report.js';
+import { inboxRouter } from './routes/inbox.js';
+import { seedInboxDemoIfRequested } from './inbox-demo-seed.js';
 import { pulseRouter } from './routes/pulse.js';
 import { pulseLayoutPlanRouter } from './routes/pulse-layout-plan.js';
 import { dashboardLayoutPlanRouter } from './routes/dashboard-layout-plan.js';
@@ -253,6 +256,7 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   app.use(helpRouter);
   app.use(versionsRouter);
   app.use(imgBlockReportRouter);
+  app.use(inboxRouter);
   app.use(toolsRouter);
   app.use(nodesRouter);
   app.use(pulseRouter);
@@ -364,6 +368,7 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
   let dashboardsStore: DashboardsStore | undefined;
   let layoutHintsStore: LayoutHintsStore | undefined;
   let blockedImgHostsStore: BlockedImgHostsStore | undefined;
+  let inboxStore: InboxStore | undefined;
   try {
     packsStore = new PacksStore(opts.dbPath);
     dashboardsStore = new DashboardsStore(opts.dbPath);
@@ -396,6 +401,19 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
   } catch {
     // Non-fatal: blocked-img suggestions just won't appear.
   }
+
+  // Inbox store. Same DB file. The /inbox surface degrades to an
+  // empty-state if the table can't be created.
+  try {
+    inboxStore = new InboxStore(opts.dbPath);
+  } catch {
+    // Non-fatal: /inbox renders empty state instead.
+  }
+
+  // Demo seed: when SUA_INBOX_DEMO=1, drop three sample rows (one per
+  // priority) into an empty inbox so the page renders something
+  // before real producers ship in PR 3. No-op without the env flag.
+  seedInboxDemoIfRequested(inboxStore);
 
   // Integrations store. Same DB file. Independently optional from packs/
   // dashboards so a schema issue in either doesn't keep the other offline.
@@ -464,6 +482,7 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     dashboardsStore,
     layoutHintsStore,
     blockedImgHostsStore,
+    inboxStore,
     integrationsStore,
     plannerTelemetryStore,
     plannerLoopStepLogStore,

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Smoke tests for the Inbox routes (PR 2 of the Inbox MVP). The store
+ * itself is unit-tested in core; these check that the routes wire the
+ * store + views correctly and that the top nav highlights the page.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import request from 'supertest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AgentStore,
+  InboxStore,
+  LocalProvider,
+  MemorySecretsStore,
+  RunStore,
+  buildLoopbackAllowlist,
+  loadAgents,
+} from '@some-useful-agents/core';
+import { buildDashboardApp } from '../index.js';
+import type { DashboardContext } from '../context.js';
+import { SESSION_COOKIE } from '../auth-middleware.js';
+import { MemorySecretsSession } from '../secrets-session.js';
+
+const TOKEN = 'a'.repeat(64);
+const PORT = 3993;
+const COOKIE = `${SESSION_COOKIE}=${TOKEN}`;
+
+let dir: string;
+let provider: LocalProvider;
+let runStore: RunStore;
+let agentStore: AgentStore;
+let inboxStore: InboxStore;
+
+async function makeApp() {
+  dir = mkdtempSync(join(tmpdir(), 'sua-inbox-routes-'));
+  const dbPath = join(dir, 'runs.db');
+  const agentsDir = join(dir, 'agents', 'local');
+  mkdirSync(agentsDir, { recursive: true });
+
+  const secretsStore = new MemorySecretsStore();
+  runStore = new RunStore(dbPath);
+  agentStore = new AgentStore(dbPath);
+  inboxStore = new InboxStore(dbPath);
+  provider = new LocalProvider(dbPath, secretsStore);
+  await provider.initialize();
+
+  const ctx: DashboardContext = {
+    token: TOKEN,
+    allowlist: buildLoopbackAllowlist(PORT),
+    port: PORT,
+    provider,
+    runStore,
+    agentStore,
+    loadAgents: () => loadAgents({ directories: [agentsDir] }),
+    secretsStore,
+    secretsSession: new MemorySecretsSession({ backing: secretsStore }),
+    tokenPath: join(dir, 'mcp-token'),
+    retentionDays: 30,
+    dbPath,
+    secretsPath: join(dir, 'secrets.enc'),
+    rotateToken: () => 'r'.repeat(64),
+    inboxStore,
+    allowUntrustedShell: new Set(),
+    activeRuns: new Map(),
+    dataDir: dir,
+    dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
+  };
+  return buildDashboardApp(ctx);
+}
+
+afterEach(async () => {
+  if (provider) {
+    const start = Date.now();
+    while ((provider as unknown as { running?: { size: number } }).running?.size && Date.now() - start < 2000) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    await provider.shutdown();
+  }
+  try { runStore?.close(); } catch { /* ignore */ }
+  try { agentStore?.close(); } catch { /* ignore */ }
+  try { inboxStore?.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('GET /inbox', () => {
+  it('renders an empty state when no messages exist', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .get('/inbox')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Inbox');
+    expect(res.text).toContain('Inbox zero');
+    // Top nav highlights /inbox.
+    expect(res.text).toMatch(/<a href="\/inbox"[^>]*class="is-active"/);
+  });
+
+  it('groups messages by priority newest-first', async () => {
+    const app = await makeApp();
+    inboxStore.add({ priority: 'low', source: 'cadence', title: 'low-pri item', body: 'x' });
+    inboxStore.add({ priority: 'high', source: 'run-failure', agentId: 'foo', title: 'high-pri item', body: 'y' });
+    inboxStore.add({ priority: 'medium', source: 'permission-request', title: 'med-pri item', body: 'z' });
+
+    const res = await request(app)
+      .get('/inbox')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('High');
+    expect(res.text).toContain('Medium');
+    expect(res.text).toContain('Low');
+    // High section must appear before Medium and Low in the HTML stream.
+    const hi = res.text.indexOf('high-pri item');
+    const med = res.text.indexOf('med-pri item');
+    const lo = res.text.indexOf('low-pri item');
+    expect(hi).toBeGreaterThan(0);
+    expect(hi).toBeLessThan(med);
+    expect(med).toBeLessThan(lo);
+  });
+});
+
+describe('GET /inbox/:id', () => {
+  it('renders the message detail page', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({
+      priority: 'high',
+      source: 'run-failure',
+      agentId: 'astro',
+      runId: 'run-abc',
+      title: 'Detail title',
+      body: 'Detail body markdown.',
+      contextJson: JSON.stringify({ exit: 1 }),
+    });
+    const res = await request(app)
+      .get(`/inbox/${m.id}`)
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Detail title');
+    expect(res.text).toContain('Detail body markdown.');
+    expect(res.text).toContain('Context payload');
+    expect(res.text).toContain('/agents/astro');
+    expect(res.text).toContain('/runs/run-abc');
+    expect(res.text).toMatch(/<a href="\/inbox"[^>]*class="is-active"/);
+  });
+
+  it('renders 404 for an unknown message id', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .get('/inbox/no-such-id')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE);
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -1,0 +1,45 @@
+/**
+ * Routes for the Inbox surface:
+ *   GET /inbox        — priority-grouped list of active items
+ *   GET /inbox/:id    — message detail + conversation thread
+ *
+ * Mutation routes (dismiss, respond, triage) ship in follow-up PRs;
+ * MVP is read-only so the surface can be validated before producers
+ * are wired.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { getContext } from '../context.js';
+import { renderInboxList } from '../views/inbox-list.js';
+import { renderInboxDetail } from '../views/inbox-detail.js';
+import { renderNotFoundPage } from '../views/not-found.js';
+
+export const inboxRouter: Router = Router();
+
+inboxRouter.get('/inbox', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const rows = ctx.inboxStore ? ctx.inboxStore.list() : [];
+  res.type('html').send(renderInboxList({ rows }));
+});
+
+inboxRouter.get('/inbox/:id', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  if (!ctx.inboxStore) {
+    res.status(404).type('html').send(renderNotFoundPage({
+      path: req.originalUrl,
+      message: 'Inbox is not available — the store failed to initialize.',
+    }));
+    return;
+  }
+  const message = ctx.inboxStore.get(id);
+  if (!message) {
+    res.status(404).type('html').send(renderNotFoundPage({
+      path: req.originalUrl,
+      message: `No inbox message with id "${id}".`,
+    }));
+    return;
+  }
+  const responses = ctx.inboxStore.listResponses(id);
+  res.type('html').send(renderInboxDetail({ message, responses }));
+});

--- a/packages/dashboard/src/views/inbox-detail.ts
+++ b/packages/dashboard/src/views/inbox-detail.ts
@@ -1,0 +1,132 @@
+import type { InboxMessage, InboxResponse } from '@some-useful-agents/core';
+import { html, render, type SafeHtml } from './html.js';
+import { layout } from './layout.js';
+import { pageHeader } from './page-header.js';
+import { formatAge } from './components.js';
+
+export interface InboxDetailOptions {
+  message: InboxMessage;
+  responses: InboxResponse[];
+  flash?: { kind: 'error' | 'info' | 'ok'; message: string };
+}
+
+const PRIORITY_BADGE: Record<string, string> = {
+  high: 'badge--warn',
+  medium: 'badge--info',
+  low: 'badge--muted',
+};
+
+const ROLE_LABEL: Record<string, string> = {
+  user: 'You',
+  triage: 'Triage agent',
+  system: 'System',
+};
+
+/**
+ * Render the inbox-message detail page. Sections:
+ *   - header — priority + source + age + status
+ *   - body   — short markdown summary the producer wrote
+ *   - context — collapsible <details> of the structured producer payload
+ *   - recommendation — triage agent's suggestion (PR 4+)
+ *   - responses timeline — conversation thread (PR 4+)
+ *
+ * Mirrors the run-detail shell pattern but trims to a single-column
+ * layout — no DAG / widget panes.
+ */
+export function renderInboxDetail(opts: InboxDetailOptions): string {
+  const { message, responses, flash } = opts;
+
+  const ageIso = new Date(message.createdAt).toISOString();
+  const badgeClass = PRIORITY_BADGE[message.priority] ?? 'badge--muted';
+
+  const headerMeta = html`
+    <div style="display: flex; gap: var(--space-3); align-items: center; flex-wrap: wrap; font-size: var(--font-size-sm); color: var(--color-text-muted); margin-top: var(--space-1);">
+      <span class="badge ${badgeClass}">${message.priority}</span>
+      <span>${message.source}</span>
+      <span>${formatAge(ageIso)}</span>
+      <span><span class="badge badge--muted">${message.status}</span></span>
+      ${message.agentId ? html`<a href="/agents/${message.agentId}">${message.agentId}</a>` : html``}
+      ${message.runId ? html`<a href="/runs/${message.runId}" class="mono">run ${message.runId.slice(0, 8)}</a>` : html``}
+    </div>
+  `;
+
+  const bodyBlock = html`
+    <section class="card" style="margin-top: var(--space-4);">
+      <h3 style="margin: 0 0 var(--space-2);">Details</h3>
+      <div style="white-space: pre-wrap;">${message.body}</div>
+    </section>
+  `;
+
+  const contextBlock = message.contextJson ? html`
+    <section class="card" style="margin-top: var(--space-3);">
+      <details>
+        <summary style="cursor: pointer; font-weight: var(--weight-semibold);">Context payload</summary>
+        <pre class="mono" style="font-size: var(--font-size-xs); margin: var(--space-2) 0 0; overflow-x: auto;">${pretty(message.contextJson)}</pre>
+      </details>
+    </section>
+  ` : html``;
+
+  const recommendationBlock = message.recommendation ? html`
+    <section class="card" style="margin-top: var(--space-3);">
+      <h3 style="margin: 0 0 var(--space-2);">Recommendation</h3>
+      <div style="white-space: pre-wrap;">${message.recommendation}</div>
+      ${message.triageRunId ? html`
+        <p class="dim" style="font-size: var(--font-size-xs); margin: var(--space-2) 0 0;">
+          From triage run <a href="/runs/${message.triageRunId}" class="mono">${message.triageRunId.slice(0, 8)}</a>
+        </p>
+      ` : html``}
+    </section>
+  ` : html``;
+
+  const responsesBlock = responses.length > 0
+    ? html`
+      <section class="card" style="margin-top: var(--space-3);">
+        <h3 style="margin: 0 0 var(--space-2);">Conversation</h3>
+        ${responses.map((r) => html`
+          <div style="border-top: 1px solid var(--color-border); padding: var(--space-2) 0;">
+            <div style="font-size: var(--font-size-xs); color: var(--color-text-muted); margin-bottom: var(--space-1);">
+              ${ROLE_LABEL[r.role] ?? r.role} · ${formatAge(new Date(r.createdAt).toISOString())}
+            </div>
+            <div style="white-space: pre-wrap;">${r.body}</div>
+          </div>
+        `) as unknown as SafeHtml[]}
+      </section>`
+    : html`
+      <section class="card" style="margin-top: var(--space-3);">
+        <p class="dim" style="font-size: var(--font-size-sm); margin: 0;">
+          No replies yet. The triage agent + interactive replies ship in upcoming PRs.
+        </p>
+      </section>
+    `;
+
+  const pageBody = html`
+    ${pageHeader({
+      title: message.title,
+      back: { href: '/inbox', label: 'Inbox' },
+    })}
+    ${headerMeta}
+    ${bodyBlock}
+    ${contextBlock}
+    ${recommendationBlock}
+    ${responsesBlock}
+  `;
+
+  return render(layout({
+    title: `${message.title} · Inbox`,
+    activeNav: 'inbox',
+    flash,
+  }, pageBody));
+}
+
+/**
+ * Pretty-print a JSON string for the collapsible context panel. If the
+ * payload isn't valid JSON we display it verbatim — context_json is
+ * producer-controlled and we'd rather show garbage than crash.
+ */
+function pretty(raw: string): string {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+}

--- a/packages/dashboard/src/views/inbox-list.ts
+++ b/packages/dashboard/src/views/inbox-list.ts
@@ -1,0 +1,106 @@
+import type { InboxMessage, InboxPriority } from '@some-useful-agents/core';
+import { html, render, type SafeHtml } from './html.js';
+import { layout } from './layout.js';
+import { pageHeader } from './page-header.js';
+import { formatAge } from './components.js';
+
+export interface InboxListOptions {
+  rows: InboxMessage[];
+  flash?: { kind: 'error' | 'info' | 'ok'; message: string };
+}
+
+const PRIORITY_LABEL: Record<InboxPriority, string> = {
+  high: 'High',
+  medium: 'Medium',
+  low: 'Low',
+};
+
+const PRIORITY_HINT: Record<InboxPriority, string> = {
+  high: 'Failed runs and other action-needed-now items',
+  medium: 'Authorisations and pending decisions',
+  low: 'Housekeeping reminders',
+};
+
+const SOURCE_LABEL: Record<string, string> = {
+  'run-failure': 'Run failure',
+  'permission-request': 'Permission',
+  'cadence': 'Cadence',
+  'manual': 'Manual',
+};
+
+/**
+ * Render the inbox list page. Rows are grouped by priority into three
+ * sections (High / Medium / Low) so the operator's eye lands on the
+ * urgent items first. Within each section, rows are newest-first.
+ * Mirrors the list-table pattern from runs-list.ts but groups
+ * vertically instead of using a single sortable table.
+ */
+export function renderInboxList(opts: InboxListOptions): string {
+  const { rows, flash } = opts;
+
+  const groups: Record<InboxPriority, InboxMessage[]> = {
+    high: rows.filter((r) => r.priority === 'high'),
+    medium: rows.filter((r) => r.priority === 'medium'),
+    low: rows.filter((r) => r.priority === 'low'),
+  };
+
+  const sections = (Object.keys(groups) as InboxPriority[]).map((priority) => {
+    const items = groups[priority];
+    if (items.length === 0) return html``;
+    const tbody = items.map((m) => html`
+      <tr>
+        <td>${m.agentId ? html`<a href="/agents/${m.agentId}">${m.agentId}</a>` : html`<span class="dim">—</span>`}</td>
+        <td><a href="/inbox/${m.id}">${m.title}</a></td>
+        <td class="dim">${SOURCE_LABEL[m.source] ?? m.source}</td>
+        <td class="dim">${formatAge(new Date(m.createdAt).toISOString())}</td>
+        <td><span class="badge badge--muted">${m.status}</span></td>
+      </tr>
+    `);
+    return html`
+      <section style="margin-bottom: var(--space-5);">
+        <h2 style="margin: 0 0 var(--space-1); font-size: var(--font-size-lg);">
+          ${PRIORITY_LABEL[priority]}
+          <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-sm); margin-left: var(--space-2);">
+            ${String(items.length)} ${items.length === 1 ? 'item' : 'items'}
+          </span>
+        </h2>
+        <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-2);">${PRIORITY_HINT[priority]}</p>
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Agent</th>
+              <th>Title</th>
+              <th>Source</th>
+              <th>Age</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>${tbody as unknown as SafeHtml[]}</tbody>
+        </table>
+      </section>
+    `;
+  });
+
+  const empty = rows.length === 0
+    ? html`
+      <div class="settings-empty mt-0">
+        <h3 class="mt-0">Inbox zero</h3>
+        <p class="dim">
+          No items need your attention. Producers (failed-run hooks, CSP-block escalation,
+          cadence reminders) ship in upcoming PRs — until then this page shows demo data
+          with <code>SUA_INBOX_DEMO=1</code>.
+        </p>
+      </div>`
+    : html``;
+
+  const body = html`
+    ${pageHeader({
+      title: 'Inbox',
+      description: 'Things that need your attention, ordered by priority.',
+    })}
+    ${empty}
+    ${sections as unknown as SafeHtml[]}
+  `;
+
+  return render(layout({ title: 'Inbox', activeNav: 'inbox', flash }, body));
+}

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -24,7 +24,7 @@ import { footer } from './footer.js';
 export interface LayoutOptions {
   title: string;
   /** Highlight in the nav (one of: agents, tools, runs, pulse, packs, settings, help). */
-  activeNav?: 'agents' | 'tools' | 'nodes' | 'runs' | 'pulse' | 'packs' | 'scheduled' | 'settings' | 'help';
+  activeNav?: 'agents' | 'tools' | 'nodes' | 'runs' | 'pulse' | 'packs' | 'scheduled' | 'inbox' | 'settings' | 'help';
   /** Flash banner shown at the top of the body (errors from prior actions). */
   flash?: { kind: 'error' | 'info' | 'ok'; message: string };
   /** Widen the main column (for screens with 2-col layouts). */
@@ -70,6 +70,7 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
   <nav class="topbar__nav">
     <a href="/pulse" class="${opts.activeNav === 'pulse' ? 'is-active' : ''}">Pulse</a>
     <a href="/scheduled" class="${opts.activeNav === 'scheduled' ? 'is-active' : ''}">Scheduled</a>
+    <a href="/inbox" class="${opts.activeNav === 'inbox' ? 'is-active' : ''}">Inbox</a>
     <a href="/agents" class="${opts.activeNav === 'agents' || opts.activeNav === 'tools' || opts.activeNav === 'nodes' || opts.activeNav === 'runs' || opts.activeNav === 'packs' ? 'is-active' : ''}">Agents</a>
     <a href="/settings" class="${opts.activeNav === 'settings' ? 'is-active' : ''}">Settings</a>
     <a href="/help" class="${opts.activeNav === 'help' ? 'is-active' : ''}">Help</a>


### PR DESCRIPTION
## Summary
- Top nav gains **Inbox** between Scheduled and Agents (`activeNav: 'inbox'`)
- `GET /inbox` — priority-grouped list (High / Medium / Low sections, each a small table)
- `GET /inbox/:id` — detail page with badges, body, collapsible Context payload, recommendation placeholder, conversation placeholder
- `inboxStore` optional on context — booting without it renders empty state
- `SUA_INBOX_DEMO=1` env flag seeds one row per priority on boot so the UI is visible before producers are wired in PR 3
- 4 route smoke tests + dogfooded screenshots

## Dependency
Includes the merge of #380 (`feat/inbox-store-foundation`) so this branch builds against the InboxStore. Both target `main`; when #380 squash-merges first, this PR's merge commit is a clean no-op.

## Why
The dashboard accumulates several "needs your attention" signals across disconnected surfaces (failed runs in `/runs`, CSP-blocked image hosts in pills + inline cards, stale agents in dim text only the layout planner sees). No single place to ask "what does the system want me to do right now?". This PR ships the surface so we can validate the grid layout, priority grouping, and detail page shape before committing to producer hooks (PR 3), the triage system agent (PR 4), and CLI verbs + cadence + verify (PR 5).

User-approved plan: `~/.claude/plans/jiggly-giggling-stroustrup.md` (MVP-first scope).

## Test plan
- [x] `npx vitest run packages/dashboard/src/routes/inbox.test.ts` — 4 tests
- [x] Full suite: `npx vitest run` → 1734 / 3 skipped (was 1730; +4)
- [x] Clean build green
- [x] Manual: `SUA_INBOX_DEMO=1 node packages/cli/dist/index.js dashboard start --port 3000` → `/inbox` shows three priority sections with one row each; top nav highlights Inbox; clicking a row opens detail with badges + body + collapsed Context payload; back link returns to `/inbox`
- [x] DB spot-check: `sqlite3 data/runs.db "SELECT priority, source, title FROM inbox_messages;"` confirms 3 rows
- [ ] Without `SUA_INBOX_DEMO=1` and an empty inbox, page renders "Inbox zero" empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)