### PR TITLE
fix(dashboard,examples): inbox modal preserves selections + triage dispatches CSP permission edits

### DIFF
--- a/.changeset/inbox-modal-focus-and-permission-dispatch.md
+++ b/.changeset/inbox-modal-focus-and-permission-dispatch.md
@@ -1,0 +1,29 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox modal: preserve selections + triage now dispatches CSP permission edits.
+
+Two fixes bundled:
+
+1. **Selection-preserving polls.** The modal polls every 1.5s and used
+   to replace `content.innerHTML` unconditionally, destroying any
+   text the operator had highlighted in the conversation (e.g.
+   copying triage's reply) and pulling focus out of the composer.
+   The poll now skips the DOM swap entirely when the operator is
+   actively interacting — focus inside the modal or a text selection
+   anchored inside it — and just reschedules the next tick.
+
+2. **Triage dispatches CSP-block permission requests.** Previously the
+   triage prompt told operators to open Config → Permissions and
+   edit the agent by hand. Now it routes csp-block messages through
+   the existing analyzer → editor pipeline: it proposes
+   `agent-analyzer` with a surgical FOCUS that names the exact host
+   to add to `permissions.imgSrc`, which emits a minimal YAML diff
+   and auto-proposes an `agent-editor` action card for one-click
+   approval. New OUTPUT FORMAT example covers the
+   apod.nasa.gov / demo-astro-tile case verbatim.

--- a/agents/examples/inbox-triage.yaml
+++ b/agents/examples/inbox-triage.yaml
@@ -155,9 +155,27 @@ nodes:
         dismiss if it succeeds". Don't speculate without the data.
 
       - source=permission-request → name the missing permission (host,
-        path, tool) and the concrete config path the user updates. If
-        the request is for a CSP image host, point at the agent's
-        Config → Permissions panel.
+        path, tool). If the inbox message has an `agentId` AND the
+        request is for a CSP image host (look for "csp-block", "image
+        host", or a hostname in the context payload), DO NOT tell the
+        operator to open the dashboard and edit it by hand. Propose
+        `agent-analyzer` with a SURGICAL focus that names the exact
+        edit:
+
+          FOCUS: "Add the host '<host>' to permissions.imgSrc on this
+                  agent. Make NO other changes. Set classification to
+                  SUGGESTIONS and return the minimal YAML diff."
+
+        The analyzer emits the corrected YAML, validates it, and the
+        dashboard auto-proposes an `agent-editor` action card with
+        the diff — the operator clicks Run to commit. This is the
+        dispatch path: triage names the change, operator approves
+        it, the system applies it.
+
+        For permission-requests WITHOUT an agentId (rare; some
+        permission flows are global), THEN fall back to giving the
+        operator concrete steps. Default to dispatch-via-analyzer
+        whenever the target agent is known.
 
       - source=cadence → name the housekeeping action and where to do
         it ("archive these agents from /agents", "set a schedule on
@@ -291,6 +309,27 @@ nodes:
             "agentId": "agent-analyzer",
             "inputs": { "FOCUS": "Why does this fail with exit 1? What's the minimal change to make it pass?" },
             "rationale": "Get concrete diff suggestions targeting the exit-code failure."
+          }
+        ]
+      }
+      </plan>
+
+      Example dispatching a CSP image-host permission edit (operator
+      pasted a csp-block notice for agent demo-astro-tile and host
+      apod.nasa.gov). DO NOT tell them to open Config → Permissions
+      by hand — propose the analyzer with a surgical FOCUS so the
+      change goes through the Run/approve loop:
+
+      <plan>
+      {
+        "messageId": "{{inputs.MESSAGE_ID}}",
+        "recommendation": "Want me to add `apod.nasa.gov` to `demo-astro-tile`'s allowed image hosts? I'll have agent-analyzer produce the YAML diff and queue an agent-editor card for your approval.",
+        "actions": [
+          {
+            "type": "run-agent",
+            "agentId": "agent-analyzer",
+            "inputs": { "FOCUS": "Add the host 'apod.nasa.gov' to permissions.imgSrc on this agent. Make NO other changes. Classification MUST be SUGGESTIONS and the YAML diff MUST be minimal." },
+            "rationale": "Produce a one-line permission-edit diff; the editor card auto-follows for approval."
           }
         ]
       }

--- a/packages/dashboard/src/views/inbox-modal.js.ts
+++ b/packages/dashboard/src/views/inbox-modal.js.ts
@@ -98,6 +98,17 @@ export const INBOX_MODAL_JS = `
       .then(function (r) { if (!r.ok) throw new Error('fragment fetch failed'); return r.text(); })
       .then(function (text) {
         if (currentId !== id) return; // user opened a different message
+        // Don't blow away the modal DOM mid-interaction. innerHTML
+        // replacement destroys both text selections (operator copying
+        // triage's reply) and caret position in the composer. When the
+        // user is actively interacting, skip THIS refresh and just
+        // reschedule — the next tick will catch up. The polling deadline
+        // logic in maybeSchedulePoll() keeps us watching until the user
+        // stops interacting.
+        if (userIsInteracting()) {
+          maybeSchedulePoll();
+          return;
+        }
         content.innerHTML = text;
         applyAnimations();
         scrollToBottom();
@@ -105,6 +116,27 @@ export const INBOX_MODAL_JS = `
         maybeSchedulePoll();
       })
       .catch(function () { /* swallow; user can close + retry */ });
+  }
+
+  /**
+   * True if the operator is actively interacting with the modal — they
+   * have focus inside it (typing), or they have a non-empty text
+   * selection anchored inside it (highlighting text to copy). In
+   * either case, a poll-driven refresh should NOT call focus
+   * because that wipes the selection / caret position.
+   */
+  function userIsInteracting() {
+    if (content.contains(document.activeElement)) return true;
+    var sel = window.getSelection && window.getSelection();
+    if (sel && !sel.isCollapsed && sel.rangeCount > 0) {
+      try {
+        var anchor = sel.anchorNode;
+        if (anchor && content.contains(anchor.nodeType === 1 ? anchor : anchor.parentNode)) {
+          return true;
+        }
+      } catch (_) { /* ignore */ }
+    }
+    return false;
   }
 
   function focusFirstInteractive() {


### PR DESCRIPTION
## Summary

Two bundled fixes around the inbox modal, both surfaced while debugging triage's reply on a csp-block message:

### 1. Modal polls were destroying text selections

The modal polls `/inbox/:id/fragment` every 1.5s and unconditionally replaced `content.innerHTML` with the new fragment. When the operator was highlighting text in the conversation (to copy triage's reply) or had the composer focused, that DOM swap wiped both — focus jumped, selection vanished.

New `userIsInteracting()` check skips the DOM swap entirely when the operator has focus inside the modal OR has a non-empty text selection anchored inside it. The poll just reschedules; the next tick catches up once they stop interacting. Initial render still auto-focuses the textarea.

Verified via browse: textarea focus survives multiple poll cycles after a programmatic text-selection inside the conversation.

### 2. Triage now DISPATCHES CSP-image-host permission edits

Previously triage handed the operator manual instructions for CSP image-host permission requests:

> Add `apod.nasa.gov` to the `demo-astro-tile` agent's allowed image hosts in the dashboard: open the agent, go to **Config → Permissions**, and add the host under the CSP image allowlist.

The dispatch infrastructure (analyzer → editor pipeline) already exists — triage just wasn't using it. New behavior for `source=permission-request`: when the inbox message has an `agentId` AND the request is for a CSP image host, propose `agent-analyzer` with a surgical FOCUS:

```
FOCUS: "Add the host 'apod.nasa.gov' to permissions.imgSrc on this agent.
        Make NO other changes. Classification MUST be SUGGESTIONS and the
        YAML diff MUST be minimal."
```

Analyzer emits a one-line YAML diff, the dashboard auto-proposes an `agent-editor` action card with the diff preview, operator clicks Run to commit. Same Diagnose → Propose → Apply loop already used for failed-run fixes, just applied to permission edits.

New OUTPUT FORMAT example covers the `apod.nasa.gov` / `demo-astro-tile` case verbatim so the model has the exact shape to copy.

For permission-requests without an `agentId` (rare; some flows are global), triage still falls back to the manual-steps response.

## Test plan

- [x] `npm run build` clean.
- [x] `npx vitest run` — **1820 pass / 3 skipped**.
- [x] Browse dogfood the focus fix: programmatic text selection inside the modal conversation, wait > 1.5s (poll fires), verify selection + focus survive.
- [ ] Manual dogfood of the dispatch path: post a fresh csp-block-style message, confirm triage's reply proposes `agent-analyzer` (with the surgical FOCUS) instead of giving manual instructions.

## Follow-ups (queued)

- Per-area provider default (from earlier handoff queue)
- Auto-rerun after agent-editor commits a fix
- Reject-distinct-from-skip on action cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)