### PR TITLE
fix(dashboard): inbox modal indicator + composer z-index + witty waiting labels

### DIFF
--- a/.changeset/inbox-modal-indicator-fixes-and-witty-labels.md
+++ b/.changeset/inbox-modal-indicator-fixes-and-witty-labels.md
@@ -1,0 +1,42 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox modal: thinking indicator now shows after Post reply, timeline
+no longer scrolls behind the composer, witty waiting labels rotate.
+
+Three fixes bundled — both bugs surfaced live while building the
+streaming UX (plan path B, PR 1 of 4):
+
+1. **Thinking indicator never appeared after Post reply.** PR #397's
+   `userIsInteracting()` skipped the DOM refresh whenever focus was
+   inside the modal. Post-reply the textarea clears but focus stays
+   in it, so the refresh would silently skip forever — the operator
+   saw nothing happen and couldn't tell whether triage was running
+   or had crashed. Refresh only worked on full page reload.
+   `userIsInteracting()` now treats an empty focused textarea/input
+   as NOT interacting (no caret position to wipe, no in-progress
+   text). Selections and non-empty inputs still suppress refresh,
+   so the original "don't wipe text selections" guarantee from
+   PR #397 holds.
+
+2. **Timeline avatars scrolled behind the composer.** The composer
+   uses `position: sticky` but the timeline avatars carry
+   `z-index: 1` so they punch through the rail line. Without an
+   explicit stacking context, the avatars from the last messages
+   bled through the sticky composer on long conversations.
+   Composer now gets `z-index: 2` on top of its solid background.
+
+3. **Witty waiting labels.** The thinking indicator now rotates
+   through a curated phase-aware label set: triage thinking gets
+   "Pondering…", "Distilling tokens…", "Marinating thoughts…",
+   "Cogitating…", etc; action-running gets "Dispatching…",
+   "Crunching…", "Tracing call graph…"; verifying gets
+   "Double-checking…", "Sanity-checking…". 2s cadence with a 220ms
+   cross-fade. `renderThinkingIndicator` gains a
+   `data-thinking-phase` attribute so the right label set is used.
+   The action-card running state picks up the same affordance.

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -2215,6 +2215,20 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
   0%, 60%, 100% { opacity: 0.25; transform: scale(0.7); }
   30%           { opacity: 1;    transform: scale(1); }
 }
+/* Witty waiting-label cross-fade. The JS rotation loop
+ * (updateWaitingLabels in inbox-modal.js.ts) toggles --out for the
+ * 220ms exit window before swapping textContent, then removes --out
+ * so the new label fades in. Keep the transition tight so the label
+ * never feels sluggish. */
+.inbox-thinking__label {
+  display: inline-block;
+  transition: opacity 220ms ease-out, transform 220ms ease-out;
+  opacity: 1;
+}
+.inbox-thinking__label--out {
+  opacity: 0;
+  transform: translateY(-2px);
+}
 
 /* Inbox list: data-inbox-row-id rows get a row-hover affordance so
  * users see the click target. Title link inherits the row hover. */
@@ -3012,6 +3026,13 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
   border-top: 1px solid var(--color-border);
   padding: var(--space-3) 0 0;
   margin-top: var(--space-3);
+  /* The timeline avatars have z-index:1 so they punch through the
+   * vertical rail line (see .inbox-timeline::before). Without an
+   * explicit stacking context here, the avatars from the last
+   * messages would scroll up THROUGH the sticky composer when the
+   * conversation gets long. Bump above the avatar plane and give
+   * the composer a solid bg so nothing bleeds through. */
+  z-index: 2;
 }
 .inbox-composer textarea {
   width: 100%;

--- a/packages/dashboard/src/views/inbox-detail.ts
+++ b/packages/dashboard/src/views/inbox-detail.ts
@@ -418,9 +418,14 @@ function renderActionStatusBody(meta: InboxActionMeta): SafeHtml {
     case 'proposed':
       return html``;
     case 'running':
+      // Action-running picks up the same witty-label rotation as the
+      // triage indicator — different phase, different label set
+      // ("Dispatching…", "Crunching…"). data-action-running is the
+      // hook the modal-poll watchdog uses to keep the modal alive
+      // while the sub-agent runs.
       return html`
-        <div class="inbox-action__running">
-          Running
+        <div class="inbox-action__running inbox-thinking" data-action-running="1" data-thinking-phase="action-running">
+          <span class="inbox-thinking__label" data-thinking-label>Running</span>
           <span class="inbox-thinking__dots"><span></span><span></span><span></span></span>
         </div>
       `;
@@ -512,11 +517,15 @@ function formatDuration(meta: InboxActionMeta): string {
 
 /** Pulsing-dots "Triage agent is thinking…" indicator. */
 function renderThinkingIndicator(): SafeHtml {
+  // data-thinking-phase lets the modal JS pick the right label set
+  // when it rotates copy underneath the dots. The default seed text
+  // is a sensible label so users with JS disabled (or before the
+  // rotation loop fires) still see something coherent.
   return html`
-    <div class="inbox-thinking" data-triage-pending="1">
+    <div class="inbox-thinking" data-triage-pending="1" data-thinking-phase="triage">
       <div class="inbox-thinking__avatar">Tri</div>
       <div>
-        Triage agent is thinking
+        <span class="inbox-thinking__label" data-thinking-label>Triage agent is thinking</span>
         <span class="inbox-thinking__dots"><span></span><span></span><span></span></span>
       </div>
     </div>

--- a/packages/dashboard/src/views/inbox-modal.js.ts
+++ b/packages/dashboard/src/views/inbox-modal.js.ts
@@ -82,6 +82,61 @@ export const INBOX_MODAL_JS = `
       if (!firstRender && !seenMsgIds[id]) el.classList.add('inbox-msg--new');
       seenMsgIds[id] = true;
     }
+    // Re-attach the waiting-label rotation in case the fragment refresh
+    // replaced the thinking indicator DOM. updateWaitingLabels reads
+    // [data-thinking-label] freshly each tick so a swapped node is
+    // handled automatically.
+    updateWaitingLabels();
+  }
+
+  // Witty waiting labels — rotate the copy under the thinking dots
+  // every 2s while triage is busy. Phase pulled from the indicator's
+  // data-thinking-phase so the label set fits the moment (triage vs
+  // action-running vs verifying). Cross-fade is CSS-driven.
+  var WAITING_LABELS = {
+    triage: [
+      'Pondering', 'Distilling tokens', 'Marinating thoughts',
+      'Cogitating', 'Polishing prose', 'Consulting the muse',
+      'Brewing ideas', 'Threading reasoning', 'Synthesizing',
+      'Steeping reply', 'Sketching response', 'Untangling intent',
+    ],
+    'action-running': [
+      'Dispatching', 'Running it', 'Crunching',
+      'Compiling notes', 'Tracing call graph',
+    ],
+    verifying: [
+      'Double-checking', 'Verifying', 'Sanity-checking',
+    ],
+  };
+  var waitingTimer = null;
+  function updateWaitingLabels() {
+    if (waitingTimer) { clearInterval(waitingTimer); waitingTimer = null; }
+    var labelEl = content.querySelector('[data-thinking-label]');
+    if (!labelEl) return;
+    var indicator = labelEl.closest('.inbox-thinking');
+    var phase = indicator ? (indicator.getAttribute('data-thinking-phase') || 'triage') : 'triage';
+    var labels = WAITING_LABELS[phase] || WAITING_LABELS.triage;
+    // Seed with a random label so the indicator never repeats the
+    // same one across consecutive triage runs.
+    var idx = Math.floor(Math.random() * labels.length);
+    var rotate = function () {
+      // Re-query each tick so a re-render swap is handled gracefully.
+      var el = content.querySelector('[data-thinking-label]');
+      if (!el) { if (waitingTimer) { clearInterval(waitingTimer); waitingTimer = null; } return; }
+      idx = (idx + 1) % labels.length;
+      el.classList.add('inbox-thinking__label--out');
+      setTimeout(function () {
+        var still = content.querySelector('[data-thinking-label]');
+        if (!still) return;
+        still.textContent = labels[idx];
+        still.classList.remove('inbox-thinking__label--out');
+      }, 220);
+    };
+    waitingTimer = setInterval(rotate, 2000);
+    // Run one rotation immediately so the seed label gets replaced
+    // by something from the curated set within the first tick — this
+    // proves to the operator that the loop is alive.
+    setTimeout(rotate, 600);
   }
 
   function scrollToBottom() {
@@ -120,13 +175,37 @@ export const INBOX_MODAL_JS = `
 
   /**
    * True if the operator is actively interacting with the modal — they
-   * have focus inside it (typing), or they have a non-empty text
-   * selection anchored inside it (highlighting text to copy). In
-   * either case, a poll-driven refresh should NOT call focus
-   * because that wipes the selection / caret position.
+   * have a non-empty text selection anchored inside it (highlighting
+   * text to copy), or they are typing into a non-empty input. In
+   * either case, a poll-driven refresh should NOT swap the DOM
+   * because that wipes the selection or in-progress text.
+   *
+   * Critical: an EMPTY focused textarea does NOT count as interacting.
+   * After Post reply, the textarea clears but focus stays in it —
+   * if we treated that as interacting, refresh() would skip swaps
+   * forever, the thinking indicator + triage reply would never
+   * appear, and the operator would be staring at a stale modal
+   * wondering if anything happened.
    */
   function userIsInteracting() {
-    if (content.contains(document.activeElement)) return true;
+    var active = document.activeElement;
+    if (content.contains(active)) {
+      // Empty input fields don't count — the operator hasn't started
+      // typing yet, so a fragment swap is safe (and necessary).
+      var tag = active.tagName;
+      if (tag === 'TEXTAREA' || tag === 'INPUT') {
+        var val = active.value != null ? String(active.value) : '';
+        if (val.length === 0) {
+          // Fall through to the selection check below.
+        } else {
+          return true;
+        }
+      } else {
+        // Any non-input element with focus (button, link, details
+        // summary) is genuine interaction.
+        return true;
+      }
+    }
     var sel = window.getSelection && window.getSelection();
     if (sel && !sel.isCollapsed && sel.rangeCount > 0) {
       try {


### PR DESCRIPTION
## Summary

Three fixes bundled while building the streaming UX (plan path B, **PR 1 of 4**). Two bugs surfaced live during dogfood; the witty labels were the originally-scoped PR 1.

### 1. Thinking indicator never appeared after Post reply

PR #397's `userIsInteracting()` skipped the DOM refresh whenever focus was inside the modal. Post-reply the textarea clears but focus stays in it, so the refresh silently skipped forever — operator saw nothing happen, couldn't tell whether triage was running or had crashed. Only a **full page reload** would show new replies. User's exact words: *"we see the new reply on page reload but not otherwise"*.

`userIsInteracting()` now treats an empty focused textarea/input as NOT interacting (no caret position to wipe, no in-progress text). Selections and non-empty inputs still suppress refresh, preserving the original PR #397 guarantee.

### 2. Timeline avatars scrolled behind the composer

Timeline avatars carry `z-index: 1` so they punch through the rail line. The sticky composer didn't have an explicit stacking context, so on long conversations the last avatars bled through. User's words: *"timeline scrolls behind the chat box - bug"*. Composer now gets `z-index: 2` over its solid background.

### 3. Witty waiting labels (originally scoped PR 1)

The thinking indicator rotates through a phase-aware label set every 2s with a 220ms cross-fade:

- **triage**: Pondering · Distilling tokens · Marinating thoughts · Cogitating · Polishing prose · Consulting the muse · Brewing ideas · Threading reasoning · Synthesizing · Steeping reply · Sketching response · Untangling intent
- **action-running**: Dispatching · Running it · Crunching · Compiling notes · Tracing call graph
- **verifying**: Double-checking · Verifying · Sanity-checking

`renderThinkingIndicator` gains `data-thinking-phase`; the action-card running state picks up the same affordance.

## Test plan

- [x] `npm run build` clean.
- [x] `npx vitest run` — **1823 pass / 3 skipped**.
- [x] **Live dogfooded both fixes**: Post reply, indicator appeared at **t=0.7s** (`"indicator":"yes"` via DOM probe), label rotated from seed *"Triage agent is thinking"* to **"Polishing prose"** by t=3s.
- [x] Screenshot confirms TRI avatar + rotating label + animated dots while the user's settled reply sits above.

## Plan link

See `~/.claude/plans/shimmering-sprouting-brooks.md`. Next: **PR 2 — SSE endpoint + structured event bus** (no per-token yet; replaces fragment poll with EventSource so action card transitions feel live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)