### PR TITLE
feat(dashboard): inbox triage can propose runnable sub-agent actions

### DIFF
--- a/.changeset/inbox-triage-actions.md
+++ b/.changeset/inbox-triage-actions.md
@@ -1,0 +1,29 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox triage can now propose running sub-agents on your behalf.
+
+The `inbox-triage` agent learns about an `ALLOWED_SUB_AGENTS` allowlist
+and may include an `actions[]` array in its `<plan>` block. The
+dashboard renders each proposed action as a card in the conversation
+thread with Run / Skip controls — nothing executes until the operator
+clicks Run. Running an action invokes the target agent via
+`executeAgentDag`, streams the row through `proposed → running →
+completed | failed`, and surfaces a result preview + run link. After
+the last proposed action resolves and at least one ran, triage gets a
+follow-up turn to summarize what came back.
+
+New: `action` response role, `InboxActionMeta` payload (stored in
+`inbox_responses.meta_json`), and routes `POST /inbox/:id/actions/:rid/run`
+and `/skip`. Modal polling extends to keep refreshing while any action
+is in `running` state. Hard cap of 10 actions per message guards
+against runaway proposal loops; out-of-allowlist or malformed actions
+land as `system` refusal notes.
+
+The v1 allowlist is hardcoded to `suggest-improvements` (intersected
+with installed agents at runtime).

--- a/agents/examples/inbox-triage.yaml
+++ b/agents/examples/inbox-triage.yaml
@@ -55,6 +55,16 @@ inputs:
     description: >
       The conversation thread to date, one entry per line as
       `[ROLE] body`. Empty on the first triage of a fresh message.
+  ALLOWED_SUB_AGENTS:
+    type: string
+    required: false
+    default: ""
+    description: >
+      Comma-separated list of agent ids the triage agent may propose
+      running on the operator's behalf (e.g. "suggest-improvements").
+      Proposals targeting an id not in this list are refused at the
+      route layer with a visible note in the conversation. Empty means
+      the triage agent is text-only and must not propose `actions`.
 
 nodes:
   - id: triage
@@ -88,6 +98,9 @@ nodes:
       Conversation so far (may be empty — you are the first responder):
       {{inputs.CONVERSATION}}
 
+      Agents you may propose running on the operator's behalf (may be empty):
+      {{inputs.ALLOWED_SUB_AGENTS}}
+
       ════════════════════════════════════════════════════════════════
       WHAT TO RECOMMEND
       ════════════════════════════════════════════════════════════════
@@ -113,11 +126,41 @@ nodes:
         ask from the operator and respond to it directly.
 
       ════════════════════════════════════════════════════════════════
+      PROPOSING ACTIONS
+      ════════════════════════════════════════════════════════════════
+
+      When `ALLOWED_SUB_AGENTS` is non-empty AND running one of those
+      agents would help the operator (e.g. produce a diagnosis,
+      suggest a fix, summarize a noisy log), include an `actions`
+      array in the plan. Each entry proposes running ONE sub-agent.
+      The dashboard renders these as Run / Skip cards inline in the
+      conversation — they DO NOT auto-execute. The operator clicks
+      Run to actually invoke the sub-agent; you (the triage agent)
+      then get a follow-up turn to summarize what came back.
+
+      Rules:
+      - Only propose `agentId`s that appear verbatim in `ALLOWED_SUB_AGENTS`.
+      - At most 3 actions per turn. Keep them tight and complementary,
+        not redundant.
+      - `inputs` keys must be plausible inputs for the target agent
+        (use the agent id + your prior knowledge). Values must be strings.
+      - `rationale` is shown to the operator under the Run/Skip
+        buttons — explain in one sentence why this action helps.
+      - If the conversation already shows a prior action of the same
+        kind that ran and completed, DO NOT propose it again — instead
+        summarize its result in `recommendation`.
+
+      If `ALLOWED_SUB_AGENTS` is empty OR no action would help, omit
+      `actions` entirely (or send an empty array). Text-only
+      recommendations are perfectly fine.
+
+      ════════════════════════════════════════════════════════════════
       OUTPUT FORMAT — exact shape, single <plan>...</plan> block
       ════════════════════════════════════════════════════════════════
 
       Wrap the JSON in <plan>…</plan> tags. Output ONLY the <plan>
-      block — no preamble, no markdown fences around it. Example:
+      block — no preamble, no markdown fences around it. Example
+      (text-only, no actions proposed):
 
       <plan>
       {
@@ -127,11 +170,33 @@ nodes:
       }
       </plan>
 
+      Example with a proposed sub-agent action (only when
+      `suggest-improvements` is in ALLOWED_SUB_AGENTS):
+
+      <plan>
+      {
+        "messageId": "{{inputs.MESSAGE_ID}}",
+        "recommendation": "The agent's prompt asks for JSON but doesn't pin the schema. I can run suggest-improvements on it for a concrete diff.",
+        "actions": [
+          {
+            "type": "run-agent",
+            "agentId": "suggest-improvements",
+            "inputs": { "AGENT_ID": "demo-failing-agent" },
+            "rationale": "Get a concrete prompt-schema fix to apply."
+          }
+        ]
+      }
+      </plan>
+
       VALIDATION RULES (failing these means the route discards the response):
       - `messageId` MUST equal {{inputs.MESSAGE_ID}}.
       - `recommendation` is required, 10..2000 chars, plain text or simple markdown.
       - `verifyHint` is optional — set it when the operator can re-run
         a known action to confirm the fix. Leave it absent for
         ambiguous or judgement-call recommendations.
+      - `actions` is optional. When present, must be an array of 0..3
+        entries each with `type: "run-agent"`, a string `agentId` in
+        the allowlist, an optional string-to-string `inputs` map, and
+        a `rationale` string.
     maxTurns: 1
     timeout: 60

--- a/packages/core/src/inbox-store.test.ts
+++ b/packages/core/src/inbox-store.test.ts
@@ -166,6 +166,47 @@ describe('InboxStore.addResponse + listResponses', () => {
     const responses = store.listResponses(m.id);
     expect(responses[0].metaJson).toBe('{"host":"apod.nasa.gov"}');
   });
+
+  it('accepts the `action` role for sub-agent proposals', () => {
+    const m = addMinimal();
+    const meta = JSON.stringify({
+      kind: 'action', status: 'proposed', agentId: 'suggest-improvements',
+      inputs: { TOPIC: 't' }, rationale: 'try it',
+    });
+    const r = store.addResponse(m.id, 'action', 'Run suggest-improvements.', meta);
+    expect(r.role).toBe('action');
+    const fetched = store.getResponse(r.id);
+    expect(fetched?.role).toBe('action');
+    expect(fetched?.metaJson).toBe(meta);
+  });
+});
+
+describe('InboxStore.getResponse + updateResponse', () => {
+  it('getResponse returns null for unknown ids', () => {
+    expect(store.getResponse('nope')).toBeNull();
+  });
+
+  it('updateResponse patches body and/or metaJson, leaves untouched fields alone', () => {
+    const m = addMinimal();
+    const r = store.addResponse(m.id, 'action', 'initial', JSON.stringify({ kind: 'action', status: 'proposed', agentId: 'x', inputs: {} }));
+    store.updateResponse(r.id, { metaJson: JSON.stringify({ kind: 'action', status: 'running', agentId: 'x', inputs: {}, startedAt: 1 }) });
+    const after = store.getResponse(r.id);
+    expect(after?.body).toBe('initial');
+    expect(JSON.parse(after!.metaJson!).status).toBe('running');
+    store.updateResponse(r.id, { body: 'updated body' });
+    expect(store.getResponse(r.id)?.body).toBe('updated body');
+  });
+
+  it('updateResponse with metaJson=null clears the meta', () => {
+    const m = addMinimal();
+    const r = store.addResponse(m.id, 'action', 'b', JSON.stringify({ kind: 'action', status: 'proposed', agentId: 'x', inputs: {} }));
+    store.updateResponse(r.id, { metaJson: null });
+    expect(store.getResponse(r.id)?.metaJson).toBeUndefined();
+  });
+
+  it('updateResponse throws on unknown id', () => {
+    expect(() => store.updateResponse('nope', { body: 'x' })).toThrow(/no response with id/);
+  });
 });
 
 describe('InboxStore.findByDedupeKey', () => {

--- a/packages/core/src/inbox-store.ts
+++ b/packages/core/src/inbox-store.ts
@@ -39,8 +39,46 @@ export type InboxStatus = typeof INBOX_STATUSES[number];
 export const INBOX_SOURCES = ['run-failure', 'permission-request', 'cadence', 'manual'] as const;
 export type InboxSource = typeof INBOX_SOURCES[number];
 
-export const INBOX_RESPONSE_ROLES = ['user', 'triage', 'system'] as const;
+export const INBOX_RESPONSE_ROLES = ['user', 'triage', 'system', 'action'] as const;
 export type InboxResponseRole = typeof INBOX_RESPONSE_ROLES[number];
+
+/**
+ * Lifecycle for an `action`-role response (triage proposing a sub-agent
+ * run). State transitions: `proposed` → `running` → `completed | failed`,
+ * or `proposed` → `skipped`. `refused` is terminal when allowlist /
+ * depth checks reject the proposal at insert time.
+ */
+export const INBOX_ACTION_STATUSES = [
+  'proposed',
+  'running',
+  'completed',
+  'failed',
+  'skipped',
+  'refused',
+] as const;
+export type InboxActionStatus = typeof INBOX_ACTION_STATUSES[number];
+
+/**
+ * Structured payload stored in `inbox_responses.meta_json` for
+ * `action`-role rows. The view + route read this to drive Run/Skip
+ * buttons and status rendering; the body field is just a
+ * human-readable rationale.
+ */
+export interface InboxActionMeta {
+  kind: 'action';
+  status: InboxActionStatus;
+  agentId: string;
+  inputs: Record<string, string>;
+  rationale?: string;
+  /** Sub-agent run id once execution starts. */
+  runId?: string;
+  startedAt?: number;
+  endedAt?: number;
+  /** First ~500 chars of the sub-agent's terminal output. */
+  resultSummary?: string;
+  /** Set when status is `refused` or `failed`. */
+  refusalReason?: string;
+}
 
 export interface InboxMessage {
   id: string;
@@ -445,6 +483,49 @@ export class InboxStore {
       VALUES (?, ?, ?, ?, ?, ?)
     `).run(id, messageId, now, role, body, metaJson ?? null);
     return { id, messageId, createdAt: now, role, body, metaJson };
+  }
+
+  /**
+   * Fetch a single response row by id. Used by the action-execution
+   * routes (`/inbox/:id/actions/:rid/run|skip`) to load the proposed
+   * action and verify it's still in `proposed` state before mutating.
+   */
+  getResponse(id: string): InboxResponse | null {
+    const row = this.db.prepare(
+      `SELECT id, message_id, created_at, role, body, meta_json
+        FROM inbox_responses WHERE id = ?`,
+    ).get(id) as Record<string, unknown> | undefined;
+    return row ? this.rowToResponse(row) : null;
+  }
+
+  /**
+   * Update an existing response's body and/or meta_json. Used to
+   * transition `action` rows through their lifecycle (proposed →
+   * running → completed). Pass `undefined` to leave a field
+   * unchanged; pass `null` for `metaJson` to clear it.
+   */
+  updateResponse(
+    id: string,
+    patch: { body?: string; metaJson?: string | null },
+  ): void {
+    const fields: string[] = [];
+    const params: (string | null)[] = [];
+    if (patch.body !== undefined) {
+      fields.push('body = ?');
+      params.push(patch.body);
+    }
+    if (patch.metaJson !== undefined) {
+      fields.push('meta_json = ?');
+      params.push(patch.metaJson);
+    }
+    if (fields.length === 0) return;
+    params.push(id);
+    const result = this.db.prepare(
+      `UPDATE inbox_responses SET ${fields.join(', ')} WHERE id = ?`,
+    ).run(...params);
+    if (result.changes === 0) {
+      throw new Error(`InboxStore.updateResponse: no response with id "${id}"`);
+    }
   }
 
   listResponses(messageId: string): InboxResponse[] {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -93,6 +93,7 @@ export {
   INBOX_STATUSES,
   INBOX_SOURCES,
   INBOX_RESPONSE_ROLES,
+  INBOX_ACTION_STATUSES,
   normalizeTags,
   type InboxMessage,
   type InboxResponse,
@@ -100,6 +101,8 @@ export {
   type InboxStatus,
   type InboxSource,
   type InboxResponseRole,
+  type InboxActionStatus,
+  type InboxActionMeta,
   type AddMessageInput,
   type ListMessagesOpts,
 } from './inbox-store.js';

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -2111,6 +2111,7 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
 .inbox-msg__avatar--user { background: var(--color-primary, #2dd4bf); }
 .inbox-msg__avatar--triage { background: var(--color-info, #60a5fa); }
 .inbox-msg__avatar--system { background: var(--color-text-muted, #8b93a7); }
+.inbox-msg__avatar--action { background: var(--color-warn, #f59e0b); }
 .inbox-msg__body { flex: 1; min-width: 0; }
 .inbox-msg__meta {
   font-size: var(--font-size-xs);
@@ -2286,4 +2287,107 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
 }
 .inbox-detail__thread {
   margin-top: var(--space-2);
+}
+
+/* ---------- Inbox conversation: action cards ---------- */
+/* When triage proposes running a sub-agent it lands in the thread as
+ * an `action`-role response. The card surfaces the agentId + inputs +
+ * a rationale, plus Run/Skip controls while status="proposed". As
+ * lifecycle ticks through running → completed/failed/skipped, the
+ * controls disappear and the status body fills in. */
+.inbox-action__status {
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  font-weight: var(--weight-semibold);
+  padding: 1px 6px;
+  border-radius: 2px;
+  background: var(--color-surface-raised);
+  color: var(--color-text-muted);
+}
+.inbox-action--proposed .inbox-action__status { color: var(--color-warn, #f59e0b); }
+.inbox-action--running .inbox-action__status { color: var(--color-info, #60a5fa); }
+.inbox-action--completed .inbox-action__status { color: var(--color-ok, #34d399); }
+.inbox-action--failed .inbox-action__status,
+.inbox-action--refused .inbox-action__status { color: var(--color-danger, #f87171); }
+.inbox-action--skipped .inbox-action__status { color: var(--color-text-muted); }
+
+.inbox-action__card {
+  margin-top: 4px;
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-left: 3px solid var(--color-warn, #f59e0b);
+  border-radius: var(--radius-sm, 4px);
+}
+.inbox-action--running .inbox-action__card { border-left-color: var(--color-info, #60a5fa); }
+.inbox-action--completed .inbox-action__card { border-left-color: var(--color-ok, #34d399); }
+.inbox-action--failed .inbox-action__card,
+.inbox-action--refused .inbox-action__card { border-left-color: var(--color-danger, #f87171); }
+.inbox-action--skipped .inbox-action__card { border-left-color: var(--color-text-muted); opacity: 0.7; }
+
+.inbox-action__headline {
+  font-size: var(--font-size-sm);
+  font-weight: var(--weight-semibold);
+}
+.inbox-action__rationale {
+  margin-top: 4px;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+.inbox-action__inputs {
+  margin: var(--space-2) 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+  font-size: var(--font-size-xs);
+}
+.inbox-action__inputs li {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+}
+.inbox-action__input-key {
+  color: var(--color-text-muted);
+}
+.inbox-action__input-val {
+  color: var(--color-text);
+}
+.inbox-action__controls {
+  margin-top: var(--space-2);
+  display: flex;
+  gap: var(--space-2);
+}
+.inbox-action__running {
+  margin-top: var(--space-2);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--font-size-sm);
+  color: var(--color-info, #60a5fa);
+}
+.inbox-action__result {
+  margin-top: var(--space-2);
+  font-size: var(--font-size-sm);
+}
+.inbox-action__result--ok { color: var(--color-text); }
+.inbox-action__result--err { color: var(--color-danger, #f87171); }
+.inbox-action__result--muted { color: var(--color-text-muted); }
+.inbox-action__preview {
+  margin-top: 4px;
+  padding: 6px 8px;
+  background: var(--color-surface-raised, #1f2430);
+  border-radius: 3px;
+  font-size: var(--font-size-xs);
+  max-height: 8rem;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+.inbox-action__reason {
+  margin-top: 4px;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
 }

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -365,6 +365,106 @@ describe('Row + fragment rendering for star + tags', () => {
   });
 });
 
+describe('POST /inbox/:id/actions/:rid/run + /skip', () => {
+  // The action lifecycle routes operate on `action`-role responses
+  // that triage would normally insert when its <plan> includes an
+  // `actions[]` array. Here we insert proposed rows directly via the
+  // InboxStore — same shape, no LLM round-trip — and exercise the
+  // transitions.
+
+  function proposeAction(messageId: string, agentId: string, rationale: string) {
+    return inboxStore.addResponse(messageId, 'action', rationale, JSON.stringify({
+      kind: 'action',
+      status: 'proposed',
+      agentId,
+      inputs: { TOPIC: 'demo' },
+      rationale,
+    }));
+  }
+
+  it('/skip transitions a proposed action to skipped', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const r = proposeAction(m.id, 'suggest-improvements', 'try it');
+    const res = await request(app)
+      .post(`/inbox/${m.id}/actions/${r.id}/skip`)
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(204);
+    const after = inboxStore.getResponse(r.id);
+    expect(after).not.toBeNull();
+    const meta = JSON.parse(after!.metaJson!);
+    expect(meta.status).toBe('skipped');
+    expect(typeof meta.endedAt).toBe('number');
+  });
+
+  it('/skip on a non-proposed row returns 409', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const r = proposeAction(m.id, 'suggest-improvements', 'try it');
+    inboxStore.updateResponse(r.id, {
+      metaJson: JSON.stringify({ kind: 'action', status: 'skipped', agentId: 'suggest-improvements', inputs: {} }),
+    });
+    const res = await request(app)
+      .post(`/inbox/${m.id}/actions/${r.id}/skip`)
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(409);
+  });
+
+  it('/skip on a non-existent rid returns 409', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const res = await request(app)
+      .post(`/inbox/${m.id}/actions/nope/skip`)
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(409);
+  });
+
+  it('/skip with rid that belongs to a different message returns 409', async () => {
+    const app = await makeApp();
+    const m1 = inboxStore.add({ priority: 'medium', source: 'manual', title: 'a', body: 'a' });
+    const m2 = inboxStore.add({ priority: 'medium', source: 'manual', title: 'b', body: 'b' });
+    const r = proposeAction(m1.id, 'suggest-improvements', 'r');
+    const res = await request(app)
+      .post(`/inbox/${m2.id}/actions/${r.id}/skip`)
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(409);
+  });
+
+  it('/run on a proposed action returns 204 and transitions meta off "proposed"', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const r = proposeAction(m.id, 'suggest-improvements', 'try it');
+    const res = await request(app)
+      .post(`/inbox/${m.id}/actions/${r.id}/run`)
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    // Returns 204 immediately; the agent runs fire-and-forget.
+    expect(res.status).toBe(204);
+    // Give the dispatcher a tick to enter the running state. The
+    // sub-agent isn't installed in this test setup so the row will
+    // promptly settle in `failed` ("agent not installed") rather than
+    // hanging in `running` — either is "not proposed" and that's what
+    // we assert.
+    await new Promise((r) => setTimeout(r, 30));
+    const after = inboxStore.getResponse(r.id);
+    expect(after).not.toBeNull();
+    const meta = JSON.parse(after!.metaJson!);
+    expect(meta.status).not.toBe('proposed');
+  });
+
+  it('/run on a non-proposed row returns 409', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const r = proposeAction(m.id, 'suggest-improvements', 'try it');
+    inboxStore.updateResponse(r.id, {
+      metaJson: JSON.stringify({ kind: 'action', status: 'completed', agentId: 'suggest-improvements', inputs: {} }),
+    });
+    const res = await request(app)
+      .post(`/inbox/${m.id}/actions/${r.id}/run`)
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(409);
+  });
+});
+
 describe('POST /inbox/:id/triage', () => {
   it('returns 204 (AJAX) and inserts a synthetic "Asked triage" user marker', async () => {
     const app = await makeApp();

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -30,6 +30,9 @@ import {
   extractPlanJson,
   parseAgent,
   type RunStatus,
+  type InboxActionMeta,
+  type InboxActionStatus,
+  type InboxResponse,
 } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 import {
@@ -48,6 +51,27 @@ const SORT_KEYS = new Set<InboxSortKey>(['priority', 'source', 'agent', 'title',
 const SORT_DIRS = new Set<InboxSortDir>(['asc', 'desc']);
 const TRIAGE_AGENT_ID = 'inbox-triage';
 const PENDING_USER_REPLY_WINDOW_MS = 30_000;
+
+/**
+ * Agent IDs that the inbox-triage agent is allowed to propose running
+ * on the operator's behalf. Intersected with what's actually installed
+ * in the agentStore at proposal time. v1 keeps this hardcoded — a
+ * future PR can move it to a `agents/areas/inbox.yaml` per-area config.
+ */
+const TRIAGE_SUB_AGENT_ALLOWLIST: readonly string[] = [
+  'suggest-improvements',
+];
+
+/**
+ * Hard cap on `action`-role responses per inbox message. Triage gets a
+ * follow-up turn after each action resolves; without a cap, a bad
+ * prompt could fan out indefinitely. 10 is enough room for a few rounds
+ * of "run X, summarize, run Y on the result" without going wild.
+ */
+const MAX_ACTIONS_PER_MESSAGE = 10;
+
+/** Truncate the sub-agent run output that's stored in action meta. */
+const ACTION_RESULT_PREVIEW_LIMIT = 500;
 
 function parseSort(req: Request): { sort: InboxSortKey; dir: InboxSortDir } {
   const sortRaw = typeof req.query.sort === 'string' ? req.query.sort : '';
@@ -270,22 +294,95 @@ inboxRouter.post('/inbox/:id/tags', (req: Request, res: Response) => {
   res.redirect(303, `${detailUrl}?ok=${encodeURIComponent('Tags updated.')}`);
 });
 
+/**
+ * POST /inbox/:id/actions/:rid/run — execute a proposed sub-agent
+ * action. Loads the `action`-role response, verifies it's still in
+ * `proposed` state, runs the target agent via executeAgentDag, then
+ * patches the row through running → completed/failed. When all
+ * non-skipped actions for this message are in a terminal state, fires
+ * a follow-up triage turn so the agent can summarize what came back.
+ */
+inboxRouter.post('/inbox/:id/actions/:rid/run', async (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const rid = Array.isArray(req.params.rid) ? req.params.rid[0] : req.params.rid;
+  const detailUrl = `/inbox/${encodeURIComponent(id)}`;
+  if (!ctx.inboxStore || !ctx.inboxStore.get(id)) {
+    if (isAjax(req)) { res.status(404).end(); return; }
+    res.redirect(303, `/inbox?error=${encodeURIComponent('Message not found.')}`);
+    return;
+  }
+  const response = ctx.inboxStore.getResponse(rid);
+  const meta = response ? parseActionMeta(response) : null;
+  if (!response || response.messageId !== id || !meta || meta.status !== 'proposed') {
+    if (isAjax(req)) { res.status(409).end(); return; }
+    res.redirect(303, `${detailUrl}?error=${encodeURIComponent('Action is not runnable.')}`);
+    return;
+  }
+  if (isAjax(req)) { res.status(204).end(); }
+  // Fire-and-forget; the modal polls /fragment for state.
+  void runProposedAction(ctx, id, response, meta).catch((err) => {
+    process.stderr.write(`[inbox-triage] action ${rid} crashed: ${(err as Error)?.message ?? err}\n`);
+  });
+  if (!isAjax(req)) {
+    res.redirect(303, `${detailUrl}?ok=${encodeURIComponent('Action started.')}`);
+  }
+});
+
+/**
+ * POST /inbox/:id/actions/:rid/skip — mark a proposed action as
+ * skipped. The operator chose not to run it. No re-fire of triage —
+ * skipping is the "no thanks" signal; if every action gets skipped,
+ * we let the conversation rest unless the operator asks again.
+ */
+inboxRouter.post('/inbox/:id/actions/:rid/skip', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const rid = Array.isArray(req.params.rid) ? req.params.rid[0] : req.params.rid;
+  const detailUrl = `/inbox/${encodeURIComponent(id)}`;
+  if (!ctx.inboxStore || !ctx.inboxStore.get(id)) {
+    if (isAjax(req)) { res.status(404).end(); return; }
+    res.redirect(303, `/inbox?error=${encodeURIComponent('Message not found.')}`);
+    return;
+  }
+  const response = ctx.inboxStore.getResponse(rid);
+  const meta = response ? parseActionMeta(response) : null;
+  if (!response || response.messageId !== id || !meta || meta.status !== 'proposed') {
+    if (isAjax(req)) { res.status(409).end(); return; }
+    res.redirect(303, `${detailUrl}?error=${encodeURIComponent('Action is not skippable.')}`);
+    return;
+  }
+  try {
+    ctx.inboxStore.updateResponse(rid, {
+      metaJson: JSON.stringify({ ...meta, status: 'skipped', endedAt: Date.now() }),
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (isAjax(req)) { res.status(500).end(); return; }
+    res.redirect(303, `${detailUrl}?error=${encodeURIComponent(`Skip failed: ${msg}`)}`);
+    return;
+  }
+  if (isAjax(req)) { res.status(204).end(); return; }
+  res.redirect(303, `${detailUrl}?ok=${encodeURIComponent('Skipped.')}`);
+});
+
 // ── helpers ─────────────────────────────────────────────────────────
 
 /**
- * Triage is "pending" if either:
- *   (a) the message has a triageRunId whose run is in flight, OR
+ * Triage is "pending" — and the modal should keep polling — if any of:
+ *   (a) the message has a triageRunId whose run is in flight,
  *   (b) the most recent response is from the user, posted in the
- *       last 30 seconds, with no later triage or system reply.
- *
- * Branch (b) covers the unavoidable race between POST /respond
- * returning 204 and the dag-executor inserting its run-store row
- * (which we'd later capture into triageRunId).
+ *       last 30 seconds, with no later triage / system / action reply
+ *       (covers the race between POST /respond returning 204 and the
+ *       dag-executor inserting its run-store row), or
+ *   (c) any `action`-role response on this message is in `running`
+ *       state (the sub-agent is mid-flight; updates land via
+ *       updateResponse and the modal should re-render).
  */
 function isTriagePending(
   ctx: ReturnType<typeof getContext>,
   message: { triageRunId?: string },
-  responses: { role: string; createdAt: number }[],
+  responses: InboxResponse[],
 ): boolean {
   if (message.triageRunId) {
     try {
@@ -293,10 +390,218 @@ function isTriagePending(
       if (run && (run.status === 'pending' || run.status === 'running')) return true;
     } catch { /* ignore */ }
   }
+  for (const r of responses) {
+    if (r.role !== 'action') continue;
+    const meta = parseActionMeta(r);
+    if (meta?.status === 'running') return true;
+  }
   if (responses.length === 0) return false;
   const last = responses[responses.length - 1];
   if (last.role !== 'user') return false;
   return Date.now() - last.createdAt < PENDING_USER_REPLY_WINDOW_MS;
+}
+
+/**
+ * Parse the `meta_json` payload of an `action`-role response. Returns
+ * null when the row isn't an action or the meta is missing / malformed —
+ * callers treat that as "not an actionable action."
+ */
+function parseActionMeta(r: InboxResponse): InboxActionMeta | null {
+  if (r.role !== 'action' || !r.metaJson) return null;
+  try {
+    const parsed = JSON.parse(r.metaJson) as Partial<InboxActionMeta>;
+    if (parsed && parsed.kind === 'action' && typeof parsed.agentId === 'string' && typeof parsed.status === 'string') {
+      return parsed as InboxActionMeta;
+    }
+  } catch { /* swallow */ }
+  return null;
+}
+
+/**
+ * Build the effective allowlist of sub-agent ids triage may propose
+ * running: the static list intersected with what's currently installed
+ * in the agentStore. This guards against the prompt mentioning agents
+ * that aren't present on this instance.
+ */
+function getSubAgentAllowlist(ctx: ReturnType<typeof getContext>): string[] {
+  return TRIAGE_SUB_AGENT_ALLOWLIST.filter((id) => ctx.agentStore.getAgent(id));
+}
+
+/**
+ * Parse + validate the `actions` field from a triage `<plan>` block.
+ * Returns valid action proposals + the rejected ones (with a reason)
+ * so the route can surface refusals as `system` responses in the
+ * conversation. Unknown agent ids fall into rejected.
+ */
+function parseProposedActions(
+  rawActions: unknown,
+  allowlist: readonly string[],
+): { accepted: InboxActionMeta[]; rejected: { agentId: string; reason: string }[] } {
+  const accepted: InboxActionMeta[] = [];
+  const rejected: { agentId: string; reason: string }[] = [];
+  if (!Array.isArray(rawActions)) return { accepted, rejected };
+  const allowSet = new Set(allowlist);
+  for (const entry of rawActions.slice(0, 3)) {
+    if (!entry || typeof entry !== 'object') continue;
+    const e = entry as Record<string, unknown>;
+    const type = typeof e.type === 'string' ? e.type : '';
+    const agentId = typeof e.agentId === 'string' ? e.agentId : '';
+    if (type !== 'run-agent' || !agentId) {
+      rejected.push({ agentId: agentId || '<unknown>', reason: 'malformed action entry' });
+      continue;
+    }
+    if (!allowSet.has(agentId)) {
+      rejected.push({ agentId, reason: 'not in ALLOWED_SUB_AGENTS' });
+      continue;
+    }
+    const inputs: Record<string, string> = {};
+    if (e.inputs && typeof e.inputs === 'object' && !Array.isArray(e.inputs)) {
+      for (const [k, v] of Object.entries(e.inputs as Record<string, unknown>)) {
+        if (typeof k === 'string' && typeof v === 'string') inputs[k] = v;
+      }
+    }
+    const rationale = typeof e.rationale === 'string' ? e.rationale.trim() : undefined;
+    accepted.push({
+      kind: 'action',
+      status: 'proposed',
+      agentId,
+      inputs,
+      rationale: rationale || undefined,
+    });
+  }
+  return { accepted, rejected };
+}
+
+/**
+ * Execute a single proposed action: walks meta through `running`,
+ * dispatches `executeAgentDag` on the sub-agent, then patches meta to
+ * `completed | failed` with run lineage + a short result preview. When
+ * all proposed actions on the parent message have resolved (any
+ * non-`proposed` state) AND at least one ran, re-fire triage so it can
+ * summarize the outcome in the conversation.
+ */
+async function runProposedAction(
+  ctx: ReturnType<typeof getContext>,
+  messageId: string,
+  response: InboxResponse,
+  meta: InboxActionMeta,
+): Promise<void> {
+  if (!ctx.inboxStore) return;
+  const subAgent = ctx.agentStore.getAgent(meta.agentId);
+  if (!subAgent) {
+    ctx.inboxStore.updateResponse(response.id, {
+      metaJson: JSON.stringify({
+        ...meta,
+        status: 'failed',
+        endedAt: Date.now(),
+        refusalReason: `Agent "${meta.agentId}" is not installed.`,
+      }),
+    });
+    return;
+  }
+  const startedAt = Date.now();
+  ctx.inboxStore.updateResponse(response.id, {
+    metaJson: JSON.stringify({ ...meta, status: 'running', startedAt }),
+  });
+
+  let runId: string | undefined;
+  let nextStatus: InboxActionStatus = 'failed';
+  let resultSummary: string | undefined;
+  let refusalReason: string | undefined;
+  try {
+    const run = await executeAgentDag(
+      subAgent,
+      {
+        triggeredBy: 'dashboard',
+        inputs: meta.inputs,
+      },
+      {
+        runStore: ctx.runStore,
+        secretsStore: ctx.secretsStore,
+        variablesStore: ctx.variablesStore,
+        dataRoot: ctx.agentStore.dataRoot,
+      },
+    );
+    runId = run.id;
+    if (run.status === 'completed') {
+      nextStatus = 'completed';
+      const raw = typeof run.result === 'string' ? run.result : '';
+      resultSummary = raw.length > ACTION_RESULT_PREVIEW_LIMIT
+        ? raw.slice(0, ACTION_RESULT_PREVIEW_LIMIT) + '…'
+        : raw;
+    } else {
+      nextStatus = 'failed';
+      refusalReason = run.error ?? `Run ended in status ${run.status}.`;
+    }
+  } catch (err) {
+    nextStatus = 'failed';
+    refusalReason = err instanceof Error ? err.message : String(err);
+  }
+  ctx.inboxStore.updateResponse(response.id, {
+    metaJson: JSON.stringify({
+      ...meta,
+      status: nextStatus,
+      startedAt,
+      endedAt: Date.now(),
+      runId,
+      resultSummary,
+      refusalReason,
+    }),
+  });
+
+  // If every proposed action on this message has now resolved AND at
+  // least one ran (completed or failed), re-fire triage so it gets a
+  // summary turn. Purely skipped sets do NOT trigger the follow-up —
+  // we treat all-skip as "operator declined, move on."
+  if (allActionsResolved(ctx, messageId) && atLeastOneActionExecuted(ctx, messageId)) {
+    void runTriageAgent(ctx, messageId).catch(() => { /* swallow */ });
+  }
+}
+
+function allActionsResolved(
+  ctx: ReturnType<typeof getContext>,
+  messageId: string,
+): boolean {
+  if (!ctx.inboxStore) return false;
+  const responses = ctx.inboxStore.listResponses(messageId);
+  for (const r of responses) {
+    if (r.role !== 'action') continue;
+    const m = parseActionMeta(r);
+    if (m && (m.status === 'proposed' || m.status === 'running')) return false;
+  }
+  return true;
+}
+
+function atLeastOneActionExecuted(
+  ctx: ReturnType<typeof getContext>,
+  messageId: string,
+): boolean {
+  if (!ctx.inboxStore) return false;
+  const responses = ctx.inboxStore.listResponses(messageId);
+  for (const r of responses) {
+    if (r.role !== 'action') continue;
+    const m = parseActionMeta(r);
+    if (m && (m.status === 'completed' || m.status === 'failed')) return true;
+  }
+  return false;
+}
+
+/**
+ * Count `action`-role responses for a message regardless of status.
+ * Used to enforce MAX_ACTIONS_PER_MESSAGE — once we've fanned out N
+ * actions on a single thread, refuse new proposals as a runaway
+ * guard.
+ */
+function countActionsOnMessage(
+  ctx: ReturnType<typeof getContext>,
+  messageId: string,
+): number {
+  if (!ctx.inboxStore) return 0;
+  let n = 0;
+  for (const r of ctx.inboxStore.listResponses(messageId)) {
+    if (r.role === 'action') n++;
+  }
+  return n;
 }
 
 /**
@@ -332,9 +637,21 @@ async function runTriageAgent(
   }
   if (!triage) return;
 
+  // Build conversation snapshot for the prompt. For action-role rows,
+  // include the structured status so the model can see what already
+  // ran rather than just the rationale body.
   const conversation = ctx.inboxStore.listResponses(messageId)
-    .map((r) => `[${r.role}] ${r.body}`)
+    .map((r) => {
+      if (r.role === 'action') {
+        const m = parseActionMeta(r);
+        const suffix = m ? ` (status=${m.status}${m.resultSummary ? `; result=${m.resultSummary.slice(0, 200)}` : ''})` : '';
+        return `[action] ${r.body}${suffix}`;
+      }
+      return `[${r.role}] ${r.body}`;
+    })
     .join('\n');
+
+  const allowlist = getSubAgentAllowlist(ctx);
 
   let runId: string | undefined;
   try {
@@ -350,6 +667,7 @@ async function runTriageAgent(
           MESSAGE_SOURCE: message.source,
           CONTEXT_JSON: message.contextJson ?? '',
           CONVERSATION: conversation,
+          ALLOWED_SUB_AGENTS: allowlist.join(', '),
         },
       },
       {
@@ -401,7 +719,7 @@ async function runTriageAgent(
       );
       return;
     }
-    let parsed: { recommendation?: unknown; verifyHint?: unknown };
+    let parsed: { recommendation?: unknown; verifyHint?: unknown; actions?: unknown };
     try {
       parsed = JSON.parse(planJson);
     } catch {
@@ -422,6 +740,34 @@ async function runTriageAgent(
       rec,
       verifyHint ? JSON.stringify({ verifyHint }) : undefined,
     );
+
+    // Parse + persist any proposed actions (only when allowlist is
+    // non-empty). Refusals (out-of-allowlist or malformed) get a
+    // single grouped `system` note so the operator can see what was
+    // declined and why.
+    if (allowlist.length > 0) {
+      const { accepted, rejected } = parseProposedActions(parsed.actions, allowlist);
+      const existing = countActionsOnMessage(ctx, messageId);
+      const budget = Math.max(0, MAX_ACTIONS_PER_MESSAGE - existing);
+      const toInsert = accepted.slice(0, budget);
+      const overflow = accepted.length - toInsert.length;
+      for (const action of toInsert) {
+        const body = action.rationale
+          ?? `Run agent \`${action.agentId}\`.`;
+        ctx.inboxStore.addResponse(messageId, 'action', body, JSON.stringify(action));
+      }
+      const notes: string[] = [];
+      for (const r of rejected) {
+        notes.push(`Refused action on \`${r.agentId}\`: ${r.reason}.`);
+      }
+      if (overflow > 0) {
+        notes.push(`Skipped ${overflow} additional proposed action${overflow === 1 ? '' : 's'} — message has reached the per-thread action cap (${MAX_ACTIONS_PER_MESSAGE}).`);
+      }
+      if (notes.length > 0) {
+        ctx.inboxStore.addResponse(messageId, 'system', notes.join('\n'));
+      }
+    }
+
     try {
       ctx.inboxStore.updateStatus(messageId, 'awaiting_user', { recommendation: rec, triageRunId: runId });
     } catch { /* ignore */ }

--- a/packages/dashboard/src/views/inbox-detail.ts
+++ b/packages/dashboard/src/views/inbox-detail.ts
@@ -1,4 +1,10 @@
-import type { InboxMessage, InboxResponse, InboxResponseRole } from '@some-useful-agents/core';
+import type {
+  InboxMessage,
+  InboxResponse,
+  InboxResponseRole,
+  InboxActionMeta,
+  InboxActionStatus,
+} from '@some-useful-agents/core';
 import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
@@ -34,6 +40,7 @@ const ROLE_LABEL: Record<InboxResponseRole, string> = {
   user: 'You',
   triage: 'Triage agent',
   system: 'System',
+  action: 'Proposed action',
 };
 
 /** Two-character avatar text per role (mirrors Slack-style avatars). */
@@ -41,6 +48,17 @@ const ROLE_AVATAR: Record<InboxResponseRole, string> = {
   user: 'You',
   triage: 'Tri',
   system: 'Sys',
+  action: 'Act',
+};
+
+/** Human label for each action-card status. */
+const ACTION_STATUS_LABEL: Record<InboxActionStatus, string> = {
+  proposed: 'Proposed',
+  running: 'Running',
+  completed: 'Completed',
+  failed: 'Failed',
+  skipped: 'Skipped',
+  refused: 'Refused',
 };
 
 /**
@@ -194,9 +212,12 @@ function pretty(raw: string): string {
 /**
  * Slack-style conversation entry: avatar + name + time + body. The
  * `data-msg-id` attribute lets the modal JS detect new entries
- * between refreshes and animate them in once.
+ * between refreshes and animate them in once. `action`-role rows
+ * branch to a card renderer that surfaces Run / Skip controls + the
+ * sub-agent's status.
  */
 function renderConversationEntry(r: InboxResponse): SafeHtml {
+  if (r.role === 'action') return renderActionEntry(r);
   const role = (ROLE_LABEL[r.role] ?? r.role);
   const avatar = ROLE_AVATAR[r.role] ?? r.role.slice(0, 1).toUpperCase();
   return html`
@@ -211,6 +232,150 @@ function renderConversationEntry(r: InboxResponse): SafeHtml {
       </div>
     </div>
   `;
+}
+
+/**
+ * Inline parse of an action-role response's `meta_json`. Mirrors the
+ * route's `parseActionMeta` (deliberately duplicated to keep the
+ * view's import surface from leaking into route helpers).
+ */
+function parseActionMeta(r: InboxResponse): InboxActionMeta | null {
+  if (r.role !== 'action' || !r.metaJson) return null;
+  try {
+    const parsed = JSON.parse(r.metaJson) as Partial<InboxActionMeta>;
+    if (parsed && parsed.kind === 'action'
+      && typeof parsed.agentId === 'string'
+      && typeof parsed.status === 'string') {
+      return parsed as InboxActionMeta;
+    }
+  } catch { /* swallow */ }
+  return null;
+}
+
+/** Render an action-role row as a card whose body depends on status. */
+function renderActionEntry(r: InboxResponse): SafeHtml {
+  const meta = parseActionMeta(r);
+  if (!meta) {
+    // Malformed action row — fall back to plain rendering so the
+    // operator at least sees the body text.
+    return html`
+      <div class="inbox-msg" data-msg-id="${r.id}">
+        <div class="inbox-msg__avatar inbox-msg__avatar--action">Act</div>
+        <div class="inbox-msg__body">
+          <div class="inbox-msg__meta"><span class="inbox-msg__meta-name">Action (malformed)</span></div>
+          <div class="inbox-msg__text">${r.body}</div>
+        </div>
+      </div>
+    `;
+  }
+
+  const statusLabel = ACTION_STATUS_LABEL[meta.status] ?? meta.status;
+  const inputsRendered = renderActionInputs(meta.inputs);
+  const messageId = '__inbox_message_id__'; // hijacked from form action below
+
+  // Drives modal-poll keep-alive while the action is running.
+  const runningAttr = meta.status === 'running' ? 'data-action-running="1"' : '';
+
+  const controlsBlock = meta.status === 'proposed'
+    ? html`
+      <div class="inbox-action__controls">
+        <form method="POST" action="/inbox/${r.messageId}/actions/${r.id}/run"
+          data-inbox-modal-form data-inbox-modal-keeps-triage="1" style="margin:0;">
+          <button type="submit" class="btn btn--xs btn--primary">Run</button>
+        </form>
+        <form method="POST" action="/inbox/${r.messageId}/actions/${r.id}/skip"
+          data-inbox-modal-form style="margin:0;">
+          <button type="submit" class="btn btn--xs btn--ghost">Skip</button>
+        </form>
+      </div>
+    `
+    : html``;
+  void messageId;
+
+  const detailBlock = renderActionStatusBody(meta);
+
+  return html`
+    <div class="inbox-msg inbox-msg--action inbox-action inbox-action--${meta.status}" data-msg-id="${r.id}" ${runningAttr as unknown as SafeHtml}>
+      <div class="inbox-msg__avatar inbox-msg__avatar--action">Act</div>
+      <div class="inbox-msg__body">
+        <div class="inbox-msg__meta">
+          <span class="inbox-msg__meta-name">Triage proposed</span>
+          <span class="inbox-action__status">${statusLabel}</span>
+          <span>${formatAge(new Date(r.createdAt).toISOString())}</span>
+        </div>
+        <div class="inbox-action__card">
+          <div class="inbox-action__headline">
+            Run agent <span class="mono">${meta.agentId}</span>
+            ${meta.runId ? html` · <a href="/runs/${meta.runId}" class="mono">run ${meta.runId.slice(0, 8)}</a>` : html``}
+          </div>
+          ${meta.rationale ? html`<div class="inbox-action__rationale">${meta.rationale}</div>` : html``}
+          ${inputsRendered}
+          ${detailBlock}
+          ${controlsBlock}
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+function renderActionInputs(inputs: Record<string, string>): SafeHtml {
+  const keys = Object.keys(inputs);
+  if (keys.length === 0) return html``;
+  const rows = keys.map((k) => html`
+    <li><span class="inbox-action__input-key mono">${k}</span> <span class="inbox-action__input-val mono">${inputs[k]}</span></li>
+  `);
+  return html`
+    <ul class="inbox-action__inputs">${rows as unknown as SafeHtml[]}</ul>
+  `;
+}
+
+function renderActionStatusBody(meta: InboxActionMeta): SafeHtml {
+  switch (meta.status) {
+    case 'proposed':
+      return html``;
+    case 'running':
+      return html`
+        <div class="inbox-action__running">
+          Running
+          <span class="inbox-thinking__dots"><span></span><span></span><span></span></span>
+        </div>
+      `;
+    case 'completed': {
+      const dur = formatDuration(meta);
+      const preview = meta.resultSummary?.trim();
+      return html`
+        <div class="inbox-action__result inbox-action__result--ok">
+          Completed${dur ? ` in ${dur}` : ''}.
+          ${preview ? html`<pre class="inbox-action__preview mono">${preview}</pre>` : html``}
+        </div>
+      `;
+    }
+    case 'failed':
+      return html`
+        <div class="inbox-action__result inbox-action__result--err">
+          Failed${formatDuration(meta) ? ` after ${formatDuration(meta)}` : ''}.
+          ${meta.refusalReason ? html`<div class="inbox-action__reason">${meta.refusalReason}</div>` : html``}
+        </div>
+      `;
+    case 'skipped':
+      return html`<div class="inbox-action__result inbox-action__result--muted">Skipped by operator.</div>`;
+    case 'refused':
+      return html`
+        <div class="inbox-action__result inbox-action__result--err">
+          Refused. ${meta.refusalReason ? html`<span>${meta.refusalReason}</span>` : html``}
+        </div>
+      `;
+    default:
+      return html``;
+  }
+}
+
+function formatDuration(meta: InboxActionMeta): string {
+  if (typeof meta.startedAt !== 'number' || typeof meta.endedAt !== 'number') return '';
+  const ms = meta.endedAt - meta.startedAt;
+  if (ms < 0) return '';
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
 }
 
 /** Pulsing-dots "Triage agent is thinking…" indicator. */

--- a/packages/dashboard/src/views/inbox-modal.js.ts
+++ b/packages/dashboard/src/views/inbox-modal.js.ts
@@ -55,6 +55,9 @@ export const INBOX_MODAL_JS = `
 
   function shouldKeepPolling() {
     if (content.querySelector('[data-triage-pending="1"]')) return true;
+    // Any proposed sub-agent action that's currently executing means
+    // we need to keep refreshing to surface its lifecycle updates.
+    if (content.querySelector('[data-action-running="1"]')) return true;
     if (Date.now() < keepPollingUntil) return true;
     return false;
   }


### PR DESCRIPTION
## Summary

The chat now has hands. Triage can propose running other agents on the operator's behalf as cards in the conversation thread; nothing executes until the operator clicks **Run**.

- **Triage prompt** learns about an `ALLOWED_SUB_AGENTS` input (v1 hardcoded to `suggest-improvements`). When set, it may include `actions[]` in its `<plan>` block — entries like `{type: 'run-agent', agentId, inputs, rationale}`.
- **Conversation thread** gains a fourth role: `action`. The card renders with an agent id headline, the inputs as key/value pills, the rationale, and Run / Skip buttons while `status="proposed"`. As lifecycle ticks through `running → completed | failed | skipped`, the controls disappear and the body fills in (spinner → result preview / run link / error reason).
- **`POST /inbox/:id/actions/:rid/run`** dispatches `executeAgentDag` on the sub-agent, patches `meta_json` through running → completed/failed, and stores a result preview + run link. Once every proposed action has resolved AND at least one actually ran, triage gets a follow-up turn to summarize the outcome.
- **`POST /inbox/:id/actions/:rid/skip`** marks proposed → skipped. Pure skips don't re-fire triage — that signal means "no thanks, move on."
- **Modal polling** extends its keep-alive predicate to cover `[data-action-running="1"]` so the thread refreshes through the entire sub-agent lifecycle without a page reload.

Guards:
- Out-of-allowlist or malformed action proposals land as a single grouped `system` refusal note in the thread.
- Hard cap of 10 `action`-role rows per inbox message — prevents runaway fan-out if a prompt regresses.
- Sub-agent isn't installed → action settles in `failed` with reason "Agent `<id>` is not installed."

## Test plan
- [ ] /inbox with `SUA_INBOX_DEMO=1`, click a demo failure row → modal opens
- [ ] Reply with a question that would benefit from running `suggest-improvements` (e.g. "what would you change in this agent?")
- [ ] Verify a proposed action card appears with Run / Skip
- [ ] Click Run → card transitions to running (spinner), then completed/failed with a result preview
- [ ] After action resolves, triage gets a follow-up turn summarizing
- [ ] Click Skip on a fresh proposal → card transitions to skipped, no re-fire
- [ ] `gh pr checks` → all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)