### PR TITLE
fix(dashboard): inbox reply optimistic UI + double-submit guard

### DIFF
--- a/.changeset/inbox-reply-optimistic-no-double-send.md
+++ b/.changeset/inbox-reply-optimistic-no-double-send.md
@@ -1,0 +1,33 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox modal: optimistic reply UI + double-submit guard.
+
+Operators were double-clicking Post reply during the network +
+LLM-kickoff window and getting duplicate "You" messages in the
+conversation. The disable-on-submit only fired in the current event
+loop and didn't survive `refresh()` re-rendering the form, so the
+second submit slipped through to the route.
+
+Two fixes:
+
+1. **In-flight guard.** `data-inflight="1"` on the form is checked at
+   the very top of the submit handler — a duplicate submit (rapid
+   double-click, Enter-then-click) is dropped before fetch fires.
+   The flag clears on success and failure so legitimate retries
+   after a failed POST still work.
+
+2. **Optimistic reply.** For the Post-reply path, the modal JS
+   echoes the operator's message into the timeline immediately:
+   a `<li>` matching renderConversationEntry's structure with a
+   `data-pending="1"` marker, italic + 0.55 opacity styling, "You ·
+   Sending…" meta. The textarea clears, the viewport scrolls to
+   the new entry. On success, refresh() replaces the placeholder
+   with the canonical server-rendered entry; on failure, the
+   placeholder is removed and the textarea text restored so the
+   operator can edit and retry without losing their input.

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -2129,6 +2129,19 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
   white-space: pre-wrap;
   word-wrap: break-word;
 }
+/* Optimistic "Sending..." placeholder rendered by the modal JS the
+ * moment Post reply submits. Dimmed so the operator can tell it's
+ * not yet confirmed, but visible enough that they know their text
+ * went somewhere — no more clicking twice while waiting for the
+ * network. The placeholder is replaced by the real persisted entry
+ * on the next fragment refresh. */
+.inbox-msg[data-pending] {
+  opacity: 0.55;
+  animation: inbox-msg-in 140ms ease-out;
+}
+.inbox-msg[data-pending] .inbox-msg__text {
+  font-style: italic;
+}
 
 @keyframes inbox-msg-in {
   from { opacity: 0; transform: translateY(6px); }

--- a/packages/dashboard/src/views/inbox-modal.js.ts
+++ b/packages/dashboard/src/views/inbox-modal.js.ts
@@ -286,6 +286,15 @@ export const INBOX_MODAL_JS = `
     if (!(form instanceof HTMLFormElement)) return;
     if (!form.hasAttribute('data-inbox-modal-form')) return;
     e.preventDefault();
+
+    // In-flight guard. A submit that beats the disable to the
+    // browsers event loop (rapid double-click, Enter-then-click)
+    // gets dropped here so the route never sees the duplicate. The
+    // flag clears in the .then/.catch below so a legitimate retry
+    // after failure still works.
+    if (form.getAttribute('data-inflight') === '1') return;
+    form.setAttribute('data-inflight', '1');
+
     var action = form.getAttribute('action');
     var method = (form.getAttribute('method') || 'POST').toUpperCase();
     var formData = new FormData(form);
@@ -297,6 +306,27 @@ export const INBOX_MODAL_JS = `
     // server's triageRunId capture races our first refresh.
     var keepsTriagePolling = form.getAttribute('data-inbox-modal-keeps-triage') === '1';
     if (keepsTriagePolling) keepPollingUntil = Date.now() + 30000;
+
+    // Optimistic UI for the reply path. Without this, the operator
+    // clicks Post reply, sees no movement for the network round-
+    // trip + LLM kickoff window, and clicks again — producing a
+    // duplicate "You" message in the conversation. Echo the message
+    // into the timeline immediately, clear the textarea, and dim
+    // the placeholder until the real one lands from refresh().
+    var isReplyForm = !!action && action.indexOf('/respond') !== -1;
+    var pendingEntry = null;
+    var savedTextareaValue = '';
+    var textarea = null;
+    if (isReplyForm) {
+      textarea = form.querySelector('textarea[name="body"]')
+        || content.querySelector('textarea[name="body"]');
+      var body = textarea ? (textarea.value || '').trim() : '';
+      if (body) {
+        savedTextareaValue = textarea ? textarea.value : '';
+        pendingEntry = appendPendingReply(body);
+        if (textarea) textarea.value = '';
+      }
+    }
 
     fetch(action, {
       method: method,
@@ -311,6 +341,9 @@ export const INBOX_MODAL_JS = `
         if (!r.ok) throw new Error('mutation failed: ' + r.status);
       })
       .then(function () {
+        // refresh() will replace the pending placeholder with the
+        // real persisted entry, so no manual cleanup needed.
+        form.removeAttribute('data-inflight');
         if (dismissAfter) {
           var row = document.querySelector('[data-inbox-row-id="' + cssEscape(currentId || '') + '"]');
           if (row && row.parentNode) row.parentNode.removeChild(row);
@@ -320,9 +353,75 @@ export const INBOX_MODAL_JS = `
         }
       })
       .catch(function () {
+        form.removeAttribute('data-inflight');
         for (var i = 0; i < submits.length; i++) submits[i].disabled = false;
+        // Rollback the optimistic UI so the operator can edit and
+        // retry instead of losing their text.
+        if (pendingEntry && pendingEntry.parentNode) {
+          pendingEntry.parentNode.removeChild(pendingEntry);
+        }
+        if (textarea && savedTextareaValue) {
+          textarea.value = savedTextareaValue;
+        }
       });
   });
+
+  /**
+   * Append a "Sending…" placeholder bubble to the conversation
+   * timeline. Matches the structure of renderConversationEntry so the
+   * CSS styles it like a real user message, plus a data-pending
+   * attribute that drives the dimmed appearance. Returns the
+   * <li> element so the catch path can remove it on failure.
+   */
+  function appendPendingReply(bodyText) {
+    var ul = content.querySelector('ul.inbox-timeline');
+    if (!ul) {
+      // The "no replies yet" empty state doesn't render a <ul>; build
+      // one so the optimistic append has a home. The fragment refresh
+      // will replace this with the canonical server-rendered timeline.
+      var section = content.querySelector('.inbox-modal__timeline-section');
+      if (!section) return null;
+      var emptyP = section.querySelector('p.dim');
+      if (emptyP && emptyP.parentNode) emptyP.parentNode.removeChild(emptyP);
+      ul = document.createElement('ul');
+      ul.className = 'inbox-timeline';
+      section.appendChild(ul);
+    }
+    var li = document.createElement('li');
+    li.className = 'inbox-timeline__entry';
+    var msg = document.createElement('div');
+    msg.className = 'inbox-msg';
+    msg.setAttribute('data-pending', '1');
+    var avatar = document.createElement('div');
+    avatar.className = 'inbox-msg__avatar inbox-msg__avatar--user';
+    avatar.textContent = 'You';
+    var bodyEl = document.createElement('div');
+    bodyEl.className = 'inbox-msg__body';
+    var meta = document.createElement('div');
+    meta.className = 'inbox-msg__meta';
+    var name = document.createElement('span');
+    name.className = 'inbox-msg__meta-name';
+    name.textContent = 'You';
+    var age = document.createElement('span');
+    age.textContent = 'Sending…';
+    meta.appendChild(name);
+    meta.appendChild(age);
+    var text = document.createElement('div');
+    text.className = 'inbox-msg__text';
+    text.textContent = bodyText;
+    bodyEl.appendChild(meta);
+    bodyEl.appendChild(text);
+    msg.appendChild(avatar);
+    msg.appendChild(bodyEl);
+    li.appendChild(msg);
+    ul.appendChild(li);
+    // Scroll the optimistic message into view so the operator sees
+    // it land.
+    requestAnimationFrame(function () {
+      content.scrollTop = content.scrollHeight;
+    });
+    return li;
+  }
 
   function cssEscape(s) {
     return String(s).replace(/[^a-zA-Z0-9_-]/g, function (c) {


### PR DESCRIPTION
## Summary

Surfaced live: operator typed *"can you build me an agent that tells better jokes?"*, clicked Post reply, triage replied + proposed an action card — and the same message appeared a second time 10 seconds later. Easy double-click during the network + LLM-kickoff window.

The existing `disable submit buttons on submit` defense only held within a single event loop and got blown away when `refresh()` re-rendered the form with fresh enabled buttons.

## Fix

**1. In-flight guard.** Set `data-inflight="1"` on the form at the top of the submit handler. Subsequent submits within the in-flight window return early before the fetch fires. The flag clears in both `.then` and `.catch` so legitimate retries after a failed POST still work.

**2. Optimistic reply UI.** For the Post-reply path specifically (action ends with `/respond`), echo the operator's message into the timeline immediately:

- New `<li class=\"inbox-timeline__entry\">` matching `renderConversationEntry`'s structure
- `data-pending=\"1\"` on the inner `.inbox-msg`, styled with `opacity: 0.55` + italic body text
- Meta reads *"You · Sending…"* instead of a timestamp
- Textarea clears, viewport scrolls to the new entry

On success → `refresh()` (existing behavior) replaces the placeholder with the canonical server-rendered entry. On failure → placeholder removed + textarea text restored so the operator can edit and retry without losing input.

## Test plan

- [x] `npm run build` clean.
- [x] `npx vitest run` — **1823 pass / 3 skipped**.
- [x] **Live double-submit dogfood**: fired two `submit` events on the reply form in the same tick. DOM probe confirmed exactly **1 pending entry** appended — second submit dropped by the in-flight guard.
- [x] Screenshot confirms: pending message shows *"You · Sending…"*, italic + dim, textarea cleared, footer build-info matches the running binary.

## Queued (still paused)

The `feat/inbox-row-modal-copy-polish` work (right-side rework, modal resize, copy button, dismiss-count refresh) is still stashed. Resuming once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)