### PR TITLE
feat(dashboard): inbox sortable grid + dismiss + reply

### DIFF
--- a/.changeset/inbox-sortable-grid-and-actions.md
+++ b/.changeset/inbox-sortable-grid-and-actions.md
@@ -1,0 +1,33 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox: single sortable grid + dismiss + reply.
+
+Dogfood feedback on the MVP (#381): the three priority-grouped tables
+fragment the view and source isn't visible enough.
+
+- `/inbox` is now one sortable table with columns Priority / Source /
+  Agent / Title / Age / Status. Click any header to sort; the active
+  column shows ↑/↓. Default sort is Priority asc (high first) with
+  age desc tiebreaker.
+- Priority + Source each render as colored badges so the eye picks
+  out high-pri and run-failure rows at a glance (`badge--warn` for
+  high + run-failure, `badge--info` for medium + permission,
+  `badge--muted` for low + cadence/manual).
+- Detail page gains two actions:
+  - `POST /inbox/:id/dismiss` — terminal-state the message, redirect
+    with an `ok` flash. Idempotent.
+  - `POST /inbox/:id/respond` — append a `user`-role entry to the
+    conversation thread (8 KB cap). The Conversation card now
+    shows the reply form inline.
+- Terminal-state messages (dismissed/resolved) hide both action
+  affordances and show a "closed N ago" hint instead.
+
+Source-specific actions (allow-host for permission-request, retry-run
+for run-failure, etc.) and the triage agent that auto-replies to the
+thread ship in follow-up PRs.

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -98,7 +98,7 @@ describe('GET /inbox', () => {
     expect(res.text).toMatch(/<a href="\/inbox"[^>]*class="is-active"/);
   });
 
-  it('groups messages by priority newest-first', async () => {
+  it('renders one sortable table with priority + source badges, high first by default', async () => {
     const app = await makeApp();
     inboxStore.add({ priority: 'low', source: 'cadence', title: 'low-pri item', body: 'x' });
     inboxStore.add({ priority: 'high', source: 'run-failure', agentId: 'foo', title: 'high-pri item', body: 'y' });
@@ -109,16 +109,125 @@ describe('GET /inbox', () => {
       .set('Host', `127.0.0.1:${PORT}`)
       .set('Cookie', COOKIE);
     expect(res.status).toBe(200);
-    expect(res.text).toContain('High');
-    expect(res.text).toContain('Medium');
-    expect(res.text).toContain('Low');
-    // High section must appear before Medium and Low in the HTML stream.
+    // Single table, not three sections.
+    expect(res.text).toContain('<th>');
+    expect((res.text.match(/<table class="table">/g) ?? []).length).toBe(1);
+    // Source labels rendered as badges with the right palette.
+    expect(res.text).toMatch(/badge badge--warn">Run failure/);
+    expect(res.text).toMatch(/badge badge--info">Permission/);
+    expect(res.text).toMatch(/badge badge--muted">Cadence/);
+    // Default order is priority ASC (high first) by createdAt tiebreaker.
     const hi = res.text.indexOf('high-pri item');
     const med = res.text.indexOf('med-pri item');
     const lo = res.text.indexOf('low-pri item');
     expect(hi).toBeGreaterThan(0);
     expect(hi).toBeLessThan(med);
     expect(med).toBeLessThan(lo);
+  });
+
+  it('honours ?sort=source&dir=asc by reordering rows alphabetically', async () => {
+    const app = await makeApp();
+    inboxStore.add({ priority: 'low', source: 'run-failure', agentId: 'a', title: 'A1', body: 'x' });
+    inboxStore.add({ priority: 'low', source: 'cadence', agentId: 'b', title: 'B1', body: 'y' });
+    inboxStore.add({ priority: 'low', source: 'manual', agentId: 'c', title: 'C1', body: 'z' });
+
+    const res = await request(app)
+      .get('/inbox?sort=source&dir=asc')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE);
+    expect(res.status).toBe(200);
+    const cadenceAt = res.text.indexOf('B1');
+    const manualAt = res.text.indexOf('C1');
+    const runFailureAt = res.text.indexOf('A1');
+    // alphabetical by source: cadence, manual, run-failure
+    expect(cadenceAt).toBeLessThan(manualAt);
+    expect(manualAt).toBeLessThan(runFailureAt);
+    // Active column shows ↑ indicator.
+    expect(res.text).toMatch(/Source ↑/);
+  });
+
+  it('falls back to defaults for unknown sort / dir values', async () => {
+    const app = await makeApp();
+    inboxStore.add({ priority: 'high', source: 'run-failure', title: 'high-pri', body: 'x' });
+    inboxStore.add({ priority: 'low', source: 'cadence', title: 'low-pri', body: 'y' });
+    const res = await request(app)
+      .get('/inbox?sort=nope&dir=sideways')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE);
+    expect(res.status).toBe(200);
+    expect(res.text.indexOf('high-pri')).toBeLessThan(res.text.indexOf('low-pri'));
+  });
+});
+
+describe('POST /inbox/:id/dismiss', () => {
+  it('sets status=dismissed and redirects with an ok flash', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const res = await request(app)
+      .post(`/inbox/${m.id}/dismiss`)
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/^\/inbox\?ok=/);
+    expect(inboxStore.get(m.id)!.status).toBe('dismissed');
+  });
+
+  it('redirects with an error flash for unknown ids', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post('/inbox/nope/dismiss')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/^\/inbox\?error=/);
+  });
+});
+
+describe('POST /inbox/:id/respond', () => {
+  it('appends a user response and redirects to the detail page', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const res = await request(app)
+      .post(`/inbox/${m.id}/respond`)
+      .type('form')
+      .send({ body: 'I tried X, still failing.' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(new RegExp(`^/inbox/${m.id}\\?ok=`));
+    const responses = inboxStore.listResponses(m.id);
+    expect(responses).toHaveLength(1);
+    expect(responses[0].role).toBe('user');
+    expect(responses[0].body).toBe('I tried X, still failing.');
+  });
+
+  it('rejects empty body with an error flash; nothing is stored', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const res = await request(app)
+      .post(`/inbox/${m.id}/respond`)
+      .type('form')
+      .send({ body: '   ' })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/error=/);
+    expect(inboxStore.listResponses(m.id)).toEqual([]);
+  });
+
+  it('rejects oversize body with an error flash', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const oversize = 'x'.repeat(9000);
+    const res = await request(app)
+      .post(`/inbox/${m.id}/respond`)
+      .type('form')
+      .send({ body: oversize })
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/error=/);
+    expect(inboxStore.listResponses(m.id)).toEqual([]);
   });
 });
 

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -1,25 +1,50 @@
 /**
  * Routes for the Inbox surface:
- *   GET /inbox        — priority-grouped list of active items
- *   GET /inbox/:id    — message detail + conversation thread
+ *   GET  /inbox                  — single sortable grid of active items
+ *   GET  /inbox/:id              — message detail + conversation thread
+ *   POST /inbox/:id/dismiss      — set status='dismissed' + redirect
+ *   POST /inbox/:id/respond      — append a user reply to the thread
  *
- * Mutation routes (dismiss, respond, triage) ship in follow-up PRs;
- * MVP is read-only so the surface can be validated before producers
- * are wired.
+ * The triage agent (auto-classify + recommend) and source-specific
+ * action buttons (e.g. allow-host, retry-run) ship in a follow-up PR.
  */
 
 import { Router, type Request, type Response } from 'express';
 import { getContext } from '../context.js';
-import { renderInboxList } from '../views/inbox-list.js';
+import {
+  renderInboxList,
+  type InboxSortKey,
+  type InboxSortDir,
+  INBOX_DEFAULT_SORT,
+} from '../views/inbox-list.js';
 import { renderInboxDetail } from '../views/inbox-detail.js';
 import { renderNotFoundPage } from '../views/not-found.js';
 
 export const inboxRouter: Router = Router();
 
+const SORT_KEYS = new Set<InboxSortKey>(['priority', 'source', 'agent', 'title', 'age', 'status']);
+const SORT_DIRS = new Set<InboxSortDir>(['asc', 'desc']);
+
+function parseSort(req: Request): { sort: InboxSortKey; dir: InboxSortDir } {
+  const sortRaw = typeof req.query.sort === 'string' ? req.query.sort : '';
+  const dirRaw = typeof req.query.dir === 'string' ? req.query.dir : '';
+  const sort = SORT_KEYS.has(sortRaw as InboxSortKey) ? (sortRaw as InboxSortKey) : INBOX_DEFAULT_SORT.sort;
+  const dir = SORT_DIRS.has(dirRaw as InboxSortDir) ? (dirRaw as InboxSortDir) : INBOX_DEFAULT_SORT.dir;
+  return { sort, dir };
+}
+
+function parseFlash(req: Request): { kind: 'ok' | 'error' | 'info'; message: string } | undefined {
+  if (typeof req.query.ok === 'string') return { kind: 'ok', message: req.query.ok };
+  if (typeof req.query.error === 'string') return { kind: 'error', message: req.query.error };
+  if (typeof req.query.info === 'string') return { kind: 'info', message: req.query.info };
+  return undefined;
+}
+
 inboxRouter.get('/inbox', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
   const rows = ctx.inboxStore ? ctx.inboxStore.list() : [];
-  res.type('html').send(renderInboxList({ rows }));
+  const { sort, dir } = parseSort(req);
+  res.type('html').send(renderInboxList({ rows, sort, dir, flash: parseFlash(req) }));
 });
 
 inboxRouter.get('/inbox/:id', (req: Request, res: Response) => {
@@ -41,5 +66,61 @@ inboxRouter.get('/inbox/:id', (req: Request, res: Response) => {
     return;
   }
   const responses = ctx.inboxStore.listResponses(id);
-  res.type('html').send(renderInboxDetail({ message, responses }));
+  res.type('html').send(renderInboxDetail({ message, responses, flash: parseFlash(req) }));
+});
+
+/**
+ * POST /inbox/:id/dismiss — terminal-state the message and redirect
+ * back to the inbox grid. Idempotent: dismissing an already-dismissed
+ * message is a no-op.
+ */
+inboxRouter.post('/inbox/:id/dismiss', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  if (!ctx.inboxStore || !ctx.inboxStore.get(id)) {
+    res.redirect(303, `/inbox?error=${encodeURIComponent('Message not found.')}`);
+    return;
+  }
+  try {
+    ctx.inboxStore.dismiss(id);
+    res.redirect(303, `/inbox?ok=${encodeURIComponent('Dismissed.')}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/inbox/${encodeURIComponent(id)}?error=${encodeURIComponent(`Dismiss failed: ${msg}`)}`);
+  }
+});
+
+/**
+ * POST /inbox/:id/respond — append a `user`-role entry to the
+ * conversation thread. Body: `body` (urlencoded form field). The
+ * eventual triage agent will read these as the operator's side of
+ * the dialogue.
+ */
+inboxRouter.post('/inbox/:id/respond', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const detailUrl = `/inbox/${encodeURIComponent(id)}`;
+  if (!ctx.inboxStore || !ctx.inboxStore.get(id)) {
+    res.redirect(303, `/inbox?error=${encodeURIComponent('Message not found.')}`);
+    return;
+  }
+  const body = typeof req.body?.body === 'string' ? req.body.body.trim() : '';
+  if (!body) {
+    res.redirect(303, `${detailUrl}?error=${encodeURIComponent('Reply cannot be empty.')}`);
+    return;
+  }
+  // Cap reply size to keep one runaway paste from bloating the DB.
+  // 8 KB is generous for human-typed text and an order of magnitude
+  // beyond what an LLM-driven reply would carry.
+  if (body.length > 8192) {
+    res.redirect(303, `${detailUrl}?error=${encodeURIComponent('Reply is too long (max 8 KB).')}`);
+    return;
+  }
+  try {
+    ctx.inboxStore.addResponse(id, 'user', body);
+    res.redirect(303, `${detailUrl}?ok=${encodeURIComponent('Reply added.')}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `${detailUrl}?error=${encodeURIComponent(`Reply failed: ${msg}`)}`);
+  }
 });

--- a/packages/dashboard/src/views/inbox-detail.ts
+++ b/packages/dashboard/src/views/inbox-detail.ts
@@ -78,24 +78,43 @@ export function renderInboxDetail(opts: InboxDetailOptions): string {
     </section>
   ` : html``;
 
-  const responsesBlock = responses.length > 0
+  // Conversation timeline: each entry is a small block with role +
+  // age + body. Empty state hints that the triage agent (next PR)
+  // will fill this in automatically.
+  const responsesBlock = html`
+    <section class="card" style="margin-top: var(--space-3);">
+      <h3 style="margin: 0 0 var(--space-2);">Conversation</h3>
+      ${responses.length > 0
+        ? html`${responses.map((r) => html`
+            <div style="border-top: 1px solid var(--color-border); padding: var(--space-2) 0;">
+              <div style="font-size: var(--font-size-xs); color: var(--color-text-muted); margin-bottom: var(--space-1);">
+                ${ROLE_LABEL[r.role] ?? r.role} · ${formatAge(new Date(r.createdAt).toISOString())}
+              </div>
+              <div style="white-space: pre-wrap;">${r.body}</div>
+            </div>
+          `) as unknown as SafeHtml[]}`
+        : html`<p class="dim" style="font-size: var(--font-size-sm); margin: 0 0 var(--space-2);">No replies yet. Add a note below; the triage agent will join the thread in an upcoming PR.</p>`}
+      ${replyForm(message)}
+    </section>
+  `;
+
+  // Action bar — surfaces the catch-all "Dismiss" verb for any
+  // message. Source-specific actions (allow-host, retry-run, etc.)
+  // ship as a follow-up PR; for now Dismiss is the universal action
+  // the user asked for in the first dogfood pass.
+  const actionsBlock = message.status === 'dismissed' || message.status === 'resolved'
     ? html`
       <section class="card" style="margin-top: var(--space-3);">
-        <h3 style="margin: 0 0 var(--space-2);">Conversation</h3>
-        ${responses.map((r) => html`
-          <div style="border-top: 1px solid var(--color-border); padding: var(--space-2) 0;">
-            <div style="font-size: var(--font-size-xs); color: var(--color-text-muted); margin-bottom: var(--space-1);">
-              ${ROLE_LABEL[r.role] ?? r.role} · ${formatAge(new Date(r.createdAt).toISOString())}
-            </div>
-            <div style="white-space: pre-wrap;">${r.body}</div>
-          </div>
-        `) as unknown as SafeHtml[]}
+        <p class="dim" style="margin: 0; font-size: var(--font-size-sm);">
+          This message is ${message.status}. ${message.resolvedAt ? html`Closed ${formatAge(new Date(message.resolvedAt).toISOString())}.` : html``}
+        </p>
       </section>`
     : html`
-      <section class="card" style="margin-top: var(--space-3);">
-        <p class="dim" style="font-size: var(--font-size-sm); margin: 0;">
-          No replies yet. The triage agent + interactive replies ship in upcoming PRs.
-        </p>
+      <section class="card" style="margin-top: var(--space-3); display: flex; gap: var(--space-2); align-items: center;">
+        <form method="POST" action="/inbox/${message.id}/dismiss" style="margin: 0;">
+          <button type="submit" class="btn btn--sm btn--ghost">Dismiss</button>
+        </form>
+        <span class="dim" style="font-size: var(--font-size-xs);">Hide this message from the queue. Reopen with the status filter on /inbox.</span>
       </section>
     `;
 
@@ -108,6 +127,7 @@ export function renderInboxDetail(opts: InboxDetailOptions): string {
     ${bodyBlock}
     ${contextBlock}
     ${recommendationBlock}
+    ${actionsBlock}
     ${responsesBlock}
   `;
 
@@ -129,4 +149,29 @@ function pretty(raw: string): string {
   } catch {
     return raw;
   }
+}
+
+/**
+ * Inline reply form rendered inside the Conversation card. POSTs to
+ * /inbox/:id/respond which appends a `user`-role entry to the thread.
+ * Hidden when the message is in a terminal state — once you've
+ * dismissed/resolved, the conversation is closed.
+ */
+function replyForm(message: InboxMessage): SafeHtml {
+  if (message.status === 'dismissed' || message.status === 'resolved') return html``;
+  return html`
+    <form method="POST" action="/inbox/${message.id}/respond"
+      style="margin: var(--space-2) 0 0; padding-top: var(--space-2); border-top: 1px solid var(--color-border); display: flex; flex-direction: column; gap: var(--space-2);">
+      <label style="font-size: var(--font-size-xs); color: var(--color-text-muted);">
+        Reply
+      </label>
+      <textarea name="body" rows="3" required maxlength="8192"
+        placeholder="Describe what you tried, ask a follow-up, or note a decision."
+        class="form-field"
+        style="padding: var(--space-2); font-size: var(--font-size-sm); resize: vertical;"></textarea>
+      <div style="display: flex; justify-content: flex-end;">
+        <button type="submit" class="btn btn--sm btn--primary">Post reply</button>
+      </div>
+    </form>
+  `;
 }

--- a/packages/dashboard/src/views/inbox-list.ts
+++ b/packages/dashboard/src/views/inbox-list.ts
@@ -1,87 +1,153 @@
-import type { InboxMessage, InboxPriority } from '@some-useful-agents/core';
+import type { InboxMessage, InboxPriority, InboxSource } from '@some-useful-agents/core';
 import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
 import { formatAge } from './components.js';
 
+export type InboxSortKey = 'priority' | 'source' | 'agent' | 'title' | 'age' | 'status';
+export type InboxSortDir = 'asc' | 'desc';
+
 export interface InboxListOptions {
   rows: InboxMessage[];
+  sort: InboxSortKey;
+  dir: InboxSortDir;
   flash?: { kind: 'error' | 'info' | 'ok'; message: string };
 }
 
-const PRIORITY_LABEL: Record<InboxPriority, string> = {
-  high: 'High',
-  medium: 'Medium',
-  low: 'Low',
+/**
+ * Default sort is priority ASC (high first) with age DESC as the
+ * secondary tiebreaker — matches what the queue is *for*: the most
+ * urgent recent thing on top.
+ */
+export const INBOX_DEFAULT_SORT: { sort: InboxSortKey; dir: InboxSortDir } = {
+  sort: 'priority',
+  dir: 'asc',
 };
 
-const PRIORITY_HINT: Record<InboxPriority, string> = {
-  high: 'Failed runs and other action-needed-now items',
-  medium: 'Authorisations and pending decisions',
-  low: 'Housekeeping reminders',
+/**
+ * Strong visual marker per priority — the operator's eye should pick
+ * out high-pri rows at a glance. Mirrors the warn/info/muted palette
+ * used elsewhere (badge--warn for failed runs, badge--info for active
+ * status, badge--muted for neutral metadata).
+ */
+const PRIORITY_BADGE: Record<InboxPriority, string> = {
+  high: 'badge--warn',
+  medium: 'badge--info',
+  low: 'badge--muted',
 };
 
-const SOURCE_LABEL: Record<string, string> = {
+/**
+ * Source labels + badge variants. The badge gives "what kind of issue
+ * is this" affordance at a glance — the user asked for this in the
+ * first dogfood pass.
+ */
+const SOURCE_LABEL: Record<InboxSource, string> = {
   'run-failure': 'Run failure',
   'permission-request': 'Permission',
   'cadence': 'Cadence',
   'manual': 'Manual',
 };
+const SOURCE_BADGE: Record<InboxSource, string> = {
+  'run-failure': 'badge--warn',
+  'permission-request': 'badge--info',
+  'cadence': 'badge--muted',
+  'manual': 'badge--muted',
+};
+
+const PRIORITY_RANK: Record<InboxPriority, number> = { high: 0, medium: 1, low: 2 };
 
 /**
- * Render the inbox list page. Rows are grouped by priority into three
- * sections (High / Medium / Low) so the operator's eye lands on the
- * urgent items first. Within each section, rows are newest-first.
- * Mirrors the list-table pattern from runs-list.ts but groups
- * vertically instead of using a single sortable table.
+ * Sort messages client-side (JS, not SQL) — keeps the store API
+ * focused on the canonical priority+age order and lets the UI layer
+ * own presentation. Limit is 200 server-side; in-memory sort cost is
+ * negligible.
+ */
+export function sortMessages(
+  rows: InboxMessage[],
+  sort: InboxSortKey,
+  dir: InboxSortDir,
+): InboxMessage[] {
+  const sign = dir === 'asc' ? 1 : -1;
+  const copy = rows.slice();
+  copy.sort((a, b) => {
+    switch (sort) {
+      case 'priority':
+        return sign * (PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority])
+          || (b.createdAt - a.createdAt); // newer first as tiebreaker
+      case 'age':
+        // age DESC (= "newest first") is what users mean by "by age".
+        // Treat `asc` as oldest-first and `desc` as newest-first.
+        return dir === 'asc' ? a.createdAt - b.createdAt : b.createdAt - a.createdAt;
+      case 'source':
+        return sign * a.source.localeCompare(b.source) || (b.createdAt - a.createdAt);
+      case 'agent':
+        return sign * (a.agentId ?? '').localeCompare(b.agentId ?? '') || (b.createdAt - a.createdAt);
+      case 'title':
+        return sign * a.title.localeCompare(b.title);
+      case 'status':
+        return sign * a.status.localeCompare(b.status) || (b.createdAt - a.createdAt);
+      default:
+        return 0;
+    }
+  });
+  return copy;
+}
+
+/**
+ * Build the URL for a column header. Click the active column → flip
+ * direction; click a different column → switch to it with that
+ * column's natural default direction (priority asc, age desc, etc.).
+ */
+function sortUrl(col: InboxSortKey, current: { sort: InboxSortKey; dir: InboxSortDir }): string {
+  const sameCol = col === current.sort;
+  let dir: InboxSortDir;
+  if (sameCol) {
+    dir = current.dir === 'asc' ? 'desc' : 'asc';
+  } else {
+    // Per-column natural defaults: age + status are most useful
+    // descending (newest first / triaged-on-top), the rest ascending.
+    dir = (col === 'age' || col === 'status') ? 'desc' : 'asc';
+  }
+  const params = new URLSearchParams();
+  if (col !== INBOX_DEFAULT_SORT.sort) params.set('sort', col);
+  if (dir !== INBOX_DEFAULT_SORT.dir || col !== INBOX_DEFAULT_SORT.sort) params.set('dir', dir);
+  const qs = params.toString();
+  return qs ? `/inbox?${qs}` : '/inbox';
+}
+
+function sortIndicator(col: InboxSortKey, current: { sort: InboxSortKey; dir: InboxSortDir }): string {
+  if (col !== current.sort) return '';
+  return current.dir === 'asc' ? ' ↑' : ' ↓';
+}
+
+/**
+ * Render the inbox list page as a single sortable grid. Each column
+ * header is a link that toggles the sort direction (clicking the
+ * active column) or switches to that column (default direction per
+ * column). The "affordance for what kind of issue" comes from the
+ * priority + source badges — the eye lands on warn-styled rows first.
  */
 export function renderInboxList(opts: InboxListOptions): string {
-  const { rows, flash } = opts;
+  const { rows, sort, dir, flash } = opts;
+  const sorted = sortMessages(rows, sort, dir);
+  const current = { sort, dir };
 
-  const groups: Record<InboxPriority, InboxMessage[]> = {
-    high: rows.filter((r) => r.priority === 'high'),
-    medium: rows.filter((r) => r.priority === 'medium'),
-    low: rows.filter((r) => r.priority === 'low'),
-  };
+  const header = (col: InboxSortKey, label: string): SafeHtml => html`
+    <th><a href="${sortUrl(col, current)}" class="inbox-sort-header">${label}${sortIndicator(col, current)}</a></th>
+  `;
 
-  const sections = (Object.keys(groups) as InboxPriority[]).map((priority) => {
-    const items = groups[priority];
-    if (items.length === 0) return html``;
-    const tbody = items.map((m) => html`
-      <tr>
-        <td>${m.agentId ? html`<a href="/agents/${m.agentId}">${m.agentId}</a>` : html`<span class="dim">—</span>`}</td>
-        <td><a href="/inbox/${m.id}">${m.title}</a></td>
-        <td class="dim">${SOURCE_LABEL[m.source] ?? m.source}</td>
-        <td class="dim">${formatAge(new Date(m.createdAt).toISOString())}</td>
-        <td><span class="badge badge--muted">${m.status}</span></td>
-      </tr>
-    `);
-    return html`
-      <section style="margin-bottom: var(--space-5);">
-        <h2 style="margin: 0 0 var(--space-1); font-size: var(--font-size-lg);">
-          ${PRIORITY_LABEL[priority]}
-          <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-sm); margin-left: var(--space-2);">
-            ${String(items.length)} ${items.length === 1 ? 'item' : 'items'}
-          </span>
-        </h2>
-        <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-2);">${PRIORITY_HINT[priority]}</p>
-        <table class="table">
-          <thead>
-            <tr>
-              <th>Agent</th>
-              <th>Title</th>
-              <th>Source</th>
-              <th>Age</th>
-              <th>Status</th>
-            </tr>
-          </thead>
-          <tbody>${tbody as unknown as SafeHtml[]}</tbody>
-        </table>
-      </section>
-    `;
-  });
+  const tbody = sorted.map((m) => html`
+    <tr>
+      <td><span class="badge ${PRIORITY_BADGE[m.priority]}">${m.priority}</span></td>
+      <td><span class="badge ${SOURCE_BADGE[m.source]}">${SOURCE_LABEL[m.source]}</span></td>
+      <td>${m.agentId ? html`<a href="/agents/${m.agentId}">${m.agentId}</a>` : html`<span class="dim">—</span>`}</td>
+      <td><a href="/inbox/${m.id}">${m.title}</a></td>
+      <td class="dim">${formatAge(new Date(m.createdAt).toISOString())}</td>
+      <td><span class="badge badge--muted">${m.status}</span></td>
+    </tr>
+  `);
 
-  const empty = rows.length === 0
+  const table = rows.length === 0
     ? html`
       <div class="settings-empty mt-0">
         <h3 class="mt-0">Inbox zero</h3>
@@ -91,15 +157,28 @@ export function renderInboxList(opts: InboxListOptions): string {
           with <code>SUA_INBOX_DEMO=1</code>.
         </p>
       </div>`
-    : html``;
+    : html`
+      <table class="table">
+        <thead>
+          <tr>
+            ${header('priority', 'Priority')}
+            ${header('source', 'Source')}
+            ${header('agent', 'Agent')}
+            ${header('title', 'Title')}
+            ${header('age', 'Age')}
+            ${header('status', 'Status')}
+          </tr>
+        </thead>
+        <tbody>${tbody as unknown as SafeHtml[]}</tbody>
+      </table>
+    `;
 
   const body = html`
     ${pageHeader({
       title: 'Inbox',
-      description: 'Things that need your attention, ordered by priority.',
+      description: 'Things that need your attention. Click a column header to sort.',
     })}
-    ${empty}
-    ${sections as unknown as SafeHtml[]}
+    ${table}
   `;
 
   return render(layout({ title: 'Inbox', activeNav: 'inbox', flash }, body));


### PR DESCRIPTION
## Summary
- `/inbox` becomes one sortable table (Priority / Source / Agent / Title / Age / Status) instead of three priority-grouped sub-tables — click any header to sort, active column shows ↑/↓
- Priority + Source render as colored badges (warn / info / muted) so high-pri + run-failure rows pop visually — the "affordance for what kind of issue" you asked for
- Detail page gains two actions:
  - **Dismiss** → POST `/inbox/:id/dismiss`, idempotent, redirects with ok flash
  - **Reply** form inside the Conversation card → POST `/inbox/:id/respond`, appends `user`-role entry (8 KB cap)
- Terminal-state messages (dismissed/resolved) hide action affordances and show a "closed N ago" hint instead
- 7 new route tests (sort default, ?sort=source, bogus values fall back, dismiss happy + unknown, respond happy + empty + oversize)

## Dogfood verification
- `/inbox` shows one table with Priority ↑ indicator; sorting by Source via URL alphabetizes the rows
- `/inbox/:id` shows Dismiss button + Reply textarea; Post-reply round-trips and the entry appears in the timeline on reload
- Terminal-state messages drop both forms cleanly

Both screenshots saved during dogfood — single table + detail with Dismiss + Reply form.

## Why
Dogfooding feedback on the MVP (#381): "these should be one sortable grid instead of three grids, with affordance for what kind of issue. Clicking to open an issue should give you a modal or detail view where you can take action or start a conversation."

## Deferred to next PR
- Source-specific action buttons (allow-host for permission-request, retry-run for run-failure, etc.)
- The triage system agent that auto-replies in the Conversation thread
- Both are sketched in `~/.claude/plans/jiggly-giggling-stroustrup.md` PR 3 / PR 4

## Test plan
- [x] `npx vitest run packages/dashboard/src/routes/inbox.test.ts` — 11 tests
- [x] Full suite: `npx vitest run` → 1741 / 3 skipped (was 1734; +7)
- [x] Clean build green
- [x] Manual: visit `/inbox` with `SUA_INBOX_DEMO=1` → single sortable table, badges for priority + source
- [x] Manual: click column header → URL updates with ?sort=…&dir=… and rows reorder
- [x] Manual: click into a message → Dismiss button hides it; Reply textarea posts to the thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)