### PR TITLE
feat(dashboard): inbox toolbar + modal polish

### DIFF
--- a/.changeset/inbox-toolbar-and-modal-polish.md
+++ b/.changeset/inbox-toolbar-and-modal-polish.md
@@ -1,0 +1,56 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox toolbar + modal polish — tighter, denser, fewer competing
+visual elements.
+
+**Toolbar** (`/inbox` upper-right):
+- Drops the bordered card around the filter group; controls sit on
+  the page background.
+- Search input becomes a single 32px-tall pill with inline `⌕` icon
+  and `×` clear button; submits on Enter and 350ms debounced input.
+- "Starred" checkbox → chip toggle (active state filled, inactive
+  outlined). Auto-submits on change.
+- "All tags" → unstyled select inside a `# tags` chip. Auto-submits.
+- Apply button removed entirely.
+- `Clear` link renamed to `Reset` for consistency with other
+  toolbars.
+
+**Modal** (per-thread):
+- `×` close button in the top-right corner; the separate "Close"
+  link at the bottom-right is gone.
+- Title row tightened: title + star only. Source label removed
+  (it's implicit in the agent/run links and surfaced on the list).
+- Meta row consolidated: priority dot + status badge + agent link +
+  run link + age (right-aligned). Replaces the old loose flex of
+  pills and timestamps.
+- Tags now render as pills with inline `×` to remove; an
+  always-present "Add tag…" input appends on Enter. Replaces the
+  textarea + Save tags button.
+- "DETAILS" and "CONTEXT PAYLOAD" headings removed — body lands
+  directly; context becomes a small `▸` disclosure.
+- "Reply" label dropped (placeholder is enough).
+- Footer consolidated to ONE right-aligned row: `Ask triage`,
+  `Dismiss`, and `Post reply` cluster together so the eye finds the
+  primary action in a predictable spot. The primary button reaches
+  the textarea form via `form="..."` so the composer + actions can
+  occupy distinct visual zones without nesting.
+- Grid-row unification: list-view rows and the modal share the same
+  priority-dot + agent/run-link vocabulary, and the group headings on
+  the list lighten (no uppercase, no raised background, no hard
+  bottom border) so they read as section labels rather than
+  competing chrome.
+- Empty-body conversations (manual `+ New conversation` threads with
+  no seeded body) hide the `(empty)` placeholder so the modal opens
+  clean until the operator's first reply lands.
+- Add-tag input renders as a dashed pill so it visually matches the
+  existing tag pills instead of showing a bare borderless field with
+  a heavy browser focus outline.
+
+All CSS uses existing design tokens. No schema or route changes.
+1808 tests pass.

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -2706,20 +2706,20 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
   overflow: hidden;
 }
 .inbox-list__group-head {
-  padding: var(--space-2) var(--space-3);
-  background: var(--color-surface-raised);
-  font-size: var(--font-size-xs);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  font-weight: var(--weight-semibold);
-  color: var(--color-text-muted);
-  border-bottom: 1px solid var(--color-border);
+  padding: var(--space-1) var(--space-3);
   display: flex;
   align-items: center;
   gap: var(--space-2);
+  color: var(--color-text-muted);
+}
+.inbox-list__group-label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-text);
 }
 .inbox-list__group-count {
-  color: var(--color-text);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
   font-weight: var(--weight-medium);
 }
 .inbox-row2 {
@@ -2856,11 +2856,17 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
   padding: 0;
   align-items: flex-start;
 }
+.inbox-timeline__entry .inbox-msg {
+  /* Larger gap between avatar column and body so the rail-line break
+   * around each avatar reads cleanly without a box-shadow halo. */
+  gap: var(--space-3);
+}
 .inbox-timeline__entry .inbox-msg__avatar {
-  /* Lift the avatar so it visually covers the rail line. */
+  /* Lift the avatar above the absolute rail line so the dot covers
+   * the line at each entry. No box-shadow ring — the solid background
+   * of the avatar circle handles the visual break on its own. */
   position: relative;
   z-index: 1;
-  box-shadow: 0 0 0 3px var(--color-bg);
 }
 .inbox-composer {
   position: sticky;
@@ -2882,4 +2888,324 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
   align-items: center;
   margin-top: var(--space-2);
   gap: var(--space-2);
+}
+
+/* ========================================================================
+ * Inbox toolbar + modal polish (PR #392)
+ * ----------------------------------------------------------------------
+ * Toolbar: inline chips, no card border, autosubmit
+ *   .inbox-toolbar         — single-row flex container
+ *   .inbox-toolbar__search — search input with inline icon + × clear
+ *   .inbox-chip            — pill toggle for Starred / Tag filters
+ *
+ * Modal polish:
+ *   .inbox-modal__close    — × button in top-right corner of the modal
+ *   .inbox-modal__title-row — title + star, no extra meta
+ *   .inbox-modal__meta     — single tight meta row (priority dot + status + links)
+ *   .inbox-modal__priority — colored dot replacing the priority badge
+ *   .inbox-modal__tags     — pill row (replaces textarea + Save tags)
+ *   .inbox-pill            — tag pill with ×
+ *   .inbox-composer__footer — single right-aligned row: ghost actions + primary
+ * ======================================================================*/
+
+.inbox-toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  border: 0;
+}
+.inbox-toolbar__search {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex: 0 1 18rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  height: 32px;
+  padding: 0 var(--space-2);
+  transition: border-color 120ms ease-out;
+}
+.inbox-toolbar__search:focus-within {
+  border-color: var(--color-primary);
+  box-shadow: var(--shadow-focus);
+}
+.inbox-toolbar__search-icon {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  margin-right: var(--space-1);
+  flex-shrink: 0;
+}
+.inbox-toolbar__q {
+  background: transparent;
+  border: 0;
+  outline: 0;
+  flex: 1;
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  padding: 0;
+  min-width: 0;
+}
+.inbox-toolbar__q::placeholder { color: var(--color-text-muted); }
+.inbox-toolbar__clear {
+  background: transparent;
+  border: 0;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: var(--font-size-md);
+  padding: 0 var(--space-1);
+  line-height: 1;
+}
+.inbox-toolbar__clear:hover { color: var(--color-text); }
+.inbox-toolbar__reset {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  text-decoration: none;
+  padding: 0 var(--space-2);
+  align-self: center;
+}
+.inbox-toolbar__reset:hover { color: var(--color-text); }
+
+/* Chip toggles for Starred + Tag */
+.inbox-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  height: 32px;
+  padding: 0 var(--space-3);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+  transition: background 80ms ease-out, color 80ms ease-out, border-color 80ms ease-out;
+}
+.inbox-chip:hover { border-color: var(--color-border-strong); color: var(--color-text); }
+.inbox-chip input[type="checkbox"] {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+.inbox-chip--active {
+  background: var(--color-primary-soft);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+.inbox-chip__icon { font-weight: var(--weight-semibold); }
+.inbox-chip--select { padding: 0 var(--space-2) 0 var(--space-3); }
+.inbox-chip__select {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font-size: inherit;
+  cursor: pointer;
+  outline: 0;
+  padding: 0 var(--space-3) 0 0;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M1 1l4 4 4-4' stroke='%238b93a7' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 0 center;
+}
+
+/* Match the + New conversation button height to the toolbar chips */
+.inbox-new-btn { height: 32px; line-height: 1; }
+
+/* ---------- Modal close × in top-right ---------- */
+.inbox-modal { position: relative; }
+.inbox-modal__close {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  color: var(--color-text-muted);
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  z-index: 5;
+}
+.inbox-modal__close:hover { background: var(--color-surface-raised); color: var(--color-text); }
+
+/* ---------- Modal title row + meta + tags ---------- */
+.inbox-modal__title-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin: 0;
+  padding-right: 32px;
+}
+.inbox-modal__title {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-lg);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  flex: 1;
+  word-break: break-word;
+}
+.inbox-modal__star-form { margin: 0; flex-shrink: 0; }
+
+.inbox-modal__meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+.inbox-modal__priority {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
+.inbox-modal__priority--high { background: var(--color-warn, #f59e0b); }
+.inbox-modal__priority--medium { background: var(--color-info, #60a5fa); }
+.inbox-modal__priority--low { background: var(--color-text-muted); }
+.inbox-modal__link { color: var(--color-text); text-decoration: none; }
+.inbox-modal__link:hover { color: var(--color-primary); text-decoration: underline; }
+.inbox-modal__sep { color: var(--color-text-muted); opacity: 0.5; }
+.inbox-modal__age { margin-left: auto; color: var(--color-text-muted); font-size: var(--font-size-xs); }
+
+/* Tag pills */
+.inbox-modal__tags {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-top: var(--space-2);
+}
+.inbox-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 22px;
+  padding: 0 8px 0 10px;
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  font-size: var(--font-size-xs);
+  color: var(--color-text);
+}
+.inbox-pill__remove {
+  background: transparent;
+  border: 0;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  line-height: 1;
+  padding: 0;
+  width: 14px;
+  height: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+}
+.inbox-pill__remove:hover { background: var(--color-border); color: var(--color-text); }
+.inbox-modal__tag-add {
+  display: inline-flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 10px;
+  background: var(--color-surface);
+  border: 1px dashed var(--color-border);
+  border-radius: 999px;
+  font-size: var(--font-size-xs);
+  color: var(--color-text);
+  min-width: 6rem;
+  outline: 0;
+  transition: border-color 80ms ease-out, background 80ms ease-out;
+}
+.inbox-modal__tag-add:hover {
+  border-color: var(--color-text-muted);
+}
+.inbox-modal__tag-add:focus {
+  border-style: solid;
+  border-color: var(--color-text-muted);
+  background: var(--color-surface-raised);
+}
+.inbox-modal__tag-add::placeholder { color: var(--color-text-muted); }
+
+/* Body without a heading */
+.inbox-modal__body {
+  margin-top: var(--space-3);
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  color: var(--color-text);
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+}
+
+/* Context payload as a subtle disclosure */
+.inbox-modal__context { margin-top: var(--space-3); }
+.inbox-modal__context > summary {
+  cursor: pointer;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  list-style: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.inbox-modal__context > summary::-webkit-details-marker { display: none; }
+.inbox-modal__context > summary::before {
+  content: '▸';
+  font-size: 10px;
+  transition: transform 120ms ease-out;
+  display: inline-block;
+}
+.inbox-modal__context[open] > summary::before { transform: rotate(90deg); }
+.inbox-modal__context > pre {
+  margin: var(--space-2) 0 0;
+  font-size: var(--font-size-xs);
+  overflow-x: auto;
+  max-height: 12rem;
+  background: var(--color-surface-raised);
+  padding: var(--space-2);
+  border-radius: var(--radius-sm);
+}
+
+.inbox-modal__timeline-section {
+  margin-top: var(--space-3);
+}
+
+/* ---------- Consolidated composer footer ---------- */
+.inbox-composer__form { margin: 0; }
+.inbox-composer__textarea {
+  width: 100%;
+  resize: vertical;
+  font-size: var(--font-size-sm);
+  padding: var(--space-2);
+  line-height: 1.5;
+}
+.inbox-composer__footer {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  margin-top: var(--space-2);
+  gap: var(--space-2);
+}
+.inbox-composer--terminal {
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--space-3);
+  margin-top: var(--space-3);
 }

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -293,12 +293,14 @@ describe('GET /inbox with filters', () => {
     expect(res.text).toContain('cherry-fruit');
   });
 
-  it('renders the filter bar with current values and a Clear link', async () => {
+  it('renders the toolbar with current search value and a Reset link', async () => {
     const app = await makeApp();
     const res = await request(app).get('/inbox?q=hello').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
-    expect(res.text).toContain('class="inbox-filter"');
+    expect(res.text).toContain('class="inbox-toolbar"');
     expect(res.text).toContain('value="hello"');
-    expect(res.text).toMatch(/href="\/inbox"[^>]*>Clear</);
+    expect(res.text).toMatch(/href="\/inbox"[^>]*>Reset</);
+    // Apply button replaced by autosubmit.
+    expect(res.text).not.toContain('>Apply<');
   });
 });
 

--- a/packages/dashboard/src/views/inbox-detail.ts
+++ b/packages/dashboard/src/views/inbox-detail.ts
@@ -85,50 +85,63 @@ export function renderInboxDetailFragment(opts: InboxDetailOptions): SafeHtml {
     <div class="flash flash--${flash.kind}" style="margin: 0 0 var(--space-2);">${flash.message}</div>
   ` : html``;
 
-  // Header meta row + a star control on the right. The star form is
-  // intercepted by inbox-modal.js (via data-inbox-modal-form) so
-  // clicking it toggles in place without a page reload.
+  // Tight meta row: priority dot + status + agent link + run link + age.
+  // Priority becomes a colored dot rather than a full badge to lower
+  // its visual weight; the status badge stays because it's the
+  // operator's primary "what state is this in" signal. Source is now
+  // implicit via the priority + agent + runId combination (it's
+  // surfaced on the list view).
   const headerMeta = html`
-    <div style="display: flex; gap: var(--space-2); align-items: center; flex-wrap: wrap; font-size: var(--font-size-sm); color: var(--color-text-muted); margin-top: var(--space-1);">
-      <span class="badge ${badgeClass}">${message.priority}</span>
-      <span>${SOURCE_LABEL[message.source] ?? message.source}</span>
-      <span>${formatAge(new Date(message.createdAt).toISOString())}</span>
+    <div class="inbox-modal__meta">
+      <span class="inbox-modal__priority inbox-modal__priority--${message.priority}" title="${message.priority} priority"></span>
       <span class="badge badge--muted">${message.status}</span>
-      ${message.agentId ? html`<a href="/agents/${message.agentId}">${message.agentId}</a>` : html``}
-      ${message.runId ? html`<a href="/runs/${message.runId}" class="mono">run ${message.runId.slice(0, 8)}</a>` : html``}
-      <form method="POST" action="/inbox/${message.id}/star" data-inbox-modal-form style="margin: 0 0 0 auto;">
-        <input type="hidden" name="starred" value="${message.starred ? '0' : '1'}">
-        <button type="submit" class="inbox-star ${message.starred ? 'inbox-star--on' : ''}" aria-label="${message.starred ? 'Unstar' : 'Star'}">★</button>
-      </form>
+      ${message.agentId ? html`<a href="/agents/${message.agentId}" class="inbox-modal__link">${message.agentId}</a>` : html``}
+      ${message.runId ? html`<span class="inbox-modal__sep">·</span><a href="/runs/${message.runId}" class="inbox-modal__link mono">run ${message.runId.slice(0, 8)}</a>` : html``}
+      <span class="inbox-modal__age">${formatAge(new Date(message.createdAt).toISOString())}</span>
     </div>
   `;
 
-  // Tag editor: comma-separated input. Existing tags are pre-filled.
-  // Form submit replaces the entire tag set; clearing the input
-  // removes all tags. Validation happens in the store (invalid
-  // entries are silently dropped).
-  const tagsBlock = html`
-    <form method="POST" action="/inbox/${message.id}/tags" data-inbox-modal-form
-      style="margin-top: var(--space-2); display: flex; align-items: center; gap: var(--space-2); font-size: var(--font-size-xs);">
-      <label style="color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.06em; font-weight: var(--weight-semibold);">Tags</label>
-      <input type="text" name="tags" value="${message.tags.join(', ')}"
-        placeholder="auth, network, …" class="form-field"
-        style="flex: 1; padding: var(--space-1) var(--space-2); font-size: var(--font-size-xs);">
-      <button type="submit" class="btn btn--xs btn--ghost">Save tags</button>
+  // Star control sits in the title row, top-right (mirrors the
+  // modal-shell ✕ close button alignment).
+  const starControl = html`
+    <form method="POST" action="/inbox/${message.id}/star" data-inbox-modal-form class="inbox-modal__star-form">
+      <input type="hidden" name="starred" value="${message.starred ? '0' : '1'}">
+      <button type="submit" class="inbox-star ${message.starred ? 'inbox-star--on' : ''}" aria-label="${message.starred ? 'Unstar' : 'Star'}">★</button>
     </form>
   `;
 
-  const bodyBlock = html`
-    <section style="margin-top: var(--space-3);">
-      <h4 style="margin: 0 0 var(--space-1); font-size: var(--font-size-sm); text-transform: uppercase; letter-spacing: 0.06em; color: var(--color-text-muted);">Details</h4>
-      <div style="white-space: pre-wrap;">${message.body}</div>
-    </section>
+  // Tags as pills with inline ×. The form submits the full tag set on
+  // every change (existing route contract — `tags` is a CSV); JS
+  // handles add/remove deltas client-side and then submits.
+  const tagPills = message.tags.map((t) => html`
+    <span class="inbox-pill" data-inbox-tag="${t}">
+      ${t}<button type="button" class="inbox-pill__remove" data-inbox-tag-remove="${t}" aria-label="Remove tag ${t}">×</button>
+    </span>
+  `);
+  const tagsBlock = html`
+    <form method="POST" action="/inbox/${message.id}/tags" data-inbox-modal-form
+      data-inbox-tags-form data-inbox-modal-quiet="1" class="inbox-modal__tags">
+      <input type="hidden" name="tags" value="${message.tags.join(', ')}" data-inbox-tags-input>
+      ${tagPills as unknown as SafeHtml[]}
+      <input type="text" class="inbox-modal__tag-add" placeholder="Add tag…" aria-label="Add tag"
+        data-inbox-tag-add maxlength="32">
+    </form>
   `;
 
+  // Body lands without a heading — it IS the content, no label needed.
+  // Manual conversations seed body with '(empty)' so the store's
+  // NOT NULL constraint is satisfied; suppress that visually so the
+  // modal opens clean until the operator's first reply lands.
+  const trimmedBody = message.body.trim();
+  const hasBody = trimmedBody.length > 0 && trimmedBody !== '(empty)';
+  const bodyBlock = hasBody ? html`
+    <div class="inbox-modal__body">${message.body}</div>
+  ` : html``;
+
   const contextBlock = message.contextJson ? html`
-    <details style="margin-top: var(--space-3);">
-      <summary style="cursor: pointer; font-size: var(--font-size-xs); color: var(--color-text-muted); font-weight: var(--weight-semibold); text-transform: uppercase; letter-spacing: 0.06em;">Context payload</summary>
-      <pre class="mono" style="font-size: var(--font-size-xs); margin: var(--space-2) 0 0; overflow-x: auto; max-height: 12rem;">${pretty(message.contextJson)}</pre>
+    <details class="inbox-modal__context">
+      <summary>Context payload</summary>
+      <pre class="mono">${pretty(message.contextJson)}</pre>
     </details>
   ` : html``;
 
@@ -137,10 +150,11 @@ export function renderInboxDetailFragment(opts: InboxDetailOptions): SafeHtml {
   `);
 
   // Conversation rendered as a vertical timeline. Each `<li>` carries
-  // the avatar dot that overlaps the rail line drawn by .inbox-timeline.
+  // the avatar dot that overlaps the rail line drawn by
+  // .inbox-timeline. No "Conversation" heading — the timeline shape
+  // is self-evident.
   const timelineBlock = html`
-    <section style="margin-top: var(--space-3); padding-top: var(--space-3); border-top: 1px solid var(--color-border);">
-      <h4 style="margin: 0 0 var(--space-2); font-size: var(--font-size-sm); text-transform: uppercase; letter-spacing: 0.06em; color: var(--color-text-muted);">Conversation</h4>
+    <section class="inbox-modal__timeline-section">
       ${responses.length === 0 && !triagePending
         ? html`<p class="dim" style="font-size: var(--font-size-sm); margin: 0 0 var(--space-2);">No replies yet. Use the composer below — the triage agent will join automatically.</p>`
         : html`<ul class="inbox-timeline">${timeline as unknown as SafeHtml[]}</ul>`}
@@ -148,55 +162,76 @@ export function renderInboxDetailFragment(opts: InboxDetailOptions): SafeHtml {
     </section>
   `;
 
-  const actionsRow = isTerminal
+  // Single consolidated footer: composer textarea on top, then a single
+  // right-aligned row with Ask triage and Dismiss as ghost secondaries
+  // sitting beside the Post reply primary on the right.
+  const composer = isTerminal
     ? html`
-      <p class="dim" style="margin: var(--space-3) 0 0; font-size: var(--font-size-sm);">
-        This message is ${message.status}.${message.resolvedAt ? html` Closed ${formatAge(new Date(message.resolvedAt).toISOString())}.` : html``}
-      </p>`
+      <div class="inbox-composer inbox-composer--terminal">
+        <p class="dim" style="margin: 0; font-size: var(--font-size-sm);">
+          This message is ${message.status}.${message.resolvedAt ? html` Closed ${formatAge(new Date(message.resolvedAt).toISOString())}.` : html``}
+        </p>
+      </div>
+    `
     : html`
-      <div class="inbox-composer__row">
-        <form method="POST" action="/inbox/${message.id}/triage" data-inbox-modal-form data-inbox-modal-keeps-triage="1" style="margin: 0;">
-          <button type="submit" class="btn btn--sm btn--ghost" ${triagePending ? 'disabled' : ''}>
-            ${triagePending ? 'Triaging…' : 'Ask triage'}
+      <div class="inbox-composer">
+        ${replyComposerOnly(message, triagePending ?? false)}
+        <div class="inbox-composer__footer">
+          <form method="POST" action="/inbox/${message.id}/triage" data-inbox-modal-form data-inbox-modal-keeps-triage="1" style="margin: 0;">
+            <button type="submit" class="btn btn--sm btn--ghost" ${triagePending ? 'disabled' : ''}>
+              ${triagePending ? 'Triaging…' : 'Ask triage'}
+            </button>
+          </form>
+          <form method="POST" action="/inbox/${message.id}/dismiss" data-inbox-modal-form data-inbox-modal-dismiss-on-success="1" style="margin: 0;">
+            <button type="submit" class="btn btn--sm btn--ghost">Dismiss</button>
+          </form>
+          <button type="submit" form="inbox-reply-form" class="btn btn--sm btn--primary"
+            ${triagePending ? 'disabled' : ''}>
+            ${triagePending ? 'Waiting…' : 'Post reply'}
           </button>
-        </form>
-        <form method="POST" action="/inbox/${message.id}/dismiss" data-inbox-modal-form data-inbox-modal-dismiss-on-success="1" style="margin: 0;">
-          <button type="submit" class="btn btn--sm btn--ghost">Dismiss</button>
-        </form>
+        </div>
       </div>
     `;
 
-  // Pinned composer sits below the scrolling timeline. Sticky-bottom
-  // keeps it on screen even when the operator scrolls back through
-  // long threads — no hunting for the reply box.
-  const composer = isTerminal ? html`` : html`
-    <div class="inbox-composer">
-      ${replyForm(message, triagePending ?? false)}
-      ${actionsRow}
-    </div>
-  `;
-  const terminalNote = isTerminal ? actionsRow : html``;
-
-  // Sticky top region: title + meta + tags + details + context all stay
-  // pinned while the conversation thread scrolls below.
+  // Title row: title (left) + star (right). Close × lives in the modal
+  // shell's corner (see inbox-modal.ts). The old "Close" link at the
+  // bottom-right is gone.
   return html`
     <div class="inbox-detail">
       <div class="inbox-detail__header">
-        <header style="margin: 0;">
-          <h3 id="inbox-modal-title" style="margin: 0;">${message.title}</h3>
-          ${headerMeta}
-          ${tagsBlock}
+        <header class="inbox-modal__title-row">
+          <h3 id="inbox-modal-title" class="inbox-modal__title">${message.title}</h3>
+          ${starControl}
         </header>
+        ${headerMeta}
+        ${tagsBlock}
         ${flashBlock}
         ${bodyBlock}
         ${contextBlock}
       </div>
       <div class="inbox-detail__thread">
         ${timelineBlock}
-        ${terminalNote}
       </div>
       ${composer}
     </div>
+  `;
+}
+
+/**
+ * Composer textarea only — the submit button moves into the
+ * footer row alongside Ask triage / Dismiss. The `<form id>` lets
+ * the footer's primary button reach it via `form="inbox-reply-form"`.
+ */
+function replyComposerOnly(message: InboxMessage, triagePending: boolean): SafeHtml {
+  if (message.status === 'dismissed' || message.status === 'resolved') return html``;
+  return html`
+    <form id="inbox-reply-form" method="POST" action="/inbox/${message.id}/respond"
+      data-inbox-modal-form data-inbox-modal-keeps-triage="1" class="inbox-composer__form">
+      <textarea name="body" rows="3" required maxlength="8192"
+        ${triagePending ? 'disabled' : ''}
+        placeholder="Describe what you tried, ask a follow-up, or note a decision. The triage agent will respond."
+        class="form-field inbox-composer__textarea"></textarea>
+    </form>
   `;
 }
 
@@ -459,31 +494,3 @@ function renderThinkingIndicator(): SafeHtml {
   `;
 }
 
-/**
- * Reply form. Disabled while triage is pending so the user can't
- * queue a second turn before the first response lands. Carries
- * `data-inbox-modal-keeps-triage` so the JS bumps the polling
- * deadline on submit (covers the race where the dag-executor
- * hasn't inserted its run row yet).
- */
-function replyForm(message: InboxMessage, triagePending: boolean): SafeHtml {
-  if (message.status === 'dismissed' || message.status === 'resolved') return html``;
-  return html`
-    <form method="POST" action="/inbox/${message.id}/respond" data-inbox-modal-form data-inbox-modal-keeps-triage="1"
-      style="margin: var(--space-3) 0 0; padding-top: var(--space-2); border-top: 1px solid var(--color-border); display: flex; flex-direction: column; gap: var(--space-2);">
-      <label style="font-size: var(--font-size-xs); color: var(--color-text-muted);">
-        Reply
-      </label>
-      <textarea name="body" rows="3" required maxlength="8192"
-        ${triagePending ? 'disabled' : ''}
-        placeholder="Describe what you tried, ask a follow-up, or note a decision. The triage agent will respond."
-        class="form-field"
-        style="padding: var(--space-2); font-size: var(--font-size-sm); resize: vertical;"></textarea>
-      <div style="display: flex; justify-content: flex-end;">
-        <button type="submit" class="btn btn--sm btn--primary" ${triagePending ? 'disabled' : ''}>
-          ${triagePending ? 'Waiting on triage…' : 'Post reply'}
-        </button>
-      </div>
-    </form>
-  `;
-}

--- a/packages/dashboard/src/views/inbox-list.ts
+++ b/packages/dashboard/src/views/inbox-list.ts
@@ -144,23 +144,32 @@ export function renderInboxList(opts: InboxListOptions): string {
 
 function renderFilterBar(filter: { q: string; starred: boolean; tag: string }, allTags: string[]): SafeHtml {
   const tagOptions = allTags.map((t) => html`
-    <option value="${t}" ${filter.tag === t ? 'selected' : ''}>${t}</option>
+    <option value="${t}" ${filter.tag === t ? 'selected' : ''}>#${t}</option>
   `);
   const hasFilter = !!filter.q || filter.starred || !!filter.tag;
+  // Inline toolbar: chips for Starred + Tag, search with inline clear,
+  // autosubmit on change/Enter. No card border, no Apply button — the
+  // form posts itself via JS (see inbox-modal.js.ts toolbar handler).
   return html`
-    <form class="inbox-filter" method="GET" action="/inbox" style="margin: 0;">
-      <input type="text" name="q" value="${filter.q}" placeholder="Search…"
-        class="form-field inbox-filter__q" style="min-width: 14rem;">
-      <label class="inbox-filter__starred" style="font-size: var(--font-size-xs);">
-        <input type="checkbox" name="starred" value="1" ${filter.starred ? 'checked' : ''}>
-        ★ Starred
+    <form class="inbox-toolbar" method="GET" action="/inbox" role="search" data-inbox-toolbar>
+      <div class="inbox-toolbar__search">
+        <span class="inbox-toolbar__search-icon" aria-hidden="true">⌕</span>
+        <input type="text" name="q" value="${filter.q}" placeholder="Search messages…"
+          class="inbox-toolbar__q" data-inbox-toolbar-q>
+        ${filter.q ? html`<button type="button" class="inbox-toolbar__clear" data-inbox-toolbar-clear aria-label="Clear search">×</button>` : html``}
+      </div>
+      <label class="inbox-chip ${filter.starred ? 'inbox-chip--active' : ''}" data-inbox-chip>
+        <input type="checkbox" name="starred" value="1" ${filter.starred ? 'checked' : ''} data-inbox-toolbar-submit>
+        <span aria-hidden="true">★</span> Starred
       </label>
-      <select name="tag" class="form-field inbox-filter__tag">
-        <option value="">All tags</option>
-        ${tagOptions as unknown as SafeHtml[]}
-      </select>
-      <button type="submit" class="btn btn--sm btn--ghost">Apply</button>
-      ${hasFilter ? html`<a class="btn btn--sm btn--ghost" href="/inbox">Clear</a>` : html``}
+      <label class="inbox-chip inbox-chip--select ${filter.tag ? 'inbox-chip--active' : ''}">
+        <span class="inbox-chip__icon" aria-hidden="true">#</span>
+        <select name="tag" class="inbox-chip__select" data-inbox-toolbar-submit>
+          <option value="">tags</option>
+          ${tagOptions as unknown as SafeHtml[]}
+        </select>
+      </label>
+      ${hasFilter ? html`<a class="inbox-toolbar__reset" href="/inbox" aria-label="Clear all filters">Reset</a>` : html``}
     </form>
   `;
 }
@@ -268,11 +277,15 @@ function renderMain(rows: InboxMessage[]): SafeHtml {
 }
 
 function renderGroup(priority: InboxPriority, rows: InboxMessage[]): SafeHtml {
+  // Group header uses the same priority dot as the rows, so the
+  // color cue is shared between the group label and each row's
+  // priority indicator — single design language.
   return html`
-    <section class="inbox-list__group">
+    <section class="inbox-list__group" data-priority="${priority}">
       <header class="inbox-list__group-head">
-        <span>${PRIORITY_LABEL[priority]}</span>
-        <span class="inbox-list__group-count">· ${rows.length}</span>
+        <span class="inbox-modal__priority inbox-modal__priority--${priority}"></span>
+        <span class="inbox-list__group-label">${PRIORITY_LABEL[priority]}</span>
+        <span class="inbox-list__group-count">${rows.length}</span>
       </header>
       ${rows.map((m) => renderRow(m)) as unknown as SafeHtml[]}
     </section>
@@ -280,7 +293,21 @@ function renderGroup(priority: InboxPriority, rows: InboxMessage[]): SafeHtml {
 }
 
 function renderRow(m: InboxMessage): SafeHtml {
-  const tagChips = m.tags.length === 0 ? html`` : html`<span style="display: inline-flex; gap: 4px; margin-left: var(--space-1);">${m.tags.map((t) => html`<span class="inbox-tag-chip" style="font-size: 10px;">${t}</span>`) as unknown as SafeHtml[]}</span>`;
+  const tagChips = m.tags.length === 0
+    ? html``
+    : html`<span class="inbox-row2__tags">${m.tags.map((t) => html`<span class="inbox-tag-chip">${t}</span>`) as unknown as SafeHtml[]}</span>`;
+  // Agent + run link rendered inline like the modal's meta row:
+  // `agent-id · run abc12345`. Both links share the .inbox-modal__link
+  // styling so hover/focus behavior is identical.
+  const agentRunCell = (m.agentId || m.runId)
+    ? html`
+      <span class="inbox-row2__agent">
+        ${m.agentId ? html`<a href="/agents/${m.agentId}" class="inbox-modal__link mono" data-inbox-row-stop>${m.agentId}</a>` : html``}
+        ${m.agentId && m.runId ? html`<span class="inbox-modal__sep">·</span>` : html``}
+        ${m.runId ? html`<a href="/runs/${m.runId}" class="inbox-modal__link mono" data-inbox-row-stop>${m.runId.slice(0, 8)}</a>` : html``}
+      </span>
+    `
+    : html`<span class="inbox-row2__agent dim">—</span>`;
   return html`
     <div class="inbox-row2" data-inbox-row-id="${m.id}" id="row-${m.id}">
       <button type="button" class="inbox-row2__chevron" data-inbox-row-chevron
@@ -289,11 +316,10 @@ function renderRow(m: InboxMessage): SafeHtml {
         <input type="hidden" name="starred" value="${m.starred ? '0' : '1'}">
         <button type="submit" class="inbox-star ${m.starred ? 'inbox-star--on' : ''}" aria-label="${m.starred ? 'Unstar' : 'Star'}">★</button>
       </form>
-      <span class="badge ${PRIORITY_BADGE[m.priority]}">${m.priority}</span>
-      <span class="inbox-row2__agent">${m.agentId ?? '—'}</span>
+      <span class="inbox-modal__priority inbox-modal__priority--${m.priority}" title="${m.priority} priority"></span>
+      ${agentRunCell}
       <span class="inbox-row2__title">
-        <a href="/inbox/${m.id}" data-inbox-row-link style="text-decoration: none; color: inherit;"
-          class="inbox-row2__title-text">${m.title}</a>
+        <a href="/inbox/${m.id}" data-inbox-row-link class="inbox-row2__title-text">${m.title}</a>
         ${tagChips}
       </span>
       <span class="inbox-row2__age">${formatAge(new Date(m.createdAt).toISOString())}</span>

--- a/packages/dashboard/src/views/inbox-modal.js.ts
+++ b/packages/dashboard/src/views/inbox-modal.js.ts
@@ -297,5 +297,74 @@ export const INBOX_MODAL_JS = `
       return '\\\\' + c.charCodeAt(0).toString(16) + ' ';
     });
   }
+
+  // ── Inbox list toolbar: autosubmit + search debounce + chip clear ──
+  (function setupInboxToolbar() {
+    var form = document.querySelector('[data-inbox-toolbar]');
+    if (!form) return;
+    var q = form.querySelector('[data-inbox-toolbar-q]');
+    var qTimer = null;
+    if (q) {
+      q.addEventListener('input', function () {
+        if (qTimer) clearTimeout(qTimer);
+        qTimer = setTimeout(function () { form.submit(); }, 350);
+      });
+      q.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          if (qTimer) clearTimeout(qTimer);
+          form.submit();
+        }
+      });
+    }
+    var clear = form.querySelector('[data-inbox-toolbar-clear]');
+    if (clear) {
+      clear.addEventListener('click', function () {
+        if (q) { q.value = ''; q.focus(); }
+        form.submit();
+      });
+    }
+    var autoEls = form.querySelectorAll('[data-inbox-toolbar-submit]');
+    for (var ai = 0; ai < autoEls.length; ai++) {
+      autoEls[ai].addEventListener('change', function () { form.submit(); });
+    }
+  })();
+
+  // ── Tag pills inside the modal (add / remove with quiet submit) ──
+  // The remove buttons + the Add-tag input live in the rendered
+  // fragment; we delegate on the modal element since the fragment
+  // refreshes after every save.
+  modal.addEventListener('click', function (e) {
+    var rm = e.target.closest && e.target.closest('[data-inbox-tag-remove]');
+    if (!rm) return;
+    e.preventDefault();
+    e.stopPropagation();
+    var tag = rm.getAttribute('data-inbox-tag-remove');
+    var hidden = modal.querySelector('[data-inbox-tags-input]');
+    if (!hidden) return;
+    var current = String(hidden.value).split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+    var next = current.filter(function (t) { return t !== tag; });
+    hidden.value = next.join(', ');
+    var form = hidden.form;
+    if (form && form.requestSubmit) form.requestSubmit();
+    else if (form) form.submit();
+  });
+  modal.addEventListener('keydown', function (e) {
+    var add = e.target.closest && e.target.closest('[data-inbox-tag-add]');
+    if (!add) return;
+    if (e.key !== 'Enter') return;
+    e.preventDefault();
+    var raw = String(add.value).trim().toLowerCase();
+    if (!raw) return;
+    var hidden = modal.querySelector('[data-inbox-tags-input]');
+    if (!hidden) return;
+    var current = String(hidden.value).split(',').map(function (s) { return s.trim(); }).filter(Boolean);
+    if (current.indexOf(raw) === -1) current.push(raw);
+    hidden.value = current.join(', ');
+    add.value = '';
+    var form = hidden.form;
+    if (form && form.requestSubmit) form.requestSubmit();
+    else if (form) form.submit();
+  });
 })();
 `;

--- a/packages/dashboard/src/views/inbox-modal.ts
+++ b/packages/dashboard/src/views/inbox-modal.ts
@@ -11,12 +11,10 @@ import { html, type SafeHtml } from './html.js';
 export function renderInboxModalShell(): SafeHtml {
   return html`
     <div class="modal-backdrop" id="inbox-modal" role="dialog" aria-modal="true" aria-labelledby="inbox-modal-title" hidden>
-      <div class="modal" style="max-width: 44rem; max-height: 88vh; display: flex; flex-direction: column;">
+      <div class="modal inbox-modal" style="max-width: 44rem; max-height: 88vh; display: flex; flex-direction: column;">
+        <button type="button" class="inbox-modal__close" data-inbox-modal-close aria-label="Close">×</button>
         <div id="inbox-modal-content" style="flex: 1; overflow-y: auto; min-height: 0;">
           <p class="dim" style="margin: 0; padding: var(--space-4) 0; text-align: center;">Loading…</p>
-        </div>
-        <div class="modal__actions" style="justify-content: flex-end; margin-top: var(--space-3); padding-top: var(--space-3); border-top: 1px solid var(--color-border); flex-shrink: 0;">
-          <button type="button" class="btn btn--ghost" data-inbox-modal-close>Close</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Polish pass on `/inbox` after #391 shipped the Linear+Slack feel. Six visible items + one quiet hygiene drop, all CSS + view-template only — no schema, no routes, no JS contract changes.

**Toolbar** — drops the bordered card; search becomes a 32px pill with inline `⌕` + `×`; Starred + tags become chips; Apply button removed; Clear → Reset. All controls share the 32px height of `+ New conversation`.

**Modal** —
- `×` close in top-right corner (old text link removed)
- Tight title + meta row: priority dot · status · agent link · run link · age
- Tags as pills with inline `×` + always-present **Add tag…** dashed pill that matches the tag aesthetic (was a bare borderless input with a heavy browser focus outline)
- `DETAILS` / `CONTEXT PAYLOAD` headings dropped (body lands directly; context as `▸` disclosure)
- Footer consolidates to a **single right-aligned row** with `Ask triage`, `Dismiss`, `Post reply` clustered so the eye finds the primary in a predictable spot
- Redundant timeline-section border-top dropped — composer's own border-top is enough
- Manual `+ New conversation` threads hide the `(empty)` body seed so the modal opens clean until the first reply lands

**List rows + group headers** — share the modal's priority-dot + agent/run-link vocabulary; group heads lighten (no uppercase, no raised bg, no hard bottom border) so they read as section labels.

## Test plan
- [x] `npm run build` clean
- [x] `npx vitest run` — 1808 pass / 3 skipped (no delta from main)
- [x] `SUA_INBOX_DEMO=1` dashboard: opened `/inbox/<id>` for a seeded row + a freshly-created empty conversation; verified body suppression, dashed pill on Add tag, right-aligned footer, no double divider lines.

## Follow-ups (queued)
- `agent-catalog-search` system agent — triage currently can't answer "find me an agent that does X"
- LLM provider waterfall + pin semantics fix (plan at `~/.claude/plans/shimmering-sprouting-brooks.md`)
- Pulse summary tile + top-nav unread badge
- Auto-rerun after agent-editor commits a fix
- Per-area provider default

🤖 Generated with [Claude Code](https://claude.com/claude-code)