### PR TITLE
fix(dashboard): triage auto-refreshes stale allowlist agents + clear error when dispatch target missing

### DIFF
--- a/.changeset/triage-stale-allowlist-and-missing-target.md
+++ b/.changeset/triage-stale-allowlist-and-missing-target.md
@@ -1,0 +1,36 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox triage: auto-refresh stale allowlist agents + clear error when dispatch target is missing.
+
+Two compounding bugs that broke the analyzer dispatch path shipped
+in #397:
+
+1. **Stale system allowlist agents.** The auto-import in
+   `getSubAgentAllowlist` only fired when an allowlist agent
+   (analyzer / editor / catalog-search) wasn't installed at all —
+   never when the bundled YAML on disk had changed since install.
+   Operators who installed `agent-analyzer` before PR #394 still had
+   the pre-preflight version (`AGENT_YAML: required: true`, no
+   preflight node) and any dispatch died at input resolution with a
+   generic "Missing required input AGENT_YAML" — looking like an
+   analyzer bug rather than a stale-install issue. Now compares the
+   installed exported YAML against the bundled file and re-imports
+   when they differ. Scoped to allowlist entries only; user agents
+   are never touched.
+
+2. **Silent enrichment when target agent is missing.** When the
+   inbox message referenced an agent that wasn't installed (e.g. a
+   permission-request for `demo-astro-tile` on a fresh catalog),
+   `enrichAgentAnalyzerInputs` silently left `AGENT_YAML` empty and
+   the analyzer dispatch went through anyway — surfacing the same
+   confusing "missing required input" rather than the real cause.
+   Now the route refuses the dispatch upfront, sets the action card
+   to failed with a clear refusalReason, and posts a system response
+   to the conversation: "Can't dispatch agent-analyzer — the target
+   agent <id> is not installed in this catalog."

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -594,6 +594,81 @@ describe('POST /inbox/:id/actions/:rid/run — agent-analyzer enrichment', () =>
     expect(meta.status).toBe('completed');
     expect(meta.resultSummary).toContain('target-agent-marker');
   });
+
+  it('refuses the dispatch with a clear message when the target agent is NOT installed', async () => {
+    // Regression for the dispatch failure we saw live: the inbox
+    // message referenced an agent that didn't exist in the local
+    // catalog, so enrichment silently left AGENT_YAML empty and the
+    // analyzer died at input resolution with a generic "missing
+    // required input" — which looked like an analyzer bug rather
+    // than the real cause. Now the route refuses the dispatch up
+    // front and posts a system response explaining what to do.
+    const app = await makeApp();
+
+    // Install the analyzer stub so the agentStore lookup for the
+    // sub-agent succeeds (otherwise we'd hit the existing
+    // "not installed" branch first).
+    const analyzerYaml = [
+      'id: agent-analyzer',
+      'name: Agent Analyzer',
+      'description: stub',
+      'nodes:',
+      '  - id: noop',
+      '    type: shell',
+      '    command: echo ok',
+    ].join('\n');
+    agentStore.upsertAgent(parseAgent(analyzerYaml), 'dashboard', 'test fixture');
+
+    // Inbox message references an agent that is NOT installed.
+    const msg = inboxStore.add({
+      priority: 'medium',
+      source: 'permission-request',
+      title: 'csp-block test',
+      body: 'apod.nasa.gov is blocked',
+      agentId: 'ghost-agent-not-installed',
+    });
+
+    const proposed = inboxStore.addResponse(
+      msg.id,
+      'action',
+      'analyze the missing agent',
+      JSON.stringify({
+        kind: 'action',
+        status: 'proposed',
+        agentId: 'agent-analyzer',
+        inputs: { FOCUS: 'Add a host to permissions.imgSrc' },
+        rationale: 'csp dispatch',
+      }),
+    );
+
+    const res = await request(app)
+      .post(`/inbox/${msg.id}/actions/${proposed.id}/run`)
+      .set('X-Requested-With', 'fetch')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE);
+    expect(res.status).toBe(204);
+
+    // Wait for the route to update the action status.
+    const deadline = Date.now() + 1500;
+    let after = inboxStore.getResponse(proposed.id);
+    while (Date.now() < deadline) {
+      after = inboxStore.getResponse(proposed.id);
+      const m = after?.metaJson ? JSON.parse(after.metaJson) : null;
+      if (m && m.status !== 'proposed' && m.status !== 'running') break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    const meta = JSON.parse(after!.metaJson!);
+    expect(meta.status).toBe('failed');
+    expect(meta.refusalReason).toMatch(/ghost-agent-not-installed/);
+    expect(meta.refusalReason).toMatch(/not installed/i);
+
+    // And a system response was posted to the conversation so the
+    // operator sees the explanation in-thread.
+    const responses = inboxStore.listResponses(msg.id);
+    const systemReply = responses.find((r) => r.role === 'system');
+    expect(systemReply).toBeDefined();
+    expect(systemReply!.body).toMatch(/ghost-agent-not-installed/);
+  });
 });
 
 describe('POST /inbox/:id/actions/:rid/run — agent-catalog-search enrichment', () => {
@@ -885,5 +960,47 @@ describe('POST /inbox/:id/triage', () => {
     expect(r1.status).toBe(303);
     const r2 = await request(app).post('/inbox/nope/triage').set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
     expect(r2.status).toBe(404);
+  });
+
+  it('auto-refreshes stale system allowlist agents from bundled examples', async () => {
+    // Regression for the dispatch failure: pre-#394 installs of
+    // agent-analyzer had AGENT_YAML required:true with no preflight
+    // node. The old auto-import only fired when the agent was
+    // absent — never refreshed an existing install — so operators
+    // still saw the broken behavior after the fix shipped. The route
+    // now compares the installed YAML against the bundled YAML on
+    // disk and re-imports when they differ.
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+
+    // Install a deliberately STALE agent-analyzer: minimal stub,
+    // very different from agents/examples/agent-analyzer.yaml.
+    const staleYaml = [
+      'id: agent-analyzer',
+      'name: STALE Analyzer (pre-refresh)',
+      'description: stale stub for regression test',
+      'nodes:',
+      '  - id: noop',
+      '    type: shell',
+      '    command: echo stale',
+    ].join('\n');
+    agentStore.upsertAgent(parseAgent(staleYaml), 'dashboard', 'pre-refresh stub');
+    const before = agentStore.getAgent('agent-analyzer')!;
+    expect(before.name).toBe('STALE Analyzer (pre-refresh)');
+
+    // Firing triage walks the allowlist, which is where the refresh
+    // hook lives. We don't care whether the LLM run succeeds — only
+    // that the allowlist refresh fired BEFORE the dispatch.
+    await request(app).post(`/inbox/${m.id}/triage`).set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+
+    // Allow a brief tick for the async triage path to start; the
+    // refresh happens synchronously inside getSubAgentAllowlist
+    // BEFORE the executor dispatch.
+    await new Promise((r) => setTimeout(r, 100));
+
+    const after = agentStore.getAgent('agent-analyzer')!;
+    expect(after.name).not.toBe('STALE Analyzer (pre-refresh)');
+    // The bundled YAML defines the canonical analyzer name.
+    expect(after.name).toBe('Agent Analyzer');
   });
 });

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -544,15 +544,27 @@ function parseActionMeta(r: InboxResponse): InboxActionMeta | null {
 function getSubAgentAllowlist(ctx: ReturnType<typeof getContext>): string[] {
   const available: string[] = [];
   for (const id of TRIAGE_SUB_AGENT_ALLOWLIST) {
-    if (ctx.agentStore.getAgent(id)) {
-      available.push(id);
-      continue;
-    }
     try {
       const yamlPath = join(resolve(ALLOWLIST_AUTOIMPORT_DIR), `${id}.yaml`);
       const yamlText = readFileSync(yamlPath, 'utf-8');
       const parsed = parseAgent(yamlText);
-      ctx.agentStore.upsertAgent(parsed, 'import', `Auto-imported for inbox triage allowlist`);
+      const installed = ctx.agentStore.getAgent(id);
+
+      // Auto-install when absent. Auto-refresh when the bundled YAML
+      // differs from the installed one — system allowlist agents
+      // (analyzer, editor, catalog-search) ship with the package and
+      // get prompt + node updates over time. Without this refresh,
+      // operators who installed an older version see broken triage
+      // dispatches when the route's contract has evolved (e.g.
+      // PR #394's preflight + required:false on AGENT_YAML). Scoped
+      // to allowlist entries only — user agents are never touched.
+      const needsImport = !installed;
+      const needsRefresh = installed && exportAgent(installed) !== exportAgent(parsed);
+      if (needsImport || needsRefresh) {
+        ctx.agentStore.upsertAgent(parsed, 'import', needsImport
+          ? 'Auto-imported for inbox triage allowlist'
+          : 'Auto-refreshed from agents/examples/ (bundled YAML changed)');
+      }
       if (ctx.agentStore.getAgent(id)) available.push(id);
     } catch {
       // No example YAML to import from — skip; the allowlist just
@@ -779,10 +791,34 @@ async function runProposedAction(
   // Per-agent input enrichment. Triage's prompt context can't carry
   // heavyweight inputs (full agent YAMLs, catalog snapshots), so we
   // inject them here at action-run time based on agentId.
+  //
+  // Pre-flight the analyzer dispatch: if the inbox message's
+  // referenced agent isn't installed locally, enrichment will leave
+  // AGENT_YAML empty and the analyzer dies at input resolution with a
+  // generic "Missing required input" — confusing for the operator
+  // because it looks like a triage / analyzer bug rather than the
+  // real cause (target agent not in the catalog). Refuse the dispatch
+  // up front with a clear conversation message instead.
   let effectiveInputs = meta.inputs;
   if (meta.agentId === 'agent-analyzer') {
     const parentMessage = ctx.inboxStore.get(messageId);
-    effectiveInputs = enrichAgentAnalyzerInputs(ctx, parentMessage?.agentId, meta.inputs);
+    const targetAgentId = parentMessage?.agentId;
+    if (targetAgentId && !ctx.agentStore.getAgent(targetAgentId)) {
+      const reason = `Can't dispatch agent-analyzer — the target agent "${targetAgentId}" is not installed in this catalog. Install it (e.g. from agents/examples or via the Agents → Import page) and try again.`;
+      ctx.inboxStore.updateResponse(response.id, {
+        metaJson: JSON.stringify({
+          ...meta,
+          status: 'failed',
+          startedAt,
+          endedAt: Date.now(),
+          refusalReason: reason,
+        }),
+      });
+      ctx.inboxStore.addResponse(messageId, 'system', reason);
+      maybeRefireTriage(ctx, messageId);
+      return;
+    }
+    effectiveInputs = enrichAgentAnalyzerInputs(ctx, targetAgentId, meta.inputs);
   } else if (meta.agentId === 'agent-catalog-search') {
     effectiveInputs = enrichAgentCatalogSearchInputs(ctx, meta.inputs);
   }


### PR DESCRIPTION
## Summary

Two compounding bugs broke the analyzer dispatch path shipped in #397. Surfaced live when dogfooding the apod.nasa.gov / demo-astro-tile case — triage proposed the agent-analyzer action correctly, but clicking Run failed instantly with `Failed at node "analyze" (setup): Missing required input "AGENT_YAML"`.

### Root cause

**Bug 1: Stale system allowlist agents.** `getSubAgentAllowlist` only auto-imported when the agent wasn't installed at all. Operators who installed `agent-analyzer` before PR #394 (which added the `preflight` node + made `AGENT_YAML` optional) still had the pre-fix version sitting in their catalog — every dispatch into the live route died at input resolution. The diagnosis SQL on the live dashboard:

```
agent-analyzer current_version: 8
created_at: 2026-05-19T03:45:49.566Z  (pre-#394)
nodes: analyze, validate, fix          (no preflight)
AGENT_YAML.required: true              (no default)
```

**Bug 2: Silent enrichment when target agent is missing.** The inbox message referenced `demo-astro-tile`, which wasn't in this catalog. `enrichAgentAnalyzerInputs` did the lookup, got `null`, and silently let `AGENT_YAML` stay empty — so the dispatch went through to the analyzer with no payload, dying with the same opaque "missing required input" rather than the real cause.

### Fix

**`getSubAgentAllowlist`** now compares the installed exported YAML against the bundled `agents/examples/<id>.yaml` and re-imports on diff. Scoped to `TRIAGE_SUB_AGENT_ALLOWLIST` only (analyzer / editor / catalog-search) — user agents are never auto-refreshed. New commit-message vocabulary: `"Auto-refreshed from agents/examples/ (bundled YAML changed)"`.

**`runProposedAction`** now precheck-rejects analyzer dispatches when the inbox message's referenced agent isn't installed:

- Action card → `status: failed` with `refusalReason: "Can't dispatch agent-analyzer — the target agent <id> is not installed in this catalog. Install it (e.g. from agents/examples or via the Agents → Import page) and try again."`
- A `system`-role response is posted to the conversation with the same message so the operator sees it in-thread.

## Test plan

- [x] `npm run build` clean.
- [x] `npx vitest run` — **1822 pass / 3 skipped** (+2 from baseline).
- [x] New regression tests:
  - `auto-refreshes stale system allowlist agents from bundled examples` — installs a deliberately-stale agent-analyzer stub, fires triage, asserts the agent gets refreshed to the bundled definition.
  - `refuses the dispatch with a clear message when the target agent is NOT installed` — inbox message references a ghost agent, asserts action becomes `failed` with a refusalReason mentioning the missing agent + a system response is posted.
- [x] **Live verification on the running dashboard**: triggered triage on the broken inbox message (`e1f1d978`). Confirmed `agent-analyzer` auto-bumped from version 8 → 9 with commit `"Auto-refreshed from agents/examples/ (bundled YAML changed)"`; current version now has 5 nodes (preflight/analyze/validate/fix/summarize) and `AGENT_YAML.required: false`.

## Follow-ups (queued — paused mid-flight to ship this)

- Right-side row UX rework (human labels for statuses, hierarchy for "your turn", grouped age+status)
- Resizable inbox modal (drag the bottom of the modal, not just the textarea)
- Copy-this-reply button on conversation turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)