### PR TITLE
fix(examples): agent-analyzer preflight guard + outputWidget + signal

### DIFF
--- a/.changeset/agent-analyzer-preflight-and-widget.md
+++ b/.changeset/agent-analyzer-preflight-and-widget.md
@@ -1,0 +1,25 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+agent-analyzer: friendlier missing-AGENT_YAML error + outputWidget + signal.
+
+The analyzer used to fail at setup time with an opaque generic
+"missing required input" error whenever it was invoked without the
+dashboard's automatic YAML injection (manual run, scheduled trigger,
+programmatic call). The input is now `required: false` with an empty
+default, and a new `preflight` shell node runs first to validate it.
+On empty input the operator sees a one-shot human-readable message
+naming the three ways to supply the YAML — not a stack trace.
+
+Also adds the missing `outputWidget` (key-value with classification,
+summary, has_suggested_yaml, source_node) and `signal` (text-headline
+for Pulse), driven by a new trailing `summarize` shell node that
+emits a JSON envelope extracted from the analyze (or fix) output.
+
+Regression test in `agent-yaml.test.ts` locks in the preflight-first
+ordering + widget+signal declaration.

--- a/agents/examples/agent-analyzer.yaml
+++ b/agents/examples/agent-analyzer.yaml
@@ -10,8 +10,15 @@ source: examples
 inputs:
   AGENT_YAML:
     type: string
-    required: true
-    description: The full YAML definition of the agent to analyze.
+    required: false
+    default: ""
+    description: >
+      The full YAML definition of the agent to analyze. Required at
+      runtime — when empty, the `preflight` shell node fails fast with
+      a clear human-facing message. We keep this `required: false` with
+      an empty default so the executor doesn't reject the run at setup
+      time with an opaque "missing required input" error; the preflight
+      guard produces a much better diagnostic instead.
   FOCUS:
     type: string
     required: false
@@ -29,8 +36,30 @@ inputs:
     description: Node types, signal templates, output widgets, available agents, and patterns. Injected at analysis time.
 
 nodes:
+  - id: preflight
+    type: shell
+    # Cheap fast-fail. The dashboard's "Suggest improvements" flow
+    # injects AGENT_YAML automatically, but a manual run, scheduled
+    # trigger, or programmatic invocation that forgets the input
+    # otherwise produces an opaque generic executor error. Catching
+    # the empty case here gives the operator a one-line explanation
+    # of what to do instead.
+    command: |
+      if [ -z "$AGENT_YAML" ] || [ ${#AGENT_YAML} -lt 10 ]; then
+        echo "agent-analyzer requires AGENT_YAML — the full YAML of the agent to analyze."
+        echo ""
+        echo "From the dashboard: open any agent's detail page and click 'Suggest improvements' — the button injects the YAML automatically."
+        echo "From a manual run: paste the agent's YAML into the AGENT_YAML input field on the Run-now form."
+        echo "From a schedule or programmatic call: pass AGENT_YAML in the inputs map."
+        exit 1
+      fi
+      echo '{"ok":true,"yaml_length":'${#AGENT_YAML}'}'
+    timeout: 5
+
   - id: analyze
     type: llm-prompt
+    dependsOn:
+      - preflight
     prompt: |
       You are an expert agent architect reviewing a sua DAG agent.
 
@@ -208,3 +237,69 @@ nodes:
       </yaml>
     maxTurns: 4
     timeout: 240
+
+  - id: summarize
+    type: shell
+    # Final node — emits a small JSON envelope so the agent has a
+    # structured run.result for the outputWidget. Reads from `fix` when
+    # validation failed (so the corrected XML wins), otherwise from
+    # `analyze`. Soft-deps on `fix` so a skipped `fix` doesn't block
+    # this from running; the empty $UPSTREAM_FIX_RESULT case is handled.
+    dependsOn:
+      - analyze
+      - validate
+      - fix
+    command: |
+      # Prefer fix output when validate said invalid AND fix actually ran.
+      VALIDATE_VALID=$(echo "$UPSTREAM_VALIDATE_RESULT" | grep -o '"valid":[a-z]*' | head -1)
+      if [ "$VALIDATE_VALID" = '"valid":false' ] && [ -n "$UPSTREAM_FIX_RESULT" ]; then
+        SRC="$UPSTREAM_FIX_RESULT"
+        SOURCE_NODE="fix"
+      else
+        SRC="$UPSTREAM_ANALYZE_RESULT"
+        SOURCE_NODE="analyze"
+      fi
+
+      CLASSIFICATION=$(printf '%s' "$SRC" | sed -n 's:.*<classification>\([^<]*\)</classification>.*:\1:p' | head -1)
+      SUMMARY=$(printf '%s' "$SRC" | sed -n 's:.*<summary>\([^<]*\)</summary>.*:\1:p' | head -1)
+      HAS_YAML=$(printf '%s' "$SRC" | grep -c '<yaml>' || true)
+
+      # JSON-escape via node so quotes / newlines in the summary don't
+      # corrupt the envelope.
+      node -e '
+        const c = (process.argv[1] || "UNKNOWN").trim();
+        const s = (process.argv[2] || "").trim();
+        const sn = process.argv[3] || "analyze";
+        const hasYaml = (process.argv[4] || "0").trim() !== "0";
+        console.log(JSON.stringify({
+          classification: c,
+          summary: s,
+          has_suggested_yaml: hasYaml,
+          source_node: sn,
+        }));
+      ' "$CLASSIFICATION" "$SUMMARY" "$SOURCE_NODE" "$HAS_YAML"
+    timeout: 15
+
+outputWidget:
+  type: key-value
+  fields:
+    - name: classification
+      label: Assessment
+      type: badge
+    - name: summary
+      label: Summary
+      type: text
+    - name: has_suggested_yaml
+      label: YAML diff available
+      type: badge
+    - name: source_node
+      label: Source node
+      type: text
+
+signal:
+  title: Agent Analyzer
+  icon: "🔎"
+  template: text-headline
+  mapping:
+    headline: summary
+    badge: classification

--- a/packages/core/src/agent-yaml.test.ts
+++ b/packages/core/src/agent-yaml.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { parseAgent, exportAgent, AgentYamlParseError } from './agent-yaml.js';
 import type { Agent } from './agent-v2-types.js';
 
@@ -342,5 +344,50 @@ nodes:
     // Round-trip preserves them.
     const a2 = parseAgent(exportAgent(a1));
     expect(a2).toEqual(a1);
+  });
+});
+
+describe('agents/examples/agent-analyzer.yaml — preflight guard + widget', () => {
+  // Locks in the contract that:
+  // - AGENT_YAML is required:false so the executor doesn't reject at
+  //   setup with an opaque "missing required input" error;
+  // - the first node is `preflight` (no deps), which validates the
+  //   input and bails with a human-readable shell message;
+  // - `analyze` depends on preflight so a missing-YAML run dead-ends
+  //   at the friendly preflight error instead of hitting Claude;
+  // - the agent declares an outputWidget + signal so standalone runs
+  //   render properly on /runs/:id and Pulse.
+  it('parses, declares preflight as the first guard, and has widget+signal', () => {
+    const yaml = readFileSync(
+      join(__dirname, '..', '..', '..', 'agents', 'examples', 'agent-analyzer.yaml'),
+      'utf-8',
+    );
+    const a = parseAgent(yaml);
+
+    // Schema: AGENT_YAML must not be required (preflight is the gate).
+    expect(a.inputs?.AGENT_YAML?.required).not.toBe(true);
+    expect(a.inputs?.AGENT_YAML?.default).toBe('');
+
+    // First node must be preflight + a shell that exits non-zero on
+    // empty AGENT_YAML, so the operator-visible error is the
+    // human-readable message we wrote — not the executor's generic
+    // "missing required input" or a Claude turn that fails silently.
+    expect(a.nodes[0].id).toBe('preflight');
+    expect(a.nodes[0].type).toBe('shell');
+    expect(a.nodes[0].dependsOn ?? []).toEqual([]);
+    expect(a.nodes[0].command).toMatch(/AGENT_YAML/);
+    expect(a.nodes[0].command).toMatch(/Suggest improvements/);
+
+    // analyze gates on preflight.
+    const analyze = a.nodes.find((n) => n.id === 'analyze');
+    expect(analyze?.dependsOn).toContain('preflight');
+
+    // outputWidget is declared with at least one field (the schema
+    // requires this for non-ai widgets).
+    expect(a.outputWidget?.type).toBe('key-value');
+    expect((a.outputWidget?.fields ?? []).length).toBeGreaterThan(0);
+
+    // signal template is declared for Pulse.
+    expect(a.signal?.template).toBe('text-headline');
   });
 });


### PR DESCRIPTION
## Summary

Three issues with the agent-analyzer example, fixed together:

### 1. Opaque "missing input" error → friendly preflight

When the analyzer is invoked without the dashboard's "Suggest improvements" auto-injection (manual run, scheduled trigger, programmatic call), the executor used to reject the run at setup with a generic opaque error. Now:

- `AGENT_YAML` is `required: false` with `default: ""` so the executor never rejects at setup.
- A new **`preflight`** shell node runs first (no deps) and exits non-zero with a one-shot human message naming the three ways to supply the YAML.
- `analyze` now `dependsOn: [preflight]` so empty-YAML runs dead-end at the friendly diagnostic instead of hitting Claude with no payload.

Operator sees this in the run detail:
```
agent-analyzer requires AGENT_YAML — the full YAML of the agent to analyze.

From the dashboard: open any agent's detail page and click 'Suggest improvements' — the button injects the YAML automatically.
From a manual run: paste the agent's YAML into the AGENT_YAML input field on the Run-now form.
From a schedule or programmatic call: pass AGENT_YAML in the inputs map.
```

### 2. Missing outputWidget

Added `outputWidget: key-value` with fields `classification`, `summary`, `has_suggested_yaml`, `source_node`. Driven by a new trailing **`summarize`** shell node that extracts the XML envelope from `analyze` (or `fix` when the validate-then-fix self-correction recovered) and emits a JSON envelope.

### 3. Missing signal

Added `signal: text-headline` for Pulse, mapping the summary as headline and classification as badge.

## Test plan

- [x] `node -e "parseAgent(...)"` round-trips cleanly (5 nodes: preflight, analyze, validate, fix, summarize; widget + signal present).
- [x] Empty-AGENT_YAML smoke test: `executeAgentDag` returns `status: failed`, preflight error is the human message, downstream nodes are correctly `skipped`/`condition_not_met`.
- [x] `npx vitest run` — 1809 pass / 3 skipped (+1 regression test in `agent-yaml.test.ts` locking the preflight-first contract).

## Follow-ups (queued)

- `agent-catalog-search` (PR #393) — slot ahead of the LLM waterfall once merged.
- LLM provider waterfall + pin semantics fix (plan at \`~/.claude/plans/shimmering-sprouting-brooks.md\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)