### PR TITLE
feat(dashboard): inbox in-place modal + Slack-style triage conversation

### DIFF
--- a/.changeset/inbox-slack-feel.md
+++ b/.changeset/inbox-slack-feel.md
@@ -1,0 +1,55 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox: in-place modal + Slack-style triage conversation.
+
+Dogfood feedback: "doesn't feel fluid to have to go to a new page load
+to have a conversation about the current row, and I'd like the triage
+agent to join the thread." A previous take stalled because the modal
+polled on a `triageRunId` marker that races the dag-executor — when
+the executor's run-store row landed after the modal's first refresh,
+polling stopped and the agent's reply never appeared.
+
+This PR:
+
+- **Single sortable grid** (Priority / Source / Agent / Title / Age /
+  Status) replacing the three priority-grouped tables. Click any
+  column header to sort; the active column shows ↑/↓. Priority and
+  Source render as colored badges (warn/info/muted) so high-pri and
+  run-failure rows pop visually.
+- **In-place modal** opens on row click — no page navigation. The
+  `<a href="/inbox/:id">` link still works as a fallback for
+  right-click "open in new tab" and no-JS users. Esc / backdrop /
+  Close all dismiss.
+- **Slack-style conversation thread**: avatar + name + timestamp +
+  body per entry, colour-coded by role (YOU teal, TRI info-blue,
+  SYS muted). New entries on each fragment refresh get a one-shot
+  `inbox-msg--new` slide-in animation. The conversation pane
+  auto-scrolls to the bottom when new content lands.
+- **Animated "thinking..." indicator** with three pulsing dots
+  (Slack-style typing). Replaces the previous static text.
+- **Reliable polling**: the modal force-polls for 30s after every
+  Reply / Ask-triage submit, in addition to honouring the
+  `data-triage-pending="1"` marker. The server-side fragment also
+  reports pending when the latest response is a user reply <30s old
+  with no later triage/system reply — covers the unavoidable race
+  between POST returning 204 and the dag-executor's run-store row
+  appearing.
+- **`agents/examples/inbox-triage.yaml`** — `source: examples`
+  system agent. Single llm-prompt node; takes message + context +
+  conversation as inputs; emits `<plan>{messageId, recommendation,
+  verifyHint}</plan>` parsed by the route (mirrors layout-planner
+  pattern; no new built-in tool, no SSRF whitelist).
+- **`POST /inbox/:id/triage`** inserts a synthetic "Asked triage to
+  take another look" user marker before kicking off the agent, so
+  the operator's action is visible in the thread.
+- **Dual-mode mutation routes**: 204 with no body for AJAX (modal
+  fetch), 303 redirect for plain form posts (fallback page).
+- 16 route tests cover sort, fragment rendering with avatars,
+  pending-indicator derivation, all three mutation routes in both
+  modes, and synthetic-marker insertion on /triage.

--- a/agents/examples/inbox-triage.yaml
+++ b/agents/examples/inbox-triage.yaml
@@ -1,0 +1,137 @@
+# Inbox Triage — joins the conversation thread on an inbox message and
+# emits a concrete recommendation.
+#
+# Invoked by `POST /inbox/:id/triage` (and auto-fired by the
+# `/inbox/:id/respond` handler whenever the user posts a reply). The
+# dashboard parses the agent's `<plan>{...}</plan>` block, appends the
+# recommendation as a `triage`-role response to the message's
+# inbox_responses thread, and (if `verifyHint` is set) holds it for
+# the future verification loop.
+
+id: inbox-triage
+name: Inbox Triage
+description: >
+  Reads an inbox message (title, body, context, conversation so far) and
+  recommends the next concrete action. Joins the conversation thread.
+status: active
+source: examples
+
+# Triage should land in seconds, not minutes — fail fast if the LLM
+# stalls so the modal's "thinking..." indicator doesn't lie indefinitely.
+timeoutSec: 60
+
+inputs:
+  MESSAGE_ID:
+    type: string
+    required: true
+    description: Inbox message id (uuid) so the route can match the response back.
+  MESSAGE_TITLE:
+    type: string
+    required: true
+    description: The message title from the producer.
+  MESSAGE_BODY:
+    type: string
+    required: true
+    description: The producer's short markdown summary.
+  MESSAGE_PRIORITY:
+    type: string
+    required: true
+    description: 'high | medium | low — sets urgency of the recommendation.'
+  MESSAGE_SOURCE:
+    type: string
+    required: true
+    description: 'run-failure | permission-request | cadence | manual.'
+  CONTEXT_JSON:
+    type: string
+    required: false
+    default: ""
+    description: >
+      Structured producer payload (failed-run details, blocked host,
+      stale-agent list, etc.). Parse if useful.
+  CONVERSATION:
+    type: string
+    required: false
+    default: ""
+    description: >
+      The conversation thread to date, one entry per line as
+      `[ROLE] body`. Empty on the first triage of a fresh message.
+
+nodes:
+  - id: triage
+    type: llm-prompt
+    prompt: |
+      You are the Inbox Triage agent for the sua agent platform. The
+      operator opened an inbox message and either explicitly asked for
+      a triage recommendation, or just posted a reply that the system
+      auto-routed to you.
+
+      Read the message, parse the context payload if structured, look
+      at the conversation so far, and return ONE concrete, actionable
+      recommendation. Keep it tight — operators are skimming, not
+      reading essays.
+
+      ════════════════════════════════════════════════════════════════
+      MESSAGE
+      ════════════════════════════════════════════════════════════════
+
+      id:       {{inputs.MESSAGE_ID}}
+      priority: {{inputs.MESSAGE_PRIORITY}}
+      source:   {{inputs.MESSAGE_SOURCE}}
+      title:    {{inputs.MESSAGE_TITLE}}
+
+      Body:
+      {{inputs.MESSAGE_BODY}}
+
+      Context (may be empty / JSON / arbitrary):
+      {{inputs.CONTEXT_JSON}}
+
+      Conversation so far (may be empty — you are the first responder):
+      {{inputs.CONVERSATION}}
+
+      ════════════════════════════════════════════════════════════════
+      WHAT TO RECOMMEND
+      ════════════════════════════════════════════════════════════════
+
+      Match the recommendation to the source:
+
+      - source=run-failure → diagnose the failure if the context has
+        an exit code / error line. Recommend either (a) a one-line fix
+        the user should try, (b) the dashboard path that shows the
+        full failed run, or (c) "this looks transient, retry once and
+        dismiss if it succeeds". Don't speculate without the data.
+
+      - source=permission-request → name the missing permission (host,
+        path, tool) and the concrete config path the user updates. If
+        the request is for a CSP image host, point at the agent's
+        Config → Permissions panel.
+
+      - source=cadence → name the housekeeping action and where to do
+        it ("archive these agents from /agents", "set a schedule on
+        agent X via /scheduled", etc.).
+
+      - source=manual → use your judgment. Treat the body as a free-form
+        ask from the operator and respond to it directly.
+
+      ════════════════════════════════════════════════════════════════
+      OUTPUT FORMAT — exact shape, single <plan>...</plan> block
+      ════════════════════════════════════════════════════════════════
+
+      Wrap the JSON in <plan>…</plan> tags. Output ONLY the <plan>
+      block — no preamble, no markdown fences around it. Example:
+
+      <plan>
+      {
+        "messageId": "{{inputs.MESSAGE_ID}}",
+        "recommendation": "Run failed with exit 1 because `which apod` returned no match. Install the apod CLI (brew install apod) or switch to the http-get version of the agent.",
+        "verifyHint": "Re-run the agent; it should reach the parse-output node without exit code 1."
+      }
+      </plan>
+
+      VALIDATION RULES (failing these means the route discards the response):
+      - `messageId` MUST equal {{inputs.MESSAGE_ID}}.
+      - `recommendation` is required, 10..2000 chars, plain text or simple markdown.
+      - `verifyHint` is optional — set it when the operator can re-run
+        a known action to confirm the fix. Leave it absent for
+        ambiguous or judgement-call recommendations.
+    maxTurns: 1
+    timeout: 60

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -2078,3 +2078,111 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
 .add-tile-card--create .add-tile-card__icon {
   font-size: 1.25rem;
 }
+
+/* ---------- Inbox conversation (modal-driven) ---------- */
+/* Slack-feel: avatar + body + meta with animated reveal for new
+ * entries. The modal JS adds .inbox-msg--new to messages that appeared
+ * since the last fragment fetch; the animation runs once and the class
+ * stays on the element (CSS handles the one-shot semantics). */
+.inbox-msg {
+  display: flex;
+  gap: var(--space-2);
+  padding: var(--space-3) 0;
+  border-top: 1px solid var(--color-border);
+  align-items: flex-start;
+}
+.inbox-msg:first-child {
+  border-top: none;
+  padding-top: var(--space-2);
+}
+.inbox-msg__avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: var(--weight-semibold);
+  color: var(--color-bg, #0d1117);
+  flex-shrink: 0;
+  text-transform: uppercase;
+}
+.inbox-msg__avatar--user { background: var(--color-primary, #2dd4bf); }
+.inbox-msg__avatar--triage { background: var(--color-info, #60a5fa); }
+.inbox-msg__avatar--system { background: var(--color-text-muted, #8b93a7); }
+.inbox-msg__body { flex: 1; min-width: 0; }
+.inbox-msg__meta {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  margin-bottom: 2px;
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+.inbox-msg__meta-name {
+  color: var(--color-text);
+  font-weight: var(--weight-semibold);
+}
+.inbox-msg__text {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+@keyframes inbox-msg-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.inbox-msg--new { animation: inbox-msg-in 260ms ease-out; }
+
+/* Animated three-dot "agent is thinking" indicator. Mirrors the
+ * Slack typing animation: three dots with staggered pulse. The
+ * indicator carries data-triage-pending="1" so inbox-modal.js polls
+ * the fragment until it disappears. */
+.inbox-thinking {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) 0;
+  border-top: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+.inbox-thinking__avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--color-info, #60a5fa);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: var(--weight-semibold);
+  color: var(--color-bg, #0d1117);
+  text-transform: uppercase;
+}
+.inbox-thinking__dots {
+  display: inline-flex;
+  gap: 4px;
+  margin-left: var(--space-1);
+}
+.inbox-thinking__dots span {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  animation: inbox-think 1.4s ease-in-out infinite;
+}
+.inbox-thinking__dots span:nth-child(2) { animation-delay: 0.2s; }
+.inbox-thinking__dots span:nth-child(3) { animation-delay: 0.4s; }
+@keyframes inbox-think {
+  0%, 60%, 100% { opacity: 0.25; transform: scale(0.7); }
+  30%           { opacity: 1;    transform: scale(1); }
+}
+
+/* Inbox list: data-inbox-row-id rows get a row-hover affordance so
+ * users see the click target. Title link inherits the row hover. */
+.inbox-row { cursor: pointer; }
+.inbox-row:hover { background: var(--color-surface-raised); }
+.inbox-row a { text-decoration: none; }

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -1,7 +1,11 @@
 /**
- * Smoke tests for the Inbox routes (PR 2 of the Inbox MVP). The store
- * itself is unit-tested in core; these check that the routes wire the
- * store + views correctly and that the top nav highlights the page.
+ * Inbox routes — covers the sortable grid, fragment renderer, modal
+ * mutation routes (dual 204/303 mode), and the pending-state
+ * derivation that drives the modal's polling loop.
+ *
+ * Triage agent end-to-end requires an LLM provider; the route is
+ * verified to kick off (and to add a synthetic user marker when
+ * invoked explicitly) but the agent's run isn't asserted here.
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
@@ -85,74 +89,187 @@ afterEach(async () => {
 });
 
 describe('GET /inbox', () => {
-  it('renders an empty state when no messages exist', async () => {
+  it('renders empty state when no messages exist', async () => {
     const app = await makeApp();
-    const res = await request(app)
-      .get('/inbox')
-      .set('Host', `127.0.0.1:${PORT}`)
-      .set('Cookie', COOKIE);
+    const res = await request(app).get('/inbox').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
     expect(res.status).toBe(200);
-    expect(res.text).toContain('Inbox');
     expect(res.text).toContain('Inbox zero');
-    // Top nav highlights /inbox.
     expect(res.text).toMatch(/<a href="\/inbox"[^>]*class="is-active"/);
   });
 
-  it('groups messages by priority newest-first', async () => {
+  it('renders one sortable table; rows carry data-inbox-row-id; modal shell is present + hidden', async () => {
     const app = await makeApp();
-    inboxStore.add({ priority: 'low', source: 'cadence', title: 'low-pri item', body: 'x' });
-    inboxStore.add({ priority: 'high', source: 'run-failure', agentId: 'foo', title: 'high-pri item', body: 'y' });
-    inboxStore.add({ priority: 'medium', source: 'permission-request', title: 'med-pri item', body: 'z' });
+    inboxStore.add({ priority: 'low', source: 'cadence', title: 'low-pri', body: 'x' });
+    const high = inboxStore.add({ priority: 'high', source: 'run-failure', agentId: 'foo', title: 'high-pri', body: 'y' });
+    inboxStore.add({ priority: 'medium', source: 'permission-request', title: 'med-pri', body: 'z' });
 
-    const res = await request(app)
-      .get('/inbox')
-      .set('Host', `127.0.0.1:${PORT}`)
-      .set('Cookie', COOKIE);
+    const res = await request(app).get('/inbox').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
     expect(res.status).toBe(200);
-    expect(res.text).toContain('High');
-    expect(res.text).toContain('Medium');
-    expect(res.text).toContain('Low');
-    // High section must appear before Medium and Low in the HTML stream.
-    const hi = res.text.indexOf('high-pri item');
-    const med = res.text.indexOf('med-pri item');
-    const lo = res.text.indexOf('low-pri item');
-    expect(hi).toBeGreaterThan(0);
-    expect(hi).toBeLessThan(med);
-    expect(med).toBeLessThan(lo);
+    expect((res.text.match(/<table class="table inbox-table">/g) ?? []).length).toBe(1);
+    expect(res.text).toContain(`data-inbox-row-id="${high.id}"`);
+    expect(res.text.indexOf('high-pri')).toBeLessThan(res.text.indexOf('low-pri'));
+    expect(res.text).toContain('id="inbox-modal"');
+    expect(res.text).toMatch(/id="inbox-modal"[^>]*hidden/);
+  });
+
+  it('honours ?sort=source&dir=asc and shows the ↑ indicator on the active column', async () => {
+    const app = await makeApp();
+    inboxStore.add({ priority: 'low', source: 'run-failure', title: 'R', body: 'x' });
+    inboxStore.add({ priority: 'low', source: 'cadence', title: 'C', body: 'y' });
+    const res = await request(app).get('/inbox?sort=source&dir=asc').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(200);
+    expect(res.text.indexOf('>C<')).toBeLessThan(res.text.indexOf('>R<'));
+    expect(res.text).toMatch(/Source ↑/);
+  });
+
+  it('falls back to defaults for unknown sort / dir', async () => {
+    const app = await makeApp();
+    inboxStore.add({ priority: 'high', source: 'run-failure', title: 'H', body: 'x' });
+    inboxStore.add({ priority: 'low', source: 'cadence', title: 'L', body: 'y' });
+    const res = await request(app).get('/inbox?sort=nope&dir=sideways').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.text.indexOf('>H<')).toBeLessThan(res.text.indexOf('>L<'));
   });
 });
 
-describe('GET /inbox/:id', () => {
-  it('renders the message detail page', async () => {
+describe('GET /inbox/:id and /:id/fragment', () => {
+  it('full-page render includes badges, body, and the action forms', async () => {
     const app = await makeApp();
     const m = inboxStore.add({
-      priority: 'high',
-      source: 'run-failure',
-      agentId: 'astro',
-      runId: 'run-abc',
-      title: 'Detail title',
-      body: 'Detail body markdown.',
-      contextJson: JSON.stringify({ exit: 1 }),
+      priority: 'high', source: 'run-failure', agentId: 'astro', runId: 'run-xyz',
+      title: 'Detail title', body: 'Detail body.', contextJson: JSON.stringify({ exit: 1 }),
     });
-    const res = await request(app)
-      .get(`/inbox/${m.id}`)
-      .set('Host', `127.0.0.1:${PORT}`)
-      .set('Cookie', COOKIE);
+    const res = await request(app).get(`/inbox/${m.id}`).set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
     expect(res.status).toBe(200);
     expect(res.text).toContain('Detail title');
-    expect(res.text).toContain('Detail body markdown.');
-    expect(res.text).toContain('Context payload');
-    expect(res.text).toContain('/agents/astro');
-    expect(res.text).toContain('/runs/run-abc');
-    expect(res.text).toMatch(/<a href="\/inbox"[^>]*class="is-active"/);
+    expect(res.text).toContain(`action="/inbox/${m.id}/respond"`);
+    expect(res.text).toContain(`action="/inbox/${m.id}/dismiss"`);
+    expect(res.text).toContain(`action="/inbox/${m.id}/triage"`);
   });
 
-  it('renders 404 for an unknown message id', async () => {
+  it('fragment is inner HTML only (no <html>, no top-nav)', async () => {
     const app = await makeApp();
-    const res = await request(app)
-      .get('/inbox/no-such-id')
-      .set('Host', `127.0.0.1:${PORT}`)
-      .set('Cookie', COOKIE);
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 'Frag', body: 'fb' });
+    const res = await request(app).get(`/inbox/${m.id}/fragment`).set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Frag');
+    expect(res.text).not.toContain('<html');
+    expect(res.text).not.toContain('topbar__nav');
+    expect(res.text).toContain('id="inbox-modal-title"');
+  });
+
+  it('renders conversation entries with data-msg-id + role avatars', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const r1 = inboxStore.addResponse(m.id, 'user', 'first reply');
+    const res = await request(app).get(`/inbox/${m.id}/fragment`).set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.text).toContain(`data-msg-id="${r1.id}"`);
+    expect(res.text).toContain('inbox-msg__avatar--user');
+    expect(res.text).toContain('first reply');
+  });
+
+  it('renders the thinking indicator when the most recent response is a recent user reply', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    inboxStore.addResponse(m.id, 'user', 'just posted');
+    const res = await request(app).get(`/inbox/${m.id}/fragment`).set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.text).toContain('data-triage-pending="1"');
+    expect(res.text).toContain('inbox-thinking');
+  });
+
+  it('does NOT render the thinking indicator when the most recent response is from triage', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    inboxStore.addResponse(m.id, 'user', 'q');
+    inboxStore.addResponse(m.id, 'triage', 'here is what to do');
+    const res = await request(app).get(`/inbox/${m.id}/fragment`).set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.text).not.toContain('data-triage-pending="1"');
+  });
+
+  it('returns 404 fragments without layout chrome', async () => {
+    const app = await makeApp();
+    const res = await request(app).get('/inbox/nope/fragment').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
     expect(res.status).toBe(404);
+    expect(res.text).not.toContain('<html');
+  });
+});
+
+describe('POST /inbox/:id/dismiss', () => {
+  it('303 for plain form, 204 for fetch', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const form = await request(app).post(`/inbox/${m.id}/dismiss`).set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(form.status).toBe(303);
+    expect(form.headers.location).toMatch(/^\/inbox\?ok=/);
+    expect(inboxStore.get(m.id)!.status).toBe('dismissed');
+
+    const m2 = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const ajax = await request(app).post(`/inbox/${m2.id}/dismiss`).set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(ajax.status).toBe(204);
+    expect(inboxStore.get(m2.id)!.status).toBe('dismissed');
+  });
+
+  it('404 (AJAX) / 303 with error (form) for unknown ids', async () => {
+    const app = await makeApp();
+    const r1 = await request(app).post('/inbox/nope/dismiss').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(r1.status).toBe(303);
+    const r2 = await request(app).post('/inbox/nope/dismiss').set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(r2.status).toBe(404);
+  });
+});
+
+describe('POST /inbox/:id/respond', () => {
+  it('appends a user response; 303 for form, 204 for AJAX', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const form = await request(app)
+      .post(`/inbox/${m.id}/respond`).type('form').send({ body: 'tried X' })
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(form.status).toBe(303);
+    expect(form.headers.location).toMatch(new RegExp(`^/inbox/${m.id}\\?ok=`));
+
+    const ajax = await request(app)
+      .post(`/inbox/${m.id}/respond`).type('form').send({ body: 'second' })
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(ajax.status).toBe(204);
+
+    const responses = inboxStore.listResponses(m.id);
+    expect(responses.length).toBeGreaterThanOrEqual(2);
+    const userReplies = responses.filter((r) => r.role === 'user');
+    expect(userReplies.map((r) => r.body)).toEqual(['tried X', 'second']);
+  });
+
+  it('rejects empty and oversize bodies', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const empty = await request(app)
+      .post(`/inbox/${m.id}/respond`).type('form').send({ body: '   ' })
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(empty.status).toBe(400);
+    const big = await request(app)
+      .post(`/inbox/${m.id}/respond`).type('form').send({ body: 'x'.repeat(9000) })
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(big.status).toBe(400);
+    expect(inboxStore.listResponses(m.id)).toEqual([]);
+  });
+});
+
+describe('POST /inbox/:id/triage', () => {
+  it('returns 204 (AJAX) and inserts a synthetic "Asked triage" user marker', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const res = await request(app).post(`/inbox/${m.id}/triage`).set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(204);
+    const responses = inboxStore.listResponses(m.id);
+    expect(responses.length).toBeGreaterThanOrEqual(1);
+    expect(responses[0].role).toBe('user');
+    expect(responses[0].body).toContain('Asked triage');
+  });
+
+  it('404 (AJAX) / 303 (form) for unknown ids', async () => {
+    const app = await makeApp();
+    const r1 = await request(app).post('/inbox/nope/triage').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(r1.status).toBe(303);
+    const r2 = await request(app).post('/inbox/nope/triage').set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(r2.status).toBe(404);
   });
 });

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -1,25 +1,81 @@
 /**
  * Routes for the Inbox surface:
- *   GET /inbox        — priority-grouped list of active items
- *   GET /inbox/:id    — message detail + conversation thread
  *
- * Mutation routes (dismiss, respond, triage) ship in follow-up PRs;
- * MVP is read-only so the surface can be validated before producers
- * are wired.
+ *   GET  /inbox                 — single sortable grid of active items
+ *   GET  /inbox/:id             — full-page detail (fallback for direct links)
+ *   GET  /inbox/:id/fragment    — inner detail HTML for the modal
+ *   POST /inbox/:id/dismiss     — terminal-state the message
+ *   POST /inbox/:id/respond     — append user-role response; auto-fires triage
+ *   POST /inbox/:id/triage      — run the inbox-triage system agent; result
+ *                                 parsed + appended as a triage-role response
+ *
+ * Mutation routes return:
+ *   - 303 redirect for non-AJAX (plain form posts)
+ *   - 204 with no body for AJAX (modal's fetch wrapper sets
+ *     `X-Requested-With: fetch`)
+ *
+ * Triage pending detection (used by GET /:id/fragment) checks both:
+ *   - a captured triageRunId whose run is pending/running, AND
+ *   - "kicked off recently" — newest response is a user response
+ *     within the last 30s with no later triage/system reply. Covers
+ *     the race where the dag-executor hasn't yet inserted its
+ *     run-store row when the modal first polls.
  */
 
 import { Router, type Request, type Response } from 'express';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import {
+  executeAgentDag,
+  extractPlanJson,
+  parseAgent,
+  type RunStatus,
+} from '@some-useful-agents/core';
 import { getContext } from '../context.js';
-import { renderInboxList } from '../views/inbox-list.js';
-import { renderInboxDetail } from '../views/inbox-detail.js';
+import {
+  renderInboxList,
+  type InboxSortKey,
+  type InboxSortDir,
+  INBOX_DEFAULT_SORT,
+} from '../views/inbox-list.js';
+import { renderInboxDetail, renderInboxDetailFragment } from '../views/inbox-detail.js';
+import { render } from '../views/html.js';
 import { renderNotFoundPage } from '../views/not-found.js';
 
 export const inboxRouter: Router = Router();
 
+const SORT_KEYS = new Set<InboxSortKey>(['priority', 'source', 'agent', 'title', 'age', 'status']);
+const SORT_DIRS = new Set<InboxSortDir>(['asc', 'desc']);
+const TRIAGE_AGENT_ID = 'inbox-triage';
+const PENDING_USER_REPLY_WINDOW_MS = 30_000;
+
+function parseSort(req: Request): { sort: InboxSortKey; dir: InboxSortDir } {
+  const sortRaw = typeof req.query.sort === 'string' ? req.query.sort : '';
+  const dirRaw = typeof req.query.dir === 'string' ? req.query.dir : '';
+  const sort = SORT_KEYS.has(sortRaw as InboxSortKey) ? (sortRaw as InboxSortKey) : INBOX_DEFAULT_SORT.sort;
+  const dir = SORT_DIRS.has(dirRaw as InboxSortDir) ? (dirRaw as InboxSortDir) : INBOX_DEFAULT_SORT.dir;
+  return { sort, dir };
+}
+
+function parseFlash(req: Request): { kind: 'ok' | 'error' | 'info'; message: string } | undefined {
+  if (typeof req.query.ok === 'string') return { kind: 'ok', message: req.query.ok };
+  if (typeof req.query.error === 'string') return { kind: 'error', message: req.query.error };
+  if (typeof req.query.info === 'string') return { kind: 'info', message: req.query.info };
+  return undefined;
+}
+
+function isAjax(req: Request): boolean {
+  const xrw = req.get('x-requested-with');
+  if (xrw && xrw.toLowerCase() === 'fetch') return true;
+  const accept = req.get('accept') ?? '';
+  return accept.includes('application/json');
+}
+
 inboxRouter.get('/inbox', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
   const rows = ctx.inboxStore ? ctx.inboxStore.list() : [];
-  res.type('html').send(renderInboxList({ rows }));
+  const { sort, dir } = parseSort(req);
+  res.type('html').send(renderInboxList({ rows, sort, dir, flash: parseFlash(req) }));
 });
 
 inboxRouter.get('/inbox/:id', (req: Request, res: Response) => {
@@ -41,5 +97,263 @@ inboxRouter.get('/inbox/:id', (req: Request, res: Response) => {
     return;
   }
   const responses = ctx.inboxStore.listResponses(id);
-  res.type('html').send(renderInboxDetail({ message, responses }));
+  const triagePending = isTriagePending(ctx, message, responses);
+  res.type('html').send(renderInboxDetail({ message, responses, flash: parseFlash(req), triagePending }));
 });
+
+inboxRouter.get('/inbox/:id/fragment', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  if (!ctx.inboxStore) {
+    res.status(404).type('html').send('<p>Inbox unavailable.</p>');
+    return;
+  }
+  const message = ctx.inboxStore.get(id);
+  if (!message) {
+    res.status(404).type('html').send('<p>Message not found.</p>');
+    return;
+  }
+  const responses = ctx.inboxStore.listResponses(id);
+  const triagePending = isTriagePending(ctx, message, responses);
+  res.type('html').send(render(renderInboxDetailFragment({ message, responses, triagePending })));
+});
+
+inboxRouter.post('/inbox/:id/dismiss', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  if (!ctx.inboxStore || !ctx.inboxStore.get(id)) {
+    if (isAjax(req)) { res.status(404).end(); return; }
+    res.redirect(303, `/inbox?error=${encodeURIComponent('Message not found.')}`);
+    return;
+  }
+  try {
+    ctx.inboxStore.dismiss(id);
+    if (isAjax(req)) { res.status(204).end(); return; }
+    res.redirect(303, `/inbox?ok=${encodeURIComponent('Dismissed.')}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (isAjax(req)) { res.status(500).end(); return; }
+    res.redirect(303, `/inbox/${encodeURIComponent(id)}?error=${encodeURIComponent(`Dismiss failed: ${msg}`)}`);
+  }
+});
+
+inboxRouter.post('/inbox/:id/respond', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const detailUrl = `/inbox/${encodeURIComponent(id)}`;
+  if (!ctx.inboxStore || !ctx.inboxStore.get(id)) {
+    if (isAjax(req)) { res.status(404).end(); return; }
+    res.redirect(303, `/inbox?error=${encodeURIComponent('Message not found.')}`);
+    return;
+  }
+  const bodyRaw = typeof req.body?.body === 'string' ? req.body.body.trim() : '';
+  if (!bodyRaw) {
+    if (isAjax(req)) { res.status(400).end(); return; }
+    res.redirect(303, `${detailUrl}?error=${encodeURIComponent('Reply cannot be empty.')}`);
+    return;
+  }
+  if (bodyRaw.length > 8192) {
+    if (isAjax(req)) { res.status(400).end(); return; }
+    res.redirect(303, `${detailUrl}?error=${encodeURIComponent('Reply is too long (max 8 KB).')}`);
+    return;
+  }
+  try {
+    ctx.inboxStore.addResponse(id, 'user', bodyRaw);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (isAjax(req)) { res.status(500).end(); return; }
+    res.redirect(303, `${detailUrl}?error=${encodeURIComponent(`Reply failed: ${msg}`)}`);
+    return;
+  }
+  // Auto-fire triage. Fire-and-forget; the modal polls /fragment for
+  // the response. The conversation thread itself signals "in progress"
+  // via the user-reply-within-30s heuristic in isTriagePending.
+  void runTriageAgent(ctx, id).catch(() => { /* logged in helper */ });
+
+  if (isAjax(req)) { res.status(204).end(); return; }
+  res.redirect(303, `${detailUrl}?ok=${encodeURIComponent('Reply added.')}`);
+});
+
+inboxRouter.post('/inbox/:id/triage', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const detailUrl = `/inbox/${encodeURIComponent(id)}`;
+  if (!ctx.inboxStore || !ctx.inboxStore.get(id)) {
+    if (isAjax(req)) { res.status(404).end(); return; }
+    res.redirect(303, `/inbox?error=${encodeURIComponent('Message not found.')}`);
+    return;
+  }
+  // Insert a synthetic user "Ask triage" marker so the conversation
+  // shows what the operator just did. The triage agent receives the
+  // updated CONVERSATION and responds.
+  try {
+    ctx.inboxStore.addResponse(id, 'user', '(Asked triage to take another look.)');
+  } catch { /* swallow */ }
+  void runTriageAgent(ctx, id).catch(() => { /* swallow */ });
+  if (isAjax(req)) { res.status(204).end(); return; }
+  res.redirect(303, `${detailUrl}?ok=${encodeURIComponent('Triage agent invoked.')}`);
+});
+
+// ── helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Triage is "pending" if either:
+ *   (a) the message has a triageRunId whose run is in flight, OR
+ *   (b) the most recent response is from the user, posted in the
+ *       last 30 seconds, with no later triage or system reply.
+ *
+ * Branch (b) covers the unavoidable race between POST /respond
+ * returning 204 and the dag-executor inserting its run-store row
+ * (which we'd later capture into triageRunId).
+ */
+function isTriagePending(
+  ctx: ReturnType<typeof getContext>,
+  message: { triageRunId?: string },
+  responses: { role: string; createdAt: number }[],
+): boolean {
+  if (message.triageRunId) {
+    try {
+      const run = ctx.runStore.getRun(message.triageRunId);
+      if (run && (run.status === 'pending' || run.status === 'running')) return true;
+    } catch { /* ignore */ }
+  }
+  if (responses.length === 0) return false;
+  const last = responses[responses.length - 1];
+  if (last.role !== 'user') return false;
+  return Date.now() - last.createdAt < PENDING_USER_REPLY_WINDOW_MS;
+}
+
+/**
+ * Spawn the inbox-triage system agent for a message. Lazy-installs the
+ * YAML on first call (mirrors layout-planner). After the run
+ * completes, parses the `<plan>{...}</plan>` block and appends a
+ * `triage`-role response to the conversation. Sets the message
+ * status to `awaiting_user` so subsequent renders carry the
+ * recommendation context.
+ */
+async function runTriageAgent(
+  ctx: ReturnType<typeof getContext>,
+  messageId: string,
+): Promise<void> {
+  if (!ctx.inboxStore) return;
+  const message = ctx.inboxStore.get(messageId);
+  if (!message) return;
+
+  let triage = ctx.agentStore.getAgent(TRIAGE_AGENT_ID);
+  if (!triage) {
+    try {
+      const yamlPath = join(resolve('agents/examples'), `${TRIAGE_AGENT_ID}.yaml`);
+      const yamlText = readFileSync(yamlPath, 'utf-8');
+      const parsed = parseAgent(yamlText);
+      ctx.agentStore.upsertAgent(parsed, 'import', 'Auto-imported for inbox triage');
+      triage = ctx.agentStore.getAgent(TRIAGE_AGENT_ID);
+    } catch (err) {
+      process.stderr.write(
+        `[inbox-triage] could not load agent yaml: ${(err as Error)?.message ?? String(err)}\n`,
+      );
+      return;
+    }
+  }
+  if (!triage) return;
+
+  const conversation = ctx.inboxStore.listResponses(messageId)
+    .map((r) => `[${r.role}] ${r.body}`)
+    .join('\n');
+
+  let runId: string | undefined;
+  try {
+    const runPromise = executeAgentDag(
+      triage,
+      {
+        triggeredBy: 'dashboard',
+        inputs: {
+          MESSAGE_ID: message.id,
+          MESSAGE_TITLE: message.title,
+          MESSAGE_BODY: message.body,
+          MESSAGE_PRIORITY: message.priority,
+          MESSAGE_SOURCE: message.source,
+          CONTEXT_JSON: message.contextJson ?? '',
+          CONVERSATION: conversation,
+        },
+      },
+      {
+        runStore: ctx.runStore,
+        secretsStore: ctx.secretsStore,
+        variablesStore: ctx.variablesStore,
+        dataRoot: ctx.agentStore.dataRoot,
+      },
+    );
+    // Capture the runId once it lands. Race the executor to avoid
+    // blocking the auto-fire path; the conversation-based pending
+    // heuristic carries us through if this misses.
+    await Promise.race([runPromise, new Promise((r) => setTimeout(r, 250))]);
+    const { rows } = ctx.runStore.queryRuns({
+      agentName: TRIAGE_AGENT_ID,
+      statuses: ['running', 'completed', 'failed', 'pending'] as RunStatus[],
+      limit: 1,
+      offset: 0,
+    });
+    const recent = rows[0];
+    if (recent) {
+      runId = recent.id;
+      try {
+        ctx.inboxStore.updateStatus(
+          messageId,
+          message.status === 'open' ? 'triaged' : message.status,
+          { triageRunId: runId },
+        );
+      } catch { /* ignore — message may have been dismissed mid-flight */ }
+    }
+    const finished = await runPromise;
+    void finished;
+
+    const run = runId ? ctx.runStore.getRun(runId) : null;
+    if (!run || run.status !== 'completed' || !run.result) {
+      ctx.inboxStore.addResponse(
+        messageId,
+        'system',
+        `Triage agent did not complete (${run?.status ?? 'unknown'}). ${run?.error ?? ''}`.trim(),
+      );
+      return;
+    }
+    const planJson = extractPlanJson(run.result);
+    if (!planJson) {
+      ctx.inboxStore.addResponse(
+        messageId,
+        'system',
+        'Triage agent returned no <plan>…</plan> block; raw response was discarded.',
+      );
+      return;
+    }
+    let parsed: { recommendation?: unknown; verifyHint?: unknown };
+    try {
+      parsed = JSON.parse(planJson);
+    } catch {
+      ctx.inboxStore.addResponse(messageId, 'system', 'Triage agent returned malformed JSON.');
+      return;
+    }
+    const rec = typeof parsed.recommendation === 'string' ? parsed.recommendation.trim() : '';
+    if (!rec || rec.length < 10 || rec.length > 2000) {
+      ctx.inboxStore.addResponse(messageId, 'system', 'Triage agent recommendation failed validation.');
+      return;
+    }
+    const verifyHint = typeof parsed.verifyHint === 'string' && parsed.verifyHint.trim()
+      ? parsed.verifyHint.trim()
+      : undefined;
+    ctx.inboxStore.addResponse(
+      messageId,
+      'triage',
+      rec,
+      verifyHint ? JSON.stringify({ verifyHint }) : undefined,
+    );
+    try {
+      ctx.inboxStore.updateStatus(messageId, 'awaiting_user', { recommendation: rec, triageRunId: runId });
+    } catch { /* ignore */ }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`[inbox-triage] run failed: ${msg}\n${(err as Error)?.stack ?? ''}\n`);
+    try {
+      ctx.inboxStore.addResponse(messageId, 'system', `Triage agent crashed: ${msg}`);
+    } catch { /* ignore */ }
+  }
+}

--- a/packages/dashboard/src/views/inbox-detail.ts
+++ b/packages/dashboard/src/views/inbox-detail.ts
@@ -1,4 +1,4 @@
-import type { InboxMessage, InboxResponse } from '@some-useful-agents/core';
+import type { InboxMessage, InboxResponse, InboxResponseRole } from '@some-useful-agents/core';
 import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
@@ -8,6 +8,13 @@ export interface InboxDetailOptions {
   message: InboxMessage;
   responses: InboxResponse[];
   flash?: { kind: 'error' | 'info' | 'ok'; message: string };
+  /**
+   * When true, the triage agent has a run in `pending` or `running` for
+   * this message (or one was just kicked off and the run-store hasn't
+   * caught up yet). The fragment renders a `[data-triage-pending="1"]`
+   * thinking indicator that inbox-modal.js polls on.
+   */
+  triagePending?: boolean;
 }
 
 const PRIORITY_BADGE: Record<string, string> = {
@@ -16,101 +23,126 @@ const PRIORITY_BADGE: Record<string, string> = {
   low: 'badge--muted',
 };
 
-const ROLE_LABEL: Record<string, string> = {
+const SOURCE_LABEL: Record<string, string> = {
+  'run-failure': 'Run failure',
+  'permission-request': 'Permission',
+  'cadence': 'Cadence',
+  'manual': 'Manual',
+};
+
+const ROLE_LABEL: Record<InboxResponseRole, string> = {
   user: 'You',
   triage: 'Triage agent',
   system: 'System',
 };
 
-/**
- * Render the inbox-message detail page. Sections:
- *   - header — priority + source + age + status
- *   - body   — short markdown summary the producer wrote
- *   - context — collapsible <details> of the structured producer payload
- *   - recommendation — triage agent's suggestion (PR 4+)
- *   - responses timeline — conversation thread (PR 4+)
- *
- * Mirrors the run-detail shell pattern but trims to a single-column
- * layout — no DAG / widget panes.
- */
-export function renderInboxDetail(opts: InboxDetailOptions): string {
-  const { message, responses, flash } = opts;
+/** Two-character avatar text per role (mirrors Slack-style avatars). */
+const ROLE_AVATAR: Record<InboxResponseRole, string> = {
+  user: 'You',
+  triage: 'Tri',
+  system: 'Sys',
+};
 
-  const ageIso = new Date(message.createdAt).toISOString();
+/**
+ * Self-contained fragment of the message detail — no <html>, <body>,
+ * or layout chrome. Fetched by `inbox-modal.js` via
+ * `/inbox/:id/fragment` and injected into the modal's content
+ * container. The full-page `renderInboxDetail` wraps this in the
+ * standard dashboard layout for direct-link access + accessibility.
+ */
+export function renderInboxDetailFragment(opts: InboxDetailOptions): SafeHtml {
+  const { message, responses, flash, triagePending } = opts;
   const badgeClass = PRIORITY_BADGE[message.priority] ?? 'badge--muted';
+  const isTerminal = message.status === 'dismissed' || message.status === 'resolved';
+
+  const flashBlock = flash ? html`
+    <div class="flash flash--${flash.kind}" style="margin: 0 0 var(--space-2);">${flash.message}</div>
+  ` : html``;
 
   const headerMeta = html`
-    <div style="display: flex; gap: var(--space-3); align-items: center; flex-wrap: wrap; font-size: var(--font-size-sm); color: var(--color-text-muted); margin-top: var(--space-1);">
+    <div style="display: flex; gap: var(--space-2); align-items: center; flex-wrap: wrap; font-size: var(--font-size-sm); color: var(--color-text-muted); margin-top: var(--space-1);">
       <span class="badge ${badgeClass}">${message.priority}</span>
-      <span>${message.source}</span>
-      <span>${formatAge(ageIso)}</span>
-      <span><span class="badge badge--muted">${message.status}</span></span>
+      <span>${SOURCE_LABEL[message.source] ?? message.source}</span>
+      <span>${formatAge(new Date(message.createdAt).toISOString())}</span>
+      <span class="badge badge--muted">${message.status}</span>
       ${message.agentId ? html`<a href="/agents/${message.agentId}">${message.agentId}</a>` : html``}
       ${message.runId ? html`<a href="/runs/${message.runId}" class="mono">run ${message.runId.slice(0, 8)}</a>` : html``}
     </div>
   `;
 
   const bodyBlock = html`
-    <section class="card" style="margin-top: var(--space-4);">
-      <h3 style="margin: 0 0 var(--space-2);">Details</h3>
+    <section style="margin-top: var(--space-3);">
+      <h4 style="margin: 0 0 var(--space-1); font-size: var(--font-size-sm); text-transform: uppercase; letter-spacing: 0.06em; color: var(--color-text-muted);">Details</h4>
       <div style="white-space: pre-wrap;">${message.body}</div>
     </section>
   `;
 
   const contextBlock = message.contextJson ? html`
-    <section class="card" style="margin-top: var(--space-3);">
-      <details>
-        <summary style="cursor: pointer; font-weight: var(--weight-semibold);">Context payload</summary>
-        <pre class="mono" style="font-size: var(--font-size-xs); margin: var(--space-2) 0 0; overflow-x: auto;">${pretty(message.contextJson)}</pre>
-      </details>
-    </section>
+    <details style="margin-top: var(--space-3);">
+      <summary style="cursor: pointer; font-size: var(--font-size-xs); color: var(--color-text-muted); font-weight: var(--weight-semibold); text-transform: uppercase; letter-spacing: 0.06em;">Context payload</summary>
+      <pre class="mono" style="font-size: var(--font-size-xs); margin: var(--space-2) 0 0; overflow-x: auto; max-height: 12rem;">${pretty(message.contextJson)}</pre>
+    </details>
   ` : html``;
 
-  const recommendationBlock = message.recommendation ? html`
-    <section class="card" style="margin-top: var(--space-3);">
-      <h3 style="margin: 0 0 var(--space-2);">Recommendation</h3>
-      <div style="white-space: pre-wrap;">${message.recommendation}</div>
-      ${message.triageRunId ? html`
-        <p class="dim" style="font-size: var(--font-size-xs); margin: var(--space-2) 0 0;">
-          From triage run <a href="/runs/${message.triageRunId}" class="mono">${message.triageRunId.slice(0, 8)}</a>
-        </p>
-      ` : html``}
-    </section>
-  ` : html``;
+  const timeline = responses.map((r) => renderConversationEntry(r));
 
-  const responsesBlock = responses.length > 0
+  const conversationBlock = html`
+    <section style="margin-top: var(--space-3); padding-top: var(--space-3); border-top: 1px solid var(--color-border);">
+      <h4 style="margin: 0 0 var(--space-2); font-size: var(--font-size-sm); text-transform: uppercase; letter-spacing: 0.06em; color: var(--color-text-muted);">Conversation</h4>
+      ${responses.length === 0 && !triagePending
+        ? html`<p class="dim" style="font-size: var(--font-size-sm); margin: 0 0 var(--space-2);">No replies yet. Post a note below — the triage agent will join automatically.</p>`
+        : html`${timeline as unknown as SafeHtml[]}`}
+      ${triagePending ? renderThinkingIndicator() : html``}
+      ${replyForm(message, triagePending ?? false)}
+    </section>
+  `;
+
+  const actionsBlock = isTerminal
     ? html`
-      <section class="card" style="margin-top: var(--space-3);">
-        <h3 style="margin: 0 0 var(--space-2);">Conversation</h3>
-        ${responses.map((r) => html`
-          <div style="border-top: 1px solid var(--color-border); padding: var(--space-2) 0;">
-            <div style="font-size: var(--font-size-xs); color: var(--color-text-muted); margin-bottom: var(--space-1);">
-              ${ROLE_LABEL[r.role] ?? r.role} · ${formatAge(new Date(r.createdAt).toISOString())}
-            </div>
-            <div style="white-space: pre-wrap;">${r.body}</div>
-          </div>
-        `) as unknown as SafeHtml[]}
-      </section>`
+      <p class="dim" style="margin: var(--space-3) 0 0; font-size: var(--font-size-sm);">
+        This message is ${message.status}.${message.resolvedAt ? html` Closed ${formatAge(new Date(message.resolvedAt).toISOString())}.` : html``}
+      </p>`
     : html`
-      <section class="card" style="margin-top: var(--space-3);">
-        <p class="dim" style="font-size: var(--font-size-sm); margin: 0;">
-          No replies yet. The triage agent + interactive replies ship in upcoming PRs.
-        </p>
-      </section>
+      <div style="margin-top: var(--space-3); display: flex; gap: var(--space-2); align-items: center;">
+        <form method="POST" action="/inbox/${message.id}/triage" data-inbox-modal-form data-inbox-modal-keeps-triage="1" style="margin: 0;">
+          <button type="submit" class="btn btn--sm btn--ghost" ${triagePending ? 'disabled' : ''}>
+            ${triagePending ? 'Triaging…' : 'Ask triage'}
+          </button>
+        </form>
+        <form method="POST" action="/inbox/${message.id}/dismiss" data-inbox-modal-form data-inbox-modal-dismiss-on-success="1" style="margin: 0;">
+          <button type="submit" class="btn btn--sm btn--ghost">Dismiss</button>
+        </form>
+        <span class="dim" style="font-size: var(--font-size-xs); margin-left: auto;">
+          Dismiss closes this thread; Triage re-runs the LLM for a fresh recommendation.
+        </span>
+      </div>
     `;
 
+  return html`
+    <header style="margin: 0;">
+      <h3 id="inbox-modal-title" style="margin: 0;">${message.title}</h3>
+      ${headerMeta}
+    </header>
+    ${flashBlock}
+    ${bodyBlock}
+    ${contextBlock}
+    ${conversationBlock}
+    ${actionsBlock}
+  `;
+}
+
+/** Full-page render — used for direct `/inbox/:id` GETs (fallback). */
+export function renderInboxDetail(opts: InboxDetailOptions): string {
+  const { message, flash } = opts;
   const pageBody = html`
     ${pageHeader({
       title: message.title,
       back: { href: '/inbox', label: 'Inbox' },
     })}
-    ${headerMeta}
-    ${bodyBlock}
-    ${contextBlock}
-    ${recommendationBlock}
-    ${responsesBlock}
+    <section class="card" style="margin-top: var(--space-3);">
+      ${renderInboxDetailFragment(opts)}
+    </section>
   `;
-
   return render(layout({
     title: `${message.title} · Inbox`,
     activeNav: 'inbox',
@@ -118,15 +150,74 @@ export function renderInboxDetail(opts: InboxDetailOptions): string {
   }, pageBody));
 }
 
-/**
- * Pretty-print a JSON string for the collapsible context panel. If the
- * payload isn't valid JSON we display it verbatim — context_json is
- * producer-controlled and we'd rather show garbage than crash.
- */
 function pretty(raw: string): string {
   try {
     return JSON.stringify(JSON.parse(raw), null, 2);
   } catch {
     return raw;
   }
+}
+
+/**
+ * Slack-style conversation entry: avatar + name + time + body. The
+ * `data-msg-id` attribute lets the modal JS detect new entries
+ * between refreshes and animate them in once.
+ */
+function renderConversationEntry(r: InboxResponse): SafeHtml {
+  const role = (ROLE_LABEL[r.role] ?? r.role);
+  const avatar = ROLE_AVATAR[r.role] ?? r.role.slice(0, 1).toUpperCase();
+  return html`
+    <div class="inbox-msg" data-msg-id="${r.id}">
+      <div class="inbox-msg__avatar inbox-msg__avatar--${r.role}">${avatar}</div>
+      <div class="inbox-msg__body">
+        <div class="inbox-msg__meta">
+          <span class="inbox-msg__meta-name">${role}</span>
+          <span>${formatAge(new Date(r.createdAt).toISOString())}</span>
+        </div>
+        <div class="inbox-msg__text">${r.body}</div>
+      </div>
+    </div>
+  `;
+}
+
+/** Pulsing-dots "Triage agent is thinking…" indicator. */
+function renderThinkingIndicator(): SafeHtml {
+  return html`
+    <div class="inbox-thinking" data-triage-pending="1">
+      <div class="inbox-thinking__avatar">Tri</div>
+      <div>
+        Triage agent is thinking
+        <span class="inbox-thinking__dots"><span></span><span></span><span></span></span>
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * Reply form. Disabled while triage is pending so the user can't
+ * queue a second turn before the first response lands. Carries
+ * `data-inbox-modal-keeps-triage` so the JS bumps the polling
+ * deadline on submit (covers the race where the dag-executor
+ * hasn't inserted its run row yet).
+ */
+function replyForm(message: InboxMessage, triagePending: boolean): SafeHtml {
+  if (message.status === 'dismissed' || message.status === 'resolved') return html``;
+  return html`
+    <form method="POST" action="/inbox/${message.id}/respond" data-inbox-modal-form data-inbox-modal-keeps-triage="1"
+      style="margin: var(--space-3) 0 0; padding-top: var(--space-2); border-top: 1px solid var(--color-border); display: flex; flex-direction: column; gap: var(--space-2);">
+      <label style="font-size: var(--font-size-xs); color: var(--color-text-muted);">
+        Reply
+      </label>
+      <textarea name="body" rows="3" required maxlength="8192"
+        ${triagePending ? 'disabled' : ''}
+        placeholder="Describe what you tried, ask a follow-up, or note a decision. The triage agent will respond."
+        class="form-field"
+        style="padding: var(--space-2); font-size: var(--font-size-sm); resize: vertical;"></textarea>
+      <div style="display: flex; justify-content: flex-end;">
+        <button type="submit" class="btn btn--sm btn--primary" ${triagePending ? 'disabled' : ''}>
+          ${triagePending ? 'Waiting on triage…' : 'Post reply'}
+        </button>
+      </div>
+    </form>
+  `;
 }

--- a/packages/dashboard/src/views/inbox-list.ts
+++ b/packages/dashboard/src/views/inbox-list.ts
@@ -1,87 +1,124 @@
-import type { InboxMessage, InboxPriority } from '@some-useful-agents/core';
+import type { InboxMessage, InboxPriority, InboxSource } from '@some-useful-agents/core';
 import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
 import { formatAge } from './components.js';
+import { renderInboxModalShell } from './inbox-modal.js';
+
+export type InboxSortKey = 'priority' | 'source' | 'agent' | 'title' | 'age' | 'status';
+export type InboxSortDir = 'asc' | 'desc';
 
 export interface InboxListOptions {
   rows: InboxMessage[];
+  sort: InboxSortKey;
+  dir: InboxSortDir;
   flash?: { kind: 'error' | 'info' | 'ok'; message: string };
 }
 
-const PRIORITY_LABEL: Record<InboxPriority, string> = {
-  high: 'High',
-  medium: 'Medium',
-  low: 'Low',
+export const INBOX_DEFAULT_SORT: { sort: InboxSortKey; dir: InboxSortDir } = {
+  sort: 'priority',
+  dir: 'asc',
 };
 
-const PRIORITY_HINT: Record<InboxPriority, string> = {
-  high: 'Failed runs and other action-needed-now items',
-  medium: 'Authorisations and pending decisions',
-  low: 'Housekeeping reminders',
+const PRIORITY_BADGE: Record<InboxPriority, string> = {
+  high: 'badge--warn',
+  medium: 'badge--info',
+  low: 'badge--muted',
 };
 
-const SOURCE_LABEL: Record<string, string> = {
+const SOURCE_LABEL: Record<InboxSource, string> = {
   'run-failure': 'Run failure',
   'permission-request': 'Permission',
   'cadence': 'Cadence',
   'manual': 'Manual',
 };
 
+const SOURCE_BADGE: Record<InboxSource, string> = {
+  'run-failure': 'badge--warn',
+  'permission-request': 'badge--info',
+  'cadence': 'badge--muted',
+  'manual': 'badge--muted',
+};
+
+const PRIORITY_RANK: Record<InboxPriority, number> = { high: 0, medium: 1, low: 2 };
+
 /**
- * Render the inbox list page. Rows are grouped by priority into three
- * sections (High / Medium / Low) so the operator's eye lands on the
- * urgent items first. Within each section, rows are newest-first.
- * Mirrors the list-table pattern from runs-list.ts but groups
- * vertically instead of using a single sortable table.
+ * Client-side sort. Keeps the store API focused on its canonical
+ * priority+age order and lets the UI own presentation.
+ */
+export function sortMessages(
+  rows: InboxMessage[],
+  sort: InboxSortKey,
+  dir: InboxSortDir,
+): InboxMessage[] {
+  const sign = dir === 'asc' ? 1 : -1;
+  const copy = rows.slice();
+  copy.sort((a, b) => {
+    switch (sort) {
+      case 'priority':
+        return sign * (PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority])
+          || (b.createdAt - a.createdAt);
+      case 'age':
+        return dir === 'asc' ? a.createdAt - b.createdAt : b.createdAt - a.createdAt;
+      case 'source':
+        return sign * a.source.localeCompare(b.source) || (b.createdAt - a.createdAt);
+      case 'agent':
+        return sign * (a.agentId ?? '').localeCompare(b.agentId ?? '') || (b.createdAt - a.createdAt);
+      case 'title':
+        return sign * a.title.localeCompare(b.title);
+      case 'status':
+        return sign * a.status.localeCompare(b.status) || (b.createdAt - a.createdAt);
+      default:
+        return 0;
+    }
+  });
+  return copy;
+}
+
+function sortUrl(col: InboxSortKey, current: { sort: InboxSortKey; dir: InboxSortDir }): string {
+  const sameCol = col === current.sort;
+  const dir: InboxSortDir = sameCol
+    ? (current.dir === 'asc' ? 'desc' : 'asc')
+    : (col === 'age' || col === 'status') ? 'desc' : 'asc';
+  const params = new URLSearchParams();
+  if (col !== INBOX_DEFAULT_SORT.sort) params.set('sort', col);
+  if (dir !== INBOX_DEFAULT_SORT.dir || col !== INBOX_DEFAULT_SORT.sort) params.set('dir', dir);
+  const qs = params.toString();
+  return qs ? `/inbox?${qs}` : '/inbox';
+}
+
+function sortIndicator(col: InboxSortKey, current: { sort: InboxSortKey; dir: InboxSortDir }): string {
+  if (col !== current.sort) return '';
+  return current.dir === 'asc' ? ' ↑' : ' ↓';
+}
+
+/**
+ * Single sortable grid. Each `<tr>` carries `data-inbox-row-id` so
+ * inbox-modal.js intercepts clicks and opens the message in a modal
+ * — no page navigation. The `<a>` inside still navigates as a
+ * fallback for right-click "open in new tab" + no-JS users.
  */
 export function renderInboxList(opts: InboxListOptions): string {
-  const { rows, flash } = opts;
+  const { rows, sort, dir, flash } = opts;
+  const sorted = sortMessages(rows, sort, dir);
+  const current = { sort, dir };
 
-  const groups: Record<InboxPriority, InboxMessage[]> = {
-    high: rows.filter((r) => r.priority === 'high'),
-    medium: rows.filter((r) => r.priority === 'medium'),
-    low: rows.filter((r) => r.priority === 'low'),
-  };
+  const header = (col: InboxSortKey, label: string): SafeHtml => html`
+    <th><a href="${sortUrl(col, current)}" class="inbox-sort-header">${label}${sortIndicator(col, current)}</a></th>
+  `;
 
-  const sections = (Object.keys(groups) as InboxPriority[]).map((priority) => {
-    const items = groups[priority];
-    if (items.length === 0) return html``;
-    const tbody = items.map((m) => html`
-      <tr>
-        <td>${m.agentId ? html`<a href="/agents/${m.agentId}">${m.agentId}</a>` : html`<span class="dim">—</span>`}</td>
-        <td><a href="/inbox/${m.id}">${m.title}</a></td>
-        <td class="dim">${SOURCE_LABEL[m.source] ?? m.source}</td>
-        <td class="dim">${formatAge(new Date(m.createdAt).toISOString())}</td>
-        <td><span class="badge badge--muted">${m.status}</span></td>
-      </tr>
-    `);
-    return html`
-      <section style="margin-bottom: var(--space-5);">
-        <h2 style="margin: 0 0 var(--space-1); font-size: var(--font-size-lg);">
-          ${PRIORITY_LABEL[priority]}
-          <span class="dim" style="font-weight: var(--weight-regular); font-size: var(--font-size-sm); margin-left: var(--space-2);">
-            ${String(items.length)} ${items.length === 1 ? 'item' : 'items'}
-          </span>
-        </h2>
-        <p class="dim" style="font-size: var(--font-size-xs); margin: 0 0 var(--space-2);">${PRIORITY_HINT[priority]}</p>
-        <table class="table">
-          <thead>
-            <tr>
-              <th>Agent</th>
-              <th>Title</th>
-              <th>Source</th>
-              <th>Age</th>
-              <th>Status</th>
-            </tr>
-          </thead>
-          <tbody>${tbody as unknown as SafeHtml[]}</tbody>
-        </table>
-      </section>
-    `;
-  });
+  const tbody = sorted.map((m) => html`
+    <tr data-inbox-row-id="${m.id}" class="inbox-row">
+      <td><span class="badge ${PRIORITY_BADGE[m.priority]}">${m.priority}</span></td>
+      <td><span class="badge ${SOURCE_BADGE[m.source]}">${SOURCE_LABEL[m.source]}</span></td>
+      <td>${m.agentId ? html`<a href="/agents/${m.agentId}" data-inbox-row-stop>${m.agentId}</a>` : html`<span class="dim">—</span>`}</td>
+      <td><a href="/inbox/${m.id}" data-inbox-row-link>${m.title}</a></td>
+      <td class="dim">${formatAge(new Date(m.createdAt).toISOString())}</td>
+      <td><span class="badge badge--muted">${m.status}</span></td>
+    </tr>
+  `);
 
-  const empty = rows.length === 0
+  const table = rows.length === 0
     ? html`
       <div class="settings-empty mt-0">
         <h3 class="mt-0">Inbox zero</h3>
@@ -91,15 +128,29 @@ export function renderInboxList(opts: InboxListOptions): string {
           with <code>SUA_INBOX_DEMO=1</code>.
         </p>
       </div>`
-    : html``;
+    : html`
+      <table class="table inbox-table">
+        <thead>
+          <tr>
+            ${header('priority', 'Priority')}
+            ${header('source', 'Source')}
+            ${header('agent', 'Agent')}
+            ${header('title', 'Title')}
+            ${header('age', 'Age')}
+            ${header('status', 'Status')}
+          </tr>
+        </thead>
+        <tbody>${tbody as unknown as SafeHtml[]}</tbody>
+      </table>
+    `;
 
   const body = html`
     ${pageHeader({
       title: 'Inbox',
-      description: 'Things that need your attention, ordered by priority.',
+      description: 'Things that need your attention. Click a row to open. Click a column header to sort.',
     })}
-    ${empty}
-    ${sections as unknown as SafeHtml[]}
+    ${table}
+    ${renderInboxModalShell()}
   `;
 
   return render(layout({ title: 'Inbox', activeNav: 'inbox', flash }, body));

--- a/packages/dashboard/src/views/inbox-modal.js.ts
+++ b/packages/dashboard/src/views/inbox-modal.js.ts
@@ -1,0 +1,202 @@
+/**
+ * Inbox modal — fluid in-page detail view with Slack-style live thread.
+ *
+ * Wires:
+ *   - row click → fetch /inbox/:id/fragment → reveal modal
+ *   - Reply / Dismiss / Ask-triage forms inside the modal → fetch POST
+ *   - after every mutation: re-fetch the fragment so the DOM matches state
+ *   - while [data-triage-pending="1"] OR within 30s of a user reply,
+ *     poll the fragment every 1.5s so the agent's reply appears without
+ *     user action
+ *   - track conversation entries by data-msg-id; new ones get a
+ *     `.inbox-msg--new` class so the CSS animation plays exactly once
+ *   - auto-scroll the conversation to the bottom when new content lands
+ *
+ * Dismiss closes the modal and removes the row from the list locally so
+ * the queue shrinks immediately (no full /inbox reload).
+ */
+
+export const INBOX_MODAL_JS = `
+(function () {
+  var modal = document.getElementById('inbox-modal');
+  if (!modal) return;
+  var content = document.getElementById('inbox-modal-content');
+  if (!content) return;
+
+  // Per-open state.
+  var currentId = null;
+  var pollTimer = null;
+  // Tracks ids we've already shown — anything new on the next fetch
+  // gets the slide-in animation class.
+  var seenMsgIds = Object.create(null);
+  // After a user reply we keep polling for up to ~30s even if the
+  // server hasn't yet attached a triageRunId to the message — the
+  // dag-executor + run-store insertion is racy with our 200ms wait.
+  var keepPollingUntil = 0;
+
+  function open() {
+    modal.hidden = false;
+    modal.classList.add('is-open');
+    document.body.style.overflow = 'hidden';
+  }
+  function close() {
+    modal.hidden = true;
+    modal.classList.remove('is-open');
+    document.body.style.overflow = '';
+    currentId = null;
+    seenMsgIds = Object.create(null);
+    keepPollingUntil = 0;
+    stopPoll();
+  }
+
+  function stopPoll() {
+    if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; }
+  }
+
+  function shouldKeepPolling() {
+    if (content.querySelector('[data-triage-pending="1"]')) return true;
+    if (Date.now() < keepPollingUntil) return true;
+    return false;
+  }
+
+  function maybeSchedulePoll() {
+    stopPoll();
+    if (!currentId) return;
+    if (!shouldKeepPolling()) return;
+    pollTimer = setTimeout(function () { refresh(); }, 1500);
+  }
+
+  function applyAnimations() {
+    // Mark new conversation entries so the CSS @keyframes plays. Skip
+    // animation on the very first render (everything would slide in
+    // at once — distracting). Only entries that weren't in the
+    // previous seenMsgIds set get the class.
+    var firstRender = Object.keys(seenMsgIds).length === 0;
+    var msgs = content.querySelectorAll('[data-msg-id]');
+    for (var i = 0; i < msgs.length; i++) {
+      var el = msgs[i];
+      var id = el.getAttribute('data-msg-id');
+      if (!firstRender && !seenMsgIds[id]) el.classList.add('inbox-msg--new');
+      seenMsgIds[id] = true;
+    }
+  }
+
+  function scrollToBottom() {
+    // Defer to next frame so any new content has laid out.
+    requestAnimationFrame(function () {
+      content.scrollTop = content.scrollHeight;
+    });
+  }
+
+  function refresh() {
+    if (!currentId) return;
+    var id = currentId;
+    fetch('/inbox/' + encodeURIComponent(id) + '/fragment', { credentials: 'same-origin' })
+      .then(function (r) { if (!r.ok) throw new Error('fragment fetch failed'); return r.text(); })
+      .then(function (text) {
+        if (currentId !== id) return; // user opened a different message
+        content.innerHTML = text;
+        applyAnimations();
+        scrollToBottom();
+        focusFirstInteractive();
+        maybeSchedulePoll();
+      })
+      .catch(function () { /* swallow; user can close + retry */ });
+  }
+
+  function focusFirstInteractive() {
+    var ta = content.querySelector('textarea[name="body"]');
+    if (ta && !ta.disabled) { ta.focus(); return; }
+    var btn = content.querySelector('button:not([disabled]), a');
+    if (btn) btn.focus();
+  }
+
+  function openFor(id) {
+    currentId = id;
+    seenMsgIds = Object.create(null);
+    keepPollingUntil = 0;
+    content.innerHTML = '<p class="dim" style="margin:0;padding:var(--space-4) 0;text-align:center;">Loading…</p>';
+    open();
+    refresh();
+  }
+
+  // Row click → modal.
+  document.addEventListener('click', function (e) {
+    var stop = e.target.closest && e.target.closest('[data-inbox-row-stop]');
+    if (stop) return;
+
+    var titleLink = e.target.closest && e.target.closest('[data-inbox-row-link]');
+    if (titleLink) {
+      e.preventDefault();
+      var row1 = titleLink.closest('[data-inbox-row-id]');
+      if (row1) openFor(row1.getAttribute('data-inbox-row-id'));
+      return;
+    }
+
+    var row = e.target.closest && e.target.closest('[data-inbox-row-id]');
+    if (row) {
+      e.preventDefault();
+      openFor(row.getAttribute('data-inbox-row-id'));
+      return;
+    }
+
+    if (e.target === modal || (e.target.closest && e.target.closest('[data-inbox-modal-close]'))) {
+      close();
+    }
+  });
+
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && !modal.hidden) close();
+  });
+
+  // Intercept Reply / Dismiss / Triage form submits inside the modal.
+  modal.addEventListener('submit', function (e) {
+    var form = e.target;
+    if (!(form instanceof HTMLFormElement)) return;
+    if (!form.hasAttribute('data-inbox-modal-form')) return;
+    e.preventDefault();
+    var action = form.getAttribute('action');
+    var method = (form.getAttribute('method') || 'POST').toUpperCase();
+    var formData = new FormData(form);
+    var submits = form.querySelectorAll('button[type="submit"]');
+    for (var i = 0; i < submits.length; i++) submits[i].disabled = true;
+    var dismissAfter = form.getAttribute('data-inbox-modal-dismiss-on-success') === '1';
+    // /respond and /triage both auto-fire the triage agent server-side.
+    // Bump the polling deadline so we catch the response even if the
+    // server's triageRunId capture races our first refresh.
+    var keepsTriagePolling = form.getAttribute('data-inbox-modal-keeps-triage') === '1';
+    if (keepsTriagePolling) keepPollingUntil = Date.now() + 30000;
+
+    fetch(action, {
+      method: method,
+      credentials: 'same-origin',
+      body: new URLSearchParams(Array.from(formData.entries())).toString(),
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'X-Requested-With': 'fetch',
+      },
+    })
+      .then(function (r) {
+        if (!r.ok) throw new Error('mutation failed: ' + r.status);
+      })
+      .then(function () {
+        if (dismissAfter) {
+          var row = document.querySelector('[data-inbox-row-id="' + cssEscape(currentId || '') + '"]');
+          if (row && row.parentNode) row.parentNode.removeChild(row);
+          close();
+        } else {
+          refresh();
+        }
+      })
+      .catch(function () {
+        for (var i = 0; i < submits.length; i++) submits[i].disabled = false;
+      });
+  });
+
+  function cssEscape(s) {
+    return String(s).replace(/[^a-zA-Z0-9_-]/g, function (c) {
+      return '\\\\' + c.charCodeAt(0).toString(16) + ' ';
+    });
+  }
+})();
+`;

--- a/packages/dashboard/src/views/inbox-modal.ts
+++ b/packages/dashboard/src/views/inbox-modal.ts
@@ -1,0 +1,24 @@
+import { html, type SafeHtml } from './html.js';
+
+/**
+ * The modal shell lives once on /inbox and stays empty until the
+ * inbox-modal.js bundle opens it. Click a row → fetch the fragment
+ * → inject into `#inbox-modal-content` → reveal.
+ *
+ * The full-page `/inbox/:id` route still works as a fallback for
+ * right-click "open in new tab" and no-JS users.
+ */
+export function renderInboxModalShell(): SafeHtml {
+  return html`
+    <div class="modal-backdrop" id="inbox-modal" role="dialog" aria-modal="true" aria-labelledby="inbox-modal-title" hidden>
+      <div class="modal" style="max-width: 44rem; max-height: 88vh; display: flex; flex-direction: column;">
+        <div id="inbox-modal-content" style="flex: 1; overflow-y: auto; min-height: 0;">
+          <p class="dim" style="margin: 0; padding: var(--space-4) 0; text-align: center;">Loading…</p>
+        </div>
+        <div class="modal__actions" style="justify-content: flex-end; margin-top: var(--space-3); padding-top: var(--space-3); border-top: 1px solid var(--color-border); flex-shrink: 0;">
+          <button type="button" class="btn btn--ghost" data-inbox-modal-close>Close</button>
+        </div>
+      </div>
+    </div>
+  `;
+}

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -19,6 +19,7 @@ import { CSP_ALLOW_JS } from './csp-allow.js.js';
 import { CSP_IMG_REPORT_JS } from './csp-img-report.js.js';
 import { WIDGET_IMG_FALLBACK_JS } from './widget-img-fallback.js.js';
 import { INSTALL_PACKS_MODAL_JS } from './install-packs-modal.js.js';
+import { INBOX_MODAL_JS } from './inbox-modal.js.js';
 import { footer } from './footer.js';
 
 export interface LayoutOptions {
@@ -84,7 +85,7 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
   ${body}
 </main>
 ${footer()}
-<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + PULSE_MASONRY_JS + HOME_LAYOUT_JS + DASHBOARDS_LAYOUT_JS + BUILD_FROM_GOAL_JS + IMPROVE_LAYOUT_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS + WIDGET_REPLAY_INPLACE_JS + PAGE_INTRO_JS + ADD_TILE_MODAL_JS + CSP_ALLOW_JS + CSP_IMG_REPORT_JS + WIDGET_IMG_FALLBACK_JS + INSTALL_PACKS_MODAL_JS)}</script>
+<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + PULSE_MASONRY_JS + HOME_LAYOUT_JS + DASHBOARDS_LAYOUT_JS + BUILD_FROM_GOAL_JS + IMPROVE_LAYOUT_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS + WIDGET_REPLAY_INPLACE_JS + PAGE_INTRO_JS + ADD_TILE_MODAL_JS + CSP_ALLOW_JS + CSP_IMG_REPORT_JS + WIDGET_IMG_FALLBACK_JS + INSTALL_PACKS_MODAL_JS + INBOX_MODAL_JS)}</script>
 </body>
 </html>`;
 }


### PR DESCRIPTION
## Summary
- Row click on `/inbox` opens an **in-place modal** — no page navigation, no scroll loss
- Conversation thread renders **Slack-style**: role-coded avatars (YOU teal, TRI info-blue, SYS muted), name + timestamp + body, one-shot slide-in animation on new entries, auto-scroll to bottom on new content
- Animated **three-dot "thinking…" indicator** while the triage agent is responding (Slack-style pulsing)
- **Triage agent joins the thread automatically** — POST `/respond` auto-fires `inbox-triage` (new system agent, `source: examples`); the modal polls until the agent's `<plan>{recommendation, verifyHint}</plan>` lands and appears as a `triage`-role response
- **Polling race fixed**: modal force-polls for 30s after every Reply / Ask-triage, in addition to honouring `data-triage-pending="1"`. Server also reports pending when the latest response is a user reply <30s old with no later triage reply. Closes the window where the dag-executor's run-store row landed after the modal's first refresh and polling stopped before the agent's reply appeared.
- Single sortable grid (Priority / Source / Agent / Title / Age / Status) with colored badges per priority + source
- Dual-mode mutation routes: 204 for AJAX (modal fetch) / 303 for plain form posts (fallback page)
- 16 route tests + dogfooded screenshot showing the modal with avatars, conversation, and reply form

## Dogfood evidence
Modal opens over the list; conversation rendered with role-coded avatars; posted a reply; agent's recommendation appeared in the thread without a reload. Screenshot in working tree.

## Why
User feedback on the previous take:
> "this ui should feel more like a slack conversation, with animated reveals and … while the agent is thinking, items time stamped and including an icon or similar. 'Post reply' should trigger the triage agent to reply"

The triage agent had been silently failing to join the thread because the modal stopped polling before the agent's run-store row landed. This PR fixes both the UX and the reliability gap.

## Test plan
- [x] `npx vitest run packages/dashboard/src/routes/inbox.test.ts` — 16 tests (sort, fragment with avatars, pending indicator, all three mutation routes in both modes)
- [x] Full suite: `npx vitest run` — 1745 passing (2 known parallel-temp-dir flakes pass in isolation)
- [x] Clean build green
- [x] Manual: open modal → see avatars + meta + body in conversation; "Triage agent is thinking…" with pulsing dots while waiting; agent's reply appears in thread
- [ ] Manual: post a Reply, watch dots animate, confirm recommendation arrives without reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)