### PR TITLE
feat(dashboard): inbox triage can apply YAML fixes (diagnose → propose → apply)

### DIFF
--- a/.changeset/inbox-apply-fix.md
+++ b/.changeset/inbox-apply-fix.md
@@ -1,0 +1,36 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox triage can now apply YAML fixes to agents, not just suggest them.
+
+After `agent-analyzer` completes inside an inbox triage action, the
+route extracts the `<yaml>...</yaml>` block from the analyzer's
+`analyze` (or `fix`) node output and auto-proposes an `agent-editor`
+action card with a unified diff against the agent's current YAML.
+The operator reviews the diff in-place, clicks Run, and the route
+commits a new version via `agentStore.upsertAgent` (undo via the
+agent detail page's version history).
+
+- New `agents/examples/agent-editor.yaml` — minimal stub documenting
+  the contract. The actual write is performed synchronously inside
+  `runProposedAction` (special-cased via `ROUTE_HANDLED_AGENTS`),
+  not by dispatching the DAG.
+- New `transitionActionStatus` already in place from PR #388 gives
+  the editor the same race-safe idempotent treatment as analyzer.
+- Validation: refuses NEW_YAML that fails `parseAgent`, refuses when
+  parsed id doesn't match `AGENT_ID` (prevents accidental cross-agent
+  edits).
+- Triage prompt updated to clarify: do NOT propose `agent-editor`
+  directly — propose `agent-analyzer` and the route's auto-propose
+  handles the rest.
+- Unified-diff renderer in the action card (hand-rolled LCS, ~50
+  LOC, no new deps) with `+`/`-`/` ` line styling.
+
+Verified end-to-end in browser: demo-failing-agent → reply →
+analyzer proposed → run → editor auto-proposed with diff →
+run → demo-failing-agent committed at v2.

--- a/agents/examples/agent-editor.yaml
+++ b/agents/examples/agent-editor.yaml
@@ -1,0 +1,50 @@
+# Agent Editor — applies a YAML change to an existing agent.
+#
+# This agent is dispatched by inbox triage as the second step of the
+# diagnose-then-fix loop:
+#   1. agent-analyzer scans a failing agent's YAML, emits a corrected
+#      <yaml>...</yaml> block in its run result
+#   2. The dashboard route extracts that block, auto-proposes an
+#      agent-editor action card (with diff preview) targeting the
+#      same AGENT_ID
+#   3. Operator reviews the diff and clicks Run
+#   4. The route validates NEW_YAML, confirms the parsed id matches
+#      AGENT_ID, and commits the new version via
+#      `agentStore.upsertAgent` (creates a new entry in
+#      `agent_versions` — undo via the agent detail page)
+#
+# IMPORTANT: this YAML is the public-facing contract. The actual edit
+# is performed by the inbox route (`runProposedAction` in
+# packages/dashboard/src/routes/inbox.ts), not by executing the DAG
+# below. The single shell node is a no-op kept here only so the
+# allowlist's lazy-import + agentStore lookup succeed.
+
+id: agent-editor
+name: Agent Editor
+description: >
+  Commits a YAML change to an existing agent. Dispatched by inbox
+  triage as the apply-the-fix step after agent-analyzer produces a
+  validated proposed YAML. The actual upsertAgent call is performed
+  by the dashboard route, not by this DAG.
+status: active
+source: examples
+timeoutSec: 30
+
+inputs:
+  AGENT_ID:
+    type: string
+    required: true
+    description: The id of the agent to update. Must match the parsed id of NEW_YAML.
+  NEW_YAML:
+    type: string
+    required: true
+    description: >
+      The complete replacement YAML. Must pass `parseAgent` validation
+      and the parsed `id` field must equal AGENT_ID. The route refuses
+      mismatched ids to prevent triage from accidentally pointing at
+      the wrong target.
+
+nodes:
+  - id: noop
+    type: shell
+    command: echo "Edit handled by route — see runProposedAction in packages/dashboard/src/routes/inbox.ts."

--- a/agents/examples/inbox-triage.yaml
+++ b/agents/examples/inbox-triage.yaml
@@ -155,6 +155,12 @@ nodes:
       - If the conversation already shows a prior action of the same
         kind that ran and completed, DO NOT propose it again — instead
         summarize its result in `recommendation`.
+      - DO NOT propose `agent-editor` directly. It is managed by the
+        dashboard: when `agent-analyzer` produces a corrected YAML in
+        its run output, the route automatically inserts an
+        `agent-editor` action card with the diff preview. Your only
+        job for fix-applying flows is to propose `agent-analyzer` —
+        the editor proposal follows for free.
 
       If `ALLOWED_SUB_AGENTS` is empty OR no action would help, omit
       `actions` entirely (or send an empty array). Text-only

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -2391,3 +2391,47 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
   font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
+
+/* ---------- Inbox: agent-editor diff preview ---------- */
+/* Unified-diff inside a proposed agent-editor action card. Operator
+ * sees exactly what's about to change before clicking Run. */
+.inbox-action__diff {
+  margin-top: var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  background: var(--color-surface-raised, #1f2430);
+  overflow: hidden;
+}
+.inbox-action__diff-header {
+  padding: 4px var(--space-2);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+.inbox-action__diff-add { color: var(--color-ok, #34d399); font-weight: var(--weight-semibold); }
+.inbox-action__diff-del { color: var(--color-danger, #f87171); font-weight: var(--weight-semibold); }
+.inbox-action__diff-body {
+  margin: 0;
+  padding: 0;
+  font-size: var(--font-size-xs);
+  line-height: 1.45;
+  max-height: 20rem;
+  overflow: auto;
+  white-space: pre;
+}
+.inbox-action__diff-line {
+  display: block;
+  padding: 0 var(--space-2);
+}
+.inbox-action__diff-line--add {
+  background: rgba(52, 211, 153, 0.12);
+  color: var(--color-ok, #34d399);
+}
+.inbox-action__diff-line--del {
+  background: rgba(248, 113, 113, 0.12);
+  color: var(--color-danger, #f87171);
+}
+.inbox-action__diff-line--ctx {
+  color: var(--color-text-muted);
+}

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -588,6 +588,135 @@ describe('POST /inbox/:id/actions/:rid/run — agent-analyzer enrichment', () =>
   });
 });
 
+describe('POST /inbox/:id/actions/:rid/run — agent-editor write path', () => {
+  // agent-editor is route-handled: no DAG dispatch, just a synchronous
+  // upsertAgent after validation. These tests install a target agent,
+  // propose an agent-editor action, and verify the lifecycle outcomes.
+
+  function installTarget(id: string, label: string) {
+    const yaml = [
+      `id: ${id}`,
+      `name: ${label}`,
+      'description: test fixture',
+      'nodes:',
+      '  - id: noop',
+      '    type: shell',
+      '    command: echo old',
+    ].join('\n');
+    agentStore.upsertAgent(parseAgent(yaml), 'dashboard', 'test fixture');
+  }
+
+  function proposeEditor(messageId: string, agentId: string, newYaml: string) {
+    return inboxStore.addResponse(messageId, 'action', 'Apply YAML fix', JSON.stringify({
+      kind: 'action',
+      status: 'proposed',
+      agentId: 'agent-editor',
+      inputs: { AGENT_ID: agentId, NEW_YAML: newYaml },
+      rationale: 'apply the proposed fix',
+    }));
+  }
+
+  it('happy path: commits a new version via upsertAgent', async () => {
+    const app = await makeApp();
+    installTarget('target-x', 'old name');
+    const before = agentStore.getAgent('target-x');
+    const newYaml = [
+      'id: target-x',
+      'name: NEW NAME',
+      'description: updated by test',
+      'nodes:',
+      '  - id: noop',
+      '    type: shell',
+      '    command: echo new',
+    ].join('\n');
+    const msg = inboxStore.add({ priority: 'high', source: 'run-failure', title: 't', body: 'b', agentId: 'target-x' });
+    const r = proposeEditor(msg.id, 'target-x', newYaml);
+
+    const res = await request(app)
+      .post(`/inbox/${msg.id}/actions/${r.id}/run`)
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(204);
+
+    // Route-handled path is synchronous inside runProposedAction;
+    // give the microtask queue a tick to settle.
+    await new Promise((r) => setTimeout(r, 30));
+
+    const after = agentStore.getAgent('target-x');
+    expect(after?.name).toBe('NEW NAME');
+    expect((after?.version ?? 0)).toBeGreaterThan(before?.version ?? 0);
+
+    const action = JSON.parse(inboxStore.getResponse(r.id)!.metaJson!);
+    expect(action.status).toBe('completed');
+    expect(action.resultSummary).toMatch(/Updated agent .target-x. to v/);
+  });
+
+  it('refuses when NEW_YAML id mismatches AGENT_ID', async () => {
+    const app = await makeApp();
+    installTarget('target-y', 'y');
+    const mismatched = [
+      'id: someone-else',
+      'name: drift',
+      'description: drift fixture',
+      'nodes:',
+      '  - id: noop',
+      '    type: shell',
+      '    command: echo x',
+    ].join('\n');
+    const msg = inboxStore.add({ priority: 'high', source: 'run-failure', title: 't', body: 'b', agentId: 'target-y' });
+    const r = proposeEditor(msg.id, 'target-y', mismatched);
+
+    await request(app).post(`/inbox/${msg.id}/actions/${r.id}/run`)
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(agentStore.getAgent('target-y')?.name).toBe('y'); // unchanged
+    const action = JSON.parse(inboxStore.getResponse(r.id)!.metaJson!);
+    expect(action.status).toBe('failed');
+    expect(action.refusalReason).toMatch(/does not match AGENT_ID/);
+  });
+
+  it('refuses when NEW_YAML fails parseAgent validation', async () => {
+    const app = await makeApp();
+    installTarget('target-z', 'z');
+    const garbage = 'this: is: not: valid: yaml: {{{{';
+    const msg = inboxStore.add({ priority: 'high', source: 'run-failure', title: 't', body: 'b', agentId: 'target-z' });
+    const r = proposeEditor(msg.id, 'target-z', garbage);
+
+    await request(app).post(`/inbox/${msg.id}/actions/${r.id}/run`)
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    await new Promise((r) => setTimeout(r, 30));
+
+    const action = JSON.parse(inboxStore.getResponse(r.id)!.metaJson!);
+    expect(action.status).toBe('failed');
+    expect(action.refusalReason).toMatch(/failed validation/);
+  });
+
+  it('idempotent: re-running a completed agent-editor action is a no-op', async () => {
+    const app = await makeApp();
+    installTarget('target-i', 'before');
+    const okYaml = [
+      'id: target-i',
+      'name: AFTER',
+      'description: ok',
+      'nodes: [{ id: noop, type: shell, command: echo ok }]',
+    ].join('\n');
+    const msg = inboxStore.add({ priority: 'high', source: 'run-failure', title: 't', body: 'b', agentId: 'target-i' });
+    const r = proposeEditor(msg.id, 'target-i', okYaml);
+
+    await request(app).post(`/inbox/${msg.id}/actions/${r.id}/run`)
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    await new Promise((r) => setTimeout(r, 30));
+    const v1 = agentStore.getAgent('target-i')?.version ?? 0;
+
+    // Click Run a second time; idempotent path returns 204 without writing.
+    const res2 = await request(app).post(`/inbox/${msg.id}/actions/${r.id}/run`)
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res2.status).toBe(204);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(agentStore.getAgent('target-i')?.version).toBe(v1);
+  });
+});
+
 describe('POST /inbox/:id/triage', () => {
   it('returns 204 (AJAX) and inserts a synthetic "Asked triage" user marker', async () => {
     const app = await makeApp();

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -67,7 +67,17 @@ const PENDING_USER_REPLY_WINDOW_MS = 30_000;
  */
 const TRIAGE_SUB_AGENT_ALLOWLIST: readonly string[] = [
   'agent-analyzer',
+  'agent-editor',
 ];
+
+/**
+ * Agent IDs handled by the route directly rather than dispatched as a
+ * sub-agent run. The "agent" entry here exists so the allowlist + UI
+ * affordances behave consistently, but the actual side effect (e.g.
+ * committing a YAML change via `agentStore.upsertAgent`) is performed
+ * synchronously inside `runProposedAction`.
+ */
+const ROUTE_HANDLED_AGENTS: ReadonlySet<string> = new Set(['agent-editor']);
 
 /**
  * For allowlist entries that aren't already installed, the route
@@ -151,7 +161,8 @@ inboxRouter.get('/inbox/:id', (req: Request, res: Response) => {
   }
   const responses = ctx.inboxStore.listResponses(id);
   const triagePending = isTriagePending(ctx, message, responses);
-  res.type('html').send(renderInboxDetail({ message, responses, flash: parseFlash(req), triagePending }));
+  const currentTargetYaml = exportTargetAgentYaml(ctx, message.agentId);
+  res.type('html').send(renderInboxDetail({ message, responses, flash: parseFlash(req), triagePending, currentTargetYaml }));
 });
 
 inboxRouter.get('/inbox/:id/fragment', (req: Request, res: Response) => {
@@ -168,7 +179,8 @@ inboxRouter.get('/inbox/:id/fragment', (req: Request, res: Response) => {
   }
   const responses = ctx.inboxStore.listResponses(id);
   const triagePending = isTriagePending(ctx, message, responses);
-  res.type('html').send(render(renderInboxDetailFragment({ message, responses, triagePending })));
+  const currentTargetYaml = exportTargetAgentYaml(ctx, message.agentId);
+  res.type('html').send(render(renderInboxDetailFragment({ message, responses, triagePending, currentTargetYaml })));
 });
 
 inboxRouter.post('/inbox/:id/dismiss', (req: Request, res: Response) => {
@@ -495,6 +507,23 @@ function getSubAgentAllowlist(ctx: ReturnType<typeof getContext>): string[] {
 }
 
 /**
+ * Export the YAML of the agent referenced by `agentId` (the inbox
+ * message's target). The detail view passes this into the diff
+ * renderer so `agent-editor` action cards can show old-vs-new.
+ * Returns undefined when there's no target or the agent isn't
+ * installed — the view falls back to rendering just inputs.
+ */
+function exportTargetAgentYaml(
+  ctx: ReturnType<typeof getContext>,
+  agentId: string | undefined,
+): string | undefined {
+  if (!agentId) return undefined;
+  const target = ctx.agentStore.getAgent(agentId);
+  if (!target) return undefined;
+  try { return exportAgent(target); } catch { return undefined; }
+}
+
+/**
  * For agent-analyzer specifically: auto-inject AGENT_YAML (and
  * LAST_RUN_OUTPUT when available) so triage doesn't have to thread
  * the full YAML string through its <plan>. Mirrors the analyze
@@ -621,6 +650,32 @@ async function runProposedAction(
   meta: InboxActionMeta,
 ): Promise<void> {
   if (!ctx.inboxStore) return;
+
+  // The route handler already transitioned proposed → running
+  // atomically (see /actions/:rid/run); meta passed in already
+  // carries status='running' + startedAt.
+  const startedAt = meta.startedAt ?? Date.now();
+
+  // Route-handled agents (e.g. agent-editor) perform their side
+  // effect synchronously inside the route — no DAG dispatch. The
+  // YAML on disk for these agents is a stub that documents the
+  // contract; the actual write happens here.
+  if (ROUTE_HANDLED_AGENTS.has(meta.agentId)) {
+    const result = await executeRouteHandledAgent(ctx, messageId, meta);
+    ctx.inboxStore.updateResponse(response.id, {
+      metaJson: JSON.stringify({
+        ...meta,
+        status: result.status,
+        startedAt,
+        endedAt: Date.now(),
+        resultSummary: result.summary,
+        refusalReason: result.refusalReason,
+      }),
+    });
+    maybeRefireTriage(ctx, messageId);
+    return;
+  }
+
   const subAgent = ctx.agentStore.getAgent(meta.agentId);
   if (!subAgent) {
     ctx.inboxStore.updateResponse(response.id, {
@@ -633,11 +688,6 @@ async function runProposedAction(
     });
     return;
   }
-  // The route handler already transitioned proposed → running
-  // atomically (see /actions/:rid/run); meta passed in already
-  // carries status='running' + startedAt. We just preserve startedAt
-  // for the duration math at the completion update below.
-  const startedAt = meta.startedAt ?? Date.now();
 
   // Per-agent input enrichment. Today only agent-analyzer needs
   // server-side help (the AGENT_YAML it requires is heavy and lives in
@@ -653,6 +703,7 @@ async function runProposedAction(
   let nextStatus: InboxActionStatus = 'failed';
   let resultSummary: string | undefined;
   let refusalReason: string | undefined;
+  let fullResult = '';
   try {
     const run = await executeAgentDag(
       subAgent,
@@ -670,10 +721,10 @@ async function runProposedAction(
     runId = run.id;
     if (run.status === 'completed') {
       nextStatus = 'completed';
-      const raw = typeof run.result === 'string' ? run.result : '';
-      resultSummary = raw.length > ACTION_RESULT_PREVIEW_LIMIT
-        ? raw.slice(0, ACTION_RESULT_PREVIEW_LIMIT) + '…'
-        : raw;
+      fullResult = typeof run.result === 'string' ? run.result : '';
+      resultSummary = fullResult.length > ACTION_RESULT_PREVIEW_LIMIT
+        ? fullResult.slice(0, ACTION_RESULT_PREVIEW_LIMIT) + '…'
+        : fullResult;
     } else {
       nextStatus = 'failed';
       refusalReason = run.error ?? `Run ended in status ${run.status}.`;
@@ -694,13 +745,164 @@ async function runProposedAction(
     }),
   });
 
-  // If every proposed action on this message has now resolved AND at
-  // least one ran (completed or failed), re-fire triage so it gets a
-  // summary turn. Purely skipped sets do NOT trigger the follow-up —
-  // we treat all-skip as "operator declined, move on."
+  // After agent-analyzer completes successfully, look for a
+  // `<yaml>...</yaml>` block in the `analyze` (or `fix`) node output —
+  // NOT the run-level result, which is the trailing `validate` shell
+  // node's `{valid:true}` JSON. If present + valid + targeting the
+  // inbox message's agent, auto-propose an agent-editor action card
+  // with the parsed YAML.
+  if (meta.agentId === 'agent-analyzer' && nextStatus === 'completed' && runId) {
+    maybeAutoProposeEditorAction(ctx, messageId, runId);
+  }
+
+  maybeRefireTriage(ctx, messageId);
+}
+
+/** Hoisted from the end of `runProposedAction` so route-handled and
+ *  DAG-dispatched paths share the same re-fire trigger. */
+function maybeRefireTriage(
+  ctx: ReturnType<typeof getContext>,
+  messageId: string,
+): void {
   if (allActionsResolved(ctx, messageId) && atLeastOneActionExecuted(ctx, messageId)) {
     void runTriageAgent(ctx, messageId).catch(() => { /* swallow */ });
   }
+}
+
+/**
+ * Synchronous executor for agents listed in `ROUTE_HANDLED_AGENTS`.
+ * Today that's just `agent-editor`, which commits a YAML change via
+ * `agentStore.upsertAgent` after validation. Returns the action's
+ * terminal status + a summary line for the conversation thread.
+ */
+async function executeRouteHandledAgent(
+  ctx: ReturnType<typeof getContext>,
+  messageId: string,
+  meta: InboxActionMeta,
+): Promise<{ status: InboxActionStatus; summary?: string; refusalReason?: string }> {
+  if (meta.agentId === 'agent-editor') {
+    return executeAgentEditor(ctx, messageId, meta);
+  }
+  return {
+    status: 'failed',
+    refusalReason: `Route-handled agent "${meta.agentId}" has no executor.`,
+  };
+}
+
+/**
+ * Apply a YAML change to an existing agent. Validates:
+ *   - `AGENT_ID` input is present
+ *   - `NEW_YAML` parses cleanly via `parseAgent`
+ *   - parsed `id` matches `AGENT_ID` (prevents accidentally targeting
+ *     the wrong agent if triage hallucinates an id mismatch)
+ *
+ * On success commits via `agentStore.upsertAgent` (creates a new
+ * version — undo via the agent detail page). On failure leaves the
+ * agent untouched and surfaces the reason in the action card.
+ */
+function executeAgentEditor(
+  ctx: ReturnType<typeof getContext>,
+  messageId: string,
+  meta: InboxActionMeta,
+): { status: InboxActionStatus; summary?: string; refusalReason?: string } {
+  void messageId;
+  const agentId = meta.inputs.AGENT_ID;
+  const newYaml = meta.inputs.NEW_YAML;
+  if (!agentId || !newYaml) {
+    return {
+      status: 'failed',
+      refusalReason: 'agent-editor requires both AGENT_ID and NEW_YAML inputs.',
+    };
+  }
+  let parsed;
+  try {
+    parsed = parseAgent(newYaml);
+  } catch (err) {
+    return {
+      status: 'failed',
+      refusalReason: `NEW_YAML failed validation: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  if (parsed.id !== agentId) {
+    return {
+      status: 'failed',
+      refusalReason: `NEW_YAML parsed id "${parsed.id}" does not match AGENT_ID "${agentId}". Refusing the edit.`,
+    };
+  }
+  try {
+    ctx.agentStore.upsertAgent(parsed, 'dashboard', 'Inbox triage applied YAML fix');
+  } catch (err) {
+    return {
+      status: 'failed',
+      refusalReason: `upsertAgent failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  const after = ctx.agentStore.getAgent(agentId);
+  const version = after?.version ?? '?';
+  return {
+    status: 'completed',
+    summary: `Updated agent \`${agentId}\` to v${version}.`,
+  };
+}
+
+/**
+ * Extract a `<yaml>...</yaml>` block from agent-analyzer's run
+ * result, validate it, and (if it targets the inbox message's agent)
+ * auto-insert a proposed `agent-editor` action card. Silently no-ops
+ * if no yaml block is present, if it doesn't parse, if it targets a
+ * different agent, or if the per-message action cap has been hit.
+ */
+function maybeAutoProposeEditorAction(
+  ctx: ReturnType<typeof getContext>,
+  messageId: string,
+  analyzerRunId: string,
+): void {
+  if (!ctx.inboxStore) return;
+  // The analyzer DAG ends in a `validate` shell node whose tiny
+  // {valid:true} output overshadows the LLM's full response at the
+  // run-level `.result`. The actual YAML lives in the `analyze` or
+  // `fix` node's output. Prefer `fix` (later in the chain, runs only
+  // when validate found issues) over `analyze`.
+  const execs = ctx.runStore.listNodeExecutions(analyzerRunId);
+  const fix = execs.find((e) => e.nodeId === 'fix' && e.status === 'completed');
+  const analyze = execs.find((e) => e.nodeId === 'analyze' && e.status === 'completed');
+  const source = (fix?.result ?? analyze?.result ?? '').toString();
+  const match = source.match(/<yaml>\s*\n?([\s\S]*?)<\/yaml>/);
+  if (!match) return;
+  const proposedYaml = match[1].trim();
+  if (proposedYaml.length < 10) return;
+  let parsed;
+  try { parsed = parseAgent(proposedYaml); } catch { return; }
+
+  const message = ctx.inboxStore.get(messageId);
+  if (!message?.agentId || parsed.id !== message.agentId) return;
+
+  // Respect the cap so a chatty analyzer can't fan out unbounded edits.
+  if (countActionsOnMessage(ctx, messageId) >= MAX_ACTIONS_PER_MESSAGE) return;
+
+  // Avoid duplicate proposals if the same YAML was already proposed
+  // and is still pending — operator might be mid-decision.
+  for (const r of ctx.inboxStore.listResponses(messageId)) {
+    if (r.role !== 'action') continue;
+    const m = parseActionMeta(r);
+    if (m && m.agentId === 'agent-editor'
+      && (m.status === 'proposed' || m.status === 'running')
+      && m.inputs.NEW_YAML === proposedYaml) return;
+  }
+
+  const action: InboxActionMeta = {
+    kind: 'action',
+    status: 'proposed',
+    agentId: 'agent-editor',
+    inputs: { AGENT_ID: message.agentId, NEW_YAML: proposedYaml },
+    rationale: `Apply the YAML fix that agent-analyzer produced.`,
+  };
+  ctx.inboxStore.addResponse(
+    messageId,
+    'action',
+    action.rationale!,
+    JSON.stringify(action),
+  );
 }
 
 function allActionsResolved(

--- a/packages/dashboard/src/views/inbox-detail.ts
+++ b/packages/dashboard/src/views/inbox-detail.ts
@@ -21,6 +21,14 @@ export interface InboxDetailOptions {
    * thinking indicator that inbox-modal.js polls on.
    */
   triagePending?: boolean;
+  /**
+   * Current YAML of the agent referenced by `message.agentId`, used
+   * to render the unified diff inside `agent-editor`-targeting action
+   * cards. The route exports this once via `core.exportAgent` and
+   * passes it in; the view keeps no agentStore dependency. Absent
+   * when the message has no target agent or it isn't installed.
+   */
+  currentTargetYaml?: string;
 }
 
 const PRIORITY_BADGE: Record<string, string> = {
@@ -69,7 +77,7 @@ const ACTION_STATUS_LABEL: Record<InboxActionStatus, string> = {
  * standard dashboard layout for direct-link access + accessibility.
  */
 export function renderInboxDetailFragment(opts: InboxDetailOptions): SafeHtml {
-  const { message, responses, flash, triagePending } = opts;
+  const { message, responses, flash, triagePending, currentTargetYaml } = opts;
   const badgeClass = PRIORITY_BADGE[message.priority] ?? 'badge--muted';
   const isTerminal = message.status === 'dismissed' || message.status === 'resolved';
 
@@ -124,7 +132,7 @@ export function renderInboxDetailFragment(opts: InboxDetailOptions): SafeHtml {
     </details>
   ` : html``;
 
-  const timeline = responses.map((r) => renderConversationEntry(r));
+  const timeline = responses.map((r) => renderConversationEntry(r, currentTargetYaml));
 
   const conversationBlock = html`
     <section style="margin-top: var(--space-3); padding-top: var(--space-3); border-top: 1px solid var(--color-border);">
@@ -216,8 +224,8 @@ function pretty(raw: string): string {
  * branch to a card renderer that surfaces Run / Skip controls + the
  * sub-agent's status.
  */
-function renderConversationEntry(r: InboxResponse): SafeHtml {
-  if (r.role === 'action') return renderActionEntry(r);
+function renderConversationEntry(r: InboxResponse, currentTargetYaml?: string): SafeHtml {
+  if (r.role === 'action') return renderActionEntry(r, currentTargetYaml);
   const role = (ROLE_LABEL[r.role] ?? r.role);
   const avatar = ROLE_AVATAR[r.role] ?? r.role.slice(0, 1).toUpperCase();
   return html`
@@ -253,7 +261,7 @@ function parseActionMeta(r: InboxResponse): InboxActionMeta | null {
 }
 
 /** Render an action-role row as a card whose body depends on status. */
-function renderActionEntry(r: InboxResponse): SafeHtml {
+function renderActionEntry(r: InboxResponse, currentTargetYaml?: string): SafeHtml {
   const meta = parseActionMeta(r);
   if (!meta) {
     // Malformed action row — fall back to plain rendering so the
@@ -309,7 +317,9 @@ function renderActionEntry(r: InboxResponse): SafeHtml {
             ${meta.runId ? html` · <a href="/runs/${meta.runId}" class="mono">run ${meta.runId.slice(0, 8)}</a>` : html``}
           </div>
           ${meta.rationale ? html`<div class="inbox-action__rationale">${meta.rationale}</div>` : html``}
-          ${inputsRendered}
+          ${meta.agentId === 'agent-editor' && meta.inputs.NEW_YAML
+            ? renderYamlDiff(currentTargetYaml ?? '', meta.inputs.NEW_YAML)
+            : inputsRendered}
           ${detailBlock}
           ${controlsBlock}
         </div>
@@ -368,6 +378,54 @@ function renderActionStatusBody(meta: InboxActionMeta): SafeHtml {
     default:
       return html``;
   }
+}
+
+/**
+ * Render a unified-diff view of `oldYaml` vs `newYaml`. Used by
+ * agent-editor action cards so the operator sees exactly what's
+ * about to change before clicking Run. Hand-rolled LCS-based line
+ * diff — agent YAMLs are small (~100 lines) so O(m*n) memory is
+ * trivial. Lines that match render dim; removed lines red, added
+ * lines green.
+ */
+function renderYamlDiff(oldYaml: string, newYaml: string): SafeHtml {
+  const a = oldYaml.split('\n');
+  const b = newYaml.split('\n');
+  const m = a.length, n = b.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+  for (let i = m - 1; i >= 0; i--) {
+    for (let j = n - 1; j >= 0; j--) {
+      dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+  const rows: SafeHtml[] = [];
+  let plus = 0, minus = 0;
+  let i = 0, j = 0;
+  while (i < m && j < n) {
+    if (a[i] === b[j]) { rows.push(diffLine(' ', a[i])); i++; j++; }
+    else if (dp[i + 1][j] >= dp[i][j + 1]) { rows.push(diffLine('-', a[i])); i++; minus++; }
+    else { rows.push(diffLine('+', b[j])); j++; plus++; }
+  }
+  while (i < m) { rows.push(diffLine('-', a[i++])); minus++; }
+  while (j < n) { rows.push(diffLine('+', b[j++])); plus++; }
+
+  return html`
+    <div class="inbox-action__diff">
+      <div class="inbox-action__diff-header">
+        Proposed YAML change — <span class="inbox-action__diff-add">+${plus}</span> /
+        <span class="inbox-action__diff-del">-${minus}</span>
+      </div>
+      <pre class="inbox-action__diff-body mono">${rows as unknown as SafeHtml[]}</pre>
+    </div>
+  `;
+}
+
+function diffLine(kind: ' ' | '+' | '-', text: string): SafeHtml {
+  const cls = kind === '+' ? 'inbox-action__diff-line--add'
+    : kind === '-' ? 'inbox-action__diff-line--del'
+    : 'inbox-action__diff-line--ctx';
+  return html`<span class="inbox-action__diff-line ${cls}">${kind} ${text}
+</span>`;
 }
 
 function formatDuration(meta: InboxActionMeta): string {


### PR DESCRIPTION
## Summary

You asked: "Can triage actually fix the agent, not just suggest a fix?" Now it can.

After `agent-analyzer` completes inside an inbox triage action, the route extracts the `<yaml>...</yaml>` block from the analyzer's `analyze`/`fix` node output and auto-proposes an `agent-editor` action card with a **unified diff** against the agent's current YAML. The operator reviews the diff inline, clicks **Run**, and the route commits a new version via `agentStore.upsertAgent`. Undo lives in the agent detail page's version history.

### How the loop works
1. Operator replies in the inbox thread → triage proposes `agent-analyzer`
2. Operator clicks Run → analyzer scans the failing agent's YAML, emits a corrected `<yaml>` block (its existing flow includes validation + self-correction)
3. **Route auto-proposes** `agent-editor` action card with the parsed YAML + a diff against the current version
4. Operator reviews the diff (`-shell-exec ls` / `+ls` in the demo case), clicks Run
5. Route validates (`parseAgent` + id-match) → `upsertAgent` commits v2

### New pieces
- **`agents/examples/agent-editor.yaml`** — minimal stub documenting the contract. The DAG is a noop; the actual write is route-handled via the new `ROUTE_HANDLED_AGENTS` set so `runProposedAction` performs `upsertAgent` synchronously after validation.
- **`maybeAutoProposeEditorAction`** pulls the `<yaml>` block from `node_executions` (NOT `run.result`, which is the trailing `validate` shell node's tiny `{valid:true}`). Parses + verifies parsed id matches `message.agentId`. Dedupes against already-pending proposals.
- **Validation rails**: refuses NEW_YAML that fails `parseAgent`; refuses when parsed id doesn't match `AGENT_ID` (prevents accidental cross-agent edits if the analyzer regresses on id stability).
- **Unified-diff renderer** in the action card. Hand-rolled LCS, ~50 LOC, no new deps. `+` green / `-` red / ` ` dim. Capped 20rem with internal scroll.
- **Triage prompt** updated: do NOT propose `agent-editor` directly — propose `agent-analyzer` and the route's auto-propose handles the rest.

### Tests (4 new, 1786 → 1790 total)
- Happy path: commits a new agent version via upsertAgent
- Refuses when NEW_YAML id mismatches AGENT_ID
- Refuses when NEW_YAML fails parseAgent
- Idempotent: re-running a completed agent-editor action is a no-op (preserves the prior commit, no double-write)

### Verified end-to-end in browser
demo-failing-agent → "Use agent-analyzer to scan this and suggest a fix" → triage proposes analyzer → Run → analyzer emits `<yaml>` block → route auto-proposes editor card with diff (`-command: shell-exec ls` / `+command: ls`) → Run → `demo-failing-agent` committed at v2 with commit message "Inbox triage applied YAML fix".

## Test plan
- [ ] `gh pr checks` → all green
- [ ] /inbox demo-failing-agent → reply with "scan this please" → analyzer card appears
- [ ] Click Run → analyzer completes → editor card with diff appears
- [ ] Diff shows clear red/green lines for the shell-exec → exec swap
- [ ] Click Run on editor → demo-failing-agent gains a new version (visit /agents/demo-failing-agent → Versions tab)
- [ ] Re-clicking Run on the same editor card is a no-op (no double-write)

## Follow-ups
- Top-nav unread badge + Pulse summary tile (still queued)
- Auto-rerun-after-fix: after editor commits v2, kick off a verification run of the fixed agent and pin the outcome to the conversation
- "Reject this fix" option distinct from Skip, so triage can learn from rejections

🤖 Generated with [Claude Code](https://claude.com/claude-code)