### PR TITLE
feat(core,dashboard): LLM fallback when primary provider is unresponsive

### DIFF
--- a/.changeset/llm-fallback.md
+++ b/.changeset/llm-fallback.md
@@ -1,0 +1,37 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+LLM fallback policy: when the primary provider fails with a
+recognized credit/quota/binary-missing/timeout error, node-spawner
+automatically retries the same prompt under a configured fallback
+provider. Operators configure both providers from a new
+`/settings/llm` page that also includes a Probe button for liveness
+checks and a "last fallback fired" status line.
+
+- New `LlmSettingsStore` (file-backed JSON at
+  `data/.sua/llm-settings.json`) — `{ primary, fallback?, lastFallback? }`
+- New `classifyLlmFailure(SpawnResult)` buckets failures into
+  `credit_exhausted | quota_exceeded | binary_missing | timeout |
+  rate_limited | auth_required | other`. Only the first four trigger
+  a fallback; rate limits stay on the primary (transient), auth
+  failures bubble up (operator action required), `other` is treated
+  as a real bug we don't want to mask.
+- `spawnNodeReal` accepts an `llmSettings` snapshot in opts and
+  retries with the fallback provider when applicable. The snapshot
+  carries an `onFallback` callback that records telemetry back to
+  the store so the settings page can show "fallback fired 3m ago on
+  agent X because credit_exhausted."
+- `DagExecutorDeps.llmSettings` threads the snapshot through; every
+  dashboard `executeAgentDag` call site (inbox, run-now, build,
+  layout planners, widget-run, run-mutations) is wired up.
+- New `/settings/llm` route + view with primary/fallback dropdowns,
+  Save button, Probe button (spawns each CLI with `--version`,
+  reports reachable/failed inline), and a status panel for last
+  fallback telemetry. New "LLM" tab in the settings shell nav.
+
+19 new tests covering store CRUD + the failure classifier.

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { startDashboardServer } from '@some-useful-agents/dashboard';
 import { getMcpTokenPath, readMcpToken } from '@some-useful-agents/core';
-import { loadConfig, getAgentDirs, getDbPath, getSecretsPath, getVariablesPath, getRetentionDays, getDashboardBaseUrl } from '../config.js';
+import { loadConfig, getAgentDirs, getDbPath, getSecretsPath, getVariablesPath, getLlmSettingsPath, getRetentionDays, getDashboardBaseUrl } from '../config.js';
 import * as ui from '../ui.js';
 
 function collectName(value: string, previous: string[]): string[] {
@@ -80,6 +80,7 @@ of scope for this release — wrap in launchd / systemd if you need it.
         dbPath: getDbPath(config),
         secretsPath: getSecretsPath(config),
         variablesPath: getVariablesPath(config),
+        llmSettingsPath: getLlmSettingsPath(config),
         retentionDays: getRetentionDays(config),
         allowUntrustedShell: new Set(options.allowUntrustedShell),
         dashboardBaseUrl: getDashboardBaseUrl(config),

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -116,6 +116,10 @@ export function getVariablesPath(config: SuaConfig): string {
   return join(resolve(config.dataDir), '.sua', 'variables.json');
 }
 
+export function getLlmSettingsPath(config: SuaConfig): string {
+  return join(resolve(config.dataDir), '.sua', 'llm-settings.json');
+}
+
 export function getRetentionDays(config: SuaConfig): number {
   return config.runRetentionDays ?? 30;
 }

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -97,6 +97,15 @@ export interface DagExecutorDeps {
    */
   spawnNode?: SpawnNodeFn;
   /**
+   * Optional LLM fallback policy. When the primary provider fails
+   * with a fallback-worthy error category (credit/quota/binary/timeout),
+   * node-spawner retries the same prompt under the fallback provider
+   * and invokes `onFallback` for telemetry. Configured in
+   * `/settings/llm` and threaded through here by the dashboard
+   * context. Tests can pass undefined to skip the fallback path.
+   */
+  llmSettings?: import('./node-spawner.js').LlmSettingsSnapshot;
+  /**
    * Optional dashboard URL prefix used by the notify dispatcher to embed
    * a "view run in dashboard" link in Slack messages. When absent, the
    * link is omitted; the notify still fires.
@@ -904,7 +913,7 @@ export async function executeAgentDag(
             provider: node.provider ?? agent.provider,
             model: node.model ?? agent.model,
           };
-          const spawnOpts = { agentId: agent.id, agentSource: agent.source, allowUntrustedShell: deps.allowUntrustedShell };
+          const spawnOpts = { agentId: agent.id, agentSource: agent.source, allowUntrustedShell: deps.allowUntrustedShell, llmSettings: deps.llmSettings };
           const spawnResult = spawnFn === spawnNodeReal
             ? await spawnNodeReal(synthNode, env, spawnOpts, onProgress, effectiveSignal, onSpawn)
             : await spawnFn(synthNode, env, spawnOpts);
@@ -920,7 +929,7 @@ export async function executeAgentDag(
           model: node.model ?? agent.model,
         };
         const spawnFn = deps.spawnNode ?? spawnNodeReal;
-        const spawnOpts = { agentId: agent.id, agentSource: agent.source, allowUntrustedShell: deps.allowUntrustedShell };
+        const spawnOpts = { agentId: agent.id, agentSource: agent.source, allowUntrustedShell: deps.allowUntrustedShell, llmSettings: deps.llmSettings };
         const spawnResult = spawnFn === spawnNodeReal
           ? await spawnNodeReal(nodeWithDefaults, env, spawnOpts, onProgress, effectiveSignal, onSpawn)
           : await spawnFn(nodeWithDefaults, env, spawnOpts);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -349,11 +349,22 @@ export {
   type LlmSpawner,
   type SpawnProgress,
   type LlmSpawnOptions,
+  type LlmSettingsSnapshot,
+  type LlmFailureCategory,
+  classifyLlmFailure,
   claudeSpawner,
   claudeTextSpawner,
   codexSpawner,
   getSpawner,
 } from './node-spawner.js';
+export {
+  LlmSettingsStore,
+  LLM_PROVIDERS,
+  isProvider,
+  type LlmSettings,
+  type LlmProvider,
+  type LlmFallbackEvent,
+} from './llm-settings-store.js';
 export {
   planMigration,
   applyMigration,

--- a/packages/core/src/llm-settings-store.test.ts
+++ b/packages/core/src/llm-settings-store.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { LlmSettingsStore, LLM_PROVIDERS } from './llm-settings-store.js';
+
+let dir: string;
+let store: LlmSettingsStore;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'sua-llm-settings-'));
+  store = new LlmSettingsStore(join(dir, 'llm-settings.json'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('LlmSettingsStore', () => {
+  it('defaults to claude as primary, no fallback, when file is absent', () => {
+    const s = store.get();
+    expect(s.primary).toBe('claude');
+    expect(s.fallback).toBeUndefined();
+    expect(s.lastFallback).toBeUndefined();
+  });
+
+  it('setProviders persists primary + fallback', () => {
+    store.setProviders('codex', 'claude');
+    const s = store.get();
+    expect(s.primary).toBe('codex');
+    expect(s.fallback).toBe('claude');
+  });
+
+  it('setProviders accepts undefined fallback (no automatic switching)', () => {
+    store.setProviders('claude');
+    expect(store.get().fallback).toBeUndefined();
+  });
+
+  it('rejects invalid primary', () => {
+    expect(() => store.setProviders('made-up' as never)).toThrow(/Invalid primary/);
+  });
+
+  it('rejects invalid fallback', () => {
+    expect(() => store.setProviders('claude', 'made-up' as never)).toThrow(/Invalid fallback/);
+  });
+
+  it('rejects fallback equal to primary', () => {
+    expect(() => store.setProviders('claude', 'claude')).toThrow(/differ from primary/);
+  });
+
+  it('recordFallback writes telemetry, get() returns it', () => {
+    store.setProviders('claude', 'codex');
+    store.recordFallback({
+      at: 1700000000000,
+      primary: 'claude',
+      fallback: 'codex',
+      reason: 'credit_exhausted',
+      agentId: 'demo',
+      nodeId: 'analyze',
+    });
+    const s = store.get();
+    expect(s.lastFallback?.reason).toBe('credit_exhausted');
+    expect(s.lastFallback?.agentId).toBe('demo');
+    expect(s.lastFallback?.fallback).toBe('codex');
+  });
+
+  it('clearLastFallback resets the telemetry only (primary/fallback preserved)', () => {
+    store.setProviders('claude', 'codex');
+    store.recordFallback({
+      at: 1, primary: 'claude', fallback: 'codex', reason: 'timeout',
+    });
+    store.clearLastFallback();
+    const s = store.get();
+    expect(s.lastFallback).toBeUndefined();
+    expect(s.primary).toBe('claude');
+    expect(s.fallback).toBe('codex');
+  });
+
+  it('LLM_PROVIDERS is non-empty and matches the canonical PROVIDER_IDS list', () => {
+    expect(LLM_PROVIDERS.length).toBeGreaterThan(0);
+    expect(LLM_PROVIDERS).toContain('claude');
+  });
+
+  it('recovers from a hand-edited file with a bad primary by falling back to default', () => {
+    // Write a malformed file.
+    const path = join(dir, 'llm-settings.json');
+    require('node:fs').writeFileSync(path, JSON.stringify({
+      version: 1, settings: { primary: 'not-a-thing' },
+    }));
+    const store2 = new LlmSettingsStore(path);
+    expect(store2.get().primary).toBe('claude');
+  });
+});

--- a/packages/core/src/llm-settings-store.ts
+++ b/packages/core/src/llm-settings-store.ts
@@ -1,0 +1,145 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { PROVIDER_IDS, type LlmProvider } from './llm-providers.js';
+
+export type { LlmProvider };
+
+/**
+ * LLM provider config + fallback policy.
+ *
+ * Persistent across daemon restarts: the operator picks a primary
+ * provider via `/settings/llm`; if the primary fails with a
+ * recognized "should fall back" error category (credit exhausted,
+ * quota exceeded, binary missing, hard timeout) AND a fallback is
+ * configured, node-spawner retries the LLM attempt with the fallback
+ * provider and records the event in `lastFallback` so the settings
+ * page can show "fallback fired 3m ago on agent X because Y."
+ *
+ * File-backed JSON (mirrors `VariablesStore`) — no migration story
+ * needed for a two-field config, and the daemon can pick up edits
+ * the operator makes without a restart.
+ */
+
+/**
+ * Re-export the canonical provider list from llm-providers.ts so the
+ * settings UI's dropdowns and the validation logic here stay in sync
+ * with whatever providers the runtime actually knows how to spawn.
+ */
+export const LLM_PROVIDERS: readonly LlmProvider[] = PROVIDER_IDS;
+
+export interface LlmFallbackEvent {
+  /** Unix millis when the fallback fired. */
+  at: number;
+  primary: LlmProvider;
+  fallback: LlmProvider;
+  /** Failure category that triggered the fallback. */
+  reason: string;
+  /** The agent whose node fell back, if known. */
+  agentId?: string;
+  /** Specific node id within the agent, if known. */
+  nodeId?: string;
+}
+
+export interface LlmSettings {
+  primary: LlmProvider;
+  /** When undefined the operator has not enabled a fallback. */
+  fallback?: LlmProvider;
+  /** Set whenever the fallback most recently fired. */
+  lastFallback?: LlmFallbackEvent;
+}
+
+interface LlmSettingsFile {
+  version: 1;
+  settings: LlmSettings;
+}
+
+const DEFAULT_PRIMARY: LlmProvider = 'claude';
+
+/**
+ * File-backed LLM settings store. The file is small (<1KB) — we
+ * read on every access so the daemon can react to operator edits
+ * without holding stale state. Writes are atomic enough for this
+ * use case (single small JSON object).
+ */
+export class LlmSettingsStore {
+  private readonly path: string;
+
+  constructor(filePath: string) {
+    this.path = filePath;
+    const dir = dirname(filePath);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+
+  /** Get the current settings. Returns defaults if the file is absent. */
+  get(): LlmSettings {
+    return this.read().settings;
+  }
+
+  /**
+   * Replace the primary/fallback pair. `fallback` may be undefined to
+   * clear the fallback (no automatic retry on failure). Preserves
+   * `lastFallback` telemetry — only `recordFallback` mutates that.
+   */
+  setProviders(primary: LlmProvider, fallback?: LlmProvider): void {
+    if (!isProvider(primary)) {
+      throw new Error(`Invalid primary provider: ${primary}`);
+    }
+    if (fallback !== undefined && !isProvider(fallback)) {
+      throw new Error(`Invalid fallback provider: ${fallback}`);
+    }
+    if (fallback !== undefined && fallback === primary) {
+      throw new Error('Fallback provider must differ from primary.');
+    }
+    const data = this.read();
+    data.settings.primary = primary;
+    data.settings.fallback = fallback;
+    this.write(data);
+  }
+
+  /** Record a fallback event for the settings page's status line. */
+  recordFallback(event: LlmFallbackEvent): void {
+    const data = this.read();
+    data.settings.lastFallback = event;
+    this.write(data);
+  }
+
+  /** Clear the lastFallback telemetry (operator-driven, via UI). */
+  clearLastFallback(): void {
+    const data = this.read();
+    data.settings.lastFallback = undefined;
+    this.write(data);
+  }
+
+  private read(): LlmSettingsFile {
+    if (!existsSync(this.path)) {
+      return { version: 1, settings: { primary: DEFAULT_PRIMARY } };
+    }
+    try {
+      const raw = readFileSync(this.path, 'utf-8');
+      const parsed = JSON.parse(raw) as LlmSettingsFile;
+      if (parsed.version !== 1) {
+        throw new Error(`Unsupported llm-settings file version: ${parsed.version}`);
+      }
+      // Defensive: tolerate hand-edited files with bad providers — fall
+      // back to defaults rather than blowing up at module-load time.
+      if (!isProvider(parsed.settings?.primary)) {
+        parsed.settings = { primary: DEFAULT_PRIMARY };
+      }
+      if (parsed.settings.fallback !== undefined && !isProvider(parsed.settings.fallback)) {
+        parsed.settings.fallback = undefined;
+      }
+      return parsed;
+    } catch (err) {
+      if ((err as Error).message.includes('version')) throw err;
+      return { version: 1, settings: { primary: DEFAULT_PRIMARY } };
+    }
+  }
+
+  private write(data: LlmSettingsFile): void {
+    writeFileSync(this.path, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+  }
+}
+
+export function isProvider(value: unknown): value is LlmProvider {
+  return typeof value === 'string' && (LLM_PROVIDERS as readonly string[]).includes(value as LlmProvider);
+}

--- a/packages/core/src/node-spawner.test.ts
+++ b/packages/core/src/node-spawner.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { classifyLlmFailure, type SpawnResult } from './node-spawner.js';
+
+function r(partial: Partial<SpawnResult>): SpawnResult {
+  return {
+    result: '',
+    exitCode: 1,
+    error: '',
+    ...partial,
+  };
+}
+
+describe('classifyLlmFailure', () => {
+  it('returns other for a zero-exit (successful) result', () => {
+    expect(classifyLlmFailure(r({ exitCode: 0 }))).toBe('other');
+  });
+
+  it('detects credit exhausted via stderr', () => {
+    expect(classifyLlmFailure(r({ error: 'Your credit balance is too low.' })))
+      .toBe('credit_exhausted');
+    expect(classifyLlmFailure(r({ error: 'insufficient credit' })))
+      .toBe('credit_exhausted');
+  });
+
+  it('detects quota exceeded', () => {
+    expect(classifyLlmFailure(r({ error: 'Quota exceeded for this period.' })))
+      .toBe('quota_exceeded');
+    expect(classifyLlmFailure(r({ result: 'API usage limit reached' })))
+      .toBe('quota_exceeded');
+  });
+
+  it('detects rate limited (transient — should NOT fall back)', () => {
+    expect(classifyLlmFailure(r({ error: 'rate limit hit; retry after 30s' })))
+      .toBe('rate_limited');
+    expect(classifyLlmFailure(r({ result: 'HTTP 429 too many requests' })))
+      .toBe('rate_limited');
+  });
+
+  it('detects auth required', () => {
+    expect(classifyLlmFailure(r({ error: 'not authenticated; please log in' })))
+      .toBe('auth_required');
+    expect(classifyLlmFailure(r({ error: '401 Unauthorized' })))
+      .toBe('auth_required');
+  });
+
+  it('detects binary missing (category set OR string match)', () => {
+    expect(classifyLlmFailure(r({ category: 'spawn_failure', error: 'spawn ENOENT' })))
+      .toBe('binary_missing');
+    expect(classifyLlmFailure(r({ error: 'codex: command not found' })))
+      .toBe('binary_missing');
+  });
+
+  it('detects timeout', () => {
+    expect(classifyLlmFailure(r({ category: 'timeout', error: 'Timed out after 60s' })))
+      .toBe('timeout');
+  });
+
+  it('falls through to other for unrecognized failures', () => {
+    expect(classifyLlmFailure(r({ error: 'mysterious crash deep in the CLI' })))
+      .toBe('other');
+  });
+
+  it('checks both error AND result fields (CLI errors land in either)', () => {
+    expect(classifyLlmFailure(r({ result: 'Your credit balance is too low to continue.' })))
+      .toBe('credit_exhausted');
+  });
+});

--- a/packages/core/src/node-spawner.ts
+++ b/packages/core/src/node-spawner.ts
@@ -18,10 +18,57 @@ import { resolveUpstreamTemplate, resolveVarsTemplate, resolveStateTemplate } fr
 
 export type SpawnResult = ExecutionResult & { category?: NodeErrorCategory };
 
+/**
+ * Optional fallback policy for llm-prompt nodes. When the primary
+ * spawn returns a failure that `classifyLlmFailure` marks as
+ * fallback-worthy (credit exhausted, quota exceeded, binary missing,
+ * hard timeout) AND `fallback` is set, node-spawner retries the same
+ * prompt under the fallback provider. `onFallback` is invoked once
+ * per fallback so the runtime can record telemetry / surface the
+ * event on /settings/llm.
+ */
+export interface LlmSettingsSnapshot {
+  primary?: string;
+  fallback?: string;
+  onFallback?: (event: {
+    reason: LlmFailureCategory;
+    primary: string;
+    fallback: string;
+    agentId: string;
+    nodeId: string;
+  }) => void;
+}
+
+/**
+ * Buckets a failed llm-prompt attempt into one of a few causes so the
+ * fallback policy can decide whether to retry, switch providers, or
+ * bubble up the failure unchanged.
+ *
+ * - `credit_exhausted` / `quota_exceeded` — operator paid-tier issue;
+ *   switching providers is the helpful default
+ * - `binary_missing` — CLI not installed; switching providers is the
+ *   only way to make progress
+ * - `timeout` — hard wall-clock cap hit; the fallback may be faster
+ * - `rate_limited` — transient; retrying the same provider after a
+ *   short backoff is usually better than switching
+ * - `auth_required` — operator login expired; switching won't fix it,
+ *   bubble up
+ * - `other` — unknown / probably a real prompt or runtime bug; don't
+ *   mask by switching providers
+ */
+export type LlmFailureCategory =
+  | 'credit_exhausted'
+  | 'quota_exceeded'
+  | 'binary_missing'
+  | 'timeout'
+  | 'rate_limited'
+  | 'auth_required'
+  | 'other';
+
 export type SpawnNodeFn = (
   node: AgentNode,
   env: Record<string, string>,
-  opts: { agentId: string; agentSource: Agent['source']; allowUntrustedShell?: ReadonlySet<string> },
+  opts: { agentId: string; agentSource: Agent['source']; allowUntrustedShell?: ReadonlySet<string>; llmSettings?: LlmSettingsSnapshot },
 ) => Promise<SpawnResult>;
 
 /**
@@ -213,7 +260,7 @@ export function getSpawner(provider?: string): LlmSpawner {
 export async function spawnNodeReal(
   node: AgentNode,
   env: Record<string, string>,
-  _opts: { agentId: string; agentSource: Agent['source']; allowUntrustedShell?: ReadonlySet<string> },
+  _opts: { agentId: string; agentSource: Agent['source']; allowUntrustedShell?: ReadonlySet<string>; llmSettings?: LlmSettingsSnapshot },
   onProgress?: (event: SpawnProgress) => void,
   signal?: AbortSignal,
   onSpawn?: (pid: number, startedAtMs: number) => void,
@@ -248,14 +295,6 @@ export async function spawnNodeReal(
   resolvedPrompt = resolveStateTemplate(resolvedPrompt, env.STATE_DIR);
   resolvedPrompt = substituteInputs(resolvedPrompt, env);
 
-  const spawner = getSpawner(node.provider ?? 'claude');
-  const args = spawner.buildArgs({
-    prompt: resolvedPrompt,
-    model: node.model,
-    maxTurns: node.maxTurns,
-    allowedTools: node.allowedTools,
-  });
-
   // Strip UPSTREAM_*_RESULT env vars before exec: claude-code consumed
   // them via {{upstream.X.field}} substitution above (lines 228-233), so
   // the raw env-var copies are now dead weight. Leaving them in argv+env
@@ -267,12 +306,71 @@ export async function spawnNodeReal(
     if (!/^UPSTREAM_[A-Z0-9_]+_RESULT$/.test(k)) childEnv[k] = v;
   }
 
+  // Resolve the primary provider: explicit per-node setting wins,
+  // then the operator's configured global primary, then the hardcoded
+  // claude default. The fallback (if any) is consulted only when the
+  // primary attempt returns a fallback-worthy failure.
+  const primaryProvider = node.provider ?? _opts.llmSettings?.primary ?? 'claude';
+  const primaryResult = await runLlmAttempt(primaryProvider, node, resolvedPrompt, childEnv, onProgress, signal, onSpawn);
+
+  const fallbackProvider = _opts.llmSettings?.fallback;
+  if (!fallbackProvider || fallbackProvider === primaryProvider) {
+    return primaryResult;
+  }
+  const category = classifyLlmFailure(primaryResult);
+  if (!shouldFallback(category)) {
+    return primaryResult;
+  }
+
+  // Fire telemetry callback first so the operator sees the event on
+  // /settings/llm even if the fallback itself fails. The retry
+  // proceeds regardless.
+  _opts.llmSettings?.onFallback?.({
+    reason: category,
+    primary: primaryProvider,
+    fallback: fallbackProvider,
+    agentId: _opts.agentId,
+    nodeId: node.id,
+  });
+
+  const fallbackResult = await runLlmAttempt(fallbackProvider, node, resolvedPrompt, childEnv, onProgress, signal, onSpawn);
+  // If the fallback succeeded, return its result but tag the error
+  // field with a breadcrumb so logs show the primary was attempted
+  // first. If it also failed, return its result (the more recent
+  // attempt is the one the operator will be debugging).
+  if (fallbackResult.exitCode === 0) {
+    return {
+      ...fallbackResult,
+      error: `Fallback ${fallbackProvider} succeeded after primary ${primaryProvider} failed (${category}).`,
+    };
+  }
+  return fallbackResult;
+}
+
+/**
+ * One LLM CLI invocation under a chosen provider. Extracted so the
+ * fallback path can retry under a different provider with the same
+ * resolved prompt + env.
+ */
+async function runLlmAttempt(
+  provider: string,
+  node: AgentNode,
+  resolvedPrompt: string,
+  childEnv: Record<string, string>,
+  onProgress?: (event: SpawnProgress) => void,
+  signal?: AbortSignal,
+  onSpawn?: (pid: number, startedAtMs: number) => void,
+): Promise<SpawnResult> {
+  const spawner = getSpawner(provider);
+  const args = spawner.buildArgs({
+    prompt: resolvedPrompt,
+    model: node.model,
+    maxTurns: node.maxTurns,
+    allowedTools: node.allowedTools,
+  });
   return spawnProcess(spawner.binary, args, {
     cwd: node.workingDirectory,
     env: childEnv,
-    // Prompt rides on stdin — argv would also count toward ARG_MAX, and
-    // `{{upstream.X.result}}` substitution can produce 100KB+ prompts on
-    // agents like ashby-job-finder (fetch-jobs-html alone is multi-100KB).
     stdinInput: resolvedPrompt,
     timeoutSec: node.timeout ?? 300,
     onProgress: onProgress ? (line) => {
@@ -283,6 +381,64 @@ export async function spawnNodeReal(
     signal,
     onSpawn,
   });
+}
+
+/**
+ * Inspect a failed `SpawnResult` and classify the failure cause. The
+ * classifier is deliberately pattern-based (substring matches over
+ * stderr/error) — LLM CLIs don't expose stable exit codes for these
+ * conditions, so we rely on observable strings the CLI prints.
+ */
+export function classifyLlmFailure(result: SpawnResult): LlmFailureCategory {
+  if (result.exitCode === 0) return 'other';
+  const haystack = `${result.error ?? ''}\n${result.result ?? ''}`.toLowerCase();
+  if (result.category === 'spawn_failure'
+    || haystack.includes('command not found')
+    || haystack.includes('enoent')) {
+    return 'binary_missing';
+  }
+  if (result.category === 'timeout' || haystack.includes('timed out')) {
+    return 'timeout';
+  }
+  if (haystack.includes('credit balance')
+    || haystack.includes('insufficient credit')
+    || haystack.includes('out of credit')
+    || haystack.includes('billing')) {
+    return 'credit_exhausted';
+  }
+  if (haystack.includes('quota exceeded')
+    || haystack.includes('quota_exceeded')
+    || haystack.includes('limit exceeded')
+    || haystack.includes('usage limit')) {
+    return 'quota_exceeded';
+  }
+  if (haystack.includes('rate limit')
+    || haystack.includes('rate_limit')
+    || haystack.includes('429')
+    || haystack.includes('too many requests')) {
+    return 'rate_limited';
+  }
+  if (haystack.includes('not authenticated')
+    || haystack.includes('login required')
+    || haystack.includes('please log in')
+    || haystack.includes('401')
+    || haystack.includes('unauthorized')) {
+    return 'auth_required';
+  }
+  return 'other';
+}
+
+/**
+ * Categories worth swapping providers for. Rate limits and auth
+ * failures are excluded: rate limits are transient on the same
+ * provider, auth requires operator action, and 'other' usually means
+ * a real bug we don't want to mask by silently switching.
+ */
+function shouldFallback(category: LlmFailureCategory): boolean {
+  return category === 'credit_exhausted'
+    || category === 'quota_exceeded'
+    || category === 'binary_missing'
+    || category === 'timeout';
 }
 
 // ── Process spawner ────────────────────────────────────────────────────

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -2435,3 +2435,72 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
 .inbox-action__diff-line--ctx {
   color: var(--color-text-muted);
 }
+
+/* ---------- /settings/llm ---------- */
+.settings-llm__form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  max-width: 480px;
+  margin: var(--space-3) 0;
+}
+.settings-llm__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.settings-llm__field label {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  font-weight: var(--weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.settings-llm__actions {
+  display: flex;
+  gap: var(--space-2);
+}
+.settings-llm__status {
+  margin-top: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--color-border);
+  border-left: 3px solid var(--color-warn, #f59e0b);
+  border-radius: 4px;
+  background: var(--color-surface);
+  font-size: var(--font-size-sm);
+}
+.settings-llm__status--clean {
+  border-left-color: var(--color-ok, #34d399);
+}
+.settings-llm__status-label {
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-muted);
+  margin-bottom: 4px;
+}
+.settings-llm__probe {
+  margin-top: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: var(--font-size-sm);
+}
+.settings-llm__probe-row {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  padding: 4px 8px;
+  border-radius: 2px;
+}
+.settings-llm__probe-row--ok { background: rgba(52, 211, 153, 0.08); }
+.settings-llm__probe-row--fail { background: rgba(248, 113, 113, 0.08); }
+.settings-llm__probe-status {
+  font-weight: var(--weight-semibold);
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.settings-llm__probe-row--ok .settings-llm__probe-status { color: var(--color-ok, #34d399); }
+.settings-llm__probe-row--fail .settings-llm__probe-status { color: var(--color-danger, #f87171); }

--- a/packages/dashboard/src/context.ts
+++ b/packages/dashboard/src/context.ts
@@ -1,4 +1,4 @@
-import type { LocalProvider, RunStore, SecretsStore, AgentDefinition, AgentStore, ToolStore, VariablesStore, PacksStore, DashboardsStore, LayoutHintsStore, BlockedImgHostsStore, InboxStore, IntegrationsStore, PlannerTelemetryStore, PlannerLoopStepLogStore, PlannerMemoryStore, AgentMemoryStore } from '@some-useful-agents/core';
+import type { LocalProvider, RunStore, SecretsStore, AgentDefinition, AgentStore, ToolStore, VariablesStore, LlmSettingsStore, PacksStore, DashboardsStore, LayoutHintsStore, BlockedImgHostsStore, InboxStore, IntegrationsStore, PlannerTelemetryStore, PlannerLoopStepLogStore, PlannerMemoryStore, AgentMemoryStore } from '@some-useful-agents/core';
 import type { SecretsSession } from './secrets-session.js';
 
 /**
@@ -73,6 +73,13 @@ export interface DashboardContext {
    * autocomplete and the /settings/variables tab.
    */
   variablesStore?: VariablesStore;
+  /**
+   * v0.24+: LLM provider config + fallback policy. When set, the
+   * dashboard threads a snapshot into every `executeAgentDag` call
+   * so node-spawner can retry under the fallback provider if the
+   * primary returns a fallback-worthy error category.
+   */
+  llmSettingsStore?: LlmSettingsStore;
   /**
    * Widget packs store. Optional today (PR 1 of widget-packs-and-dashboards)
    * because no routes consume it yet; later PRs make it required.

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -18,6 +18,7 @@ import {
   AgentMemoryStore,
   loadBuiltinPacks,
   defaultBuiltinPacksDir,
+  LlmSettingsStore,
   VariablesStore,
   EncryptedFileStore,
   loadAgents,
@@ -78,6 +79,12 @@ export interface StartDashboardOptions {
   secretsPath: string;
   /** Path to the plain-text global variables file (.sua/variables.json). */
   variablesPath?: string;
+  /**
+   * Path to the LLM settings JSON file (primary + fallback provider).
+   * When unset, `/settings/llm` runs in read-only mode and the
+   * dashboard skips threading fallback policy into `executeAgentDag`.
+   */
+  llmSettingsPath?: string;
   /** Path to the bearer token file. Defaults to `~/.sua/mcp-token`. */
   tokenPath?: string;
   /** Community shell agents the operator has pre-allowed. */
@@ -363,6 +370,15 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     variablesStore = new VariablesStore(opts.variablesPath);
   }
 
+  // LLM provider settings: primary + optional fallback. Threaded into
+  // every executeAgentDag call so node-spawner can retry under the
+  // fallback when the primary returns a recognized "should fall back"
+  // error category.
+  let llmSettingsStore: LlmSettingsStore | undefined;
+  if (opts.llmSettingsPath) {
+    llmSettingsStore = new LlmSettingsStore(opts.llmSettingsPath);
+  }
+
   // Widget packs + dashboards stores. Same DB file as agents/runs/tools.
   let packsStore: PacksStore | undefined;
   let dashboardsStore: DashboardsStore | undefined;
@@ -478,6 +494,7 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     rotateToken: () => rotateMcpToken(tokenPath),
     toolStore,
     variablesStore,
+    llmSettingsStore,
     packsStore,
     dashboardsStore,
     layoutHintsStore,

--- a/packages/dashboard/src/lib/llm-settings-snapshot.ts
+++ b/packages/dashboard/src/lib/llm-settings-snapshot.ts
@@ -1,0 +1,42 @@
+import type { LlmSettingsSnapshot } from '@some-useful-agents/core';
+import type { DashboardContext } from '../context.js';
+
+/**
+ * Build a per-run snapshot of LLM provider config from the dashboard
+ * context's `LlmSettingsStore`. Pass the result as `llmSettings` on
+ * `DagExecutorDeps`; node-spawner consults it when the primary
+ * provider fails with a fallback-worthy error category and writes a
+ * telemetry event back to the store via `onFallback`.
+ *
+ * Returns undefined when no store is configured — the dag executor
+ * then runs without fallback (each llm-prompt's `node.provider`
+ * applies as-is, no retry under a different provider).
+ *
+ * The snapshot is captured at call time so operators editing
+ * /settings/llm take effect on the next run without a daemon restart.
+ */
+export function buildLlmSettingsSnapshot(
+  ctx: Pick<DashboardContext, 'llmSettingsStore'>,
+): LlmSettingsSnapshot | undefined {
+  const store = ctx.llmSettingsStore;
+  if (!store) return undefined;
+  const current = store.get();
+  return {
+    primary: current.primary,
+    fallback: current.fallback,
+    onFallback: (event) => {
+      try {
+        store.recordFallback({
+          at: Date.now(),
+          primary: event.primary as never,
+          fallback: event.fallback as never,
+          reason: event.reason,
+          agentId: event.agentId,
+          nodeId: event.nodeId,
+        });
+      } catch {
+        // Telemetry failure should never break a run.
+      }
+    },
+  };
+}

--- a/packages/dashboard/src/routes/build-orchestrator.ts
+++ b/packages/dashboard/src/routes/build-orchestrator.ts
@@ -42,6 +42,7 @@ import {
   type DashboardDesign,
 } from '@some-useful-agents/core';
 import type { getContext } from '../context.js';
+import { buildLlmSettingsSnapshot } from '../lib/llm-settings-snapshot.js';
 
 type Ctx = ReturnType<typeof getContext>;
 
@@ -147,6 +148,7 @@ async function kickoffAgentRun(args: {
       secretsStore: ctx.secretsStore,
       variablesStore: ctx.variablesStore,
       dataRoot: ctx.agentStore.dataRoot,
+      llmSettings: buildLlmSettingsSnapshot(ctx),
     },
   ).catch(() => { /* failure surfaces via runStore.getRun(runId).status */ });
   return runId;

--- a/packages/dashboard/src/routes/dashboard-layout-plan.ts
+++ b/packages/dashboard/src/routes/dashboard-layout-plan.ts
@@ -34,6 +34,7 @@ import {
   type RunStatus,
 } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
+import { buildLlmSettingsSnapshot } from '../lib/llm-settings-snapshot.js';
 import {
   computeLayoutSuggestions,
   type CurrentLayout,
@@ -188,6 +189,7 @@ async function kickoffDashboardPlannerRun(args: {
       secretsStore: ctx.secretsStore,
       variablesStore: ctx.variablesStore,
       dataRoot: ctx.agentStore.dataRoot,
+      llmSettings: buildLlmSettingsSnapshot(ctx),
     },
   );
 

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -36,6 +36,7 @@ import {
   type InboxResponse,
 } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
+import { buildLlmSettingsSnapshot } from '../lib/llm-settings-snapshot.js';
 import {
   renderInboxList,
   type InboxSortKey,
@@ -716,6 +717,7 @@ async function runProposedAction(
         secretsStore: ctx.secretsStore,
         variablesStore: ctx.variablesStore,
         dataRoot: ctx.agentStore.dataRoot,
+        llmSettings: buildLlmSettingsSnapshot(ctx),
       },
     );
     runId = run.id;
@@ -1022,6 +1024,7 @@ async function runTriageAgent(
         secretsStore: ctx.secretsStore,
         variablesStore: ctx.variablesStore,
         dataRoot: ctx.agentStore.dataRoot,
+        llmSettings: buildLlmSettingsSnapshot(ctx),
       },
     );
     // Capture the runId once it lands. Race the executor to avoid

--- a/packages/dashboard/src/routes/pulse-layout-plan.ts
+++ b/packages/dashboard/src/routes/pulse-layout-plan.ts
@@ -25,6 +25,7 @@ import {
   type RunStatus,
 } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
+import { buildLlmSettingsSnapshot } from '../lib/llm-settings-snapshot.js';
 import {
   computeLayoutSuggestions,
   type CurrentLayout,
@@ -181,6 +182,7 @@ async function kickoffLayoutPlannerRun(args: {
       secretsStore: ctx.secretsStore,
       variablesStore: ctx.variablesStore,
       dataRoot: ctx.agentStore.dataRoot,
+      llmSettings: buildLlmSettingsSnapshot(ctx),
     },
   );
 

--- a/packages/dashboard/src/routes/run-mutations.ts
+++ b/packages/dashboard/src/routes/run-mutations.ts
@@ -1,6 +1,7 @@
 import { Router, type Request, type Response } from 'express';
 import { executeAgentDag, executeAgentLoop, extractPriorAgentInputs, topologicalSort, type RunStatus } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
+import { buildLlmSettingsSnapshot } from '../lib/llm-settings-snapshot.js';
 
 export const runMutationsRouter: Router = Router();
 
@@ -164,6 +165,7 @@ runMutationsRouter.post('/runs/:id/replay', async (req: Request, res: Response) 
       allowUntrustedShell: ctx.allowUntrustedShell,
       dashboardBaseUrl: ctx.dashboardBaseUrl,
       dataRoot: ctx.agentStore.dataRoot,
+      llmSettings: buildLlmSettingsSnapshot(ctx),
     },
   );
 
@@ -283,6 +285,7 @@ runMutationsRouter.post('/runs/:id/retry', async (req: Request, res: Response) =
       allowUntrustedShell: ctx.allowUntrustedShell,
       dashboardBaseUrl: ctx.dashboardBaseUrl,
       dataRoot: ctx.agentStore.dataRoot,
+      llmSettings: buildLlmSettingsSnapshot(ctx),
     },
     { memoryStore: ctx.agentMemoryStore },
   );

--- a/packages/dashboard/src/routes/run-now-build.ts
+++ b/packages/dashboard/src/routes/run-now-build.ts
@@ -28,6 +28,7 @@ import { parse as parseRawYaml, stringify as stringifyRawYaml } from 'yaml';
 import { readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { getContext } from '../context.js';
+import { buildLlmSettingsSnapshot } from '../lib/llm-settings-snapshot.js';
 import {
   startBuildSession,
   startDraftOneSession,
@@ -372,6 +373,7 @@ async function kickoffPlannerRun(args: PlannerKickoffArgs): Promise<string | nul
       secretsStore: ctx.secretsStore,
       variablesStore: ctx.variablesStore,
       dataRoot: ctx.agentStore.dataRoot,
+      llmSettings: buildLlmSettingsSnapshot(ctx),
     },
   );
 
@@ -516,6 +518,7 @@ buildRouter.post('/agents/:name/analyze', async (req: Request, res: Response) =>
       secretsStore: ctx.secretsStore,
       variablesStore: ctx.variablesStore,
       dataRoot: ctx.agentStore.dataRoot,
+      llmSettings: buildLlmSettingsSnapshot(ctx),
     },
   );
 
@@ -716,6 +719,7 @@ Output ONLY the complete fixed YAML. Nothing else.`,
         secretsStore: ctx.secretsStore,
         variablesStore: ctx.variablesStore,
         dataRoot: ctx.agentStore.dataRoot,
+        llmSettings: buildLlmSettingsSnapshot(ctx),
       },
     );
 
@@ -1115,6 +1119,7 @@ buildRouter.post('/agents/build/commit', (req: Request, res: Response) => {
               secretsStore: ctx.secretsStore,
               variablesStore: ctx.variablesStore,
               dataRoot: ctx.agentStore.dataRoot,
+              llmSettings: buildLlmSettingsSnapshot(ctx),
             },
           ).catch(() => { /* surfaced as a failed run row */ });
         }

--- a/packages/dashboard/src/routes/run-now.ts
+++ b/packages/dashboard/src/routes/run-now.ts
@@ -5,6 +5,7 @@
 import { Router, type Request, type Response } from 'express';
 import { executeAgentWithRetry, type RunStatus } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
+import { buildLlmSettingsSnapshot } from '../lib/llm-settings-snapshot.js';
 
 export const runNowRouter: Router = Router();
 
@@ -69,6 +70,7 @@ runNowRouter.post('/agents/:name/run', async (req: Request, res: Response) => {
         allowUntrustedShell: ctx.allowUntrustedShell,
         dashboardBaseUrl: ctx.dashboardBaseUrl,
         dataRoot: ctx.agentStore.dataRoot,
+        llmSettings: buildLlmSettingsSnapshot(ctx),
       },
     );
 

--- a/packages/dashboard/src/routes/settings.ts
+++ b/packages/dashboard/src/routes/settings.ts
@@ -6,7 +6,12 @@ import {
   closePostgresPool,
   inferSqliteSnapshot,
   closeSqliteDatabase,
+  LLM_PROVIDERS,
+  isProvider,
+  type LlmProvider,
 } from '@some-useful-agents/core';
+import { spawn } from 'node:child_process';
+import { formatAge } from '../views/components.js';
 import { html } from '../views/html.js';
 import { renderSettingsShell } from '../views/settings-shell.js';
 import { renderSettingsSecrets } from '../views/settings-secrets.js';
@@ -15,6 +20,7 @@ import { renderSettingsMcpServers } from '../views/settings-mcp-servers.js';
 import { renderSettingsGeneral } from '../views/settings-general.js';
 import { renderSettingsAppearance } from '../views/settings-appearance.js';
 import { renderSettingsIntegrations } from '../views/settings-integrations.js';
+import { renderSettingsLlm } from '../views/settings-llm.js';
 import { getContext, type DashboardContext } from '../context.js';
 import { SESSION_COOKIE } from '../auth-middleware.js';
 
@@ -595,6 +601,117 @@ settingsRouter.get('/settings/appearance', (req: Request, res: Response) => {
   res.type('html').send(renderSettingsShell({ active: 'appearance', body, flash }));
 });
 
+/** Briefly spawn each CLI with --version (or similar) to confirm liveness. */
+async function probeProvider(provider: LlmProvider): Promise<{ ok: boolean; message: string }> {
+  const binary = provider === 'codex' ? 'codex' : 'claude';
+  return new Promise((resolve) => {
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    const finish = (result: { ok: boolean; message: string }) => {
+      if (settled) return;
+      settled = true;
+      try { child.kill('SIGTERM'); } catch { /* */ }
+      resolve(result);
+    };
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(binary, ['--version'], { stdio: ['ignore', 'pipe', 'pipe'] });
+    } catch (err) {
+      finish({ ok: false, message: `spawn failed: ${(err as Error).message}` });
+      return;
+    }
+    child.stdout?.on('data', (b) => { stdout += b.toString(); });
+    child.stderr?.on('data', (b) => { stderr += b.toString(); });
+    child.on('error', (err) => {
+      finish({ ok: false, message: `binary not found: ${err.message}` });
+    });
+    child.on('close', (code) => {
+      if (code === 0) {
+        const line = (stdout + stderr).split('\n').find((l) => l.trim()) ?? '';
+        finish({ ok: true, message: line.trim() || 'reachable' });
+      } else {
+        finish({ ok: false, message: (stderr || stdout || `exit ${code}`).split('\n')[0].slice(0, 200) });
+      }
+    });
+    setTimeout(() => finish({ ok: false, message: 'probe timed out after 5s' }), 5000);
+  });
+}
+
+settingsRouter.get('/settings/llm', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const { flash } = readQueryBanners(req);
+  const settings = ctx.llmSettingsStore?.get();
+  const error = typeof req.query.error === 'string' ? req.query.error : undefined;
+  const body = renderSettingsLlm({
+    settings,
+    providers: LLM_PROVIDERS,
+    error,
+    formatAge: (v) => formatAge(typeof v === 'number' ? new Date(v).toISOString() : v),
+  });
+  res.type('html').send(renderSettingsShell({ active: 'llm', body, flash }));
+});
+
+settingsRouter.post('/settings/llm', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.llmSettingsStore) {
+    redirectWith(res, '/settings/llm', 'error', 'LLM settings store not configured.');
+    return;
+  }
+  const primaryRaw = typeof req.body?.primary === 'string' ? req.body.primary : '';
+  const fallbackRaw = typeof req.body?.fallback === 'string' ? req.body.fallback : '';
+  if (!isProvider(primaryRaw)) {
+    redirectWith(res, '/settings/llm', 'error', `Invalid primary provider "${primaryRaw}".`);
+    return;
+  }
+  const fallback: LlmProvider | undefined = fallbackRaw === '' ? undefined : isProvider(fallbackRaw) ? fallbackRaw : null as never;
+  if (fallback === (null as never)) {
+    redirectWith(res, '/settings/llm', 'error', `Invalid fallback provider "${fallbackRaw}".`);
+    return;
+  }
+  if (fallback !== undefined && fallback === primaryRaw) {
+    redirectWith(res, '/settings/llm', 'error', 'Fallback must differ from primary.');
+    return;
+  }
+  try {
+    ctx.llmSettingsStore.setProviders(primaryRaw, fallback);
+  } catch (err) {
+    redirectWith(res, '/settings/llm', 'error', (err as Error).message);
+    return;
+  }
+  redirectWith(res, '/settings/llm', 'flash', 'LLM settings saved.');
+});
+
+settingsRouter.post('/settings/llm/probe', async (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const settings = ctx.llmSettingsStore?.get();
+  if (!settings) {
+    redirectWith(res, '/settings/llm', 'error', 'LLM settings store not configured.');
+    return;
+  }
+  const probe: Record<LlmProvider, { ok: boolean; message: string }> = {} as never;
+  for (const p of LLM_PROVIDERS) {
+    probe[p] = await probeProvider(p);
+  }
+  // Stash the result on a per-request basis by piggybacking the shell
+  // render (the simplest way without adding session state).
+  const error = typeof req.query.error === 'string' ? req.query.error : undefined;
+  const body = renderSettingsLlm({
+    settings,
+    providers: LLM_PROVIDERS,
+    error,
+    probe,
+    formatAge: (v) => formatAge(typeof v === 'number' ? new Date(v).toISOString() : v),
+  });
+  res.type('html').send(renderSettingsShell({ active: 'llm', body }));
+});
+
+settingsRouter.post('/settings/llm/clear-last-fallback', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (ctx.llmSettingsStore) ctx.llmSettingsStore.clearLastFallback();
+  redirectWith(res, '/settings/llm', 'flash', 'Cleared.');
+});
+
 settingsRouter.get('/settings/general', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
   const { flash } = readQueryBanners(req);
@@ -664,7 +781,7 @@ function readQueryBanners(req: Request): {
 function redirectWith(
   res: Response,
   path: string,
-  kind: 'flash' | 'unlockError' | 'setError',
+  kind: 'flash' | 'unlockError' | 'setError' | 'error',
   message: string,
   extra: Record<string, string> = {},
 ): void {

--- a/packages/dashboard/src/routes/widget-run.ts
+++ b/packages/dashboard/src/routes/widget-run.ts
@@ -1,6 +1,7 @@
 import { Router, type Request, type Response } from 'express';
 import { executeAgentWithRetry, type RunStatus } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
+import { buildLlmSettingsSnapshot } from '../lib/llm-settings-snapshot.js';
 import { renderOutputWidget } from '../views/output-widgets.js';
 import { render } from '../views/html.js';
 
@@ -45,6 +46,7 @@ widgetRunRouter.post('/agents/:name/widget-run', (req: Request, res: Response) =
       allowUntrustedShell: ctx.allowUntrustedShell,
       dashboardBaseUrl: ctx.dashboardBaseUrl,
       dataRoot: ctx.agentStore.dataRoot,
+      llmSettings: buildLlmSettingsSnapshot(ctx),
     },
   );
 

--- a/packages/dashboard/src/views/settings-llm.ts
+++ b/packages/dashboard/src/views/settings-llm.ts
@@ -1,0 +1,124 @@
+import { html, type SafeHtml } from './html.js';
+import type { LlmProvider, LlmSettings } from '@some-useful-agents/core';
+
+export interface SettingsLlmArgs {
+  /** Current persisted settings, or undefined when the store isn't wired. */
+  settings?: LlmSettings;
+  /** Provider ids the runtime knows how to spawn. */
+  providers: readonly LlmProvider[];
+  /** Pass-through error string from a recent action (probe / save). */
+  error?: string;
+  /** Probe result: `name → { ok, message }`. Absent when probe hasn't run. */
+  probe?: Record<LlmProvider, { ok: boolean; message: string }>;
+  /** Pretty timestamp helper (last fallback "3 minutes ago"). */
+  formatAge: (isoOrMs: number | string) => string;
+}
+
+const PROVIDER_LABEL: Record<LlmProvider, string> = {
+  claude: 'Claude (claude CLI)',
+  codex: 'Codex (codex CLI)',
+};
+
+export function renderSettingsLlm(args: SettingsLlmArgs): SafeHtml {
+  if (!args.settings) {
+    return html`
+      <div class="settings-empty">
+        <h3 class="mt-0">LLM settings unavailable</h3>
+        <p class="dim">
+          The dashboard was started without an <code>llmSettingsPath</code>.
+          Restart with a recent sua build to enable provider configuration.
+        </p>
+      </div>
+    `;
+  }
+
+  const errorBanner = args.error
+    ? html`<div class="flash flash--error" style="margin-bottom: var(--space-3);">${args.error}</div>`
+    : html``;
+
+  const primaryOpts = args.providers.map((p) => html`
+    <option value="${p}" ${args.settings!.primary === p ? 'selected' : ''}>${PROVIDER_LABEL[p] ?? p}</option>
+  `);
+  const fallbackOpts = args.providers.map((p) => html`
+    <option value="${p}" ${args.settings!.fallback === p ? 'selected' : ''}>${PROVIDER_LABEL[p] ?? p}</option>
+  `);
+
+  const lastFallback = args.settings.lastFallback;
+  const statusBlock = lastFallback
+    ? html`
+      <div class="settings-llm__status">
+        <div class="settings-llm__status-label">Last fallback fired</div>
+        <div>
+          <code>${lastFallback.primary}</code> → <code>${lastFallback.fallback}</code>
+          (${lastFallback.reason})
+          · ${args.formatAge(lastFallback.at)}
+          ${lastFallback.agentId ? html` · agent <code>${lastFallback.agentId}</code>` : html``}
+          ${lastFallback.nodeId ? html` · node <code>${lastFallback.nodeId}</code>` : html``}
+        </div>
+        <form method="POST" action="/settings/llm/clear-last-fallback" style="margin-top: var(--space-2);">
+          <button type="submit" class="btn btn--xs btn--ghost">Clear this notice</button>
+        </form>
+      </div>
+    `
+    : html`
+      <div class="settings-llm__status settings-llm__status--clean">
+        <div class="settings-llm__status-label">No fallback recorded</div>
+        <div class="dim">The primary provider hasn't failed in a fallback-worthy way since records started.</div>
+      </div>
+    `;
+
+  const probeBlock = args.probe
+    ? html`
+      <div class="settings-llm__probe">
+        ${(Object.entries(args.probe) as [LlmProvider, { ok: boolean; message: string }][]).map(([p, r]) => html`
+          <div class="settings-llm__probe-row settings-llm__probe-row--${r.ok ? 'ok' : 'fail'}">
+            <span class="mono">${p}</span>
+            <span class="settings-llm__probe-status">${r.ok ? 'reachable' : 'failed'}</span>
+            <span class="dim">${r.message}</span>
+          </div>
+        `) as unknown as SafeHtml[]}
+      </div>
+    `
+    : html``;
+
+  return html`
+    <section class="settings-section">
+      <h2 class="mt-0">LLM provider</h2>
+      <p class="dim">
+        Pick the primary CLI that every <code>llm-prompt</code> node calls into.
+        When configured, the fallback kicks in only on recognized credit /
+        quota / binary-missing / timeout failures — transient errors like rate
+        limits stay on the primary and retry there.
+      </p>
+
+      ${errorBanner}
+
+      <form method="POST" action="/settings/llm" class="settings-llm__form">
+        <div class="settings-llm__field">
+          <label for="llm-primary">Primary</label>
+          <select id="llm-primary" name="primary" class="form-field">
+            ${primaryOpts as unknown as SafeHtml[]}
+          </select>
+        </div>
+        <div class="settings-llm__field">
+          <label for="llm-fallback">Fallback</label>
+          <select id="llm-fallback" name="fallback" class="form-field">
+            <option value="">(no fallback)</option>
+            ${fallbackOpts as unknown as SafeHtml[]}
+          </select>
+          <p class="dim" style="font-size: var(--font-size-xs); margin: 4px 0 0;">
+            Must differ from primary. Leave blank to disable automatic
+            switching.
+          </p>
+        </div>
+        <div class="settings-llm__actions">
+          <button type="submit" class="btn btn--primary">Save</button>
+          <button type="submit" formaction="/settings/llm/probe" class="btn btn--ghost">Probe CLIs</button>
+        </div>
+      </form>
+
+      ${probeBlock}
+      ${statusBlock}
+    </section>
+  `;
+}

--- a/packages/dashboard/src/views/settings-shell.ts
+++ b/packages/dashboard/src/views/settings-shell.ts
@@ -2,7 +2,7 @@ import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
 
-export type SettingsTab = 'secrets' | 'variables' | 'mcp' | 'mcp-servers' | 'integrations' | 'appearance' | 'general';
+export type SettingsTab = 'secrets' | 'variables' | 'mcp' | 'mcp-servers' | 'integrations' | 'llm' | 'appearance' | 'general';
 
 export interface SettingsShellArgs {
   active: SettingsTab;
@@ -28,6 +28,7 @@ export function renderSettingsShell(args: SettingsShellArgs): string {
       ${tab('mcp', 'MCP')}
       ${tab('mcp-servers', 'MCP Servers')}
       ${tab('integrations', 'Integrations')}
+      ${tab('llm', 'LLM')}
       ${tab('appearance', 'Appearance')}
       ${tab('general', 'General')}
     </nav>


### PR DESCRIPTION
## Summary

When the primary LLM provider fails with a recognized **credit / quota / binary-missing / timeout** error, node-spawner automatically retries the same prompt under a configured fallback provider. Operators pick both providers from a new **/settings/llm** page that also includes a Probe button for liveness checks and a last-fallback telemetry line.

### How it works
1. `LlmSettingsStore` (file-backed at `data/.sua/llm-settings.json`) persists `{ primary, fallback?, lastFallback? }`.
2. `spawnNodeReal` runs the primary, calls `classifyLlmFailure(result)` on failure, and only retries when the bucket is **fallback-worthy**:
   - `credit_exhausted` ✓ — switch providers
   - `quota_exceeded` ✓ — switch providers
   - `binary_missing` ✓ — switch providers (CLI not installed)
   - `timeout` ✓ — switch providers (fallback may be faster)
   - `rate_limited` ✗ — transient, stays on primary
   - `auth_required` ✗ — operator action required
   - `other` ✗ — don't mask real prompt/runtime bugs
3. On fallback, the snapshot's `onFallback` callback writes telemetry to the store so `/settings/llm` shows e.g. `claude → codex (credit_exhausted) · 3m ago · agent demo · node analyze`.

### Surfaces
- **/settings/llm**: primary + fallback dropdowns, Save, Probe (spawns each CLI with `--version`), and a status panel.
- **New 'LLM' tab** in the settings shell nav.

### Wiring
`DagExecutorDeps.llmSettings` carries the snapshot. All dashboard `executeAgentDag` call sites are wired through a tiny `buildLlmSettingsSnapshot(ctx)` helper:
- `inbox.ts` (triage + sub-agent actions)
- `run-now.ts`, `run-now-build.ts`, `run-mutations.ts`
- `build-orchestrator.ts`, `pulse-layout-plan.ts`, `dashboard-layout-plan.ts`, `widget-run.ts`

### Tests (19 new, 1805 total)
- `llm-settings-store.test.ts` — CRUD, validation refusals, malformed-file recovery
- `node-spawner.test.ts` — classifier coverage across all 7 buckets

### Verified in browser
Probe button working: claude `2.1.105 (Claude Code)` + codex `codex-cli 0.131.0` both REACHABLE (green badges).

## Test plan
- [ ] `gh pr checks` → all green
- [ ] /settings → new LLM tab appears
- [ ] /settings/llm renders with primary + fallback dropdowns
- [ ] Save → primary/fallback persist across daemon restarts
- [ ] Probe → both CLIs report reachable with version
- [ ] Simulating credit exhaustion (stub a failing primary) → fallback fires + status panel shows it

## Follow-ups
- Per-area override (e.g. `agents/areas/inbox.yaml` could pin a different primary for the inbox area). Original "master agent default per area" direction.
- Cost-aware fallback choice (e.g. prefer cheaper provider on quota errors)
- Slack/notify integration on repeated fallbacks (operator wants to know if it's happening daily)

🤖 Generated with [Claude Code](https://claude.com/claude-code)