### PR TITLE
feat(dashboard): inbox in-place modal + inbox-triage system agent

### DIFF
--- a/.changeset/inbox-modal-and-triage.md
+++ b/.changeset/inbox-modal-and-triage.md
@@ -1,0 +1,55 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox: in-place modal + triage agent joins the thread.
+
+Dogfood feedback: "doesn't feel fluid to have to go to a new page load
+to have a conversation about the current row, and I'd like the triage
+agent to join the thread."
+
+This PR replaces the click-to-navigate detail flow with a modal that
+opens over the inbox list, and adds the triage system agent that
+auto-replies in the conversation thread when the user posts a reply.
+
+- **Single sortable grid** with priority + source badges (replaces
+  the three priority-grouped sub-tables from the MVP). Click any
+  column header to sort; active column shows ↑/↓.
+- **Modal in place**: row click opens `<div id="inbox-modal">` over
+  the list. `inbox-modal.js.ts` fetches `/inbox/:id/fragment`,
+  intercepts the Reply / Dismiss / Ask-triage forms via `fetch`,
+  re-fetches the fragment after each mutation, polls every 1.5s
+  while a triage run is in progress, and removes the row from the
+  list when Dismiss succeeds. Esc / backdrop / Close all dismiss.
+  The `<a href="/inbox/:id">` row link still navigates as a
+  fallback (right-click "open in new tab", no-JS users).
+- **`GET /inbox/:id/fragment`** returns inner detail HTML with no
+  layout chrome — the modal's fetch target. `GET /inbox/:id` still
+  serves the full-page version, wrapping the same fragment renderer
+  in the standard layout.
+- **`agents/examples/inbox-triage.yaml`** — new `source: examples`
+  system agent. Single llm-prompt node, takes the message + context
+  + conversation as inputs, emits `<plan>{ messageId, recommendation,
+  verifyHint }</plan>` parsed by the route (mirrors the layout-planner
+  / build-orchestrator pattern; no new built-in tool needed, no SSRF
+  whitelist).
+- **`POST /inbox/:id/triage`** — lazy-installs the YAML, spawns the
+  agent via `executeAgentDag`, parses the plan, appends a
+  `triage`-role response to the conversation, transitions the
+  message to `awaiting_user`, and mirrors the recommendation onto
+  the message row.
+- **Auto-trigger** — `POST /inbox/:id/respond` fires the triage
+  agent in the background (fire-and-forget) after storing the user
+  reply. The modal polls `/fragment` while `[data-triage-pending]`
+  is present; the agent's reply appears in the thread without any
+  user action.
+- Mutation routes return **204 for AJAX (modal) / 303 for plain
+  form posts** (fallback page) so the same endpoints serve both
+  flows cleanly.
+
+15 new route tests cover the grid sort + fragment render + all
+three mutation routes in both AJAX and form-post modes.

--- a/agents/examples/inbox-triage.yaml
+++ b/agents/examples/inbox-triage.yaml
@@ -1,0 +1,137 @@
+# Inbox Triage — joins the conversation thread on an inbox message and
+# emits a concrete recommendation.
+#
+# Invoked by `POST /inbox/:id/triage` (and auto-fired by the
+# `/inbox/:id/respond` handler whenever the user posts a reply). The
+# dashboard parses the agent's `<plan>{...}</plan>` block, appends the
+# recommendation as a `triage`-role response to the message's
+# inbox_responses thread, and (if `verifyHint` is set) holds it for
+# the future verification loop.
+
+id: inbox-triage
+name: Inbox Triage
+description: >
+  Reads an inbox message (title, body, context, conversation so far) and
+  recommends the next concrete action. Joins the conversation thread.
+status: active
+source: examples
+
+# Triage should land in seconds, not minutes — fail fast if the LLM
+# stalls so the modal's "Triaging…" spinner doesn't lie indefinitely.
+timeoutSec: 60
+
+inputs:
+  MESSAGE_ID:
+    type: string
+    required: true
+    description: Inbox message id (uuid) so the route can match the response back.
+  MESSAGE_TITLE:
+    type: string
+    required: true
+    description: The message title from the producer.
+  MESSAGE_BODY:
+    type: string
+    required: true
+    description: The producer's short markdown summary.
+  MESSAGE_PRIORITY:
+    type: string
+    required: true
+    description: 'high | medium | low — sets urgency of the recommendation.'
+  MESSAGE_SOURCE:
+    type: string
+    required: true
+    description: 'run-failure | permission-request | cadence | manual.'
+  CONTEXT_JSON:
+    type: string
+    required: false
+    default: ""
+    description: >
+      Structured producer payload (failed-run details, blocked host,
+      stale-agent list, etc.). Parse if useful.
+  CONVERSATION:
+    type: string
+    required: false
+    default: ""
+    description: >
+      The conversation thread to date, one entry per line as
+      `[ROLE] body`. Empty on the first triage of a fresh message.
+
+nodes:
+  - id: triage
+    type: llm-prompt
+    prompt: |
+      You are the Inbox Triage agent for the sua agent platform. The
+      operator opened an inbox message and either explicitly asked for
+      a triage recommendation, or just posted a reply that the system
+      auto-routed to you.
+
+      Read the message, parse the context payload if structured, look
+      at the conversation so far, and return ONE concrete, actionable
+      recommendation. Keep it tight — operators are skimming, not
+      reading essays.
+
+      ════════════════════════════════════════════════════════════════
+      MESSAGE
+      ════════════════════════════════════════════════════════════════
+
+      id:       {{inputs.MESSAGE_ID}}
+      priority: {{inputs.MESSAGE_PRIORITY}}
+      source:   {{inputs.MESSAGE_SOURCE}}
+      title:    {{inputs.MESSAGE_TITLE}}
+
+      Body:
+      {{inputs.MESSAGE_BODY}}
+
+      Context (may be empty / JSON / arbitrary):
+      {{inputs.CONTEXT_JSON}}
+
+      Conversation so far (may be empty — you are the first responder):
+      {{inputs.CONVERSATION}}
+
+      ════════════════════════════════════════════════════════════════
+      WHAT TO RECOMMEND
+      ════════════════════════════════════════════════════════════════
+
+      Match the recommendation to the source:
+
+      - source=run-failure → diagnose the failure if the context has
+        an exit code / error line. Recommend either (a) a one-line fix
+        the user should try, (b) the dashboard path that shows the
+        full failed run, or (c) "this looks transient, retry once and
+        dismiss if it succeeds". Don't speculate without the data.
+
+      - source=permission-request → name the missing permission (host,
+        path, tool) and the concrete config path the user updates. If
+        the request is for a CSP image host, point at the agent's
+        Config → Permissions panel.
+
+      - source=cadence → name the housekeeping action and where to do
+        it ("archive these agents from /agents", "set a schedule on
+        agent X via /scheduled", etc.).
+
+      - source=manual → use your judgment. Treat the body as a free-form
+        ask from the operator and respond to it directly.
+
+      ════════════════════════════════════════════════════════════════
+      OUTPUT FORMAT — exact shape, single <plan>...</plan> block
+      ════════════════════════════════════════════════════════════════
+
+      Wrap the JSON in <plan>…</plan> tags. Output ONLY the <plan>
+      block — no preamble, no markdown fences around it. Example:
+
+      <plan>
+      {
+        "messageId": "{{inputs.MESSAGE_ID}}",
+        "recommendation": "Run failed with exit 1 because `which apod` returned no match. Install the apod CLI (brew install apod) or switch to the http-get version of the agent.",
+        "verifyHint": "Re-run the agent; it should reach the parse-output node without exit code 1."
+      }
+      </plan>
+
+      VALIDATION RULES (failing these means the route discards the response):
+      - `messageId` MUST equal {{inputs.MESSAGE_ID}}.
+      - `recommendation` is required, 10..2000 chars, plain text or simple markdown.
+      - `verifyHint` is optional — set it when the operator can re-run
+        a known action to confirm the fix. Leave it absent for
+        ambiguous or judgement-call recommendations.
+    maxTurns: 1
+    timeout: 60

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -1,7 +1,15 @@
 /**
- * Smoke tests for the Inbox routes (PR 2 of the Inbox MVP). The store
- * itself is unit-tested in core; these check that the routes wire the
- * store + views correctly and that the top nav highlights the page.
+ * Smoke + integration tests for the Inbox routes. Covers:
+ *   - GET /inbox (single sortable table with default + custom sort)
+ *   - GET /inbox/:id (full page)
+ *   - GET /inbox/:id/fragment (modal-only inner HTML)
+ *   - POST /inbox/:id/dismiss + /respond + /triage (both 303 redirect
+ *     and 204 AJAX response modes)
+ *   - empty-body / oversize-body rejection on /respond
+ *
+ * The triage agent run path itself is not exercised end-to-end here
+ * (it requires the LLM provider). The route's plan-parsing helpers
+ * are covered by unit tests on extractPlanJson upstream.
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
@@ -87,72 +95,190 @@ afterEach(async () => {
 describe('GET /inbox', () => {
   it('renders an empty state when no messages exist', async () => {
     const app = await makeApp();
-    const res = await request(app)
-      .get('/inbox')
-      .set('Host', `127.0.0.1:${PORT}`)
-      .set('Cookie', COOKIE);
+    const res = await request(app).get('/inbox').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
     expect(res.status).toBe(200);
-    expect(res.text).toContain('Inbox');
     expect(res.text).toContain('Inbox zero');
-    // Top nav highlights /inbox.
     expect(res.text).toMatch(/<a href="\/inbox"[^>]*class="is-active"/);
   });
 
-  it('groups messages by priority newest-first', async () => {
+  it('renders one sortable table; rows carry data-inbox-row-id for modal hookup', async () => {
     const app = await makeApp();
-    inboxStore.add({ priority: 'low', source: 'cadence', title: 'low-pri item', body: 'x' });
-    inboxStore.add({ priority: 'high', source: 'run-failure', agentId: 'foo', title: 'high-pri item', body: 'y' });
-    inboxStore.add({ priority: 'medium', source: 'permission-request', title: 'med-pri item', body: 'z' });
+    inboxStore.add({ priority: 'low', source: 'cadence', title: 'low-pri', body: 'x' });
+    const high = inboxStore.add({ priority: 'high', source: 'run-failure', agentId: 'foo', title: 'high-pri', body: 'y' });
+    inboxStore.add({ priority: 'medium', source: 'permission-request', title: 'med-pri', body: 'z' });
 
-    const res = await request(app)
-      .get('/inbox')
-      .set('Host', `127.0.0.1:${PORT}`)
-      .set('Cookie', COOKIE);
+    const res = await request(app).get('/inbox').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
     expect(res.status).toBe(200);
-    expect(res.text).toContain('High');
-    expect(res.text).toContain('Medium');
-    expect(res.text).toContain('Low');
-    // High section must appear before Medium and Low in the HTML stream.
-    const hi = res.text.indexOf('high-pri item');
-    const med = res.text.indexOf('med-pri item');
-    const lo = res.text.indexOf('low-pri item');
-    expect(hi).toBeGreaterThan(0);
-    expect(hi).toBeLessThan(med);
-    expect(med).toBeLessThan(lo);
+    expect((res.text.match(/<table class="table inbox-table">/g) ?? []).length).toBe(1);
+    expect(res.text).toContain(`data-inbox-row-id="${high.id}"`);
+    // Default sort: high first, low last.
+    const hi = res.text.indexOf('high-pri');
+    const lo = res.text.indexOf('low-pri');
+    expect(hi).toBeLessThan(lo);
+    // Modal shell present + hidden by default.
+    expect(res.text).toContain('id="inbox-modal"');
+    expect(res.text).toMatch(/id="inbox-modal"[^>]*hidden/);
+  });
+
+  it('honours ?sort=source&dir=asc', async () => {
+    const app = await makeApp();
+    inboxStore.add({ priority: 'low', source: 'run-failure', title: 'R', body: 'x' });
+    inboxStore.add({ priority: 'low', source: 'cadence', title: 'C', body: 'y' });
+    const res = await request(app).get('/inbox?sort=source&dir=asc').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(200);
+    expect(res.text.indexOf('>C<')).toBeLessThan(res.text.indexOf('>R<'));
+    expect(res.text).toMatch(/Source ↑/);
+  });
+
+  it('falls back to defaults for unknown sort / dir', async () => {
+    const app = await makeApp();
+    inboxStore.add({ priority: 'high', source: 'run-failure', title: 'H', body: 'x' });
+    inboxStore.add({ priority: 'low', source: 'cadence', title: 'L', body: 'y' });
+    const res = await request(app).get('/inbox?sort=nope&dir=sideways').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(200);
+    expect(res.text.indexOf('>H<')).toBeLessThan(res.text.indexOf('>L<'));
   });
 });
 
-describe('GET /inbox/:id', () => {
-  it('renders the message detail page', async () => {
+describe('GET /inbox/:id and /:id/fragment', () => {
+  it('full page renders the detail with badge + body + actions', async () => {
     const app = await makeApp();
     const m = inboxStore.add({
-      priority: 'high',
-      source: 'run-failure',
-      agentId: 'astro',
-      runId: 'run-abc',
-      title: 'Detail title',
-      body: 'Detail body markdown.',
-      contextJson: JSON.stringify({ exit: 1 }),
+      priority: 'high', source: 'run-failure', agentId: 'astro', runId: 'run-xyz',
+      title: 'Detail title', body: 'Detail body markdown.', contextJson: JSON.stringify({ exit: 1 }),
     });
-    const res = await request(app)
-      .get(`/inbox/${m.id}`)
-      .set('Host', `127.0.0.1:${PORT}`)
-      .set('Cookie', COOKIE);
+    const res = await request(app).get(`/inbox/${m.id}`).set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
     expect(res.status).toBe(200);
     expect(res.text).toContain('Detail title');
     expect(res.text).toContain('Detail body markdown.');
     expect(res.text).toContain('Context payload');
     expect(res.text).toContain('/agents/astro');
-    expect(res.text).toContain('/runs/run-abc');
-    expect(res.text).toMatch(/<a href="\/inbox"[^>]*class="is-active"/);
+    expect(res.text).toContain('/runs/run-xyz');
+    // Action affordances + form attributes for the modal JS.
+    expect(res.text).toContain('data-inbox-modal-form');
+    expect(res.text).toContain(`action="/inbox/${m.id}/respond"`);
+    expect(res.text).toContain(`action="/inbox/${m.id}/dismiss"`);
+    expect(res.text).toContain(`action="/inbox/${m.id}/triage"`);
   });
 
-  it('renders 404 for an unknown message id', async () => {
+  it('fragment renders just the inner HTML (no layout / no <html>)', async () => {
     const app = await makeApp();
-    const res = await request(app)
-      .get('/inbox/no-such-id')
-      .set('Host', `127.0.0.1:${PORT}`)
-      .set('Cookie', COOKIE);
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 'Frag', body: 'fb' });
+    const res = await request(app).get(`/inbox/${m.id}/fragment`).set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Frag');
+    expect(res.text).not.toContain('<html');
+    expect(res.text).not.toContain('topbar__nav');
+    expect(res.text).toContain('id="inbox-modal-title"');
+  });
+
+  it('renders 404 fragments without layout chrome for unknown ids', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/inbox/nope/fragment').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
     expect(res.status).toBe(404);
+    expect(res.text).not.toContain('<html');
+  });
+});
+
+describe('POST /inbox/:id/dismiss', () => {
+  it('303 redirects for plain form posts', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const res = await request(app).post(`/inbox/${m.id}/dismiss`).set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/^\/inbox\?ok=/);
+    expect(inboxStore.get(m.id)!.status).toBe('dismissed');
+  });
+
+  it('204 with no body for fetch-style AJAX (X-Requested-With: fetch)', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const res = await request(app)
+      .post(`/inbox/${m.id}/dismiss`)
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .set('X-Requested-With', 'fetch');
+    expect(res.status).toBe(204);
+    expect(inboxStore.get(m.id)!.status).toBe('dismissed');
+  });
+
+  it('404 (AJAX) / 303 with error (form) for unknown ids', async () => {
+    const app = await makeApp();
+    const r1 = await request(app).post('/inbox/nope/dismiss').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(r1.status).toBe(303);
+    expect(r1.headers.location).toMatch(/error=/);
+    const r2 = await request(app).post('/inbox/nope/dismiss').set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(r2.status).toBe(404);
+  });
+});
+
+describe('POST /inbox/:id/respond', () => {
+  it('appends a user response; 303 for form, 204 for AJAX', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const form = await request(app)
+      .post(`/inbox/${m.id}/respond`)
+      .type('form').send({ body: 'tried X' })
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(form.status).toBe(303);
+    expect(form.headers.location).toMatch(new RegExp(`^/inbox/${m.id}\\?ok=`));
+
+    const ajax = await request(app)
+      .post(`/inbox/${m.id}/respond`)
+      .type('form').send({ body: 'second reply' })
+      .set('X-Requested-With', 'fetch')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(ajax.status).toBe(204);
+
+    const responses = inboxStore.listResponses(m.id);
+    expect(responses.map((r) => r.body)).toEqual(['tried X', 'second reply']);
+    expect(responses.every((r) => r.role === 'user')).toBe(true);
+  });
+
+  it('rejects empty body (303 with error / 400 for AJAX); nothing stored', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const form = await request(app)
+      .post(`/inbox/${m.id}/respond`).type('form').send({ body: '   ' })
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(form.status).toBe(303);
+    expect(form.headers.location).toMatch(/error=/);
+    const ajax = await request(app)
+      .post(`/inbox/${m.id}/respond`).type('form').send({ body: '' })
+      .set('X-Requested-With', 'fetch')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(ajax.status).toBe(400);
+    expect(inboxStore.listResponses(m.id)).toEqual([]);
+  });
+
+  it('rejects oversize body', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const big = 'x'.repeat(9000);
+    const res = await request(app)
+      .post(`/inbox/${m.id}/respond`).type('form').send({ body: big })
+      .set('X-Requested-With', 'fetch')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(400);
+    expect(inboxStore.listResponses(m.id)).toEqual([]);
+  });
+});
+
+describe('POST /inbox/:id/triage', () => {
+  it('returns 204 (AJAX) for known ids — fire-and-forget; agent run kicked off in background', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const res = await request(app)
+      .post(`/inbox/${m.id}/triage`)
+      .set('X-Requested-With', 'fetch')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(204);
+  });
+
+  it('404 (AJAX) / 303 (form) for unknown ids', async () => {
+    const app = await makeApp();
+    const r1 = await request(app).post('/inbox/nope/triage').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(r1.status).toBe(303);
+    const r2 = await request(app).post('/inbox/nope/triage').set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(r2.status).toBe(404);
   });
 });

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -1,25 +1,82 @@
 /**
  * Routes for the Inbox surface:
- *   GET /inbox        — priority-grouped list of active items
- *   GET /inbox/:id    — message detail + conversation thread
  *
- * Mutation routes (dismiss, respond, triage) ship in follow-up PRs;
- * MVP is read-only so the surface can be validated before producers
- * are wired.
+ *   GET  /inbox                 — single sortable grid of active items
+ *   GET  /inbox/:id             — full-page detail (fallback, direct link)
+ *   GET  /inbox/:id/fragment    — inner detail HTML for the modal
+ *   POST /inbox/:id/dismiss     — terminal-state the message
+ *   POST /inbox/:id/respond     — append user-role response; auto-fires triage
+ *   POST /inbox/:id/triage      — run the inbox-triage system agent; on
+ *                                 completion the result is parsed and
+ *                                 appended as a triage-role response
+ *
+ * Mutation routes return:
+ *   - 303 redirect for non-AJAX (form posts without fetch) so the
+ *     existing detail page still works
+ *   - 204 with no body for AJAX (modal's fetch wrapper)
+ *
+ * The `Accept: text/html` heuristic plus the explicit
+ * `X-Requested-With: fetch` header (set by the modal JS) keep the two
+ * cases distinguishable without sniffing user agents.
  */
 
 import { Router, type Request, type Response } from 'express';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import {
+  executeAgentDag,
+  extractPlanJson,
+  parseAgent,
+  type RunStatus,
+} from '@some-useful-agents/core';
 import { getContext } from '../context.js';
-import { renderInboxList } from '../views/inbox-list.js';
-import { renderInboxDetail } from '../views/inbox-detail.js';
+import {
+  renderInboxList,
+  type InboxSortKey,
+  type InboxSortDir,
+  INBOX_DEFAULT_SORT,
+} from '../views/inbox-list.js';
+import { renderInboxDetail, renderInboxDetailFragment } from '../views/inbox-detail.js';
+import { render } from '../views/html.js';
 import { renderNotFoundPage } from '../views/not-found.js';
 
 export const inboxRouter: Router = Router();
 
+const SORT_KEYS = new Set<InboxSortKey>(['priority', 'source', 'agent', 'title', 'age', 'status']);
+const SORT_DIRS = new Set<InboxSortDir>(['asc', 'desc']);
+const TRIAGE_AGENT_ID = 'inbox-triage';
+
+function parseSort(req: Request): { sort: InboxSortKey; dir: InboxSortDir } {
+  const sortRaw = typeof req.query.sort === 'string' ? req.query.sort : '';
+  const dirRaw = typeof req.query.dir === 'string' ? req.query.dir : '';
+  const sort = SORT_KEYS.has(sortRaw as InboxSortKey) ? (sortRaw as InboxSortKey) : INBOX_DEFAULT_SORT.sort;
+  const dir = SORT_DIRS.has(dirRaw as InboxSortDir) ? (dirRaw as InboxSortDir) : INBOX_DEFAULT_SORT.dir;
+  return { sort, dir };
+}
+
+function parseFlash(req: Request): { kind: 'ok' | 'error' | 'info'; message: string } | undefined {
+  if (typeof req.query.ok === 'string') return { kind: 'ok', message: req.query.ok };
+  if (typeof req.query.error === 'string') return { kind: 'error', message: req.query.error };
+  if (typeof req.query.info === 'string') return { kind: 'info', message: req.query.info };
+  return undefined;
+}
+
+function isAjax(req: Request): boolean {
+  // The modal JS uses fetch with default headers; supertest tests use
+  // the same. We treat any non-form-encoded Accept of application/json
+  // OR a fetch-style XHR header as "wants 204 not 303". Form posts
+  // from the fallback detail page get the redirect.
+  const xrw = req.get('x-requested-with');
+  if (xrw && xrw.toLowerCase() === 'fetch') return true;
+  const accept = req.get('accept') ?? '';
+  return accept.includes('application/json');
+}
+
 inboxRouter.get('/inbox', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
   const rows = ctx.inboxStore ? ctx.inboxStore.list() : [];
-  res.type('html').send(renderInboxList({ rows }));
+  const { sort, dir } = parseSort(req);
+  res.type('html').send(renderInboxList({ rows, sort, dir, flash: parseFlash(req) }));
 });
 
 inboxRouter.get('/inbox/:id', (req: Request, res: Response) => {
@@ -41,5 +98,254 @@ inboxRouter.get('/inbox/:id', (req: Request, res: Response) => {
     return;
   }
   const responses = ctx.inboxStore.listResponses(id);
-  res.type('html').send(renderInboxDetail({ message, responses }));
+  const triagePending = isTriagePending(req, message.triageRunId);
+  res.type('html').send(renderInboxDetail({ message, responses, flash: parseFlash(req), triagePending }));
 });
+
+/**
+ * The modal's fetch target. Returns the same content as the detail
+ * page but without layout chrome, so it can be injected directly into
+ * the modal's content container.
+ */
+inboxRouter.get('/inbox/:id/fragment', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  if (!ctx.inboxStore) {
+    res.status(404).type('html').send('<p>Inbox unavailable.</p>');
+    return;
+  }
+  const message = ctx.inboxStore.get(id);
+  if (!message) {
+    res.status(404).type('html').send('<p>Message not found.</p>');
+    return;
+  }
+  const responses = ctx.inboxStore.listResponses(id);
+  const triagePending = isTriagePending(req, message.triageRunId);
+  res.type('html').send(render(renderInboxDetailFragment({ message, responses, triagePending })));
+});
+
+inboxRouter.post('/inbox/:id/dismiss', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  if (!ctx.inboxStore || !ctx.inboxStore.get(id)) {
+    if (isAjax(req)) { res.status(404).end(); return; }
+    res.redirect(303, `/inbox?error=${encodeURIComponent('Message not found.')}`);
+    return;
+  }
+  try {
+    ctx.inboxStore.dismiss(id);
+    if (isAjax(req)) { res.status(204).end(); return; }
+    res.redirect(303, `/inbox?ok=${encodeURIComponent('Dismissed.')}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (isAjax(req)) { res.status(500).end(); return; }
+    res.redirect(303, `/inbox/${encodeURIComponent(id)}?error=${encodeURIComponent(`Dismiss failed: ${msg}`)}`);
+  }
+});
+
+inboxRouter.post('/inbox/:id/respond', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const detailUrl = `/inbox/${encodeURIComponent(id)}`;
+  if (!ctx.inboxStore || !ctx.inboxStore.get(id)) {
+    if (isAjax(req)) { res.status(404).end(); return; }
+    res.redirect(303, `/inbox?error=${encodeURIComponent('Message not found.')}`);
+    return;
+  }
+  const bodyRaw = typeof req.body?.body === 'string' ? req.body.body.trim() : '';
+  if (!bodyRaw) {
+    if (isAjax(req)) { res.status(400).end(); return; }
+    res.redirect(303, `${detailUrl}?error=${encodeURIComponent('Reply cannot be empty.')}`);
+    return;
+  }
+  if (bodyRaw.length > 8192) {
+    if (isAjax(req)) { res.status(400).end(); return; }
+    res.redirect(303, `${detailUrl}?error=${encodeURIComponent('Reply is too long (max 8 KB).')}`);
+    return;
+  }
+  try {
+    ctx.inboxStore.addResponse(id, 'user', bodyRaw);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (isAjax(req)) { res.status(500).end(); return; }
+    res.redirect(303, `${detailUrl}?error=${encodeURIComponent(`Reply failed: ${msg}`)}`);
+    return;
+  }
+  // Auto-trigger triage so the agent joins the conversation. Fire and
+  // forget — the modal polls /fragment for the response. Failures are
+  // logged via the dashboard's error middleware; the user's reply is
+  // safely stored regardless.
+  void runTriageAgent(ctx, id).catch(() => { /* logged inside */ });
+
+  if (isAjax(req)) { res.status(204).end(); return; }
+  res.redirect(303, `${detailUrl}?ok=${encodeURIComponent('Reply added.')}`);
+});
+
+inboxRouter.post('/inbox/:id/triage', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const detailUrl = `/inbox/${encodeURIComponent(id)}`;
+  if (!ctx.inboxStore || !ctx.inboxStore.get(id)) {
+    if (isAjax(req)) { res.status(404).end(); return; }
+    res.redirect(303, `/inbox?error=${encodeURIComponent('Message not found.')}`);
+    return;
+  }
+  void runTriageAgent(ctx, id).catch(() => { /* swallow */ });
+  if (isAjax(req)) { res.status(204).end(); return; }
+  res.redirect(303, `${detailUrl}?ok=${encodeURIComponent('Triage agent invoked.')}`);
+});
+
+// ── helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Is the triage agent currently running for this message? We use the
+ * message's recorded triageRunId + the run-store's status. Cheap
+ * read; modal poll calls it every 1.5s while the spinner is visible.
+ */
+function isTriagePending(req: Request, triageRunId: string | undefined): boolean {
+  if (!triageRunId) return false;
+  const ctx = getContext(req.app.locals);
+  try {
+    const run = ctx.runStore.getRun(triageRunId);
+    if (!run) return false;
+    return run.status === 'pending' || run.status === 'running';
+  } catch { return false; }
+}
+
+/**
+ * Spawn the inbox-triage system agent for a given message. Loads the
+ * YAML from `agents/examples/inbox-triage.yaml` on first call and
+ * upserts it into the agent store (mirrors how layout-planner is
+ * lazy-installed). After the run completes, parses the
+ * `<plan>{...}</plan>` block and appends a `triage`-role response to
+ * the message's conversation thread + transitions the message status
+ * to `triaged`.
+ */
+async function runTriageAgent(
+  ctx: ReturnType<typeof getContext>,
+  messageId: string,
+): Promise<void> {
+  if (!ctx.inboxStore) return;
+  const message = ctx.inboxStore.get(messageId);
+  if (!message) return;
+
+  // Lazy-install the triage agent from disk.
+  let triage = ctx.agentStore.getAgent(TRIAGE_AGENT_ID);
+  if (!triage) {
+    try {
+      const yamlPath = join(resolve('agents/examples'), `${TRIAGE_AGENT_ID}.yaml`);
+      const yamlText = readFileSync(yamlPath, 'utf-8');
+      const parsed = parseAgent(yamlText);
+      ctx.agentStore.upsertAgent(parsed, 'import', 'Auto-imported for inbox triage');
+      triage = ctx.agentStore.getAgent(TRIAGE_AGENT_ID);
+    } catch (err) {
+      process.stderr.write(
+        `[inbox-triage] could not load agent yaml: ${(err as Error)?.message ?? String(err)}\n`,
+      );
+      return;
+    }
+  }
+  if (!triage) return;
+
+  // Snapshot the conversation so the LLM sees prior turns. The thread
+  // is appended after we start the agent run too, but the snapshot at
+  // start time is what the agent reasons over for THIS turn.
+  const conversation = ctx.inboxStore.listResponses(messageId)
+    .map((r) => `[${r.role}] ${r.body}`)
+    .join('\n');
+
+  let runId: string | undefined;
+  try {
+    const runPromise = executeAgentDag(
+      triage,
+      {
+        triggeredBy: 'dashboard',
+        inputs: {
+          MESSAGE_ID: message.id,
+          MESSAGE_TITLE: message.title,
+          MESSAGE_BODY: message.body,
+          MESSAGE_PRIORITY: message.priority,
+          MESSAGE_SOURCE: message.source,
+          CONTEXT_JSON: message.contextJson ?? '',
+          CONVERSATION: conversation,
+        },
+      },
+      {
+        runStore: ctx.runStore,
+        secretsStore: ctx.secretsStore,
+        variablesStore: ctx.variablesStore,
+        dataRoot: ctx.agentStore.dataRoot,
+      },
+    );
+    // Record the runId on the message so the modal can poll
+    // `/fragment` and see triagePending=true while it runs. Race the
+    // dag-executor so we get the runId without blocking.
+    await Promise.race([runPromise, new Promise((r) => setTimeout(r, 200))]);
+    const { rows } = ctx.runStore.queryRuns({
+      agentName: TRIAGE_AGENT_ID,
+      statuses: ['running', 'completed', 'failed', 'pending'] as RunStatus[],
+      limit: 1,
+      offset: 0,
+    });
+    const recent = rows[0];
+    if (recent) {
+      runId = recent.id;
+      try {
+        ctx.inboxStore.updateStatus(messageId, message.status === 'open' ? 'triaged' : message.status, { triageRunId: runId });
+      } catch { /* ignore — message may have been dismissed mid-flight */ }
+    }
+    const finished = await runPromise;
+    void finished; // result text accessed via the runStore record below
+
+    const run = runId ? ctx.runStore.getRun(runId) : null;
+    if (!run || run.status !== 'completed' || !run.result) {
+      ctx.inboxStore.addResponse(
+        messageId,
+        'system',
+        `Triage agent did not complete (${run?.status ?? 'unknown'}). ${run?.error ?? ''}`.trim(),
+      );
+      return;
+    }
+    const planJson = extractPlanJson(run.result);
+    if (!planJson) {
+      ctx.inboxStore.addResponse(
+        messageId,
+        'system',
+        'Triage agent returned no <plan>…</plan> block; raw response was discarded.',
+      );
+      return;
+    }
+    let parsed: { messageId?: unknown; recommendation?: unknown; verifyHint?: unknown };
+    try {
+      parsed = JSON.parse(planJson);
+    } catch {
+      ctx.inboxStore.addResponse(messageId, 'system', 'Triage agent returned malformed JSON.');
+      return;
+    }
+    const rec = typeof parsed.recommendation === 'string' ? parsed.recommendation.trim() : '';
+    if (!rec || rec.length < 10 || rec.length > 2000) {
+      ctx.inboxStore.addResponse(messageId, 'system', 'Triage agent recommendation failed validation.');
+      return;
+    }
+    const verifyHint = typeof parsed.verifyHint === 'string' && parsed.verifyHint.trim()
+      ? parsed.verifyHint.trim()
+      : undefined;
+    ctx.inboxStore.addResponse(
+      messageId,
+      'triage',
+      rec,
+      verifyHint ? JSON.stringify({ verifyHint }) : undefined,
+    );
+    // Mirror the recommendation onto the message itself for the
+    // recommendation-card render path (full detail page).
+    try {
+      ctx.inboxStore.updateStatus(messageId, 'awaiting_user', { recommendation: rec, triageRunId: runId });
+    } catch { /* ignore terminal-state races */ }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[inbox-triage] run failed: ${msg}\n${(err as Error)?.stack ?? ''}\n`);
+    try {
+      ctx.inboxStore.addResponse(messageId, 'system', `Triage agent crashed: ${msg}`);
+    } catch { /* ignore */ }
+  }
+}

--- a/packages/dashboard/src/views/inbox-detail.ts
+++ b/packages/dashboard/src/views/inbox-detail.ts
@@ -8,6 +8,13 @@ export interface InboxDetailOptions {
   message: InboxMessage;
   responses: InboxResponse[];
   flash?: { kind: 'error' | 'info' | 'ok'; message: string };
+  /**
+   * When true, the triage agent has a run in `pending` or `running` for
+   * this message. The fragment renders a `[data-triage-pending="1"]`
+   * marker that inbox-modal.js polls on so the conversation refreshes
+   * as soon as the agent's response lands.
+   */
+  triagePending?: boolean;
 }
 
 const PRIORITY_BADGE: Record<string, string> = {
@@ -16,101 +23,144 @@ const PRIORITY_BADGE: Record<string, string> = {
   low: 'badge--muted',
 };
 
+const SOURCE_LABEL: Record<string, string> = {
+  'run-failure': 'Run failure',
+  'permission-request': 'Permission',
+  'cadence': 'Cadence',
+  'manual': 'Manual',
+};
+
 const ROLE_LABEL: Record<string, string> = {
   user: 'You',
   triage: 'Triage agent',
   system: 'System',
 };
 
-/**
- * Render the inbox-message detail page. Sections:
- *   - header — priority + source + age + status
- *   - body   — short markdown summary the producer wrote
- *   - context — collapsible <details> of the structured producer payload
- *   - recommendation — triage agent's suggestion (PR 4+)
- *   - responses timeline — conversation thread (PR 4+)
- *
- * Mirrors the run-detail shell pattern but trims to a single-column
- * layout — no DAG / widget panes.
- */
-export function renderInboxDetail(opts: InboxDetailOptions): string {
-  const { message, responses, flash } = opts;
+const ROLE_DOT_COLOR: Record<string, string> = {
+  user: 'var(--color-primary, #2dd4bf)',
+  triage: 'var(--color-info, #60a5fa)',
+  system: 'var(--color-text-muted, #8b93a7)',
+};
 
-  const ageIso = new Date(message.createdAt).toISOString();
+/**
+ * Render the message detail as a SELF-CONTAINED FRAGMENT (no <html>,
+ * <body>, layout chrome). Used by inbox-modal.js — fetched from
+ * `/inbox/:id/fragment` and injected into the modal's content
+ * container. The full-page `renderInboxDetail` below wraps this in
+ * the standard dashboard layout for direct-link access + accessibility.
+ */
+export function renderInboxDetailFragment(opts: InboxDetailOptions): SafeHtml {
+  const { message, responses, flash, triagePending } = opts;
   const badgeClass = PRIORITY_BADGE[message.priority] ?? 'badge--muted';
+  const isTerminal = message.status === 'dismissed' || message.status === 'resolved';
+
+  const flashBlock = flash ? html`
+    <div class="flash flash--${flash.kind}" style="margin: 0 0 var(--space-2);">${flash.message}</div>
+  ` : html``;
 
   const headerMeta = html`
-    <div style="display: flex; gap: var(--space-3); align-items: center; flex-wrap: wrap; font-size: var(--font-size-sm); color: var(--color-text-muted); margin-top: var(--space-1);">
+    <div style="display: flex; gap: var(--space-2); align-items: center; flex-wrap: wrap; font-size: var(--font-size-sm); color: var(--color-text-muted); margin-top: var(--space-1);">
       <span class="badge ${badgeClass}">${message.priority}</span>
-      <span>${message.source}</span>
-      <span>${formatAge(ageIso)}</span>
-      <span><span class="badge badge--muted">${message.status}</span></span>
+      <span>${SOURCE_LABEL[message.source] ?? message.source}</span>
+      <span>${formatAge(new Date(message.createdAt).toISOString())}</span>
+      <span class="badge badge--muted">${message.status}</span>
       ${message.agentId ? html`<a href="/agents/${message.agentId}">${message.agentId}</a>` : html``}
       ${message.runId ? html`<a href="/runs/${message.runId}" class="mono">run ${message.runId.slice(0, 8)}</a>` : html``}
     </div>
   `;
 
   const bodyBlock = html`
-    <section class="card" style="margin-top: var(--space-4);">
-      <h3 style="margin: 0 0 var(--space-2);">Details</h3>
+    <section style="margin-top: var(--space-3);">
+      <h4 style="margin: 0 0 var(--space-1); font-size: var(--font-size-sm); text-transform: uppercase; letter-spacing: 0.06em; color: var(--color-text-muted);">Details</h4>
       <div style="white-space: pre-wrap;">${message.body}</div>
     </section>
   `;
 
   const contextBlock = message.contextJson ? html`
-    <section class="card" style="margin-top: var(--space-3);">
-      <details>
-        <summary style="cursor: pointer; font-weight: var(--weight-semibold);">Context payload</summary>
-        <pre class="mono" style="font-size: var(--font-size-xs); margin: var(--space-2) 0 0; overflow-x: auto;">${pretty(message.contextJson)}</pre>
-      </details>
-    </section>
+    <details style="margin-top: var(--space-3);">
+      <summary style="cursor: pointer; font-size: var(--font-size-xs); color: var(--color-text-muted); font-weight: var(--weight-semibold); text-transform: uppercase; letter-spacing: 0.06em;">Context payload</summary>
+      <pre class="mono" style="font-size: var(--font-size-xs); margin: var(--space-2) 0 0; overflow-x: auto; max-height: 12rem;">${pretty(message.contextJson)}</pre>
+    </details>
   ` : html``;
 
-  const recommendationBlock = message.recommendation ? html`
-    <section class="card" style="margin-top: var(--space-3);">
-      <h3 style="margin: 0 0 var(--space-2);">Recommendation</h3>
-      <div style="white-space: pre-wrap;">${message.recommendation}</div>
-      ${message.triageRunId ? html`
-        <p class="dim" style="font-size: var(--font-size-xs); margin: var(--space-2) 0 0;">
-          From triage run <a href="/runs/${message.triageRunId}" class="mono">${message.triageRunId.slice(0, 8)}</a>
-        </p>
+  // Conversation timeline + reply form. The triage agent posts here
+  // too — its entries get the badge--info dot color.
+  const timeline = responses.map((r) => html`
+    <div style="border-top: 1px solid var(--color-border); padding: var(--space-2) 0;">
+      <div style="font-size: var(--font-size-xs); color: var(--color-text-muted); margin-bottom: var(--space-1); display: flex; align-items: center; gap: var(--space-1);">
+        <span style="display: inline-block; width: 6px; height: 6px; border-radius: 50%; background: ${ROLE_DOT_COLOR[r.role] ?? ROLE_DOT_COLOR.system};"></span>
+        ${ROLE_LABEL[r.role] ?? r.role} · ${formatAge(new Date(r.createdAt).toISOString())}
+      </div>
+      <div style="white-space: pre-wrap;">${r.body}</div>
+    </div>
+  `);
+
+  const conversationBlock = html`
+    <section style="margin-top: var(--space-3); padding-top: var(--space-3); border-top: 1px solid var(--color-border);">
+      <h4 style="margin: 0 0 var(--space-1); font-size: var(--font-size-sm); text-transform: uppercase; letter-spacing: 0.06em; color: var(--color-text-muted);">Conversation</h4>
+      ${responses.length === 0 && !triagePending
+        ? html`<p class="dim" style="font-size: var(--font-size-sm); margin: 0 0 var(--space-2);">No replies yet. Post a note below — the triage agent will join automatically.</p>`
+        : html`${timeline as unknown as SafeHtml[]}`}
+      ${triagePending ? html`
+        <div data-triage-pending="1" style="border-top: 1px solid var(--color-border); padding: var(--space-2) 0; font-size: var(--font-size-sm); color: var(--color-text-muted); display: flex; align-items: center; gap: var(--space-2);">
+          <span style="display: inline-block; width: 6px; height: 6px; border-radius: 50%; background: ${ROLE_DOT_COLOR.triage}; animation: pulse 1.2s ease-in-out infinite;"></span>
+          Triage agent is thinking…
+        </div>
       ` : html``}
+      ${replyForm(message, triagePending ?? false)}
     </section>
-  ` : html``;
+  `;
 
-  const responsesBlock = responses.length > 0
+  const actionsBlock = isTerminal
     ? html`
-      <section class="card" style="margin-top: var(--space-3);">
-        <h3 style="margin: 0 0 var(--space-2);">Conversation</h3>
-        ${responses.map((r) => html`
-          <div style="border-top: 1px solid var(--color-border); padding: var(--space-2) 0;">
-            <div style="font-size: var(--font-size-xs); color: var(--color-text-muted); margin-bottom: var(--space-1);">
-              ${ROLE_LABEL[r.role] ?? r.role} · ${formatAge(new Date(r.createdAt).toISOString())}
-            </div>
-            <div style="white-space: pre-wrap;">${r.body}</div>
-          </div>
-        `) as unknown as SafeHtml[]}
-      </section>`
+      <p class="dim" style="margin: var(--space-3) 0 0; font-size: var(--font-size-sm);">
+        This message is ${message.status}.${message.resolvedAt ? html` Closed ${formatAge(new Date(message.resolvedAt).toISOString())}.` : html``}
+      </p>`
     : html`
-      <section class="card" style="margin-top: var(--space-3);">
-        <p class="dim" style="font-size: var(--font-size-sm); margin: 0;">
-          No replies yet. The triage agent + interactive replies ship in upcoming PRs.
-        </p>
-      </section>
+      <div style="margin-top: var(--space-3); display: flex; gap: var(--space-2); align-items: center;">
+        <form method="POST" action="/inbox/${message.id}/triage" data-inbox-modal-form style="margin: 0;">
+          <button type="submit" class="btn btn--sm btn--ghost" ${triagePending ? 'disabled' : ''}>
+            ${triagePending ? 'Triaging…' : 'Ask triage'}
+          </button>
+        </form>
+        <form method="POST" action="/inbox/${message.id}/dismiss" data-inbox-modal-form data-inbox-modal-dismiss-on-success="1" style="margin: 0;">
+          <button type="submit" class="btn btn--sm btn--ghost">Dismiss</button>
+        </form>
+        <span class="dim" style="font-size: var(--font-size-xs); margin-left: auto;">
+          Dismiss closes this thread; Triage asks the LLM for a recommendation.
+        </span>
+      </div>
     `;
 
+  return html`
+    <header style="margin: 0;">
+      <h3 id="inbox-modal-title" style="margin: 0;">${message.title}</h3>
+      ${headerMeta}
+    </header>
+    ${flashBlock}
+    ${bodyBlock}
+    ${contextBlock}
+    ${conversationBlock}
+    ${actionsBlock}
+  `;
+}
+
+/**
+ * Full-page render — used for direct `/inbox/:id` GETs (right-click
+ * "open in new tab", accessibility, search-engine friendly). Wraps
+ * the same fragment in the standard layout chrome.
+ */
+export function renderInboxDetail(opts: InboxDetailOptions): string {
+  const { message, flash } = opts;
   const pageBody = html`
     ${pageHeader({
       title: message.title,
       back: { href: '/inbox', label: 'Inbox' },
     })}
-    ${headerMeta}
-    ${bodyBlock}
-    ${contextBlock}
-    ${recommendationBlock}
-    ${responsesBlock}
+    <section class="card" style="margin-top: var(--space-3);">
+      ${renderInboxDetailFragment(opts)}
+    </section>
   `;
-
   return render(layout({
     title: `${message.title} · Inbox`,
     activeNav: 'inbox',
@@ -118,15 +168,38 @@ export function renderInboxDetail(opts: InboxDetailOptions): string {
   }, pageBody));
 }
 
-/**
- * Pretty-print a JSON string for the collapsible context panel. If the
- * payload isn't valid JSON we display it verbatim — context_json is
- * producer-controlled and we'd rather show garbage than crash.
- */
 function pretty(raw: string): string {
   try {
     return JSON.stringify(JSON.parse(raw), null, 2);
   } catch {
     return raw;
   }
+}
+
+/**
+ * Inline reply form. Hidden when the message is in a terminal state.
+ * Disabled while a triage run is pending so the user can't queue a
+ * second turn while the first is still thinking — the agent posts
+ * back via `/triage`, the modal polls, the form re-enables.
+ */
+function replyForm(message: InboxMessage, triagePending: boolean): SafeHtml {
+  if (message.status === 'dismissed' || message.status === 'resolved') return html``;
+  return html`
+    <form method="POST" action="/inbox/${message.id}/respond" data-inbox-modal-form
+      style="margin: var(--space-2) 0 0; padding-top: var(--space-2); border-top: 1px solid var(--color-border); display: flex; flex-direction: column; gap: var(--space-2);">
+      <label style="font-size: var(--font-size-xs); color: var(--color-text-muted);">
+        Reply
+      </label>
+      <textarea name="body" rows="3" required maxlength="8192"
+        ${triagePending ? 'disabled' : ''}
+        placeholder="Describe what you tried, ask a follow-up, or note a decision. The triage agent will respond."
+        class="form-field"
+        style="padding: var(--space-2); font-size: var(--font-size-sm); resize: vertical;"></textarea>
+      <div style="display: flex; justify-content: flex-end;">
+        <button type="submit" class="btn btn--sm btn--primary" ${triagePending ? 'disabled' : ''}>
+          ${triagePending ? 'Waiting on triage…' : 'Post reply'}
+        </button>
+      </div>
+    </form>
+  `;
 }

--- a/packages/dashboard/src/views/inbox-list.ts
+++ b/packages/dashboard/src/views/inbox-list.ts
@@ -1,87 +1,130 @@
-import type { InboxMessage, InboxPriority } from '@some-useful-agents/core';
+import type { InboxMessage, InboxPriority, InboxSource } from '@some-useful-agents/core';
 import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
 import { formatAge } from './components.js';
+import { renderInboxModalShell } from './inbox-modal.js';
+
+export type InboxSortKey = 'priority' | 'source' | 'agent' | 'title' | 'age' | 'status';
+export type InboxSortDir = 'asc' | 'desc';
 
 export interface InboxListOptions {
   rows: InboxMessage[];
+  sort: InboxSortKey;
+  dir: InboxSortDir;
   flash?: { kind: 'error' | 'info' | 'ok'; message: string };
 }
 
-const PRIORITY_LABEL: Record<InboxPriority, string> = {
-  high: 'High',
-  medium: 'Medium',
-  low: 'Low',
+/**
+ * Default sort: Priority asc (high first) with age desc as the
+ * secondary tiebreaker — matches what the queue is *for*: the most
+ * urgent recent thing on top.
+ */
+export const INBOX_DEFAULT_SORT: { sort: InboxSortKey; dir: InboxSortDir } = {
+  sort: 'priority',
+  dir: 'asc',
 };
 
-const PRIORITY_HINT: Record<InboxPriority, string> = {
-  high: 'Failed runs and other action-needed-now items',
-  medium: 'Authorisations and pending decisions',
-  low: 'Housekeeping reminders',
+const PRIORITY_BADGE: Record<InboxPriority, string> = {
+  high: 'badge--warn',
+  medium: 'badge--info',
+  low: 'badge--muted',
 };
 
-const SOURCE_LABEL: Record<string, string> = {
+const SOURCE_LABEL: Record<InboxSource, string> = {
   'run-failure': 'Run failure',
   'permission-request': 'Permission',
   'cadence': 'Cadence',
   'manual': 'Manual',
 };
 
+const SOURCE_BADGE: Record<InboxSource, string> = {
+  'run-failure': 'badge--warn',
+  'permission-request': 'badge--info',
+  'cadence': 'badge--muted',
+  'manual': 'badge--muted',
+};
+
+const PRIORITY_RANK: Record<InboxPriority, number> = { high: 0, medium: 1, low: 2 };
+
 /**
- * Render the inbox list page. Rows are grouped by priority into three
- * sections (High / Medium / Low) so the operator's eye lands on the
- * urgent items first. Within each section, rows are newest-first.
- * Mirrors the list-table pattern from runs-list.ts but groups
- * vertically instead of using a single sortable table.
+ * Client-side sort. Keeps the store API focused on its canonical
+ * priority+age order and lets the UI own presentation.
+ */
+export function sortMessages(
+  rows: InboxMessage[],
+  sort: InboxSortKey,
+  dir: InboxSortDir,
+): InboxMessage[] {
+  const sign = dir === 'asc' ? 1 : -1;
+  const copy = rows.slice();
+  copy.sort((a, b) => {
+    switch (sort) {
+      case 'priority':
+        return sign * (PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority])
+          || (b.createdAt - a.createdAt);
+      case 'age':
+        return dir === 'asc' ? a.createdAt - b.createdAt : b.createdAt - a.createdAt;
+      case 'source':
+        return sign * a.source.localeCompare(b.source) || (b.createdAt - a.createdAt);
+      case 'agent':
+        return sign * (a.agentId ?? '').localeCompare(b.agentId ?? '') || (b.createdAt - a.createdAt);
+      case 'title':
+        return sign * a.title.localeCompare(b.title);
+      case 'status':
+        return sign * a.status.localeCompare(b.status) || (b.createdAt - a.createdAt);
+      default:
+        return 0;
+    }
+  });
+  return copy;
+}
+
+function sortUrl(col: InboxSortKey, current: { sort: InboxSortKey; dir: InboxSortDir }): string {
+  const sameCol = col === current.sort;
+  const dir: InboxSortDir = sameCol
+    ? (current.dir === 'asc' ? 'desc' : 'asc')
+    : (col === 'age' || col === 'status') ? 'desc' : 'asc';
+  const params = new URLSearchParams();
+  if (col !== INBOX_DEFAULT_SORT.sort) params.set('sort', col);
+  if (dir !== INBOX_DEFAULT_SORT.dir || col !== INBOX_DEFAULT_SORT.sort) params.set('dir', dir);
+  const qs = params.toString();
+  return qs ? `/inbox?${qs}` : '/inbox';
+}
+
+function sortIndicator(col: InboxSortKey, current: { sort: InboxSortKey; dir: InboxSortDir }): string {
+  if (col !== current.sort) return '';
+  return current.dir === 'asc' ? ' ↑' : ' ↓';
+}
+
+/**
+ * Render the inbox list page as a single sortable grid. Each `<tr>`
+ * carries `data-inbox-row-id` so inbox-modal.js can intercept clicks
+ * and open the message in a modal — no page navigation, no losing
+ * scroll position. The row's title link still works as a fallback
+ * (right-click "open in new tab", users without JS).
  */
 export function renderInboxList(opts: InboxListOptions): string {
-  const { rows, flash } = opts;
+  const { rows, sort, dir, flash } = opts;
+  const sorted = sortMessages(rows, sort, dir);
+  const current = { sort, dir };
 
-  const groups: Record<InboxPriority, InboxMessage[]> = {
-    high: rows.filter((r) => r.priority === 'high'),
-    medium: rows.filter((r) => r.priority === 'medium'),
-    low: rows.filter((r) => r.priority === 'low'),
-  };
+  const header = (col: InboxSortKey, label: string): SafeHtml => html`
+    <th><a href="${sortUrl(col, current)}" class="inbox-sort-header">${label}${sortIndicator(col, current)}</a></th>
+  `;
 
-  const sections = (Object.keys(groups) as InboxPriority[]).map((priority) => {
-    const items = groups[priority];
-    if (items.length === 0) return html``;
-    const tbody = items.map((m) => html`
-      <tr>
-        <td>${m.agentId ? html`<a href="/agents/${m.agentId}">${m.agentId}</a>` : html`<span class="dim">—</span>`}</td>
-        <td><a href="/inbox/${m.id}">${m.title}</a></td>
-        <td class="dim">${SOURCE_LABEL[m.source] ?? m.source}</td>
-        <td class="dim">${formatAge(new Date(m.createdAt).toISOString())}</td>
-        <td><span class="badge badge--muted">${m.status}</span></td>
-      </tr>
-    `);
-    return html`
-      <section style="margin-bottom: var(--space-5);">
-        <h2 style="margin: 0 0 var(--space-1); font-size: var(--font-size-lg);">
-          ${PRIORITY_LABEL[priority]}
-          <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-sm); margin-left: var(--space-2);">
-            ${String(items.length)} ${items.length === 1 ? 'item' : 'items'}
-          </span>
-        </h2>
-        <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-2);">${PRIORITY_HINT[priority]}</p>
-        <table class="table">
-          <thead>
-            <tr>
-              <th>Agent</th>
-              <th>Title</th>
-              <th>Source</th>
-              <th>Age</th>
-              <th>Status</th>
-            </tr>
-          </thead>
-          <tbody>${tbody as unknown as SafeHtml[]}</tbody>
-        </table>
-      </section>
-    `;
-  });
+  const tbody = sorted.map((m) => html`
+    <tr data-inbox-row-id="${m.id}" class="inbox-row">
+      <td><span class="badge ${PRIORITY_BADGE[m.priority]}">${m.priority}</span></td>
+      <td><span class="badge ${SOURCE_BADGE[m.source]}">${SOURCE_LABEL[m.source]}</span></td>
+      <td>${m.agentId ? html`<a href="/agents/${m.agentId}" data-inbox-row-stop>${m.agentId}</a>` : html`<span class="dim">—</span>`}</td>
+      <td><a href="/inbox/${m.id}" data-inbox-row-link>${m.title}</a></td>
+      <td class="dim">${formatAge(new Date(m.createdAt).toISOString())}</td>
+      <td><span class="badge badge--muted">${m.status}</span></td>
+    </tr>
+  `);
 
-  const empty = rows.length === 0
+  const table = rows.length === 0
     ? html`
       <div class="settings-empty mt-0">
         <h3 class="mt-0">Inbox zero</h3>
@@ -91,15 +134,29 @@ export function renderInboxList(opts: InboxListOptions): string {
           with <code>SUA_INBOX_DEMO=1</code>.
         </p>
       </div>`
-    : html``;
+    : html`
+      <table class="table inbox-table">
+        <thead>
+          <tr>
+            ${header('priority', 'Priority')}
+            ${header('source', 'Source')}
+            ${header('agent', 'Agent')}
+            ${header('title', 'Title')}
+            ${header('age', 'Age')}
+            ${header('status', 'Status')}
+          </tr>
+        </thead>
+        <tbody>${tbody as unknown as SafeHtml[]}</tbody>
+      </table>
+    `;
 
   const body = html`
     ${pageHeader({
       title: 'Inbox',
-      description: 'Things that need your attention, ordered by priority.',
+      description: 'Things that need your attention. Click a row to open. Click a column header to sort.',
     })}
-    ${empty}
-    ${sections as unknown as SafeHtml[]}
+    ${table}
+    ${renderInboxModalShell()}
   `;
 
   return render(layout({ title: 'Inbox', activeNav: 'inbox', flash }, body));

--- a/packages/dashboard/src/views/inbox-modal.js.ts
+++ b/packages/dashboard/src/views/inbox-modal.js.ts
@@ -1,0 +1,165 @@
+/**
+ * Inbox modal — fluid in-page detail view.
+ *
+ * Wires the row click → modal-open → fetch fragment → submit forms via
+ * fetch → poll for triage responses. No page navigation needed.
+ *
+ * Contract with the server:
+ *   GET  /inbox/:id/fragment              → inner detail HTML (no layout chrome)
+ *   POST /inbox/:id/dismiss               → 204; modal closes + row hides locally
+ *   POST /inbox/:id/respond {body}        → 204; we re-fetch the fragment so the
+ *                                            new user response + any triage
+ *                                            reply that posted appear in-place
+ *   POST /inbox/:id/triage                → 204; triage agent runs server-side
+ *
+ * Polling: while the fragment carries [data-triage-pending="1"] we
+ * re-fetch every 1.5s until the marker clears (the server sets it
+ * when a triage run is queued/running for the message).
+ */
+
+export const INBOX_MODAL_JS = `
+(function () {
+  var modal = document.getElementById('inbox-modal');
+  if (!modal) return;
+  var content = document.getElementById('inbox-modal-content');
+  if (!content) return;
+
+  var currentId = null;
+  var pollTimer = null;
+
+  function open() {
+    modal.hidden = false;
+    modal.classList.add('is-open');
+    document.body.style.overflow = 'hidden';
+  }
+  function close() {
+    modal.hidden = true;
+    modal.classList.remove('is-open');
+    document.body.style.overflow = '';
+    currentId = null;
+    stopPoll();
+  }
+
+  function stopPoll() {
+    if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; }
+  }
+
+  function maybeSchedulePoll() {
+    stopPoll();
+    if (!currentId) return;
+    var pending = content.querySelector('[data-triage-pending="1"]');
+    if (!pending) return;
+    pollTimer = setTimeout(function () { refresh(); }, 1500);
+  }
+
+  function refresh() {
+    if (!currentId) return;
+    var id = currentId;
+    fetch('/inbox/' + encodeURIComponent(id) + '/fragment', { credentials: 'same-origin' })
+      .then(function (r) { if (!r.ok) throw new Error('fragment fetch failed'); return r.text(); })
+      .then(function (text) {
+        if (currentId !== id) return; // user opened a different message in the meantime
+        content.innerHTML = text;
+        focusFirstInteractive();
+        maybeSchedulePoll();
+      })
+      .catch(function () { /* swallow; user can close + retry */ });
+  }
+
+  function focusFirstInteractive() {
+    var ta = content.querySelector('textarea[name="body"]');
+    if (ta) { ta.focus(); return; }
+    var btn = content.querySelector('button, a');
+    if (btn) btn.focus();
+  }
+
+  function openFor(id) {
+    currentId = id;
+    content.innerHTML = '<p class="dim" style="margin:0;padding:var(--space-4) 0;text-align:center;">Loading…</p>';
+    open();
+    refresh();
+  }
+
+  // Click anywhere on a row → open the modal for that message. Inner
+  // anchors (agent link, title link) opt out via [data-inbox-row-stop]
+  // / [data-inbox-row-link]; the title link is handled below so the
+  // row's modal still wins over the navigation.
+  document.addEventListener('click', function (e) {
+    var stop = e.target.closest && e.target.closest('[data-inbox-row-stop]');
+    if (stop) return; // let the agent link navigate normally
+
+    var titleLink = e.target.closest && e.target.closest('[data-inbox-row-link]');
+    if (titleLink) {
+      e.preventDefault();
+      var row = titleLink.closest('[data-inbox-row-id]');
+      if (row) openFor(row.getAttribute('data-inbox-row-id'));
+      return;
+    }
+
+    var row = e.target.closest && e.target.closest('[data-inbox-row-id]');
+    if (row) {
+      e.preventDefault();
+      openFor(row.getAttribute('data-inbox-row-id'));
+      return;
+    }
+
+    // Close button or backdrop click.
+    if (e.target === modal || (e.target.closest && e.target.closest('[data-inbox-modal-close]'))) {
+      close();
+    }
+  });
+
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && !modal.hidden) close();
+  });
+
+  // Intercept Reply / Dismiss / Triage form submits inside the modal.
+  // The form's action + method tell us where to POST; the response is
+  // a 204 (or 4xx with a flash message in the body) and we always
+  // re-fetch the fragment afterwards so the modal state matches the
+  // server.
+  modal.addEventListener('submit', function (e) {
+    var form = e.target;
+    if (!(form instanceof HTMLFormElement)) return;
+    if (!form.hasAttribute('data-inbox-modal-form')) return;
+    e.preventDefault();
+    var action = form.getAttribute('action');
+    var method = (form.getAttribute('method') || 'POST').toUpperCase();
+    var formData = new FormData(form);
+    // Disable submit button + textarea while in flight so a double-click
+    // doesn't double-post (the triage path can take a few seconds).
+    var submits = form.querySelectorAll('button[type="submit"]');
+    for (var i = 0; i < submits.length; i++) submits[i].disabled = true;
+    var dismissBody = form.getAttribute('data-inbox-modal-dismiss-on-success') === '1';
+    fetch(action, {
+      method: method,
+      credentials: 'same-origin',
+      body: new URLSearchParams(Array.from(formData.entries())).toString(),
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    })
+      .then(function (r) {
+        if (!r.ok) throw new Error('mutation failed: ' + r.status);
+      })
+      .then(function () {
+        if (dismissBody) {
+          // Dismiss: close modal + hide the row in the list locally so
+          // the user sees the queue shrink immediately.
+          var row = document.querySelector('[data-inbox-row-id="' + cssEscape(currentId || '') + '"]');
+          if (row && row.parentNode) row.parentNode.removeChild(row);
+          close();
+        } else {
+          refresh();
+        }
+      })
+      .catch(function () {
+        for (var i = 0; i < submits.length; i++) submits[i].disabled = false;
+      });
+  });
+
+  function cssEscape(s) {
+    return String(s).replace(/[^a-zA-Z0-9_-]/g, function (c) {
+      return '\\\\' + c.charCodeAt(0).toString(16) + ' ';
+    });
+  }
+})();
+`;

--- a/packages/dashboard/src/views/inbox-modal.ts
+++ b/packages/dashboard/src/views/inbox-modal.ts
@@ -1,0 +1,26 @@
+import { html, type SafeHtml } from './html.js';
+
+/**
+ * The modal shell lives once on /inbox and stays empty until JS opens
+ * it. inbox-modal.js.ts fetches `/inbox/:id/fragment` into the inner
+ * container, intercepts the Reply / Dismiss form submits, and polls
+ * for triage-agent updates while the conversation is alive.
+ *
+ * The `<a href="/inbox/:id">` row link still works as a fallback
+ * (right-click "open in new tab", users with JS disabled) — JS
+ * progressively enhances the click to an in-page modal.
+ */
+export function renderInboxModalShell(): SafeHtml {
+  return html`
+    <div class="modal-backdrop" id="inbox-modal" role="dialog" aria-modal="true" aria-labelledby="inbox-modal-title" hidden>
+      <div class="modal" style="max-width: 44rem; max-height: 88vh; overflow-y: auto;">
+        <div id="inbox-modal-content">
+          <p class="dim" style="margin: 0; padding: var(--space-4) 0; text-align: center;">Loading…</p>
+        </div>
+        <div class="modal__actions" style="justify-content: flex-end; margin-top: var(--space-3); padding-top: var(--space-3); border-top: 1px solid var(--color-border);">
+          <button type="button" class="btn btn--ghost" data-inbox-modal-close>Close</button>
+        </div>
+      </div>
+    </div>
+  `;
+}

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -19,6 +19,7 @@ import { CSP_ALLOW_JS } from './csp-allow.js.js';
 import { CSP_IMG_REPORT_JS } from './csp-img-report.js.js';
 import { WIDGET_IMG_FALLBACK_JS } from './widget-img-fallback.js.js';
 import { INSTALL_PACKS_MODAL_JS } from './install-packs-modal.js.js';
+import { INBOX_MODAL_JS } from './inbox-modal.js.js';
 import { footer } from './footer.js';
 
 export interface LayoutOptions {
@@ -84,7 +85,7 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
   ${body}
 </main>
 ${footer()}
-<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + PULSE_MASONRY_JS + HOME_LAYOUT_JS + DASHBOARDS_LAYOUT_JS + BUILD_FROM_GOAL_JS + IMPROVE_LAYOUT_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS + WIDGET_REPLAY_INPLACE_JS + PAGE_INTRO_JS + ADD_TILE_MODAL_JS + CSP_ALLOW_JS + CSP_IMG_REPORT_JS + WIDGET_IMG_FALLBACK_JS + INSTALL_PACKS_MODAL_JS)}</script>
+<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + PULSE_MASONRY_JS + HOME_LAYOUT_JS + DASHBOARDS_LAYOUT_JS + BUILD_FROM_GOAL_JS + IMPROVE_LAYOUT_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS + WIDGET_REPLAY_INPLACE_JS + PAGE_INTRO_JS + ADD_TILE_MODAL_JS + CSP_ALLOW_JS + CSP_IMG_REPORT_JS + WIDGET_IMG_FALLBACK_JS + INSTALL_PACKS_MODAL_JS + INBOX_MODAL_JS)}</script>
 </body>
 </html>`;
 }


### PR DESCRIPTION
## Summary
- Row click on `/inbox` now opens an **in-place modal** (over the list) instead of navigating to a new page
- Modal fetches `/inbox/:id/fragment`, intercepts Reply / Dismiss / Ask-triage form submits via `fetch`, re-renders after each mutation, **polls every 1.5s while triage is running**, removes the row from the list on successful Dismiss
- New **`inbox-triage`** system agent (`source: examples`) — single llm-prompt node, takes message + context + conversation as inputs, emits `<plan>{messageId, recommendation, verifyHint}</plan>` parsed by the route
- **Triage auto-fires** after every user reply (fire-and-forget); the agent's response appears in the conversation thread without user action
- Mutation routes return **204 for AJAX (modal) / 303 for plain form posts** so the fallback `/inbox/:id` detail page still works
- Single sortable grid (Priority / Source / Agent / Title / Age / Status) with colored badges per priority + source
- 15 route tests cover the grid, fragment, and all three mutation routes in both AJAX + form-post modes

## Why
Dogfood feedback: "doesn't feel fluid to have to go to a new page load to have a conversation about the current row, and I'd like the triage agent to join the thread."

## Architecture notes
- The triage dispatch uses the structured `<plan>` pattern from layout-planner — no new built-in tool, no SSRF whitelist
- `<a href="/inbox/:id">` row link still navigates as a fallback for right-click "open in new tab" + no-JS users
- Triage runs are fire-and-forget; the modal's poll picks up the response via `[data-triage-pending="1"]` marker
- Triage agent is lazy-installed on first call (mirrors how layout-planner is imported)

## Test plan
- [x] `npx vitest run packages/dashboard/src/routes/inbox.test.ts` — 15 tests
- [x] Full suite: `npx vitest run` → 1745 / 3 skipped
- [x] Clean build green
- [x] Manual: `SUA_INBOX_DEMO=1` daemon start, `/inbox` → click row → modal opens in place with title, badges, body, conversation, Reply form, Ask triage + Dismiss buttons. DOM probe + screenshot confirm.
- [ ] Manual end-to-end: post a Reply → modal shows "Triage agent is thinking…" → response appears in conversation thread (needs an LLM provider configured; route + agent both wired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)