### PR TITLE
feat(dashboard): inbox UX polish pack — row signal, resizable modal, copy turn, archive view

### DIFF
--- a/.changeset/inbox-row-modal-copy-polish.md
+++ b/.changeset/inbox-row-modal-copy-polish.md
@@ -1,0 +1,47 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox UX polish pack: row signal column, resizable modal, copy
+button on conversation turns, dismiss-aware empty state, and
+read-only archive view.
+
+**Right-side row signal.** Raw snake_case status badges
+(`awaiting_user`, `open`, `triaged`) replaced with human labels
+("Your turn", "Open", "Triaged", etc.). "Your turn" gets the warn
+(amber) badge variant plus a subtle left-edge accent on the row —
+the only state that demands a click stays loud, the rest fade. Age
+and status now live in one signal cell on the right so the eye
+scans them together. Modal status badge picks up the same
+vocabulary.
+
+**Resizable modal.** Drag the bottom-right gripper to grow the whole
+modal. The composer stays pinned at the bottom; the conversation
+timeline gets the extra room. Replaces the prior `resize: vertical`
+on the textarea (which expanded just that one cell — not what
+operators reached for).
+
+**Copy button on conversation turns.** Each user/triage/system entry
+gets a "Copy" affordance in its meta row, invisible until the row
+is hovered. Clicking copies the message body via
+`navigator.clipboard.writeText` (with a textarea-select fallback for
+older browsers). The label briefly switches to "Copied" / "Copy
+failed" and the button picks up an ok/err color for 1.5s.
+
+**Dismiss audit trail + dismiss-aware empty state.** Dismissing via
+the modal now hard-reloads the inbox page so the suggestion banner
+counts, priority group headers, and favorited rail all stay in
+sync. An "Inbox cleared" empty-state copy replaces the generic
+"Nothing in your inbox" when there's terminal-state history,
+acknowledging the cleanup work and offering the archive link. A
+quiet "View N dismissed / resolved →" footer link sits below the
+active list whenever the archive isn't empty.
+
+**Read-only archive view.** `?status=dismissed` and `?status=resolved`
+on `/inbox` show the terminal-state rows under a muted header with
+a "← Active inbox" back link, so operators can review or confirm
+what they just cleared.

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -2142,6 +2142,27 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
 .inbox-msg[data-pending] .inbox-msg__text {
   font-style: italic;
 }
+/* Copy-message affordance on each conversation turn. Sits in the
+ * meta row next to the timestamp. Invisible until row hover so the
+ * conversation stays clean during reading; pops in when the
+ * operator's cursor lands on a turn. */
+.inbox-msg__copy {
+  background: transparent;
+  border: 0;
+  padding: 2px 8px;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  opacity: 0;
+  transition: opacity 80ms ease-out, background 80ms ease-out, color 80ms ease-out;
+  margin-left: auto;
+}
+.inbox-msg:hover .inbox-msg__copy,
+.inbox-msg__copy:focus-visible { opacity: 1; }
+.inbox-msg__copy:hover { background: var(--color-surface-raised); color: var(--color-text); }
+.inbox-msg__copy--ok { color: var(--color-ok, #34d399); opacity: 1; }
+.inbox-msg__copy--err { color: var(--color-err, #ef4444); opacity: 1; }
 
 @keyframes inbox-msg-in {
   from { opacity: 0; transform: translateY(6px); }
@@ -2713,6 +2734,35 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
   gap: var(--space-2);
 }
 .inbox-suggest--clean { border-left-color: var(--color-ok, #34d399); }
+/* Archive view header (showing dismissed/resolved). Distinct muted
+ * tone so it's obvious you're browsing the archive, not the active
+ * inbox. */
+.inbox-suggest--archive {
+  border-left-color: var(--color-text-muted);
+  background: var(--color-surface-raised, var(--color-bg));
+}
+.inbox-archive-back {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  text-decoration: none;
+}
+.inbox-archive-back:hover { color: var(--color-text); text-decoration: underline; }
+
+/* Footer link "View N dismissed / resolved →" rendered below the
+ * active inbox list when there's terminal-state history. Quiet
+ * affordance — operators discover it after they dismiss something
+ * and want to confirm. */
+.inbox-archive-footer {
+  margin-top: var(--space-3);
+  padding: var(--space-2) 0;
+  text-align: center;
+}
+.inbox-archive-footer__link {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  text-decoration: none;
+}
+.inbox-archive-footer__link:hover { color: var(--color-text); }
 .inbox-suggest__head {
   display: flex;
   align-items: center;
@@ -2790,13 +2840,35 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
 }
 .inbox-row2 {
   display: grid;
-  grid-template-columns: 24px 24px 70px 88px 1fr 80px 90px;
+  /* Merged the prior age + status columns into a single signal cell
+   * on the right (badge + age, grouped). Keeps the row scanable as
+   * one signal instead of two unrelated chips. */
+  grid-template-columns: 24px 24px 70px 88px 1fr auto;
   align-items: center;
   gap: var(--space-2);
   padding: var(--space-2) var(--space-3);
   border-bottom: 1px solid var(--color-border);
   cursor: pointer;
   transition: background 80ms ease-out;
+}
+/* Right-side signal cell: status badge leading + age trailing.
+ * Loud variant for awaiting_user (the only row that needs a click)
+ * is driven by the badge variant set in the view. */
+.inbox-row2__signal {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  justify-self: end;
+  font-size: var(--font-size-xs);
+}
+.inbox-row2__signal .inbox-row2__age {
+  white-space: nowrap;
+}
+/* Subtle left-edge accent for the row that needs a click — the badge
+ * already says "Your turn" but operators tend to scan the rail line
+ * for color, so we mirror the cue at the row level too. */
+.inbox-row2[data-inbox-status="awaiting_user"] {
+  box-shadow: inset 3px 0 0 var(--color-warn, #f59e0b);
 }
 .inbox-row2:last-child { border-bottom: 0; }
 .inbox-row2:hover { background: var(--color-surface-raised); }
@@ -2835,9 +2907,7 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
 .inbox-row2__age {
   font-size: var(--font-size-xs);
   color: var(--color-text-muted);
-  text-align: right;
 }
-.inbox-row2__status { text-align: right; }
 .inbox-row2__preview {
   grid-column: 1 / -1;
   background: var(--color-surface-raised);
@@ -2882,12 +2952,13 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
   gap: var(--space-2);
 }
 
-/* Mobile fallback: simpler column set */
+/* Mobile fallback: simpler column set. Keep the signal cell on the
+ * right so operators still see "Your turn" on phones. */
 @media (max-width: 720px) {
-  .inbox-row2 { grid-template-columns: 24px 24px 1fr 70px; }
+  .inbox-row2 { grid-template-columns: 24px 24px 1fr auto; }
   .inbox-row2__priority,
-  .inbox-row2__source,
-  .inbox-row2__status { display: none; }
+  .inbox-row2__source { display: none; }
+  .inbox-row2__signal .inbox-row2__age { display: none; }
 }
 
 /* ---------- Modal timeline ---------- */
@@ -2944,7 +3015,7 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
 }
 .inbox-composer textarea {
   width: 100%;
-  resize: vertical;
+  resize: none;
   font-size: var(--font-size-sm);
   padding: var(--space-2);
 }
@@ -3258,7 +3329,11 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
 .inbox-composer__form { margin: 0; }
 .inbox-composer__textarea {
   width: 100%;
-  resize: vertical;
+  /* Drag the bottom of the MODAL to grow the conversation area —
+   * the textarea stays at its declared row height. (Prior
+   * `resize: vertical` on the textarea expanded just that one
+   * element, which wasn't what operators reached for.) */
+  resize: none;
   font-size: var(--font-size-sm);
   padding: var(--space-2);
   line-height: 1.5;

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -144,17 +144,36 @@ inboxRouter.get('/inbox', (req: Request, res: Response) => {
   const q = typeof req.query.q === 'string' ? req.query.q : '';
   const starred = req.query.starred === '1' || req.query.starred === 'true';
   const tag = typeof req.query.tag === 'string' ? req.query.tag : '';
+  // Archive view: ?status=dismissed or ?status=resolved. Anything else
+  // falls through to the active inbox (the store's default filter).
+  const statusQ = typeof req.query.status === 'string' ? req.query.status : '';
+  const archiveView: 'dismissed' | 'resolved' | undefined =
+    statusQ === 'dismissed' ? 'dismissed' : statusQ === 'resolved' ? 'resolved' : undefined;
   const rows = ctx.inboxStore ? ctx.inboxStore.list({
     q: q || undefined,
     starred: starred || undefined,
     tag: tag || undefined,
+    status: archiveView,
   }) : [];
   const allTags = ctx.inboxStore ? ctx.inboxStore.listAllTags() : [];
+  // terminalCount drives the "Inbox cleared" empty-state + the "View
+  // N dismissed / resolved" archive-footer link. Only computed for
+  // the active view — the archive view has its own header.
+  let terminalCount = 0;
+  if (!archiveView && ctx.inboxStore) {
+    try {
+      const dismissed = ctx.inboxStore.list({ status: 'dismissed' });
+      const resolved = ctx.inboxStore.list({ status: 'resolved' });
+      terminalCount = dismissed.length + resolved.length;
+    } catch { /* swallow — empty count is harmless */ }
+  }
   const { sort, dir } = parseSort(req);
   res.type('html').send(renderInboxList({
     rows, sort, dir, flash: parseFlash(req),
     filter: { q, starred, tag },
     allTags,
+    terminalCount,
+    archiveView,
   }));
 });
 

--- a/packages/dashboard/src/views/inbox-detail.ts
+++ b/packages/dashboard/src/views/inbox-detail.ts
@@ -37,6 +37,30 @@ const PRIORITY_BADGE: Record<string, string> = {
   low: 'badge--muted',
 };
 
+/**
+ * Human label + badge variant for each inbox-status enum. Mirrors
+ * the table in inbox-list.ts — kept here as a duplicate to avoid an
+ * import cycle, but updated together when the operator-facing
+ * vocabulary changes. `Your turn` is the load-bearing label: it's
+ * the only status that demands action.
+ */
+const STATUS_LABEL: Record<string, string> = {
+  open: 'Open',
+  triaged: 'Triaged',
+  awaiting_user: 'Your turn',
+  verifying: 'Verifying',
+  resolved: 'Resolved',
+  dismissed: 'Dismissed',
+};
+const STATUS_BADGE: Record<string, string> = {
+  open: 'badge--muted',
+  triaged: 'badge--muted',
+  awaiting_user: 'badge--warn',
+  verifying: 'badge--info',
+  resolved: 'badge--ok',
+  dismissed: 'badge--muted',
+};
+
 const SOURCE_LABEL: Record<string, string> = {
   'run-failure': 'Run failure',
   'permission-request': 'Permission',
@@ -94,7 +118,7 @@ export function renderInboxDetailFragment(opts: InboxDetailOptions): SafeHtml {
   const headerMeta = html`
     <div class="inbox-modal__meta">
       <span class="inbox-modal__priority inbox-modal__priority--${message.priority}" title="${message.priority} priority"></span>
-      <span class="badge badge--muted">${message.status}</span>
+      <span class="badge ${STATUS_BADGE[message.status] ?? 'badge--muted'}">${STATUS_LABEL[message.status] ?? message.status}</span>
       ${message.agentId ? html`<a href="/agents/${message.agentId}" class="inbox-modal__link">${message.agentId}</a>` : html``}
       ${message.runId ? html`<span class="inbox-modal__sep">·</span><a href="/runs/${message.runId}" class="inbox-modal__link mono">run ${message.runId.slice(0, 8)}</a>` : html``}
       <span class="inbox-modal__age">${formatAge(new Date(message.createdAt).toISOString())}</span>
@@ -280,8 +304,13 @@ function renderConversationEntry(r: InboxResponse, currentTargetYaml?: string): 
         <div class="inbox-msg__meta">
           <span class="inbox-msg__meta-name">${role}</span>
           <span>${formatAge(new Date(r.createdAt).toISOString())}</span>
+          <button type="button" class="inbox-msg__copy" data-inbox-copy
+            aria-label="Copy ${role} message"
+            title="Copy this message">
+            <span data-inbox-copy-label>Copy</span>
+          </button>
         </div>
-        <div class="inbox-msg__text">${r.body}</div>
+        <div class="inbox-msg__text" data-inbox-copy-source>${r.body}</div>
       </div>
     </div>
   `;

--- a/packages/dashboard/src/views/inbox-list.ts
+++ b/packages/dashboard/src/views/inbox-list.ts
@@ -1,4 +1,4 @@
-import type { InboxMessage, InboxPriority, InboxSource } from '@some-useful-agents/core';
+import type { InboxMessage, InboxPriority, InboxSource, InboxStatus } from '@some-useful-agents/core';
 import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { formatAge } from './components.js';
@@ -33,6 +33,20 @@ export interface InboxListOptions {
   flash?: { kind: 'error' | 'info' | 'ok'; message: string };
   filter?: { q: string; starred: boolean; tag: string };
   allTags?: string[];
+  /**
+   * Count of messages in terminal states (dismissed + resolved). Used
+   * by the empty-state copy to acknowledge recent cleanup work and
+   * to render the "View archive" footer link. Defaults to 0 when the
+   * route doesn't pass it.
+   */
+  terminalCount?: number;
+  /**
+   * When set, the view is showing the archive (dismissed/resolved
+   * rows) instead of the active inbox. The header renders a
+   * "Showing <status> · ← Active inbox" chip + the empty state copy
+   * changes. The list itself comes from the route's filtered query.
+   */
+  archiveView?: 'dismissed' | 'resolved';
 }
 
 export const INBOX_DEFAULT_SORT: { sort: InboxSortKey; dir: InboxSortDir } = {
@@ -57,6 +71,38 @@ const PRIORITY_BADGE: Record<InboxPriority, string> = {
   high: 'badge--warn',
   medium: 'badge--info',
   low: 'badge--muted',
+};
+
+/**
+ * Human labels for the inbox-status enum. The raw snake_case values
+ * (e.g. `awaiting_user`) read as database values, not UI copy —
+ * operators are skimming, not parsing. "Your turn" is the
+ * load-bearing label: it's the only status that demands action, so
+ * it gets distinct copy + the loudest badge variant.
+ */
+const STATUS_LABEL: Record<InboxStatus, string> = {
+  open: 'Open',
+  triaged: 'Triaged',
+  awaiting_user: 'Your turn',
+  verifying: 'Verifying',
+  resolved: 'Resolved',
+  dismissed: 'Dismissed',
+};
+
+/**
+ * Visual hierarchy: "Your turn" is the row that needs a click, so it
+ * gets the warn (amber) chip. Verifying gets info (blue) so the
+ * operator can spot in-flight work. Everything else is muted — the
+ * eye sweeps past them. Terminal statuses (resolved/dismissed) get
+ * the ok green if they ever land on this list.
+ */
+const STATUS_BADGE: Record<InboxStatus, string> = {
+  open: 'badge--muted',
+  triaged: 'badge--muted',
+  awaiting_user: 'badge--warn',
+  verifying: 'badge--info',
+  resolved: 'badge--ok',
+  dismissed: 'badge--muted',
 };
 
 /**
@@ -102,14 +148,27 @@ export function renderInboxList(opts: InboxListOptions): string {
   const rows = opts.rows;
   const filter = opts.filter ?? { q: '', starred: false, tag: '' };
   const allTags = opts.allTags ?? [];
+  const terminalCount = opts.terminalCount ?? 0;
+  const archiveView = opts.archiveView;
 
   const starredAll = rows.filter((r) => r.starred);
-  const suggestions = buildSuggestions(rows);
+  const suggestions = archiveView ? [] : buildSuggestions(rows);
 
   const filterBar = renderFilterBar(filter, allTags);
-  const suggestBanner = renderSuggestBanner(suggestions, rows.length);
+  const suggestBanner = archiveView
+    ? renderArchiveHeader(archiveView, rows.length)
+    : renderSuggestBanner(suggestions, rows.length, terminalCount);
   const rail = renderRail(starredAll);
   const main = renderMain(rows);
+  const archiveLink = !archiveView && terminalCount > 0
+    ? html`
+      <div class="inbox-archive-footer">
+        <a href="/inbox?status=dismissed" class="inbox-archive-footer__link">
+          View ${terminalCount} dismissed / resolved →
+        </a>
+      </div>
+    `
+    : html``;
 
   const body = html`
     <div class="inbox-page-head">
@@ -133,6 +192,7 @@ export function renderInboxList(opts: InboxListOptions): string {
       ${rail}
       <div class="inbox-main">
         ${main}
+        ${archiveLink}
       </div>
     </div>
 
@@ -140,6 +200,30 @@ export function renderInboxList(opts: InboxListOptions): string {
   `;
 
   return render(layout({ title: 'Inbox', activeNav: 'inbox', flash: opts.flash }, body));
+}
+
+/**
+ * Archive view header: replaces the suggested-actions banner when the
+ * operator is browsing dismissed / resolved rows. Includes a back link
+ * to the active inbox and a row count.
+ */
+function renderArchiveHeader(status: 'dismissed' | 'resolved', count: number): SafeHtml {
+  const label = status === 'dismissed' ? 'Dismissed' : 'Resolved';
+  return html`
+    <div class="inbox-suggest inbox-suggest--archive" id="inbox-suggest">
+      <div class="inbox-suggest__head">
+        <span class="inbox-suggest__title">${label}</span>
+        <a href="/inbox" class="inbox-archive-back">← Active inbox</a>
+      </div>
+      <div class="inbox-suggest__items">
+        <span style="font-size: var(--font-size-sm); color: var(--color-text-muted);">
+          ${count === 0
+            ? html`No ${status} messages.`
+            : html`Showing ${count} ${status} message${count === 1 ? '' : 's'}. These are read-only — reopen by replying from the modal.`}
+        </span>
+      </div>
+    </div>
+  `;
 }
 
 function renderFilterBar(filter: { q: string; starred: boolean; tag: string }, allTags: string[]): SafeHtml {
@@ -174,8 +258,29 @@ function renderFilterBar(filter: { q: string; starred: boolean; tag: string }, a
   `;
 }
 
-function renderSuggestBanner(suggestions: Array<{ label: string; count: number; href?: string; tag: string }>, totalRows: number): SafeHtml {
+function renderSuggestBanner(suggestions: Array<{ label: string; count: number; href?: string; tag: string }>, totalRows: number, terminalCount: number): SafeHtml {
   if (totalRows === 0) {
+    // When the active inbox is empty AND there's a terminal-state
+    // history, acknowledge the cleanup so the operator can see "yes,
+    // your dismiss landed" and offers a path back to the archive.
+    // Without terminal history this is a truly empty inbox — show
+    // the original "Nothing in your inbox" copy.
+    if (terminalCount > 0) {
+      return html`
+        <div class="inbox-suggest inbox-suggest--clean" id="inbox-suggest">
+          <div class="inbox-suggest__head">
+            <span class="inbox-suggest__title">Inbox cleared ✨</span>
+          </div>
+          <div class="inbox-suggest__items">
+            <span style="font-size: var(--font-size-sm); color: var(--color-text-muted);">
+              Nothing active. ${terminalCount} message${terminalCount === 1 ? '' : 's'} in your archive —
+              <a href="/inbox?status=dismissed" class="inbox-archive-back">view archive</a>
+              or <strong>+ New conversation</strong> to start fresh.
+            </span>
+          </div>
+        </div>
+      `;
+    }
     return html`
       <div class="inbox-suggest inbox-suggest--clean" id="inbox-suggest">
         <div class="inbox-suggest__head">
@@ -322,8 +427,10 @@ function renderRow(m: InboxMessage): SafeHtml {
         <a href="/inbox/${m.id}" data-inbox-row-link class="inbox-row2__title-text">${m.title}</a>
         ${tagChips}
       </span>
-      <span class="inbox-row2__age">${formatAge(new Date(m.createdAt).toISOString())}</span>
-      <span class="inbox-row2__status"><span class="badge badge--muted">${m.status}</span></span>
+      <span class="inbox-row2__signal" data-inbox-status="${m.status}">
+        <span class="badge ${STATUS_BADGE[m.status]}">${STATUS_LABEL[m.status]}</span>
+        <span class="inbox-row2__age dim">${formatAge(new Date(m.createdAt).toISOString())}</span>
+      </span>
 
       <div class="inbox-row2__preview" data-inbox-row-preview>
         <div class="inbox-row2__preview-body">${m.body}</div>
@@ -336,7 +443,7 @@ function renderRow(m: InboxMessage): SafeHtml {
         <div class="inbox-row2__preview-actions">
           <a href="/inbox/${m.id}" class="btn btn--sm btn--primary" data-inbox-row-link>Open thread</a>
           <span class="dim" style="font-size: var(--font-size-xs); align-self: center;">
-            ${SOURCE_LABEL[m.source]} · ${m.status}
+            ${SOURCE_LABEL[m.source]}
           </span>
         </div>
       </div>

--- a/packages/dashboard/src/views/inbox-modal.js.ts
+++ b/packages/dashboard/src/views/inbox-modal.js.ts
@@ -158,6 +158,48 @@ export const INBOX_MODAL_JS = `
   // Row click → modal. Chevron click is checked first and toggles the
   // inline preview without opening the modal.
   document.addEventListener('click', function (e) {
+    // Copy-message button on a conversation entry. Reads the
+    // sibling .inbox-msg__text textContent so we copy what the
+    // operator actually sees (newlines preserved, HTML stripped).
+    var copyBtn = e.target.closest && e.target.closest('[data-inbox-copy]');
+    if (copyBtn) {
+      e.preventDefault();
+      e.stopPropagation();
+      var msgEl = copyBtn.closest('.inbox-msg');
+      var src = msgEl && msgEl.querySelector('[data-inbox-copy-source]');
+      var text = src ? (src.innerText || src.textContent || '').trim() : '';
+      if (!text) return;
+      var labelEl = copyBtn.querySelector('[data-inbox-copy-label]');
+      var prior = labelEl ? labelEl.textContent : 'Copy';
+      var done = function (ok) {
+        if (!labelEl) return;
+        labelEl.textContent = ok ? 'Copied' : 'Copy failed';
+        copyBtn.classList.add(ok ? 'inbox-msg__copy--ok' : 'inbox-msg__copy--err');
+        setTimeout(function () {
+          labelEl.textContent = prior;
+          copyBtn.classList.remove('inbox-msg__copy--ok', 'inbox-msg__copy--err');
+        }, 1500);
+      };
+      try {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(text).then(function () { done(true); }).catch(function () { done(false); });
+        } else {
+          var ta = document.createElement('textarea');
+          ta.value = text;
+          ta.setAttribute('readonly', '');
+          ta.style.position = 'fixed';
+          ta.style.opacity = '0';
+          document.body.appendChild(ta);
+          ta.select();
+          var ok = false;
+          try { ok = document.execCommand('copy'); } catch (_) { ok = false; }
+          document.body.removeChild(ta);
+          done(ok);
+        }
+      } catch (_) { done(false); }
+      return;
+    }
+
     // Row preview toggle (chevron on the gridded row).
     var chev = e.target.closest && e.target.closest('[data-inbox-row-chevron]');
     if (chev) {
@@ -345,9 +387,12 @@ export const INBOX_MODAL_JS = `
         // real persisted entry, so no manual cleanup needed.
         form.removeAttribute('data-inflight');
         if (dismissAfter) {
-          var row = document.querySelector('[data-inbox-row-id="' + cssEscape(currentId || '') + '"]');
-          if (row && row.parentNode) row.parentNode.removeChild(row);
-          close();
+          // Hard reload so the suggestion banner counts, priority
+          // group headers, AND favorited rail all stay in sync with
+          // the now-terminal row. The prior approach (remove row +
+          // close modal) left those counts stale until the operator
+          // manually refreshed.
+          window.location.reload();
         } else {
           refresh();
         }

--- a/packages/dashboard/src/views/inbox-modal.ts
+++ b/packages/dashboard/src/views/inbox-modal.ts
@@ -11,7 +11,7 @@ import { html, type SafeHtml } from './html.js';
 export function renderInboxModalShell(): SafeHtml {
   return html`
     <div class="modal-backdrop" id="inbox-modal" role="dialog" aria-modal="true" aria-labelledby="inbox-modal-title" hidden>
-      <div class="modal inbox-modal" style="max-width: 44rem; max-height: 88vh; display: flex; flex-direction: column;">
+      <div class="modal inbox-modal" style="max-width: 44rem; height: 70vh; min-height: 24rem; max-height: 92vh; display: flex; flex-direction: column; resize: vertical; overflow: hidden;">
         <button type="button" class="inbox-modal__close" data-inbox-modal-close aria-label="Close">×</button>
         <div id="inbox-modal-content" style="flex: 1; overflow-y: auto; min-height: 0;">
           <p class="dim" style="margin: 0; padding: var(--space-4) 0; text-align: center;">Loading…</p>


### PR DESCRIPTION
## Summary

Bundles five related polish items from the inbox feedback round into one PR (overlap on `screens.css` + `inbox-modal.js.ts` made splitting more work than it was worth).

### 1. Right-side row signal

Raw `awaiting_user` / `open` / `triaged` snake_case badges replaced with human labels: **Your turn**, **Open**, **Triaged**, **Verifying**, **Resolved**, **Dismissed**. *Your turn* gets `badge--warn` (amber) plus a subtle left-edge accent on the whole row — the only state that demands a click stays loud, the rest fade. Age + status grouped into a single right-aligned signal cell. Modal header status badge picks up the same vocabulary so list ↔ modal stay consistent.

### 2. Resizable modal

Drag the bottom-right gripper to grow the whole modal. Composer stays pinned at the bottom; the conversation timeline gets the extra room. The prior `resize: vertical` on the textarea (which expanded just that one cell) is removed — that wasn't what operators reached for.

### 3. Copy button on conversation turns

Each user/triage/system entry gets a "Copy" affordance in its meta row, invisible until row hover. Uses `navigator.clipboard.writeText` with a `<textarea>.select()` fallback for older browsers. Label briefly switches to "Copied" / "Copy failed" with an ok/err color for 1.5s.

### 4. Dismiss-aware empty state + audit trail

- **Dismiss reloads the inbox page** instead of just removing the row + closing the modal — so the suggestion banner counts, priority group headers, and favorited rail all stay in sync. (Prior behavior left counts stale.)
- **"Inbox cleared ✨"** empty-state copy replaces "Nothing in your inbox" when there's terminal-state history. Acknowledges the cleanup work and links to the archive.
- **"View N dismissed / resolved →"** footer link sits below the active list whenever the archive isn't empty.

### 5. Read-only archive view

`?status=dismissed` and `?status=resolved` on `/inbox` show the terminal-state rows under a muted header with a `← Active inbox` back link. Operators can review or confirm what they just cleared.

## Test plan

- [x] `npm run build` clean.
- [x] `npx vitest run` — **1823 pass / 3 skipped**.
- [x] **Live dogfood, all five**:
  - Inbox list shows *Your turn* (amber badge) + age in one cell + the *"View 9 dismissed / resolved →"* footer.
  - `/inbox?status=dismissed` renders the archive header *"DISMISSED · Showing 9 dismissed messages... ← Active inbox"* with muted styling.
  - Modal opens with the human status badge in the header.
  - DOM probe confirmed `4 copy buttons present`, `modal resize: vertical`, modal status badge = `"Your turn"` (no more `awaiting_user`).

## Follow-ups (queued)

- Per-area provider default (still queued from earlier)
- Auto-rerun after agent-editor commits a fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)