### PR TITLE
feat(dashboard): inbox triage wires to agent-analyzer with input enrichment

### DIFF
--- a/.changeset/inbox-actions-agent-analyzer.md
+++ b/.changeset/inbox-actions-agent-analyzer.md
@@ -1,0 +1,23 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox triage can now propose running `agent-analyzer` (the agent
+behind the "Suggest improvements" button) as a sub-agent action.
+
+When triage proposes `{type:'run-agent', agentId:'agent-analyzer',
+inputs:{FOCUS:'…'}}` in its `<plan>`, the route auto-injects the
+failing agent's full YAML as `AGENT_YAML` and the most recent run
+output as `LAST_RUN_OUTPUT` — same enrichment the analyze route on
+the agent detail page uses. Triage only has to provide a one-sentence
+`FOCUS`; it doesn't have to thread the YAML through its prompt
+context. The agent is lazy-imported from `agents/examples/` on first
+call, so no manual install step is required.
+
+Hooks the inbox's action loop into a real, useful agent instead of a
+stub. Future allowlist entries can add their own per-agent input
+enrichment using the same pattern.

--- a/agents/examples/inbox-triage.yaml
+++ b/agents/examples/inbox-triage.yaml
@@ -171,22 +171,28 @@ nodes:
       </plan>
 
       Example with a proposed sub-agent action (only when
-      `suggest-improvements` is in ALLOWED_SUB_AGENTS):
+      `agent-analyzer` is in ALLOWED_SUB_AGENTS):
 
       <plan>
       {
         "messageId": "{{inputs.MESSAGE_ID}}",
-        "recommendation": "The agent's prompt asks for JSON but doesn't pin the schema. I can run suggest-improvements on it for a concrete diff.",
+        "recommendation": "The run failed with exit code 1 on a missing CLI tool. agent-analyzer can scan the YAML and return a concrete diff.",
         "actions": [
           {
             "type": "run-agent",
-            "agentId": "suggest-improvements",
-            "inputs": { "AGENT_ID": "demo-failing-agent" },
-            "rationale": "Get a concrete prompt-schema fix to apply."
+            "agentId": "agent-analyzer",
+            "inputs": { "FOCUS": "Why does this fail with exit 1? What's the minimal change to make it pass?" },
+            "rationale": "Get concrete diff suggestions targeting the exit-code failure."
           }
         ]
       }
       </plan>
+
+      The dashboard auto-injects the failing agent's full YAML +
+      most-recent run output as additional inputs to `agent-analyzer`,
+      so you don't need to thread those through `inputs` yourself.
+      Just provide `FOCUS` (a one-sentence prompt steering the
+      analysis) and the dashboard handles the rest.
 
       VALIDATION RULES (failing these means the route discards the response):
       - `messageId` MUST equal {{inputs.MESSAGE_ID}}.

--- a/packages/core/src/inbox-store.test.ts
+++ b/packages/core/src/inbox-store.test.ts
@@ -170,10 +170,10 @@ describe('InboxStore.addResponse + listResponses', () => {
   it('accepts the `action` role for sub-agent proposals', () => {
     const m = addMinimal();
     const meta = JSON.stringify({
-      kind: 'action', status: 'proposed', agentId: 'suggest-improvements',
+      kind: 'action', status: 'proposed', agentId: 'agent-analyzer',
       inputs: { TOPIC: 't' }, rationale: 'try it',
     });
-    const r = store.addResponse(m.id, 'action', 'Run suggest-improvements.', meta);
+    const r = store.addResponse(m.id, 'action', 'Run agent-analyzer.', meta);
     expect(r.role).toBe('action');
     const fetched = store.getResponse(r.id);
     expect(fetched?.role).toBe('action');

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -21,6 +21,7 @@ import {
   RunStore,
   buildLoopbackAllowlist,
   loadAgents,
+  parseAgent,
 } from '@some-useful-agents/core';
 import { buildDashboardApp } from '../index.js';
 import type { DashboardContext } from '../context.js';
@@ -385,7 +386,7 @@ describe('POST /inbox/:id/actions/:rid/run + /skip', () => {
   it('/skip transitions a proposed action to skipped', async () => {
     const app = await makeApp();
     const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
-    const r = proposeAction(m.id, 'suggest-improvements', 'try it');
+    const r = proposeAction(m.id, 'agent-analyzer', 'try it');
     const res = await request(app)
       .post(`/inbox/${m.id}/actions/${r.id}/skip`)
       .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
@@ -400,9 +401,9 @@ describe('POST /inbox/:id/actions/:rid/run + /skip', () => {
   it('/skip on a non-proposed row returns 409', async () => {
     const app = await makeApp();
     const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
-    const r = proposeAction(m.id, 'suggest-improvements', 'try it');
+    const r = proposeAction(m.id, 'agent-analyzer', 'try it');
     inboxStore.updateResponse(r.id, {
-      metaJson: JSON.stringify({ kind: 'action', status: 'skipped', agentId: 'suggest-improvements', inputs: {} }),
+      metaJson: JSON.stringify({ kind: 'action', status: 'skipped', agentId: 'agent-analyzer', inputs: {} }),
     });
     const res = await request(app)
       .post(`/inbox/${m.id}/actions/${r.id}/skip`)
@@ -423,7 +424,7 @@ describe('POST /inbox/:id/actions/:rid/run + /skip', () => {
     const app = await makeApp();
     const m1 = inboxStore.add({ priority: 'medium', source: 'manual', title: 'a', body: 'a' });
     const m2 = inboxStore.add({ priority: 'medium', source: 'manual', title: 'b', body: 'b' });
-    const r = proposeAction(m1.id, 'suggest-improvements', 'r');
+    const r = proposeAction(m1.id, 'agent-analyzer', 'r');
     const res = await request(app)
       .post(`/inbox/${m2.id}/actions/${r.id}/skip`)
       .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
@@ -433,7 +434,7 @@ describe('POST /inbox/:id/actions/:rid/run + /skip', () => {
   it('/run on a proposed action returns 204 and transitions meta off "proposed"', async () => {
     const app = await makeApp();
     const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
-    const r = proposeAction(m.id, 'suggest-improvements', 'try it');
+    const r = proposeAction(m.id, 'agent-analyzer', 'try it');
     const res = await request(app)
       .post(`/inbox/${m.id}/actions/${r.id}/run`)
       .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
@@ -454,14 +455,105 @@ describe('POST /inbox/:id/actions/:rid/run + /skip', () => {
   it('/run on a non-proposed row returns 409', async () => {
     const app = await makeApp();
     const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
-    const r = proposeAction(m.id, 'suggest-improvements', 'try it');
+    const r = proposeAction(m.id, 'agent-analyzer', 'try it');
     inboxStore.updateResponse(r.id, {
-      metaJson: JSON.stringify({ kind: 'action', status: 'completed', agentId: 'suggest-improvements', inputs: {} }),
+      metaJson: JSON.stringify({ kind: 'action', status: 'completed', agentId: 'agent-analyzer', inputs: {} }),
     });
     const res = await request(app)
       .post(`/inbox/${m.id}/actions/${r.id}/run`)
       .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
     expect(res.status).toBe(409);
+  });
+});
+
+describe('POST /inbox/:id/actions/:rid/run — agent-analyzer enrichment', () => {
+  // End-to-end: when triage proposes running `agent-analyzer` on an
+  // inbox message whose `agentId` points at an installed agent, the
+  // route auto-injects that agent's YAML as AGENT_YAML. Here we stub
+  // agent-analyzer with a shell-exec that echoes its AGENT_YAML input
+  // so we can grep the resulting run output for proof of injection.
+
+  it('auto-injects AGENT_YAML for agent-analyzer from the message agentId', async () => {
+    const app = await makeApp();
+
+    // Install a small target agent. The token "target-agent-marker" in
+    // its YAML lets us assert downstream that the analyzer received it.
+    const targetYaml = [
+      'id: target-agent-marker',
+      'name: Target Agent Marker',
+      'description: token used by enrichment test',
+      'nodes:',
+      '  - id: noop',
+      '    type: shell',
+      '    command: echo ok',
+    ].join('\n');
+    const target = parseAgent(targetYaml);
+    agentStore.upsertAgent(target, 'dashboard', 'test fixture');
+
+    // Stub agent-analyzer with a shell node that echoes whatever YAML
+    // it received. The route's enrichment passes AGENT_YAML via the
+    // executor's input map; the shell echoes the placeholder substitution.
+    const analyzerYaml = [
+      'id: agent-analyzer',
+      'name: Agent Analyzer',
+      'description: stubbed analyzer for enrichment test',
+      'inputs:',
+      '  AGENT_YAML:',
+      '    type: string',
+      '    required: true',
+      'nodes:',
+      "  - id: echo",
+      "    type: shell",
+      "    command: \"echo received: $AGENT_YAML\"",
+    ].join('\n');
+    const analyzer = parseAgent(analyzerYaml);
+    agentStore.upsertAgent(analyzer, 'dashboard', 'test fixture');
+
+    // Inbox message whose `agentId` references the target.
+    const msg = inboxStore.add({
+      priority: 'high',
+      source: 'run-failure',
+      title: 'target failed',
+      body: 'something broke',
+      agentId: 'target-agent-marker',
+    });
+
+    // Triage would normally propose this; insert it directly so we
+    // skip the LLM round-trip.
+    const proposed = inboxStore.addResponse(
+      msg.id,
+      'action',
+      'analyze the failing agent',
+      JSON.stringify({
+        kind: 'action',
+        status: 'proposed',
+        agentId: 'agent-analyzer',
+        inputs: { FOCUS: 'why does this fail' },
+        rationale: 'Get a concrete fix.',
+      }),
+    );
+
+    const res = await request(app)
+      .post(`/inbox/${msg.id}/actions/${proposed.id}/run`)
+      .set('X-Requested-With', 'fetch')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE);
+    expect(res.status).toBe(204);
+
+    // Wait for the shell node to complete. Up to ~2s — local shell
+    // is near-instant but we don't want to flake on a slow CI box.
+    const deadline = Date.now() + 2000;
+    let after = inboxStore.getResponse(proposed.id);
+    while (Date.now() < deadline) {
+      after = inboxStore.getResponse(proposed.id);
+      const m = after?.metaJson ? JSON.parse(after.metaJson) : null;
+      if (m && m.status !== 'proposed' && m.status !== 'running') break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(after).not.toBeNull();
+    const meta = JSON.parse(after!.metaJson!);
+    expect(meta.status).toBe('completed');
+    expect(meta.resultSummary).toContain('target-agent-marker');
   });
 });
 

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -26,6 +26,7 @@ import { Router, type Request, type Response } from 'express';
 import { readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import {
+  exportAgent,
   executeAgentDag,
   extractPlanJson,
   parseAgent,
@@ -54,13 +55,29 @@ const PENDING_USER_REPLY_WINDOW_MS = 30_000;
 
 /**
  * Agent IDs that the inbox-triage agent is allowed to propose running
- * on the operator's behalf. Intersected with what's actually installed
- * in the agentStore at proposal time. v1 keeps this hardcoded — a
- * future PR can move it to a `agents/areas/inbox.yaml` per-area config.
+ * on the operator's behalf. Each entry that resolves to an installed
+ * (or auto-importable) agent becomes available to triage. v1 keeps
+ * this hardcoded — a future PR can move it to a per-area config.
+ *
+ * `agent-analyzer` is the agent behind the "Suggest improvements"
+ * button on the agent detail page. When triage proposes it, the route
+ * auto-injects AGENT_YAML (from the inbox message's agentId) +
+ * LAST_RUN_OUTPUT, mirroring the analyze route at
+ * `run-now-build.ts:415`.
  */
 const TRIAGE_SUB_AGENT_ALLOWLIST: readonly string[] = [
-  'suggest-improvements',
+  'agent-analyzer',
 ];
+
+/**
+ * For allowlist entries that aren't already installed, the route
+ * lazy-imports the YAML on first triage call (mirrors what the
+ * existing analyze route does for agent-analyzer). The path lookup
+ * is conservative — any agent that isn't installed AND isn't shipped
+ * under `agents/examples/` is silently dropped from the effective
+ * allowlist.
+ */
+const ALLOWLIST_AUTOIMPORT_DIR = 'agents/examples';
 
 /**
  * Hard cap on `action`-role responses per inbox message. Triage gets a
@@ -419,12 +436,97 @@ function parseActionMeta(r: InboxResponse): InboxActionMeta | null {
 
 /**
  * Build the effective allowlist of sub-agent ids triage may propose
- * running: the static list intersected with what's currently installed
- * in the agentStore. This guards against the prompt mentioning agents
- * that aren't present on this instance.
+ * running. For entries not yet installed, attempt a one-shot import
+ * from `agents/examples/<id>.yaml` (same pattern the analyze route uses
+ * for agent-analyzer). Entries that can't be imported are silently
+ * dropped — the prompt never sees them, so triage can't propose them.
  */
 function getSubAgentAllowlist(ctx: ReturnType<typeof getContext>): string[] {
-  return TRIAGE_SUB_AGENT_ALLOWLIST.filter((id) => ctx.agentStore.getAgent(id));
+  const available: string[] = [];
+  for (const id of TRIAGE_SUB_AGENT_ALLOWLIST) {
+    if (ctx.agentStore.getAgent(id)) {
+      available.push(id);
+      continue;
+    }
+    try {
+      const yamlPath = join(resolve(ALLOWLIST_AUTOIMPORT_DIR), `${id}.yaml`);
+      const yamlText = readFileSync(yamlPath, 'utf-8');
+      const parsed = parseAgent(yamlText);
+      ctx.agentStore.upsertAgent(parsed, 'import', `Auto-imported for inbox triage allowlist`);
+      if (ctx.agentStore.getAgent(id)) available.push(id);
+    } catch {
+      // No example YAML to import from — skip; the allowlist just
+      // shrinks. Operator can install the agent manually later.
+    }
+  }
+  return available;
+}
+
+/**
+ * For agent-analyzer specifically: auto-inject AGENT_YAML (and
+ * LAST_RUN_OUTPUT when available) so triage doesn't have to thread
+ * the full YAML string through its <plan>. Mirrors the analyze
+ * route's input shape at run-now-build.ts:441-489 but stripped down
+ * (no DISCOVERY_CATALOG yet — that needs the tools/templates registry
+ * and we keep this PR focused on the inbox plumbing).
+ *
+ * Returns a new inputs object; the original is not mutated. When the
+ * inbox message has no `agentId`, the function returns the inputs
+ * unchanged and execution proceeds — agent-analyzer will fail loudly
+ * on the missing required AGENT_YAML, surfaced via the action's
+ * `failed` state in the conversation thread.
+ */
+function enrichAgentAnalyzerInputs(
+  ctx: ReturnType<typeof getContext>,
+  messageAgentId: string | undefined,
+  inputs: Record<string, string>,
+): Record<string, string> {
+  const out: Record<string, string> = { ...inputs };
+  if (!out.AGENT_YAML && messageAgentId) {
+    const target = ctx.agentStore.getAgent(messageAgentId);
+    if (target) {
+      try { out.AGENT_YAML = exportAgent(target); } catch { /* swallow */ }
+    }
+  }
+  if (!out.LAST_RUN_OUTPUT && messageAgentId) {
+    const summary = collectRunSummary(ctx, messageAgentId);
+    if (summary) out.LAST_RUN_OUTPUT = summary;
+  }
+  return out;
+}
+
+/**
+ * Distilled version of run-now-build.ts's run-output collector:
+ * grab the latest completed run's result + the latest failed run's
+ * error/output, cap at 3000 chars. Empty string when neither exists.
+ */
+function collectRunSummary(
+  ctx: ReturnType<typeof getContext>,
+  agentName: string,
+): string {
+  let out = '';
+  try {
+    const completed = ctx.runStore.listRuns({ agentName, status: 'completed', limit: 1 });
+    if (completed.length > 0 && completed[0].result) {
+      const raw = completed[0].result;
+      out = raw.length > 2000 ? raw.slice(0, 2000) + '\n...(truncated)' : raw;
+    }
+    const failed = ctx.runStore.listRuns({ agentName, status: 'failed', limit: 1 });
+    if (failed.length > 0) {
+      const f = failed[0];
+      const failedAt = f.completedAt ?? f.startedAt;
+      const completedAt = completed[0]?.completedAt ?? '';
+      if (!completedAt || failedAt > completedAt) {
+        const parts = [
+          `\n\nMOST RECENT RUN FAILED (${f.id.slice(0, 8)}):`,
+          f.error ? `Error: ${f.error}` : '',
+          f.result ? `Output: ${f.result.slice(0, 1000)}` : '',
+        ].filter(Boolean);
+        out += parts.join('\n');
+      }
+    }
+  } catch { /* swallow */ }
+  return out.length > 3000 ? out.slice(0, 3000) + '\n...(truncated)' : out;
 }
 
 /**
@@ -504,6 +606,16 @@ async function runProposedAction(
     metaJson: JSON.stringify({ ...meta, status: 'running', startedAt }),
   });
 
+  // Per-agent input enrichment. Today only agent-analyzer needs
+  // server-side help (the AGENT_YAML it requires is heavy and lives in
+  // the agentStore, not in triage's prompt context). Future allowlist
+  // entries can add their own case here.
+  let effectiveInputs = meta.inputs;
+  if (meta.agentId === 'agent-analyzer') {
+    const parentMessage = ctx.inboxStore.get(messageId);
+    effectiveInputs = enrichAgentAnalyzerInputs(ctx, parentMessage?.agentId, meta.inputs);
+  }
+
   let runId: string | undefined;
   let nextStatus: InboxActionStatus = 'failed';
   let resultSummary: string | undefined;
@@ -513,7 +625,7 @@ async function runProposedAction(
       subAgent,
       {
         triggeredBy: 'dashboard',
-        inputs: meta.inputs,
+        inputs: effectiveInputs,
       },
       {
         runStore: ctx.runStore,


### PR DESCRIPTION
## Summary

You spotted it — the action behind the **Suggest improvements** button is actually `agent-analyzer`, not the fictional `suggest-improvements` from PR #386. This PR repoints the inbox triage allowlist at the real, useful agent and wires the input enrichment so triage doesn't have to thread fat strings through its prompt.

- `TRIAGE_SUB_AGENT_ALLOWLIST` is now `['agent-analyzer']`.
- `getSubAgentAllowlist` lazy-imports allowlist entries from `agents/examples/<id>.yaml` when not already installed (same pattern the existing analyze route uses).
- `enrichAgentAnalyzerInputs` runs at action-execution time. When the proposed action targets `agent-analyzer` and the parent inbox message has an `agentId`:
  - **AGENT_YAML** ← `exportAgent(target)` (the failing agent's full YAML)
  - **LAST_RUN_OUTPUT** ← `collectRunSummary(ctx, target.id)` (latest completed result + latest-failed error/output, capped at 3KB)
  - **FOCUS** ← passed through from the triage proposal's `inputs.FOCUS`

Mirrors the analyze route's input shape at [run-now-build.ts:441-489](packages/dashboard/src/routes/run-now-build.ts#L441-L489), scoped down — no DISCOVERY_CATALOG for now (that needs the tools + templates registry; can land later if useful).

Triage prompt example updated; existing inbox tests retargeted to the new agent id; new end-to-end test installs a target agent + a stub analyzer, posts a proposed action, runs it, and asserts the result contains the target's marker token (proves AGENT_YAML enrichment fired).

## Test plan
- [ ] /inbox → demo-failing-agent failed row → reply: "what should I change in this agent?"
- [ ] Verify triage's response includes an action card for `agent-analyzer`
- [ ] Click Run → card transitions running → completed with the analyzer's suggestions in the preview
- [ ] Inspect the linked run to confirm AGENT_YAML + LAST_RUN_OUTPUT were injected
- [ ] After action resolves, triage gets a follow-up turn summarizing
- [ ] `gh pr checks` → all green

## Follow-ups
- Top-nav unread badge + Pulse summary tile (separate PR per your direction)
- DISCOVERY_CATALOG enrichment for agent-analyzer (parity with the analyze route) if/when triage benefits from broader awareness

🤖 Generated with [Claude Code](https://claude.com/claude-code)