### PR TITLE
feat(dashboard): inbox productivity overhaul (Linear + Slack feel)

### DIFF
--- a/.changeset/inbox-productivity-overhaul.md
+++ b/.changeset/inbox-productivity-overhaul.md
@@ -1,0 +1,38 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox is now the primary productivity surface: tighter nav, gridded
+list with inline preview, suggested-next-actions banner, favorited
+threads rail, + New conversation button, and a vertical timeline
+modal with a pinned composer.
+
+- **Top nav reorder**: Inbox moves to the leftmost position. Scheduled
+  moves into the Agents sub-nav (joins Tools / Nodes / Runs / Packs).
+  No URL changes — `/scheduled` still works.
+- **/inbox shell**: two-column grid with a collapsible "★ Favorited"
+  left rail (state persisted in `localStorage`), a `⚡ Suggested next
+  actions` banner above the list (deterministic counts of
+  high-priority / untriaged / awaiting items; collapsible), and a
+  priority-grouped main list of gridded rows.
+- **Inline preview**: every row gains a chevron that toggles a body +
+  context-payload preview in place with an "Open thread" button. No
+  modal needed for a quick triage glance.
+- **+ New conversation**: button in the page header. `POST /inbox/new`
+  creates a `source: manual` row, returns `X-Inbox-Id` for AJAX, opens
+  the modal on the new empty thread; first reply auto-fires triage.
+- **Modal timeline**: conversation rendered as a `<ul.inbox-timeline>`
+  with a vertical rail line and avatar dots at each entry. The
+  existing `.inbox-msg` / `.inbox-action` / `.inbox-action__diff`
+  cards become typed objects on the timeline — no data-shape changes.
+- **Pinned composer**: textarea + actions row stick to the bottom of
+  the modal so the reply box never disappears while scrolling long
+  threads.
+
+Tests updated for the new shell; new tests cover `POST /inbox/new`
+(AJAX 204 with `X-Inbox-Id`, plain-form 303, empty-title fallback)
+and the favorited rail. 1789 tests pass.

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -2504,3 +2504,382 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
 }
 .settings-llm__probe-row--ok .settings-llm__probe-status { color: var(--color-ok, #34d399); }
 .settings-llm__probe-row--fail .settings-llm__probe-status { color: var(--color-danger, #f87171); }
+
+/* ========================================================================
+ * Inbox productivity overhaul (Linear + Slack feel)
+ * ----------------------------------------------------------------------
+ * Page shell:
+ *   .inbox-shell        — two-col grid: rail + main
+ *   .inbox-rail         — collapsible left rail of starred threads
+ *   .inbox-main         — main column
+ *   .inbox-page-head    — title + actions row
+ *   .inbox-suggest      — suggested-next-actions banner (pulse-tile shape)
+ *   .inbox-list         — main message list (gridded rows)
+ *   .inbox-row2         — single gridded row (chevron + cells + preview)
+ *   .inbox-row2__preview — collapsible inline preview underneath a row
+ *
+ * Modal timeline:
+ *   .inbox-timeline     — vertical timeline with rail line
+ *   .inbox-timeline__entry  — single entry (avatar dot + content)
+ *   .inbox-composer     — pinned composer at bottom of modal
+ * ======================================================================*/
+
+.inbox-shell {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: var(--space-4);
+  align-items: start;
+}
+.inbox-shell--rail-collapsed {
+  grid-template-columns: 48px 1fr;
+}
+@media (max-width: 900px) {
+  .inbox-shell,
+  .inbox-shell--rail-collapsed { grid-template-columns: 1fr; }
+  .inbox-rail { display: none; }
+}
+
+/* ---------- Left rail: favorited threads ---------- */
+.inbox-rail {
+  position: sticky;
+  top: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  max-height: calc(100vh - var(--space-6));
+  overflow-y: auto;
+}
+.inbox-rail__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: var(--font-size-xs);
+  font-weight: var(--weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+  padding: var(--space-1) var(--space-2);
+}
+.inbox-rail__toggle {
+  background: transparent;
+  border: 0;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: 2px var(--space-1);
+  font-size: var(--font-size-sm);
+  border-radius: var(--radius-sm);
+}
+.inbox-rail__toggle:hover { background: var(--color-surface-raised); color: var(--color-text); }
+.inbox-shell--rail-collapsed .inbox-rail__head,
+.inbox-shell--rail-collapsed .inbox-rail__items { display: none; }
+.inbox-shell--rail-collapsed .inbox-rail__toggle { width: 100%; text-align: center; }
+.inbox-rail__items { display: flex; flex-direction: column; gap: var(--space-1); }
+.inbox-rail__item {
+  display: block;
+  padding: var(--space-2);
+  border-radius: var(--radius-sm);
+  text-decoration: none;
+  color: inherit;
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+.inbox-rail__item:hover {
+  background: var(--color-surface-raised);
+  border-color: var(--color-border);
+}
+.inbox-rail__item-title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--weight-medium);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.inbox-rail__item-meta {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  margin-top: 2px;
+}
+.inbox-rail__empty {
+  padding: var(--space-3) var(--space-2);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+/* ---------- Page header (title + + button) ---------- */
+.inbox-page-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin: 0 0 var(--space-3);
+}
+.inbox-page-head__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.inbox-new-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  font-weight: var(--weight-semibold);
+}
+
+/* ---------- Suggested next actions banner ---------- */
+.inbox-suggest {
+  margin: 0 0 var(--space-4);
+  padding: var(--space-3);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-left: 3px solid var(--color-info, #60a5fa);
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.inbox-suggest--clean { border-left-color: var(--color-ok, #34d399); }
+.inbox-suggest__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.inbox-suggest__title {
+  font-size: var(--font-size-xs);
+  font-weight: var(--weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+}
+.inbox-suggest__toggle {
+  background: transparent;
+  border: 0;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: var(--font-size-xs);
+}
+.inbox-suggest__items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+.inbox-suggest__item {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-3);
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  text-decoration: none;
+  color: var(--color-text);
+  cursor: pointer;
+}
+.inbox-suggest__item:hover { border-color: var(--color-border-strong); background: var(--color-surface); }
+.inbox-suggest__count {
+  font-weight: var(--weight-semibold);
+  color: var(--color-primary);
+}
+.inbox-suggest--collapsed .inbox-suggest__items { display: none; }
+
+/* ---------- Main list (gridded rows) ---------- */
+.inbox-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.inbox-list__group {
+  display: flex;
+  flex-direction: column;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+.inbox-list__group-head {
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-surface-raised);
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-muted);
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.inbox-list__group-count {
+  color: var(--color-text);
+  font-weight: var(--weight-medium);
+}
+.inbox-row2 {
+  display: grid;
+  grid-template-columns: 24px 24px 70px 88px 1fr 80px 90px;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+  cursor: pointer;
+  transition: background 80ms ease-out;
+}
+.inbox-row2:last-child { border-bottom: 0; }
+.inbox-row2:hover { background: var(--color-surface-raised); }
+.inbox-row2__chevron {
+  background: transparent;
+  border: 0;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border-radius: var(--radius-sm);
+  transition: transform 120ms ease-out;
+}
+.inbox-row2__chevron:hover { color: var(--color-text); background: var(--color-surface); }
+.inbox-row2__chevron[aria-expanded="true"] { transform: rotate(90deg); color: var(--color-text); }
+.inbox-row2__title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--weight-medium);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  overflow: hidden;
+}
+.inbox-row2__title-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.inbox-row2__agent {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+.inbox-row2__age {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  text-align: right;
+}
+.inbox-row2__status { text-align: right; }
+.inbox-row2__preview {
+  grid-column: 1 / -1;
+  background: var(--color-surface-raised);
+  border-top: 1px solid var(--color-border);
+  padding: var(--space-3) var(--space-3);
+  display: none;
+}
+.inbox-row2--expanded .inbox-row2__preview { display: block; }
+.inbox-row2--expanded { background: var(--color-surface-raised); }
+.inbox-row2__preview-body {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin: 0 0 var(--space-3);
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  max-height: 8rem;
+  overflow: hidden;
+  position: relative;
+}
+.inbox-row2__preview-tail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+.inbox-row2__preview-msg {
+  display: flex;
+  gap: var(--space-2);
+  font-size: var(--font-size-xs);
+  align-items: baseline;
+}
+.inbox-row2__preview-msg-role {
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-muted);
+  min-width: 50px;
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+}
+.inbox-row2__preview-actions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+/* Mobile fallback: simpler column set */
+@media (max-width: 720px) {
+  .inbox-row2 { grid-template-columns: 24px 24px 1fr 70px; }
+  .inbox-row2__priority,
+  .inbox-row2__source,
+  .inbox-row2__status { display: none; }
+}
+
+/* ---------- Modal timeline ---------- */
+/* Restyle the conversation thread as a vertical timeline. The
+ * existing entries (.inbox-msg, .inbox-action) keep their current
+ * structure inside; only the outer wrapper changes. */
+.inbox-timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  position: relative;
+}
+.inbox-timeline::before {
+  /* The vertical rail line. Drawn at the center of the avatar column. */
+  content: '';
+  position: absolute;
+  left: 13px;
+  top: var(--space-2);
+  bottom: var(--space-2);
+  width: 2px;
+  background: var(--color-border);
+  border-radius: 1px;
+}
+.inbox-timeline__entry {
+  position: relative;
+  padding-left: 0;
+  padding-bottom: var(--space-4);
+}
+.inbox-timeline__entry:last-child { padding-bottom: 0; }
+.inbox-timeline__entry .inbox-msg {
+  border-top: 0;
+  padding: 0;
+  align-items: flex-start;
+}
+.inbox-timeline__entry .inbox-msg__avatar {
+  /* Lift the avatar so it visually covers the rail line. */
+  position: relative;
+  z-index: 1;
+  box-shadow: 0 0 0 3px var(--color-bg);
+}
+.inbox-composer {
+  position: sticky;
+  bottom: 0;
+  background: var(--color-bg);
+  border-top: 1px solid var(--color-border);
+  padding: var(--space-3) 0 0;
+  margin-top: var(--space-3);
+}
+.inbox-composer textarea {
+  width: 100%;
+  resize: vertical;
+  font-size: var(--font-size-sm);
+  padding: var(--space-2);
+}
+.inbox-composer__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: var(--space-2);
+  gap: var(--space-2);
+}

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -94,11 +94,13 @@ describe('GET /inbox', () => {
     const app = await makeApp();
     const res = await request(app).get('/inbox').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
     expect(res.status).toBe(200);
-    expect(res.text).toContain('Inbox zero');
+    // Redesigned inbox shows the "All clear" suggested-actions banner
+    // when the inbox is empty.
+    expect(res.text).toContain('All clear');
     expect(res.text).toMatch(/<a href="\/inbox"[^>]*class="is-active"/);
   });
 
-  it('renders one sortable table; rows carry data-inbox-row-id; modal shell is present + hidden', async () => {
+  it('renders gridded rows grouped by priority; rows carry data-inbox-row-id; modal shell is present + hidden', async () => {
     const app = await makeApp();
     inboxStore.add({ priority: 'low', source: 'cadence', title: 'low-pri', body: 'x' });
     const high = inboxStore.add({ priority: 'high', source: 'run-failure', agentId: 'foo', title: 'high-pri', body: 'y' });
@@ -106,29 +108,33 @@ describe('GET /inbox', () => {
 
     const res = await request(app).get('/inbox').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
     expect(res.status).toBe(200);
-    expect((res.text.match(/<table class="table inbox-table">/g) ?? []).length).toBe(1);
+    expect(res.text).toContain('class="inbox-list"');
     expect(res.text).toContain(`data-inbox-row-id="${high.id}"`);
+    // High-priority group renders above low-priority group.
     expect(res.text.indexOf('high-pri')).toBeLessThan(res.text.indexOf('low-pri'));
     expect(res.text).toContain('id="inbox-modal"');
     expect(res.text).toMatch(/id="inbox-modal"[^>]*hidden/);
+    // New header chrome.
+    expect(res.text).toContain('id="inbox-new-conversation"');
+    expect(res.text).toContain('id="inbox-shell"');
   });
 
-  it('honours ?sort=source&dir=asc and shows the ↑ indicator on the active column', async () => {
-    const app = await makeApp();
-    inboxStore.add({ priority: 'low', source: 'run-failure', title: 'R', body: 'x' });
-    inboxStore.add({ priority: 'low', source: 'cadence', title: 'C', body: 'y' });
-    const res = await request(app).get('/inbox?sort=source&dir=asc').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
-    expect(res.status).toBe(200);
-    expect(res.text.indexOf('>C<')).toBeLessThan(res.text.indexOf('>R<'));
-    expect(res.text).toMatch(/Source ↑/);
-  });
-
-  it('falls back to defaults for unknown sort / dir', async () => {
+  it('groups rows by priority and lists high → medium → low', async () => {
     const app = await makeApp();
     inboxStore.add({ priority: 'high', source: 'run-failure', title: 'H', body: 'x' });
     inboxStore.add({ priority: 'low', source: 'cadence', title: 'L', body: 'y' });
-    const res = await request(app).get('/inbox?sort=nope&dir=sideways').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    const res = await request(app).get('/inbox').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
     expect(res.text.indexOf('>H<')).toBeLessThan(res.text.indexOf('>L<'));
+  });
+
+  it('renders the favorited rail with starred messages', async () => {
+    const app = await makeApp();
+    const starred = inboxStore.add({ priority: 'medium', source: 'manual', title: 'pinned', body: 'b' });
+    inboxStore.setStarred(starred.id, true);
+    inboxStore.add({ priority: 'low', source: 'cadence', title: 'unpinned', body: 'b' });
+    const res = await request(app).get('/inbox').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.text).toContain('class="inbox-rail"');
+    expect(res.text).toContain(`data-inbox-rail-id="${starred.id}"`);
   });
 });
 
@@ -714,6 +720,46 @@ describe('POST /inbox/:id/actions/:rid/run — agent-editor write path', () => {
     expect(res2.status).toBe(204);
     await new Promise((r) => setTimeout(r, 30));
     expect(agentStore.getAgent('target-i')?.version).toBe(v1);
+  });
+});
+
+describe('POST /inbox/new', () => {
+  it('AJAX: returns 204 with X-Inbox-Id header pointing at a fresh manual row', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post('/inbox/new')
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .send('title=My+new+thread');
+    expect(res.status).toBe(204);
+    const id = res.headers['x-inbox-id'];
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+    const row = inboxStore.get(id);
+    expect(row).not.toBeNull();
+    expect(row!.source).toBe('manual');
+    expect(row!.title).toBe('My new thread');
+    expect(row!.priority).toBe('medium');
+  });
+
+  it('plain form: redirects 303 to /inbox/:id', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post('/inbox/new')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .send('title=Hello');
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/^\/inbox\/[a-f0-9-]+$/);
+  });
+
+  it('empty title falls back to "New conversation"', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post('/inbox/new')
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE)
+      .send('title=');
+    expect(res.status).toBe(204);
+    const row = inboxStore.get(res.headers['x-inbox-id']);
+    expect(row!.title).toBe('New conversation');
   });
 });
 

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -184,6 +184,45 @@ inboxRouter.get('/inbox/:id/fragment', (req: Request, res: Response) => {
   res.type('html').send(render(renderInboxDetailFragment({ message, responses, triagePending, currentTargetYaml })));
 });
 
+/**
+ * POST /inbox/new — create an empty `source: manual` row so the
+ * operator can start a fresh conversation. Returns the new id via
+ * the `X-Inbox-Id` response header on AJAX (204); a plain form post
+ * gets a 303 redirect to `/inbox/:id`. Triage does NOT auto-fire
+ * here — it kicks in normally on the operator's first POST /respond.
+ */
+inboxRouter.post('/inbox/new', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.inboxStore) {
+    if (isAjax(req)) { res.status(503).end(); return; }
+    res.redirect(303, `/inbox?error=${encodeURIComponent('Inbox unavailable.')}`);
+    return;
+  }
+  const titleRaw = typeof req.body?.title === 'string' ? req.body.title.trim() : '';
+  const title = titleRaw.length > 0 ? titleRaw.slice(0, 200) : 'New conversation';
+  // body is required by the store; manual-source threads start blank,
+  // so we seed with a small placeholder that's overwritten the moment
+  // the operator's first /respond lands.
+  try {
+    const created = ctx.inboxStore.add({
+      priority: 'medium',
+      source: 'manual',
+      title,
+      body: '(empty)',
+    });
+    if (isAjax(req)) {
+      res.setHeader('X-Inbox-Id', created.id);
+      res.status(204).end();
+      return;
+    }
+    res.redirect(303, `/inbox/${encodeURIComponent(created.id)}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (isAjax(req)) { res.status(500).end(); return; }
+    res.redirect(303, `/inbox?error=${encodeURIComponent(`Create failed: ${msg}`)}`);
+  }
+});
+
 inboxRouter.post('/inbox/:id/dismiss', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
   const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;

--- a/packages/dashboard/src/views/inbox-detail.ts
+++ b/packages/dashboard/src/views/inbox-detail.ts
@@ -132,26 +132,29 @@ export function renderInboxDetailFragment(opts: InboxDetailOptions): SafeHtml {
     </details>
   ` : html``;
 
-  const timeline = responses.map((r) => renderConversationEntry(r, currentTargetYaml));
+  const timeline = responses.map((r) => html`
+    <li class="inbox-timeline__entry">${renderConversationEntry(r, currentTargetYaml)}</li>
+  `);
 
-  const conversationBlock = html`
+  // Conversation rendered as a vertical timeline. Each `<li>` carries
+  // the avatar dot that overlaps the rail line drawn by .inbox-timeline.
+  const timelineBlock = html`
     <section style="margin-top: var(--space-3); padding-top: var(--space-3); border-top: 1px solid var(--color-border);">
       <h4 style="margin: 0 0 var(--space-2); font-size: var(--font-size-sm); text-transform: uppercase; letter-spacing: 0.06em; color: var(--color-text-muted);">Conversation</h4>
       ${responses.length === 0 && !triagePending
-        ? html`<p class="dim" style="font-size: var(--font-size-sm); margin: 0 0 var(--space-2);">No replies yet. Post a note below — the triage agent will join automatically.</p>`
-        : html`${timeline as unknown as SafeHtml[]}`}
+        ? html`<p class="dim" style="font-size: var(--font-size-sm); margin: 0 0 var(--space-2);">No replies yet. Use the composer below — the triage agent will join automatically.</p>`
+        : html`<ul class="inbox-timeline">${timeline as unknown as SafeHtml[]}</ul>`}
       ${triagePending ? renderThinkingIndicator() : html``}
-      ${replyForm(message, triagePending ?? false)}
     </section>
   `;
 
-  const actionsBlock = isTerminal
+  const actionsRow = isTerminal
     ? html`
       <p class="dim" style="margin: var(--space-3) 0 0; font-size: var(--font-size-sm);">
         This message is ${message.status}.${message.resolvedAt ? html` Closed ${formatAge(new Date(message.resolvedAt).toISOString())}.` : html``}
       </p>`
     : html`
-      <div style="margin-top: var(--space-3); display: flex; gap: var(--space-2); align-items: center;">
+      <div class="inbox-composer__row">
         <form method="POST" action="/inbox/${message.id}/triage" data-inbox-modal-form data-inbox-modal-keeps-triage="1" style="margin: 0;">
           <button type="submit" class="btn btn--sm btn--ghost" ${triagePending ? 'disabled' : ''}>
             ${triagePending ? 'Triaging…' : 'Ask triage'}
@@ -160,16 +163,22 @@ export function renderInboxDetailFragment(opts: InboxDetailOptions): SafeHtml {
         <form method="POST" action="/inbox/${message.id}/dismiss" data-inbox-modal-form data-inbox-modal-dismiss-on-success="1" style="margin: 0;">
           <button type="submit" class="btn btn--sm btn--ghost">Dismiss</button>
         </form>
-        <span class="dim" style="font-size: var(--font-size-xs); margin-left: auto;">
-          Dismiss closes this thread; Triage re-runs the LLM for a fresh recommendation.
-        </span>
       </div>
     `;
 
+  // Pinned composer sits below the scrolling timeline. Sticky-bottom
+  // keeps it on screen even when the operator scrolls back through
+  // long threads — no hunting for the reply box.
+  const composer = isTerminal ? html`` : html`
+    <div class="inbox-composer">
+      ${replyForm(message, triagePending ?? false)}
+      ${actionsRow}
+    </div>
+  `;
+  const terminalNote = isTerminal ? actionsRow : html``;
+
   // Sticky top region: title + meta + tags + details + context all stay
-  // pinned while the conversation thread scrolls below. The modal's
-  // outer container handles vertical overflow; this sub-section uses
-  // position:sticky relative to that scroll context.
+  // pinned while the conversation thread scrolls below.
   return html`
     <div class="inbox-detail">
       <div class="inbox-detail__header">
@@ -183,9 +192,10 @@ export function renderInboxDetailFragment(opts: InboxDetailOptions): SafeHtml {
         ${contextBlock}
       </div>
       <div class="inbox-detail__thread">
-        ${conversationBlock}
-        ${actionsBlock}
+        ${timelineBlock}
+        ${terminalNote}
       </div>
+      ${composer}
     </div>
   `;
 }

--- a/packages/dashboard/src/views/inbox-list.ts
+++ b/packages/dashboard/src/views/inbox-list.ts
@@ -1,10 +1,28 @@
 import type { InboxMessage, InboxPriority, InboxSource } from '@some-useful-agents/core';
 import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
-import { pageHeader } from './page-header.js';
 import { formatAge } from './components.js';
 import { renderInboxModalShell } from './inbox-modal.js';
 
+/**
+ * /inbox — Linear-meets-Slack productivity surface.
+ *
+ * Layout:
+ *   [page header — title + filter + "+ New conversation" button]
+ *   [Suggested next actions banner — collapsible]
+ *   [two-col grid]
+ *     ├─ left rail (collapsible): starred threads, ordered by recency
+ *     └─ main: priority-grouped list of gridded rows with inline preview
+ *
+ * Row click opens the existing modal (no nav). Chevron on each row
+ * toggles an inline preview (body excerpt + "open thread") so the
+ * operator can triage without leaving the page.
+ */
+
+// Sort keys are kept for backward compatibility — the route still
+// parses them and the type union is referenced by the route file —
+// but the redesigned list groups by priority and orders within groups
+// by createdAt DESC, so the operator-visible sort is fixed.
 export type InboxSortKey = 'priority' | 'source' | 'agent' | 'title' | 'age' | 'status';
 export type InboxSortDir = 'asc' | 'desc';
 
@@ -13,21 +31,13 @@ export interface InboxListOptions {
   sort: InboxSortKey;
   dir: InboxSortDir;
   flash?: { kind: 'error' | 'info' | 'ok'; message: string };
-  /** Current filter state, used to repopulate the search bar. */
   filter?: { q: string; starred: boolean; tag: string };
-  /** All tags currently in use across the inbox, for the tag dropdown. */
   allTags?: string[];
 }
 
 export const INBOX_DEFAULT_SORT: { sort: InboxSortKey; dir: InboxSortDir } = {
   sort: 'priority',
   dir: 'asc',
-};
-
-const PRIORITY_BADGE: Record<InboxPriority, string> = {
-  high: 'badge--warn',
-  medium: 'badge--info',
-  low: 'badge--muted',
 };
 
 const SOURCE_LABEL: Record<InboxSource, string> = {
@@ -37,175 +47,277 @@ const SOURCE_LABEL: Record<InboxSource, string> = {
   'manual': 'Manual',
 };
 
-const SOURCE_BADGE: Record<InboxSource, string> = {
-  'run-failure': 'badge--warn',
-  'permission-request': 'badge--info',
-  'cadence': 'badge--muted',
-  'manual': 'badge--muted',
+const PRIORITY_LABEL: Record<InboxPriority, string> = {
+  high: 'High priority',
+  medium: 'Medium',
+  low: 'Low',
 };
 
-const PRIORITY_RANK: Record<InboxPriority, number> = { high: 0, medium: 1, low: 2 };
+const PRIORITY_BADGE: Record<InboxPriority, string> = {
+  high: 'badge--warn',
+  medium: 'badge--info',
+  low: 'badge--muted',
+};
 
 /**
- * Client-side sort. Keeps the store API focused on its canonical
- * priority+age order and lets the UI own presentation.
+ * Lightweight rules for the suggested-actions banner. Pure functions
+ * over the loaded rows — no LLM call, no I/O. Deterministic so
+ * operators can predict what they'll see.
  */
-export function sortMessages(
-  rows: InboxMessage[],
-  sort: InboxSortKey,
-  dir: InboxSortDir,
-): InboxMessage[] {
-  const sign = dir === 'asc' ? 1 : -1;
-  const copy = rows.slice();
-  copy.sort((a, b) => {
-    switch (sort) {
-      case 'priority':
-        return sign * (PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority])
-          || (b.createdAt - a.createdAt);
-      case 'age':
-        return dir === 'asc' ? a.createdAt - b.createdAt : b.createdAt - a.createdAt;
-      case 'source':
-        return sign * a.source.localeCompare(b.source) || (b.createdAt - a.createdAt);
-      case 'agent':
-        return sign * (a.agentId ?? '').localeCompare(b.agentId ?? '') || (b.createdAt - a.createdAt);
-      case 'title':
-        return sign * a.title.localeCompare(b.title);
-      case 'status':
-        return sign * a.status.localeCompare(b.status) || (b.createdAt - a.createdAt);
-      default:
-        return 0;
-    }
-  });
-  return copy;
+function buildSuggestions(rows: InboxMessage[]): Array<{ label: string; count: number; href?: string; tag: string }> {
+  const out: Array<{ label: string; count: number; href?: string; tag: string }> = [];
+  const open = rows.filter((r) => r.status === 'open' || r.status === 'triaged');
+  const highOpen = open.filter((r) => r.priority === 'high');
+  const untriaged = open.filter((r) => r.status === 'open');
+  const awaiting = rows.filter((r) => r.status === 'awaiting_user');
+
+  if (highOpen.length > 0) {
+    out.push({
+      label: `Resolve high-priority items`,
+      count: highOpen.length,
+      tag: 'high-priority',
+      href: highOpen[0] ? `#row-${highOpen[0].id}` : undefined,
+    });
+  }
+  if (untriaged.length > 0) {
+    out.push({
+      label: `Triage untriaged messages`,
+      count: untriaged.length,
+      tag: 'untriaged',
+      href: untriaged[0] ? `#row-${untriaged[0].id}` : undefined,
+    });
+  }
+  if (awaiting.length > 0) {
+    out.push({
+      label: `Reply to triage`,
+      count: awaiting.length,
+      tag: 'awaiting',
+      href: awaiting[0] ? `#row-${awaiting[0].id}` : undefined,
+    });
+  }
+  return out;
 }
 
-function sortUrl(col: InboxSortKey, current: { sort: InboxSortKey; dir: InboxSortDir }): string {
-  const sameCol = col === current.sort;
-  const dir: InboxSortDir = sameCol
-    ? (current.dir === 'asc' ? 'desc' : 'asc')
-    : (col === 'age' || col === 'status') ? 'desc' : 'asc';
-  const params = new URLSearchParams();
-  if (col !== INBOX_DEFAULT_SORT.sort) params.set('sort', col);
-  if (dir !== INBOX_DEFAULT_SORT.dir || col !== INBOX_DEFAULT_SORT.sort) params.set('dir', dir);
-  const qs = params.toString();
-  return qs ? `/inbox?${qs}` : '/inbox';
-}
-
-function sortIndicator(col: InboxSortKey, current: { sort: InboxSortKey; dir: InboxSortDir }): string {
-  if (col !== current.sort) return '';
-  return current.dir === 'asc' ? ' ↑' : ' ↓';
-}
-
-/**
- * Single sortable grid. Each `<tr>` carries `data-inbox-row-id` so
- * inbox-modal.js intercepts clicks and opens the message in a modal
- * — no page navigation. The `<a>` inside still navigates as a
- * fallback for right-click "open in new tab" + no-JS users.
- */
 export function renderInboxList(opts: InboxListOptions): string {
-  const { rows, sort, dir, flash } = opts;
+  const rows = opts.rows;
   const filter = opts.filter ?? { q: '', starred: false, tag: '' };
   const allTags = opts.allTags ?? [];
-  const sorted = sortMessages(rows, sort, dir);
-  const current = { sort, dir };
-  const hasActiveFilter = !!filter.q || filter.starred || !!filter.tag;
 
-  const header = (col: InboxSortKey, label: string): SafeHtml => html`
-    <th><a href="${sortUrl(col, current)}" class="inbox-sort-header">${label}${sortIndicator(col, current)}</a></th>
+  const starredAll = rows.filter((r) => r.starred);
+  const suggestions = buildSuggestions(rows);
+
+  const filterBar = renderFilterBar(filter, allTags);
+  const suggestBanner = renderSuggestBanner(suggestions, rows.length);
+  const rail = renderRail(starredAll);
+  const main = renderMain(rows);
+
+  const body = html`
+    <div class="inbox-page-head">
+      <div>
+        <h1 style="margin: 0; font-family: var(--font-mono); font-size: var(--font-size-xl);">Inbox</h1>
+        <p class="dim" style="margin: var(--space-1) 0 0; font-size: var(--font-size-sm);">
+          Conversations that need your attention. Click a row to open, or the chevron for a quick preview.
+        </p>
+      </div>
+      <div class="inbox-page-head__actions">
+        ${filterBar}
+        <button type="button" id="inbox-new-conversation" class="btn btn--primary inbox-new-btn">
+          <span aria-hidden="true">+</span> New conversation
+        </button>
+      </div>
+    </div>
+
+    ${suggestBanner}
+
+    <div class="inbox-shell" id="inbox-shell">
+      ${rail}
+      <div class="inbox-main">
+        ${main}
+      </div>
+    </div>
+
+    ${renderInboxModalShell()}
   `;
 
+  return render(layout({ title: 'Inbox', activeNav: 'inbox', flash: opts.flash }, body));
+}
+
+function renderFilterBar(filter: { q: string; starred: boolean; tag: string }, allTags: string[]): SafeHtml {
   const tagOptions = allTags.map((t) => html`
     <option value="${t}" ${filter.tag === t ? 'selected' : ''}>${t}</option>
   `);
-
-  // Search + filter bar above the table. The form GETs back to /inbox
-  // so filters live in the URL and can be bookmarked / shared. A
-  // simple Clear button strips every param.
-  const filterBar = html`
-    <form class="inbox-filter" method="GET" action="/inbox">
-      <input type="text" name="q" value="${filter.q}" placeholder="Search title, body, agent, or conversation…"
-        class="form-field inbox-filter__q">
-      <label class="inbox-filter__starred">
+  const hasFilter = !!filter.q || filter.starred || !!filter.tag;
+  return html`
+    <form class="inbox-filter" method="GET" action="/inbox" style="margin: 0;">
+      <input type="text" name="q" value="${filter.q}" placeholder="Search…"
+        class="form-field inbox-filter__q" style="min-width: 14rem;">
+      <label class="inbox-filter__starred" style="font-size: var(--font-size-xs);">
         <input type="checkbox" name="starred" value="1" ${filter.starred ? 'checked' : ''}>
-        ★ Starred only
+        ★ Starred
       </label>
       <select name="tag" class="form-field inbox-filter__tag">
         <option value="">All tags</option>
         ${tagOptions as unknown as SafeHtml[]}
       </select>
-      <button type="submit" class="btn btn--sm btn--primary">Apply</button>
-      ${hasActiveFilter ? html`<a class="btn btn--sm btn--ghost" href="/inbox">Clear</a>` : html``}
+      <button type="submit" class="btn btn--sm btn--ghost">Apply</button>
+      ${hasFilter ? html`<a class="btn btn--sm btn--ghost" href="/inbox">Clear</a>` : html``}
     </form>
   `;
+}
 
-  const tagChips = (tags: string[]): SafeHtml => tags.length === 0
-    ? html``
-    : html`<span class="inbox-tag-chips">${tags.map((t) => html`<a href="/inbox?tag=${encodeURIComponent(t)}" class="inbox-tag-chip" data-inbox-row-stop>${t}</a>`) as unknown as SafeHtml[]}</span>`;
-
-  const tbody = sorted.map((m) => html`
-    <tr data-inbox-row-id="${m.id}" class="inbox-row">
-      <td>
-        <form method="POST" action="/inbox/${m.id}/star" data-inbox-row-stop data-inbox-star-form style="margin:0;">
-          <input type="hidden" name="starred" value="${m.starred ? '0' : '1'}">
-          <button type="submit" class="inbox-star ${m.starred ? 'inbox-star--on' : ''}" aria-label="${m.starred ? 'Unstar' : 'Star'}">★</button>
-        </form>
-      </td>
-      <td><span class="badge ${PRIORITY_BADGE[m.priority]}">${m.priority}</span></td>
-      <td><span class="badge ${SOURCE_BADGE[m.source]}">${SOURCE_LABEL[m.source]}</span></td>
-      <td>${m.agentId ? html`<a href="/agents/${m.agentId}" data-inbox-row-stop>${m.agentId}</a>` : html`<span class="dim">—</span>`}</td>
-      <td>
-        <a href="/inbox/${m.id}" data-inbox-row-link>${m.title}</a>
-        ${tagChips(m.tags)}
-      </td>
-      <td class="dim">${formatAge(new Date(m.createdAt).toISOString())}</td>
-      <td><span class="badge badge--muted">${m.status}</span></td>
-    </tr>
-  `);
-
-  const emptyState = hasActiveFilter
-    ? html`
-      <div class="settings-empty mt-0">
-        <h3 class="mt-0">No matches</h3>
-        <p class="dim">No inbox items match the current filter. <a href="/inbox">Clear filters</a> to see everything.</p>
-      </div>`
-    : html`
-      <div class="settings-empty mt-0">
-        <h3 class="mt-0">Inbox zero</h3>
-        <p class="dim">
-          No items need your attention. Producers (failed-run hooks, CSP-block escalation,
-          cadence reminders) ship in upcoming PRs — until then this page shows demo data
-          with <code>SUA_INBOX_DEMO=1</code>.
-        </p>
-      </div>`;
-
-  const table = rows.length === 0
-    ? emptyState
-    : html`
-      <table class="table inbox-table">
-        <thead>
-          <tr>
-            <th aria-label="Star"></th>
-            ${header('priority', 'Priority')}
-            ${header('source', 'Source')}
-            ${header('agent', 'Agent')}
-            ${header('title', 'Title')}
-            ${header('age', 'Age')}
-            ${header('status', 'Status')}
-          </tr>
-        </thead>
-        <tbody>${tbody as unknown as SafeHtml[]}</tbody>
-      </table>
+function renderSuggestBanner(suggestions: Array<{ label: string; count: number; href?: string; tag: string }>, totalRows: number): SafeHtml {
+  if (totalRows === 0) {
+    return html`
+      <div class="inbox-suggest inbox-suggest--clean" id="inbox-suggest">
+        <div class="inbox-suggest__head">
+          <span class="inbox-suggest__title">All clear ✨</span>
+        </div>
+        <div class="inbox-suggest__items">
+          <span style="font-size: var(--font-size-sm); color: var(--color-text-muted);">
+            Nothing in your inbox. Click <strong>+ New conversation</strong> to start one with the triage agent.
+          </span>
+        </div>
+      </div>
     `;
-
-  const body = html`
-    ${pageHeader({
-      title: 'Inbox',
-      description: 'Things that need your attention. Click a row to open. Click a column header to sort.',
-    })}
-    ${filterBar}
-    ${table}
-    ${renderInboxModalShell()}
+  }
+  if (suggestions.length === 0) {
+    return html`
+      <div class="inbox-suggest inbox-suggest--clean" id="inbox-suggest">
+        <div class="inbox-suggest__head">
+          <span class="inbox-suggest__title">Nothing pressing</span>
+          <button type="button" class="inbox-suggest__toggle" data-inbox-suggest-toggle aria-expanded="true">Hide</button>
+        </div>
+        <div class="inbox-suggest__items">
+          <span style="font-size: var(--font-size-sm); color: var(--color-text-muted);">
+            All ${totalRows} items are resolved or dismissed. Browse below if you want to revisit.
+          </span>
+        </div>
+      </div>
+    `;
+  }
+  const items = suggestions.map((s) => html`
+    <a class="inbox-suggest__item" href="${s.href ?? '#'}" data-inbox-suggest-tag="${s.tag}">
+      <span class="inbox-suggest__count">${s.count}</span>
+      <span>${s.label}</span>
+    </a>
+  `);
+  return html`
+    <div class="inbox-suggest" id="inbox-suggest">
+      <div class="inbox-suggest__head">
+        <span class="inbox-suggest__title">⚡ Suggested next actions</span>
+        <button type="button" class="inbox-suggest__toggle" data-inbox-suggest-toggle aria-expanded="true">Hide</button>
+      </div>
+      <div class="inbox-suggest__items">
+        ${items as unknown as SafeHtml[]}
+      </div>
+    </div>
   `;
+}
 
-  return render(layout({ title: 'Inbox', activeNav: 'inbox', flash }, body));
+function renderRail(starred: InboxMessage[]): SafeHtml {
+  const items = starred.length === 0
+    ? html`<div class="inbox-rail__empty">No starred threads yet. Star a thread to pin it here.</div>`
+    : html`
+      <div class="inbox-rail__items">
+        ${starred.map((m) => html`
+          <a class="inbox-rail__item" href="/inbox/${m.id}" data-inbox-rail-id="${m.id}">
+            <div class="inbox-rail__item-title">${m.title}</div>
+            <div class="inbox-rail__item-meta">
+              <span class="badge ${PRIORITY_BADGE[m.priority]}" style="font-size: 10px; padding: 1px 4px;">${m.priority}</span>
+              <span>${formatAge(new Date(m.createdAt).toISOString())}</span>
+            </div>
+          </a>
+        `) as unknown as SafeHtml[]}
+      </div>
+    ` as unknown as SafeHtml;
+
+  return html`
+    <aside class="inbox-rail" id="inbox-rail" aria-label="Favorited threads">
+      <div class="inbox-rail__head">
+        <span>★ Favorited</span>
+        <button type="button" class="inbox-rail__toggle" data-inbox-rail-toggle aria-label="Collapse rail">‹</button>
+      </div>
+      ${items}
+    </aside>
+  `;
+}
+
+function renderMain(rows: InboxMessage[]): SafeHtml {
+  if (rows.length === 0) {
+    return html`
+      <div class="card" style="padding: var(--space-6); text-align: center; color: var(--color-text-muted);">
+        <p style="margin: 0 0 var(--space-2);">No matches.</p>
+        <p style="margin: 0; font-size: var(--font-size-sm);">
+          Adjust the filter, clear it, or start a fresh conversation with the + button above.
+        </p>
+      </div>
+    `;
+  }
+
+  const groups: Record<InboxPriority, InboxMessage[]> = { high: [], medium: [], low: [] };
+  for (const r of rows) groups[r.priority].push(r);
+  for (const k of ['high', 'medium', 'low'] as InboxPriority[]) {
+    groups[k].sort((a, b) => (b.starred ? 1 : 0) - (a.starred ? 1 : 0) || b.createdAt - a.createdAt);
+  }
+
+  const sections = (['high', 'medium', 'low'] as InboxPriority[])
+    .filter((p) => groups[p].length > 0)
+    .map((p) => renderGroup(p, groups[p]));
+
+  return html`<div class="inbox-list">${sections as unknown as SafeHtml[]}</div>`;
+}
+
+function renderGroup(priority: InboxPriority, rows: InboxMessage[]): SafeHtml {
+  return html`
+    <section class="inbox-list__group">
+      <header class="inbox-list__group-head">
+        <span>${PRIORITY_LABEL[priority]}</span>
+        <span class="inbox-list__group-count">· ${rows.length}</span>
+      </header>
+      ${rows.map((m) => renderRow(m)) as unknown as SafeHtml[]}
+    </section>
+  `;
+}
+
+function renderRow(m: InboxMessage): SafeHtml {
+  const tagChips = m.tags.length === 0 ? html`` : html`<span style="display: inline-flex; gap: 4px; margin-left: var(--space-1);">${m.tags.map((t) => html`<span class="inbox-tag-chip" style="font-size: 10px;">${t}</span>`) as unknown as SafeHtml[]}</span>`;
+  return html`
+    <div class="inbox-row2" data-inbox-row-id="${m.id}" id="row-${m.id}">
+      <button type="button" class="inbox-row2__chevron" data-inbox-row-chevron
+        aria-label="Toggle preview" aria-expanded="false">›</button>
+      <form method="POST" action="/inbox/${m.id}/star" data-inbox-row-stop data-inbox-star-form style="margin: 0;">
+        <input type="hidden" name="starred" value="${m.starred ? '0' : '1'}">
+        <button type="submit" class="inbox-star ${m.starred ? 'inbox-star--on' : ''}" aria-label="${m.starred ? 'Unstar' : 'Star'}">★</button>
+      </form>
+      <span class="badge ${PRIORITY_BADGE[m.priority]}">${m.priority}</span>
+      <span class="inbox-row2__agent">${m.agentId ?? '—'}</span>
+      <span class="inbox-row2__title">
+        <a href="/inbox/${m.id}" data-inbox-row-link style="text-decoration: none; color: inherit;"
+          class="inbox-row2__title-text">${m.title}</a>
+        ${tagChips}
+      </span>
+      <span class="inbox-row2__age">${formatAge(new Date(m.createdAt).toISOString())}</span>
+      <span class="inbox-row2__status"><span class="badge badge--muted">${m.status}</span></span>
+
+      <div class="inbox-row2__preview" data-inbox-row-preview>
+        <div class="inbox-row2__preview-body">${m.body}</div>
+        ${m.contextJson ? html`
+          <details>
+            <summary style="cursor: pointer; font-size: var(--font-size-xs); color: var(--color-text-muted);">Context payload</summary>
+            <pre class="mono" style="font-size: var(--font-size-xs); margin: var(--space-2) 0 0; overflow-x: auto; max-height: 10rem;">${tryPretty(m.contextJson)}</pre>
+          </details>
+        ` : html``}
+        <div class="inbox-row2__preview-actions">
+          <a href="/inbox/${m.id}" class="btn btn--sm btn--primary" data-inbox-row-link>Open thread</a>
+          <span class="dim" style="font-size: var(--font-size-xs); align-self: center;">
+            ${SOURCE_LABEL[m.source]} · ${m.status}
+          </span>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+function tryPretty(raw: string): string {
+  try { return JSON.stringify(JSON.parse(raw), null, 2); } catch { return raw; }
 }

--- a/packages/dashboard/src/views/inbox-modal.js.ts
+++ b/packages/dashboard/src/views/inbox-modal.js.ts
@@ -123,8 +123,84 @@ export const INBOX_MODAL_JS = `
     refresh();
   }
 
-  // Row click → modal.
+  // Row click → modal. Chevron click is checked first and toggles the
+  // inline preview without opening the modal.
   document.addEventListener('click', function (e) {
+    // Row preview toggle (chevron on the gridded row).
+    var chev = e.target.closest && e.target.closest('[data-inbox-row-chevron]');
+    if (chev) {
+      e.preventDefault();
+      e.stopPropagation();
+      var rowEl = chev.closest('[data-inbox-row-id]');
+      if (rowEl) {
+        var expanded = rowEl.classList.toggle('inbox-row2--expanded');
+        chev.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+      }
+      return;
+    }
+
+    // Rail entry → open the modal for that thread.
+    var railItem = e.target.closest && e.target.closest('[data-inbox-rail-id]');
+    if (railItem) {
+      e.preventDefault();
+      openFor(railItem.getAttribute('data-inbox-rail-id'));
+      return;
+    }
+
+    // Rail collapse / expand toggle.
+    var railToggle = e.target.closest && e.target.closest('[data-inbox-rail-toggle]');
+    if (railToggle) {
+      e.preventDefault();
+      var shell = document.getElementById('inbox-shell');
+      if (shell) {
+        var collapsed = shell.classList.toggle('inbox-shell--rail-collapsed');
+        try { localStorage.setItem('sua-inbox-rail', collapsed ? 'collapsed' : 'open'); } catch (_) {}
+        railToggle.textContent = collapsed ? '›' : '‹';
+      }
+      return;
+    }
+
+    // Suggested-actions banner collapse toggle.
+    var suggToggle = e.target.closest && e.target.closest('[data-inbox-suggest-toggle]');
+    if (suggToggle) {
+      e.preventDefault();
+      var suggest = document.getElementById('inbox-suggest');
+      if (suggest) {
+        var hidden = suggest.classList.toggle('inbox-suggest--collapsed');
+        try { localStorage.setItem('sua-inbox-suggest', hidden ? 'collapsed' : 'open'); } catch (_) {}
+        suggToggle.textContent = hidden ? 'Show' : 'Hide';
+        suggToggle.setAttribute('aria-expanded', hidden ? 'false' : 'true');
+      }
+      return;
+    }
+
+    // + New conversation: POST /inbox/new, open the returned id in-modal.
+    var newBtn = e.target.closest && e.target.closest('#inbox-new-conversation');
+    if (newBtn) {
+      e.preventDefault();
+      newBtn.disabled = true;
+      fetch('/inbox/new', {
+        method: 'POST',
+        credentials: 'same-origin',
+        body: new URLSearchParams({ title: '' }).toString(),
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'X-Requested-With': 'fetch',
+        },
+      })
+        .then(function (r) {
+          if (!r.ok) throw new Error('create failed: ' + r.status);
+          var newId = r.headers.get('X-Inbox-Id');
+          if (newId) openFor(newId);
+        })
+        .catch(function (err) {
+          // Surface failure inline; fall back to nothing.
+          console.error('inbox /new failed', err);
+        })
+        .then(function () { newBtn.disabled = false; });
+      return;
+    }
+
     var stop = e.target.closest && e.target.closest('[data-inbox-row-stop]');
     if (stop) return;
 
@@ -147,6 +223,26 @@ export const INBOX_MODAL_JS = `
       close();
     }
   });
+
+  // Restore drawer + banner state on load.
+  (function restoreShellState() {
+    try {
+      var railState = localStorage.getItem('sua-inbox-rail');
+      var shell = document.getElementById('inbox-shell');
+      if (shell && railState === 'collapsed') {
+        shell.classList.add('inbox-shell--rail-collapsed');
+        var toggle = shell.querySelector('[data-inbox-rail-toggle]');
+        if (toggle) toggle.textContent = '›';
+      }
+      var suggState = localStorage.getItem('sua-inbox-suggest');
+      var suggest = document.getElementById('inbox-suggest');
+      if (suggest && suggState === 'collapsed') {
+        suggest.classList.add('inbox-suggest--collapsed');
+        var sToggle = suggest.querySelector('[data-inbox-suggest-toggle]');
+        if (sToggle) { sToggle.textContent = 'Show'; sToggle.setAttribute('aria-expanded', 'false'); }
+      }
+    } catch (_) {}
+  })();
 
   document.addEventListener('keydown', function (e) {
     if (e.key === 'Escape' && !modal.hidden) close();

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -24,8 +24,12 @@ import { footer } from './footer.js';
 
 export interface LayoutOptions {
   title: string;
-  /** Highlight in the nav (one of: agents, tools, runs, pulse, packs, settings, help). */
-  activeNav?: 'agents' | 'tools' | 'nodes' | 'runs' | 'pulse' | 'packs' | 'scheduled' | 'inbox' | 'settings' | 'help';
+  /**
+   * Highlight in the nav. Scheduled lives under the Agents sub-nav
+   * now (see section-tabs.ts), so pages on /scheduled should pass
+   * `activeNav: 'agents'` to highlight Agents in the top bar.
+   */
+  activeNav?: 'agents' | 'tools' | 'nodes' | 'runs' | 'pulse' | 'packs' | 'inbox' | 'settings' | 'help';
   /** Flash banner shown at the top of the body (errors from prior actions). */
   flash?: { kind: 'error' | 'info' | 'ok'; message: string };
   /** Widen the main column (for screens with 2-col layouts). */
@@ -69,9 +73,8 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
 <header class="topbar">
   <a class="topbar__brand" href="/">sua</a>
   <nav class="topbar__nav">
-    <a href="/pulse" class="${opts.activeNav === 'pulse' ? 'is-active' : ''}">Pulse</a>
-    <a href="/scheduled" class="${opts.activeNav === 'scheduled' ? 'is-active' : ''}">Scheduled</a>
     <a href="/inbox" class="${opts.activeNav === 'inbox' ? 'is-active' : ''}">Inbox</a>
+    <a href="/pulse" class="${opts.activeNav === 'pulse' ? 'is-active' : ''}">Pulse</a>
     <a href="/agents" class="${opts.activeNav === 'agents' || opts.activeNav === 'tools' || opts.activeNav === 'nodes' || opts.activeNav === 'runs' || opts.activeNav === 'packs' ? 'is-active' : ''}">Agents</a>
     <a href="/settings" class="${opts.activeNav === 'settings' ? 'is-active' : ''}">Settings</a>
     <a href="/help" class="${opts.activeNav === 'help' ? 'is-active' : ''}">Help</a>

--- a/packages/dashboard/src/views/scheduled.ts
+++ b/packages/dashboard/src/views/scheduled.ts
@@ -16,6 +16,7 @@ import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
 import { cronToHuman, formatAge, statusBadge } from './components.js';
+import { sectionTabs } from './section-tabs.js';
 
 export interface ScheduledRowInput {
   agent: Agent;
@@ -54,6 +55,7 @@ export function renderScheduledPage(input: ScheduledViewInput): string {
       `. Scheduler: ${schedulerStatus}.`;
 
   const body = html`
+    ${sectionTabs('scheduled')}
     ${pageHeader({ title: 'Scheduled', description })}
     ${renderEmptyState(rows)}
     ${rows.length > 0 ? renderTable(rows) : html``}
@@ -62,7 +64,10 @@ export function renderScheduledPage(input: ScheduledViewInput): string {
   return render(layout(
     {
       title: 'Scheduled agents',
-      activeNav: 'scheduled',
+      // Scheduled lives under the Agents sub-nav now (see section-tabs.ts).
+      // Highlight Agents in the top bar; the sub-nav strip handles the
+      // tab-level highlight.
+      activeNav: 'agents',
       flash: flash ? { kind: 'info', message: flash } : undefined,
     },
     body,

--- a/packages/dashboard/src/views/section-tabs.ts
+++ b/packages/dashboard/src/views/section-tabs.ts
@@ -1,17 +1,17 @@
 import { html, type SafeHtml } from './html.js';
 
-/** The Agents section groups the building blocks + executions. */
-export type AgentsSection = 'agents' | 'tools' | 'nodes' | 'runs' | 'packs';
+/** The Agents section groups the building blocks + executions + scheduling. */
+export type AgentsSection = 'agents' | 'tools' | 'nodes' | 'runs' | 'packs' | 'scheduled';
 
 /**
  * In-page tab strip for the Agents section, mirroring the Settings shell's
  * `.tab-strip`. Rendered on each section landing page (not on deep detail
- * pages) so switching between Agents / Tools / Nodes / Runs / Packs is a
- * server-rendered click with no global subnav bar.
+ * pages) so switching between Agents / Tools / Nodes / Runs / Packs /
+ * Scheduled is a server-rendered click with no global subnav bar.
  *
- * Scheduled is a top-level nav entry instead of a sub-tab — it carries
- * cross-agent context (paused agents, next-run timing) that doesn't fit
- * the per-building-block grouping.
+ * Scheduled used to be a top-level nav entry; moved into this sub-nav
+ * once Inbox became the primary "needs your attention" surface and the
+ * top bar got rebalanced around it.
  */
 export function sectionTabs(active: AgentsSection): SafeHtml {
   const tab = (id: AgentsSection, href: string, label: string): SafeHtml => html`
@@ -24,6 +24,7 @@ export function sectionTabs(active: AgentsSection): SafeHtml {
       ${tab('nodes', '/nodes', 'Nodes')}
       ${tab('runs', '/runs', 'Runs')}
       ${tab('packs', '/packs', 'Packs')}
+      ${tab('scheduled', '/scheduled', 'Scheduled')}
     </nav>
   `;
 }


### PR DESCRIPTION
## Summary

Inbox is now the primary productivity surface, not a secondary tab. Five connected changes implementing the plan at `~/.claude/plans/lets-improve-the-placement-jaunty-backus.md`.

### Top nav reorder
- **Inbox** moves to the leftmost position (was 3rd).
- **Scheduled** relocates into the Agents sub-nav (joins Tools / Nodes / Runs / Packs). No URL changes — `/scheduled` still works, just lands inside `sectionTabs('scheduled')`.

### /inbox: gridded shell + rail + suggestions + + button
- Two-column shell: collapsible **★ Favorited** left rail (state persisted in `localStorage` key `sua-inbox-rail`) + priority-grouped main list.
- **⚡ Suggested next actions** banner above the list, with deterministic counts derived from `inboxStore.list()` — high-priority / untriaged / awaiting items. Each suggestion is a clickable chip. Collapsible; state persisted in `localStorage` key `sua-inbox-suggest`.
- **Gridded list**: tight, MUI-density rows with priority groups (High / Medium / Low). Every row has a chevron that toggles an **inline preview** showing body + context-payload + "Open thread" button. No modal needed for a quick triage glance.
- **+ New conversation** button in the page header — `POST /inbox/new` creates a `source: manual` row, returns `X-Inbox-Id` for AJAX, opens the modal on the new empty thread; first reply auto-fires triage (existing behavior).

### Modal as vertical timeline
- Conversation thread restructured as `<ul.inbox-timeline>` with a faint vertical rail line and avatar dots at each entry.
- Existing `.inbox-msg`, `.inbox-action`, `.inbox-action__diff` cards become typed objects on the timeline — **no data-shape changes**. PR #386 → #389 (action proposals, agent-analyzer wire-up, apply-fix loop) all continue working unchanged.
- **Pinned composer** sticks to the bottom of the modal via `position: sticky`. The reply box never disappears while scrolling long threads.

### CSS
All new tokens come from existing `tokens.css` — `var(--space-*)`, `var(--radius-md)`, `var(--color-border)`, `var(--color-surface-raised)`, `var(--shadow-md)`. No new variables. New classes: `.inbox-shell`, `.inbox-rail*`, `.inbox-main`, `.inbox-page-head*`, `.inbox-suggest*`, `.inbox-list*`, `.inbox-row2*`, `.inbox-timeline*`, `.inbox-composer*`.

### Tests
- Existing inbox suite updated for the new shell (priority-grouped layout, no sortable table).
- New tests: `POST /inbox/new` (AJAX 204 + `X-Inbox-Id`, plain-form 303, empty-title fallback) + favorited rail rendering.
- **1789 tests pass** (was 1786 — +3 new).

## Verified in browser
- Top nav order: `[Inbox] [Pulse] [Agents] [Settings] [Help]`. No Scheduled.
- `/scheduled` shows the section-tabs sub-nav with Scheduled active; Agents highlighted in the top bar.
- `/inbox` renders the new shell: header with filter + + button, suggested-actions banner, ★ Favorited rail (empty state when no stars), gridded rows grouped High / Medium / Low.
- Chevron click expands a row in place (body preview, context payload disclosure, "Open thread" button).
- `+ New conversation` click → modal opens on a fresh `source: manual` row titled "New conversation".
- Existing modal flows (triage, action proposals, agent-analyzer apply-fix) all continue working.

## Test plan
- [ ] `gh pr checks` → all green
- [ ] Top nav shows Inbox leftmost; no Scheduled
- [ ] `/scheduled` accessible via Agents → Scheduled sub-tab
- [ ] `/inbox` renders new shell + collapsible rail + suggested banner
- [ ] Chevron expand toggles inline preview; modal still opens on row click
- [ ] `+ New conversation` opens modal on a fresh row
- [ ] Modal timeline has rail line + dots for multi-entry threads
- [ ] Apply-fix flow (analyzer → editor) still completes

## Follow-ups (explicit non-goals)
- Real-time list updates outside the open modal (still page-refresh-driven)
- Drag-and-drop reordering of favorited rail entries
- Last-2-conversation-entries inside the inline preview (would need a per-message join — current preview shows body + context only)
- Mobile-responsive touch UX for the rail

🤖 Generated with [Claude Code](https://claude.com/claude-code)