### PR TITLE
feat(dashboard,examples): agent-catalog-search system agent

### DIFF
--- a/.changeset/agent-catalog-search.md
+++ b/.changeset/agent-catalog-search.md
@@ -1,0 +1,22 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+New system agent: agent-catalog-search.
+
+The inbox triage agent can now answer "find me an agent that does X"
+by proposing a `run-agent` action targeting `agent-catalog-search`.
+The dashboard auto-injects a JSON snapshot of every installed
+non-system agent as `AGENT_CATALOG`, so the LLM has the full picture
+without needing any file or grep tool. The search agent returns up to
+5 ranked matches with a one-line `why` for each.
+
+This unblocks discovery-style triage flows that previously dead-ended
+("No suitable agent is available in the current allowlist") because
+triage's allowlist only knew about analyzer + editor. Triage's prompt
+now includes a short agent guide describing when to propose each
+allowlisted sub-agent.

--- a/agents/examples/agent-catalog-search.yaml
+++ b/agents/examples/agent-catalog-search.yaml
@@ -1,0 +1,121 @@
+# Agent Catalog Search — helps the operator find an existing installed agent
+# that matches a natural-language query (e.g. "find me an agent that gives
+# cocktail recipes" or "any agent that monitors GitHub releases?").
+#
+# Lives in the inbox-triage sub-agent allowlist. When triage proposes a
+# `run-agent` action with `agentId: agent-catalog-search`, the inbox route
+# auto-injects `AGENT_CATALOG` (a JSON snapshot of every installed agent —
+# id, name, description, tags, source) so the LLM has the full picture
+# without needing to call any tool.
+
+id: agent-catalog-search
+name: Agent Catalog Search
+description: >
+  Searches the installed agent catalog for matches to a natural-language
+  query. Returns up to 5 ranked candidates with a one-line justification
+  each. Used by inbox triage to answer "find me an agent that does X".
+status: active
+source: examples
+
+inputs:
+  QUERY:
+    type: string
+    required: true
+    description: >
+      The natural-language question or capability the operator is
+      looking for (e.g. "cocktail recipes", "find PRs that need review",
+      "monitor weather"). Comes from the inbox conversation.
+  AGENT_CATALOG:
+    type: string
+    required: false
+    default: ""
+    description: >
+      JSON snapshot of installed agents. Each entry has
+      `{id, name, description, tags, source, status}`. Auto-injected by
+      the inbox route at action-run time.
+
+nodes:
+  - id: search
+    type: llm-prompt
+    prompt: |
+      You are the Agent Catalog Search agent for the sua platform. The
+      operator is looking for an existing agent that matches a query.
+      Your job is to scan the catalog below and return up to 5 ranked
+      matches.
+
+      IMPORTANT — TOOL USE POLICY: do NOT use Bash, Read, Grep, Glob, or
+      any file/search tools. The catalog is the complete, authoritative
+      list. If nothing in it matches, say so — do not go searching for
+      more.
+
+      ════════════════════════════════════════════════════════════════
+      QUERY
+      ════════════════════════════════════════════════════════════════
+
+      {{inputs.QUERY}}
+
+      ════════════════════════════════════════════════════════════════
+      INSTALLED AGENT CATALOG (JSON array)
+      ════════════════════════════════════════════════════════════════
+
+      {{inputs.AGENT_CATALOG}}
+
+      ════════════════════════════════════════════════════════════════
+      RANKING RULES
+      ════════════════════════════════════════════════════════════════
+
+      - Prefer agents whose `description` or `tags` directly match the
+        query topic. A semantic match counts (e.g. "weather-forecast"
+        matches "tell me about the weather").
+      - Skip agents whose `status` is not `active` unless nothing
+        active matches — in that case include them but mark
+        `note: "inactive"`.
+      - Skip system / scaffolding agents (`inbox-triage`,
+        `agent-analyzer`, `agent-editor`, `agent-catalog-search`,
+        `agent-builder`, `agent-drafter`, `goal-surveyor`,
+        `build-planner`, `layout-planner`, `dashboard-designer`)
+        unless the user is explicitly asking about agent-creation or
+        platform tooling.
+      - Rank by relevance. Score 1.0 = perfect match, 0.0 = no signal.
+      - Cap at 5 matches. If nothing scores above 0.3, return zero
+        matches and put a short explanation in `recommendation`.
+
+      ════════════════════════════════════════════════════════════════
+      OUTPUT FORMAT — exact shape, single <matches>...</matches> block
+      ════════════════════════════════════════════════════════════════
+
+      Wrap the JSON in <matches>…</matches> tags. Output ONLY the
+      <matches> block — no preamble, no markdown fences. Example:
+
+      <matches>
+      {
+        "query": "{{inputs.QUERY}}",
+        "recommendation": "Two installed agents match. weather-forecast is the closest fit; weather-stub is a development stand-in.",
+        "matches": [
+          {
+            "agentId": "weather-forecast",
+            "name": "Weather Forecast",
+            "score": 0.92,
+            "why": "Pulls current weather for a configurable city. Direct match."
+          },
+          {
+            "agentId": "weather-stub",
+            "name": "Weather Stub",
+            "score": 0.45,
+            "why": "Dev-only stub that returns canned weather data."
+          }
+        ]
+      }
+      </matches>
+
+      When nothing matches:
+
+      <matches>
+      {
+        "query": "{{inputs.QUERY}}",
+        "recommendation": "No installed agent covers this. Closest neighbors were daily-summary and research-digest, neither targets the requested topic.",
+        "matches": []
+      }
+      </matches>
+    maxTurns: 2
+    timeout: 60

--- a/agents/examples/inbox-triage.yaml
+++ b/agents/examples/inbox-triage.yaml
@@ -162,6 +162,22 @@ nodes:
         job for fix-applying flows is to propose `agent-analyzer` —
         the editor proposal follows for free.
 
+      Agent guide (when to propose which from the allowlist):
+      - `agent-analyzer` → diagnose a failed run / suggest a YAML fix
+        for the inbox message's target agent. The dashboard
+        auto-injects AGENT_YAML + LAST_RUN_OUTPUT, so you only need
+        to set `FOCUS` to a one-sentence prompt steering the
+        analysis.
+      - `agent-catalog-search` → the operator is looking for an
+        existing installed agent that matches a capability or topic
+        ("find me an agent that does X", "any agent that monitors
+        Y?", "what agent gives Z?"). Pass `QUERY` = the user's
+        request in their own words. The dashboard auto-injects the
+        installed-agent catalog as `AGENT_CATALOG`, so you don't
+        thread that yourself. Prefer this over speculating about
+        which agents exist — you don't see the catalog and the
+        operator does.
+
       If `ALLOWED_SUB_AGENTS` is empty OR no action would help, omit
       `actions` entirely (or send an empty array). Text-only
       recommendations are perfectly fine.

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -594,6 +594,108 @@ describe('POST /inbox/:id/actions/:rid/run — agent-analyzer enrichment', () =>
   });
 });
 
+describe('POST /inbox/:id/actions/:rid/run — agent-catalog-search enrichment', () => {
+  // When triage proposes running `agent-catalog-search`, the route
+  // auto-injects a JSON snapshot of every installed (non-system) agent
+  // as AGENT_CATALOG. We stub the agent with a shell echo so we can grep
+  // the resulting run output for proof of injection.
+
+  it('auto-injects AGENT_CATALOG and filters out system agents', async () => {
+    const app = await makeApp();
+
+    // Install two catalog-visible agents. The tokens in their ids let
+    // us assert each got serialized into AGENT_CATALOG.
+    for (const id of ['cocktail-mixer-marker', 'weather-forecast-marker']) {
+      const yaml = [
+        `id: ${id}`,
+        `name: ${id}`,
+        'description: enrichment-test fixture',
+        'nodes:',
+        '  - id: noop',
+        '    type: shell',
+        '    command: echo ok',
+      ].join('\n');
+      agentStore.upsertAgent(parseAgent(yaml), 'dashboard', 'test fixture');
+    }
+
+    // Install a system agent that MUST be filtered out of the catalog.
+    const sysYaml = [
+      'id: agent-analyzer',
+      'name: Agent Analyzer',
+      'description: should NOT appear in catalog',
+      'nodes:',
+      '  - id: noop',
+      '    type: shell',
+      '    command: echo ok',
+    ].join('\n');
+    agentStore.upsertAgent(parseAgent(sysYaml), 'dashboard', 'test fixture');
+
+    // Stub agent-catalog-search with a shell node that echoes the
+    // injected AGENT_CATALOG so we can read it back from the run result.
+    const stubYaml = [
+      'id: agent-catalog-search',
+      'name: Agent Catalog Search',
+      'description: stubbed for enrichment test',
+      'inputs:',
+      '  QUERY:',
+      '    type: string',
+      '    required: true',
+      '  AGENT_CATALOG:',
+      '    type: string',
+      '    required: false',
+      '    default: ""',
+      'nodes:',
+      "  - id: echo",
+      "    type: shell",
+      "    command: \"echo catalog: $AGENT_CATALOG\"",
+    ].join('\n');
+    agentStore.upsertAgent(parseAgent(stubYaml), 'dashboard', 'test fixture');
+
+    const msg = inboxStore.add({
+      priority: 'medium',
+      source: 'manual',
+      title: 'find me a cocktail recipe agent',
+      body: 'looking for something to mix drinks',
+    });
+
+    const proposed = inboxStore.addResponse(
+      msg.id,
+      'action',
+      'search the catalog',
+      JSON.stringify({
+        kind: 'action',
+        status: 'proposed',
+        agentId: 'agent-catalog-search',
+        inputs: { QUERY: 'cocktail recipe' },
+        rationale: 'find an installed agent that matches the request.',
+      }),
+    );
+
+    const res = await request(app)
+      .post(`/inbox/${msg.id}/actions/${proposed.id}/run`)
+      .set('X-Requested-With', 'fetch')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE);
+    expect(res.status).toBe(204);
+
+    const deadline = Date.now() + 2000;
+    let after = inboxStore.getResponse(proposed.id);
+    while (Date.now() < deadline) {
+      after = inboxStore.getResponse(proposed.id);
+      const m = after?.metaJson ? JSON.parse(after.metaJson) : null;
+      if (m && m.status !== 'proposed' && m.status !== 'running') break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(after).not.toBeNull();
+    const meta = JSON.parse(after!.metaJson!);
+    expect(meta.status).toBe('completed');
+    expect(meta.resultSummary).toContain('cocktail-mixer-marker');
+    expect(meta.resultSummary).toContain('weather-forecast-marker');
+    // System agent must NOT appear in the injected catalog.
+    expect(meta.resultSummary).not.toContain('agent-analyzer');
+  });
+});
+
 describe('POST /inbox/:id/actions/:rid/run — agent-editor write path', () => {
   // agent-editor is route-handled: no DAG dispatch, just a synchronous
   // upsertAgent after validation. These tests install a target agent,

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -69,7 +69,23 @@ const PENDING_USER_REPLY_WINDOW_MS = 30_000;
 const TRIAGE_SUB_AGENT_ALLOWLIST: readonly string[] = [
   'agent-analyzer',
   'agent-editor',
+  'agent-catalog-search',
 ];
+
+/**
+ * Agent ids that are themselves part of the inbox-triage scaffolding —
+ * they exist to make triage work, not as candidates to recommend back
+ * to the operator. `agent-catalog-search` filters these out of its
+ * result set so "find me an agent that does X" never proposes a system
+ * agent. Kept here (vs in the YAML) so the list stays in sync with the
+ * allowlist as new sub-agents are added.
+ */
+const SYSTEM_AGENT_IDS: ReadonlySet<string> = new Set([
+  'inbox-triage',
+  'agent-analyzer',
+  'agent-editor',
+  'agent-catalog-search',
+]);
 
 /**
  * Agent IDs handled by the route directly rather than dispatched as a
@@ -597,6 +613,37 @@ function enrichAgentAnalyzerInputs(
 }
 
 /**
+ * Inject `AGENT_CATALOG` into agent-catalog-search inputs: a JSON array
+ * of installed-agent metadata (id, name, description, tags, source,
+ * status) excluding system/scaffolding agents. The catalog-search
+ * agent's prompt also self-filters, but stripping here saves prompt
+ * tokens and prevents the LLM from accidentally proposing a system
+ * agent even on edge cases.
+ */
+function enrichAgentCatalogSearchInputs(
+  ctx: ReturnType<typeof getContext>,
+  inputs: Record<string, string>,
+): Record<string, string> {
+  const out: Record<string, string> = { ...inputs };
+  if (out.AGENT_CATALOG && out.AGENT_CATALOG.trim().length > 0) return out;
+  try {
+    const agents = ctx.agentStore.listAgents();
+    const catalog = agents
+      .filter((a) => !SYSTEM_AGENT_IDS.has(a.id))
+      .map((a) => ({
+        id: a.id,
+        name: a.name,
+        description: a.description ?? '',
+        tags: a.tags ?? [],
+        source: a.source,
+        status: a.status,
+      }));
+    out.AGENT_CATALOG = JSON.stringify(catalog);
+  } catch { /* swallow — empty catalog still lets the agent respond "no matches" */ }
+  return out;
+}
+
+/**
  * Distilled version of run-now-build.ts's run-output collector:
  * grab the latest completed run's result + the latest failed run's
  * error/output, cap at 3000 chars. Empty string when neither exists.
@@ -729,14 +776,15 @@ async function runProposedAction(
     return;
   }
 
-  // Per-agent input enrichment. Today only agent-analyzer needs
-  // server-side help (the AGENT_YAML it requires is heavy and lives in
-  // the agentStore, not in triage's prompt context). Future allowlist
-  // entries can add their own case here.
+  // Per-agent input enrichment. Triage's prompt context can't carry
+  // heavyweight inputs (full agent YAMLs, catalog snapshots), so we
+  // inject them here at action-run time based on agentId.
   let effectiveInputs = meta.inputs;
   if (meta.agentId === 'agent-analyzer') {
     const parentMessage = ctx.inboxStore.get(messageId);
     effectiveInputs = enrichAgentAnalyzerInputs(ctx, parentMessage?.agentId, meta.inputs);
+  } else if (meta.agentId === 'agent-catalog-search') {
+    effectiveInputs = enrichAgentCatalogSearchInputs(ctx, meta.inputs);
   }
 
   let runId: string | undefined;


### PR DESCRIPTION
## Summary

Triage previously dead-ended on "find me an agent that does X" because its sub-agent allowlist only knew about `agent-analyzer` and `agent-editor`. This adds a new system agent — `agent-catalog-search` — that scans the installed-agent catalog and returns up to 5 ranked matches with a one-line `why` for each. The inbox route auto-injects the catalog JSON, so the LLM has the full picture without any file/grep tool.

## Changes

- **`agents/examples/agent-catalog-search.yaml`** — new single-node LLM-prompt agent. Takes `QUERY` (the user's request) + `AGENT_CATALOG` (auto-injected) and emits a `<matches>{...}</matches>` block with ranked candidates.
- **`packages/dashboard/src/routes/inbox.ts`**:
  - Add `'agent-catalog-search'` to `TRIAGE_SUB_AGENT_ALLOWLIST`.
  - New `SYSTEM_AGENT_IDS` set (triage, analyzer, editor, catalog-search) for filtering scaffolding out of the catalog snapshot.
  - New `enrichAgentCatalogSearchInputs` helper injects `AGENT_CATALOG` as JSON of `{id, name, description, tags, source, status}` for every non-system installed agent.
  - `runProposedAction` dispatches the enricher for `agent-catalog-search`, mirroring the analyzer pattern.
- **`agents/examples/inbox-triage.yaml`** — triage prompt gains an "agent guide" section describing when to propose each allowlist entry, with the catalog-search slot teaching it to use this for "find me an agent" / "any agent that does X" queries.
- **`packages/dashboard/src/routes/inbox.test.ts`** — new test stubs `agent-catalog-search` with a shell echo and asserts the injected catalog contains the test agents but NOT the system agent.

## Test plan
- [x] `npm run build` clean
- [x] `npx vitest run` — 1809 pass / 3 skipped (was 1808 — +1 enrichment test)
- [ ] Dogfood in `SUA_INBOX_DEMO=1` dashboard: create a manual inbox conversation, ask "find me an agent that gives cocktail recipes", confirm triage proposes `agent-catalog-search` and the resulting run returns ranked matches.

## Follow-ups (queued)
- LLM provider waterfall + pin semantics fix (plan at `~/.claude/plans/shimmering-sprouting-brooks.md`)
- Pulse summary tile + top-nav unread badge
- Auto-rerun after agent-editor commits a fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)