### PR TITLE
fix(examples): inbox-triage direct voice + sharper catalog-search trigger

### DIFF
--- a/.changeset/triage-direct-voice.md
+++ b/.changeset/triage-direct-voice.md
@@ -1,0 +1,27 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+inbox-triage: direct-voice prompt + stronger catalog-search trigger.
+
+The triage `recommendation` is rendered verbatim in the conversation
+thread, but the model sometimes emitted stage directions instead of
+the actual message — e.g. "Reply with a clarifying question before
+routing: ask whether they want…" or "shortlist request: ask what
+platform or directory they want the existing trivia agent from"
+instead of just asking the question or proposing the catalog search.
+
+Adds a VOICE section near the top of the prompt with bad-vs-good
+examples (first-person direct reply, no meta-narration about
+routing/shortlisting) and two new OUTPUT FORMAT examples: a
+clarifying question done right, and a catalog-search proposal for a
+concrete topic.
+
+Also strengthens the agent guide for `agent-catalog-search` (shipped
+in #393) so the model proposes it DIRECTLY when the operator names a
+topic ("trivia", "cocktail", "weather"), without first asking which
+platform or directory — the installed catalog IS the directory.

--- a/agents/examples/inbox-triage.yaml
+++ b/agents/examples/inbox-triage.yaml
@@ -108,6 +108,41 @@ nodes:
       go searching for more. Respond with the `<plan>` block directly.
 
       ════════════════════════════════════════════════════════════════
+      VOICE — write the recommendation AS the assistant reply
+      ════════════════════════════════════════════════════════════════
+
+      The `recommendation` string is rendered verbatim in the
+      conversation as your turn. Write it as the actual message you
+      are sending to the operator — not as a stage direction
+      describing what to say. If the right move is to ask a
+      clarifying question, ASK it; do not announce that you will.
+
+      BAD (stage direction — the operator sees the meta-instruction):
+        "Reply with a clarifying question before routing: ask whether
+         they want an existing trivia-playing agent or help creating
+         one, and what it should do."
+        "Suggest the user check the logs."
+        "Recommend running agent-analyzer."
+
+      GOOD (direct reply — first-person assistant voice):
+        "Do you want an existing trivia-playing agent (one is
+         already installed: trivia-night), or help building a new
+         one — and should it generate questions, host a quiz, or
+         answer trivia?"
+        "Check the run logs at /runs/abc12345 for the full stderr."
+        "agent-analyzer can scan the YAML and propose a fix — want
+         me to run it?"
+
+      Other voice rules:
+      - First or second person ("I", "you"), never third person
+        ("the user", "the operator").
+      - Don't narrate your own process ("Let me think…", "Routing
+        this to…", "Based on the context…").
+      - Don't repeat the user's question back at them as a header.
+      - One direct response. No "Option 1 / Option 2" lists unless
+        the operator explicitly asked for choices.
+
+      ════════════════════════════════════════════════════════════════
       WHAT TO RECOMMEND
       ════════════════════════════════════════════════════════════════
 
@@ -171,12 +206,26 @@ nodes:
       - `agent-catalog-search` → the operator is looking for an
         existing installed agent that matches a capability or topic
         ("find me an agent that does X", "any agent that monitors
-        Y?", "what agent gives Z?"). Pass `QUERY` = the user's
+        Y?", "what agent gives Z?", "is there a trivia agent?",
+        "got a cocktail recipe agent?"). Pass `QUERY` = the user's
         request in their own words. The dashboard auto-injects the
         installed-agent catalog as `AGENT_CATALOG`, so you don't
-        thread that yourself. Prefer this over speculating about
-        which agents exist — you don't see the catalog and the
-        operator does.
+        thread that yourself.
+
+        Propose `agent-catalog-search` DIRECTLY when the operator
+        names a concrete topic or capability. Do NOT ask "which
+        platform" or "which directory" first — the installed
+        catalog is the only catalog, and the search agent will
+        either return matches or report none.
+
+        Only ask a clarifying question first when the request is
+        genuinely under-specified (e.g. "find me an agent" with no
+        topic). Topics like "trivia", "cocktail", "weather", "PR
+        review" are concrete enough to search on directly.
+
+        Prefer catalog-search over speculating about which agents
+        exist — you don't see the catalog, but the search agent
+        does.
 
       If `ALLOWED_SUB_AGENTS` is empty OR no action would help, omit
       `actions` entirely (or send an empty array). Text-only
@@ -195,6 +244,37 @@ nodes:
         "messageId": "{{inputs.MESSAGE_ID}}",
         "recommendation": "Run failed with exit 1 because `which apod` returned no match. Install the apod CLI (brew install apod) or switch to the http-get version of the agent.",
         "verifyHint": "Re-run the agent; it should reach the parse-output node without exit code 1."
+      }
+      </plan>
+
+      Example with a clarifying question (operator's request is
+      genuinely under-specified — e.g. "find me an agent" with no
+      topic). Ask the question directly, do NOT describe what
+      you're going to ask:
+
+      <plan>
+      {
+        "messageId": "{{inputs.MESSAGE_ID}}",
+        "recommendation": "What topic or capability are you looking for? I can search the installed catalog for things like 'weather', 'PR review', 'cocktail recipes' — anything specific you want it to do."
+      }
+      </plan>
+
+      Example proposing catalog-search (operator named a concrete
+      topic — DO NOT ask clarifying questions first; propose the
+      search directly):
+
+      <plan>
+      {
+        "messageId": "{{inputs.MESSAGE_ID}}",
+        "recommendation": "Let me check the installed catalog for trivia-related agents.",
+        "actions": [
+          {
+            "type": "run-agent",
+            "agentId": "agent-catalog-search",
+            "inputs": { "QUERY": "trivia — generate trivia questions, host a quiz, or answer trivia" },
+            "rationale": "Search the installed catalog for any agent that already covers trivia."
+          }
+        ]
       }
       </plan>
 


### PR DESCRIPTION
## Summary

The triage `recommendation` is rendered verbatim in the conversation thread, but the model has been emitting stage directions instead of the actual message:

> "Reply with a clarifying question before routing: ask whether they want an existing trivia-playing agent or help creating one…"

> "shortlist request: ask what platform or directory they want the existing trivia agent from…"

Operators see the meta-instruction in the thread, which reads as the assistant talking to itself.

## Changes

- **VOICE section** near the top of the prompt with bad-vs-good examples (first-person direct reply, no narration about routing/shortlisting/thinking).
- **OUTPUT FORMAT entry** for clarifying questions done right (asks the question in first person, no preamble).
- **OUTPUT FORMAT entry** showing the `agent-catalog-search` proposal for a concrete topic ("trivia") so the model has the exact shape to copy.
- **Sharper agent guide** for `agent-catalog-search` (shipped in #393): tells the model to propose it DIRECTLY when the operator names a concrete topic ("trivia", "cocktail", "weather") — not to ask which platform or directory first. The installed catalog IS the directory.

## Test plan

- [x] `parseAgent` round-trips the updated YAML (10103 byte prompt).
- [x] `npx vitest run` — **1810 pass / 3 skipped** (no test changes; the catalog-search regression test from #393 stays green).
- [ ] Dogfood the voice fix: in a fresh conversation, ask "is there a trivia agent?" — confirm triage proposes `agent-catalog-search` directly rather than a meta-narration about routing.
- [ ] Dogfood the clarifying-question fix: ask the vague "find me an agent" — confirm triage asks the question in first person ("What topic or capability are you looking for?") rather than narrating it.

## Follow-ups (queued)

- LLM provider waterfall + pin semantics fix (plan at `~/.claude/plans/shimmering-sprouting-brooks.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)