### PR TITLE
fix(dashboard): auto-refresh inbox-triage agent from bundled YAML

### DIFF
--- a/.changeset/inbox-triage-auto-refresh.md
+++ b/.changeset/inbox-triage-auto-refresh.md
@@ -1,0 +1,22 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+inbox-triage: auto-refresh the triage agent itself from bundled YAML.
+
+PR #398 added auto-refresh for the SUB-agent allowlist (analyzer,
+editor, catalog-search) but `inbox-triage` itself was left out. So
+operators who installed inbox-triage before PR #395 — which added
+the VOICE section telling the model to write the recommendation AS
+the assistant reply, not as stage directions — kept seeing
+"Reply directly with X: ..." prefixes on every triage turn, even
+after running the latest dashboard build.
+
+Extracts the diff-and-refresh logic into `ensureSystemAgentCurrent`
+and calls it for the triage agent at the start of `runTriageAgent`.
+Same diff trigger: refresh fires when the installed exported YAML
+differs from `agents/examples/inbox-triage.yaml` on disk.

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -962,6 +962,36 @@ describe('POST /inbox/:id/triage', () => {
     expect(r2.status).toBe(404);
   });
 
+  it('auto-refreshes a stale inbox-triage agent from the bundled YAML', async () => {
+    // Regression for the stage-direction recurrence: PR #398 added
+    // auto-refresh for the SUB-agent allowlist (analyzer/editor/
+    // catalog-search) but inbox-triage itself was excluded — so
+    // operators who installed inbox-triage before PR #395 kept seeing
+    // "Reply with X: ..." stage directions even after the fix
+    // shipped. The runner now refreshes inbox-triage too.
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+
+    const staleYaml = [
+      'id: inbox-triage',
+      'name: STALE Inbox Triage (pre-refresh)',
+      'description: stale stub for regression test',
+      'nodes:',
+      '  - id: noop',
+      '    type: shell',
+      '    command: echo stale',
+    ].join('\n');
+    agentStore.upsertAgent(parseAgent(staleYaml), 'dashboard', 'pre-refresh stub');
+    expect(agentStore.getAgent('inbox-triage')!.name).toBe('STALE Inbox Triage (pre-refresh)');
+
+    await request(app).post(`/inbox/${m.id}/triage`).set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    await new Promise((r) => setTimeout(r, 100));
+
+    const after = agentStore.getAgent('inbox-triage')!;
+    expect(after.name).not.toBe('STALE Inbox Triage (pre-refresh)');
+    expect(after.name).toBe('Inbox Triage');
+  });
+
   it('auto-refreshes stale system allowlist agents from bundled examples', async () => {
     // Regression for the dispatch failure: pre-#394 installs of
     // agent-analyzer had AGENT_YAML required:true with no preflight

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -541,34 +541,48 @@ function parseActionMeta(r: InboxResponse): InboxActionMeta | null {
  * for agent-analyzer). Entries that can't be imported are silently
  * dropped — the prompt never sees them, so triage can't propose them.
  */
+/**
+ * Auto-install OR auto-refresh a single system agent from its
+ * bundled `agents/examples/<id>.yaml`. Returns true when the agent
+ * exists in the store after the call (whether imported, refreshed,
+ * or already current); false when the disk YAML is missing or
+ * unparseable. Scoped to system agents only — `inbox-triage` itself
+ * plus everything in TRIAGE_SUB_AGENT_ALLOWLIST. User agents are
+ * never touched by this path.
+ *
+ * Refresh trigger: the installed exported YAML differs from the
+ * bundled one. The diff catches prompt updates (e.g. PR #395's
+ * VOICE section on inbox-triage) plus structural changes (e.g.
+ * PR #394's preflight node on agent-analyzer).
+ */
+function ensureSystemAgentCurrent(
+  ctx: ReturnType<typeof getContext>,
+  id: string,
+  context: string,
+): boolean {
+  try {
+    const yamlPath = join(resolve(ALLOWLIST_AUTOIMPORT_DIR), `${id}.yaml`);
+    const yamlText = readFileSync(yamlPath, 'utf-8');
+    const parsed = parseAgent(yamlText);
+    const installed = ctx.agentStore.getAgent(id);
+    const needsImport = !installed;
+    const needsRefresh = installed && exportAgent(installed) !== exportAgent(parsed);
+    if (needsImport || needsRefresh) {
+      ctx.agentStore.upsertAgent(parsed, 'import', needsImport
+        ? `Auto-imported for ${context}`
+        : 'Auto-refreshed from agents/examples/ (bundled YAML changed)');
+    }
+    return ctx.agentStore.getAgent(id) !== undefined;
+  } catch {
+    return false;
+  }
+}
+
 function getSubAgentAllowlist(ctx: ReturnType<typeof getContext>): string[] {
   const available: string[] = [];
   for (const id of TRIAGE_SUB_AGENT_ALLOWLIST) {
-    try {
-      const yamlPath = join(resolve(ALLOWLIST_AUTOIMPORT_DIR), `${id}.yaml`);
-      const yamlText = readFileSync(yamlPath, 'utf-8');
-      const parsed = parseAgent(yamlText);
-      const installed = ctx.agentStore.getAgent(id);
-
-      // Auto-install when absent. Auto-refresh when the bundled YAML
-      // differs from the installed one — system allowlist agents
-      // (analyzer, editor, catalog-search) ship with the package and
-      // get prompt + node updates over time. Without this refresh,
-      // operators who installed an older version see broken triage
-      // dispatches when the route's contract has evolved (e.g.
-      // PR #394's preflight + required:false on AGENT_YAML). Scoped
-      // to allowlist entries only — user agents are never touched.
-      const needsImport = !installed;
-      const needsRefresh = installed && exportAgent(installed) !== exportAgent(parsed);
-      if (needsImport || needsRefresh) {
-        ctx.agentStore.upsertAgent(parsed, 'import', needsImport
-          ? 'Auto-imported for inbox triage allowlist'
-          : 'Auto-refreshed from agents/examples/ (bundled YAML changed)');
-      }
-      if (ctx.agentStore.getAgent(id)) available.push(id);
-    } catch {
-      // No example YAML to import from — skip; the allowlist just
-      // shrinks. Operator can install the agent manually later.
+    if (ensureSystemAgentCurrent(ctx, id, 'inbox triage allowlist')) {
+      available.push(id);
     }
   }
   return available;
@@ -1092,21 +1106,20 @@ async function runTriageAgent(
   const message = ctx.inboxStore.get(messageId);
   if (!message) return;
 
-  let triage = ctx.agentStore.getAgent(TRIAGE_AGENT_ID);
-  if (!triage) {
-    try {
-      const yamlPath = join(resolve('agents/examples'), `${TRIAGE_AGENT_ID}.yaml`);
-      const yamlText = readFileSync(yamlPath, 'utf-8');
-      const parsed = parseAgent(yamlText);
-      ctx.agentStore.upsertAgent(parsed, 'import', 'Auto-imported for inbox triage');
-      triage = ctx.agentStore.getAgent(TRIAGE_AGENT_ID);
-    } catch (err) {
-      process.stderr.write(
-        `[inbox-triage] could not load agent yaml: ${(err as Error)?.message ?? String(err)}\n`,
-      );
-      return;
-    }
+  // Auto-install + auto-refresh inbox-triage from the bundled YAML.
+  // Pre-PR #399 this only handled the install case — operators who
+  // installed inbox-triage before PR #395's VOICE-section update kept
+  // emitting stage directions ("Reply with X: ...") in every triage
+  // turn because the older prompt was still cached in the store.
+  // Reuses the same diff-and-refresh helper that
+  // getSubAgentAllowlist uses for the sub-agent allowlist.
+  if (!ensureSystemAgentCurrent(ctx, TRIAGE_AGENT_ID, 'inbox triage')) {
+    process.stderr.write(
+      `[inbox-triage] could not load agent yaml from agents/examples/${TRIAGE_AGENT_ID}.yaml\n`,
+    );
+    return;
   }
+  const triage = ctx.agentStore.getAgent(TRIAGE_AGENT_ID);
   if (!triage) return;
 
   // Build conversation snapshot for the prompt. For action-role rows,


### PR DESCRIPTION
## Summary

The triage agent was still emitting stage directions (`"Reply directly with a short, clean joke. Suggested response: ..."`) instead of the actual reply, even after PR #395 shipped the VOICE-section fix. Root cause: PR #398's auto-refresh covered the sub-agent allowlist (analyzer / editor / catalog-search) but `inbox-triage` itself was excluded — so operators who installed inbox-triage before #395 kept running the pre-VOICE prompt forever.

Diagnosis on the live dashboard:

```
installed inbox-triage version: 2  (created 2026-05-28T19:02:54Z)
prompt: 6304 bytes
has VOICE section: false
has CSP dispatch example: false
has catalog-search guide: false
```

The disk version is 11882 bytes with all three sections.

## Fix

Extract the diff-and-refresh logic into `ensureSystemAgentCurrent(ctx, id, context)` so it can serve both call sites. Reuse it from `getSubAgentAllowlist` (existing behavior — unchanged) AND from `runTriageAgent` (new). Same trigger: refresh fires when `exportAgent(installed) !== exportAgent(parsed)` against the bundled YAML.

Scoped to system agents only — `inbox-triage` plus everything in `TRIAGE_SUB_AGENT_ALLOWLIST`. User agents are never auto-refreshed.

## Test plan

- [x] `npm run build` clean.
- [x] `npx vitest run` — **1823 pass / 3 skipped** (+1 regression test: `auto-refreshes a stale inbox-triage agent from the bundled YAML`).
- [x] **Live verification on the running dashboard**: created a fresh inbox message, posted to `/triage`, confirmed `inbox-triage` auto-bumped to version 3 with commit message `"Auto-refreshed from agents/examples/ (bundled YAML changed)"`. Current prompt now has the VOICE section + CSP dispatch + catalog-search guide.

## Queued (paused mid-flight)

The inbox-row + modal-resize + copy-button UX polish work is stashed on `feat/inbox-row-modal-copy-polish`. Will resume after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)