### PR TITLE
feat(dashboard): inbox conversation SSE — structured event bus + EventSource client

### DIFF
--- a/.changeset/inbox-sse-event-bus.md
+++ b/.changeset/inbox-sse-event-bus.md
@@ -1,0 +1,51 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox conversation SSE: structured event bus + EventSource client.
+
+Plan path B, PR 2 of 4. Replaces the 1.5s fragment poll for active
+conversations with a server-sent-events stream so action card
+transitions and triage replies land at network RTT instead of poll
+cadence. The fragment poll stays as a fallback when SSE is
+unavailable or disconnects.
+
+**Event bus.** `packages/dashboard/src/lib/inbox-event-bus.ts` —
+in-memory pub/sub keyed by `messageId`. Each channel keeps a
+50-event ring buffer for `Last-Event-ID` replay; a 5-minute idle GC
+drops abandoned channels. Listener errors are swallowed so one bad
+subscriber can't starve the rest.
+
+**SSE endpoint.** `GET /inbox/:id/events` in
+`packages/dashboard/src/routes/inbox-events.ts`. Standard SSE
+headers (`text/event-stream`, `Cache-Control: no-cache, no-transform`,
+`X-Accel-Buffering: no`), 2KB initial padding to defeat proxy
+buffering, 15s heartbeat. Honors `Last-Event-ID` for reconnect
+catch-up. Cookie auth (EventSource sends same-origin cookies
+automatically).
+
+**Publish hooks** in `routes/inbox.ts` at every lifecycle sync point:
+user reply persisted → `message:created`; `runTriageAgent` start →
+`triage:started` + `state(thinking)`; triage reply persisted →
+`triage:complete` + `state(done)`; each proposed action card →
+`action:created`; every action status transition (running, skipped,
+completed, failed, refused) → `action:status`.
+
+**Client.** `inbox-modal.js.ts` opens an `EventSource` per modal,
+listens to all event types, and schedules a single `refresh()` per
+animation frame on any event (the SSE notification is the wake-up
+signal; canonical state still comes from `/fragment`). A 20s
+watchdog forces a fragment refresh if no events or heartbeats
+arrive, keeping the UI consistent even when SSE proxies misbehave.
+
+PR 3 will start emitting per-token `triage:token` events from the
+claude CLI; PR 4 will start patching DOM incrementally for those.
+
+Tests: 14 new bus tests covering publish/subscribe semantics, ring
+buffer overflow, Last-Event-ID replay, idle GC, throwing-listener
+isolation. 4 new SSE route tests covering wire format, auth, 404,
+and Last-Event-ID replay. Total 1841 pass (+18).

--- a/packages/dashboard/src/context.ts
+++ b/packages/dashboard/src/context.ts
@@ -1,5 +1,6 @@
 import type { LocalProvider, RunStore, SecretsStore, AgentDefinition, AgentStore, ToolStore, VariablesStore, LlmSettingsStore, PacksStore, DashboardsStore, LayoutHintsStore, BlockedImgHostsStore, InboxStore, IntegrationsStore, PlannerTelemetryStore, PlannerLoopStepLogStore, PlannerMemoryStore, AgentMemoryStore } from '@some-useful-agents/core';
 import type { SecretsSession } from './secrets-session.js';
+import type { InboxEventBus } from './lib/inbox-event-bus.js';
 
 /**
  * Shared resources a request handler needs. Built once in
@@ -114,6 +115,13 @@ export interface DashboardContext {
    * Optional — booting without it just disables the Inbox surface.
    */
   inboxStore?: InboxStore;
+  /**
+   * In-memory pub/sub for inbox conversation events (PR 2 of the
+   * streaming UX rollout). Powers the SSE endpoint at
+   * `GET /inbox/:id/events`. Optional — booting without it leaves
+   * the modal on its 1.5s fragment-poll path (which still works).
+   */
+  inboxEventBus?: InboxEventBus;
   /**
    * Integrations store. Holds project-scoped named external-service configs
    * (slack, webhook, file, …) that agents and notify handlers reference by

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -58,6 +58,8 @@ import { helpRouter } from './routes/help.js';
 import { versionsRouter } from './routes/versions.js';
 import { imgBlockReportRouter } from './routes/img-block-report.js';
 import { inboxRouter } from './routes/inbox.js';
+import { inboxEventsRouter } from './routes/inbox-events.js';
+import { InboxEventBus } from './lib/inbox-event-bus.js';
 import { seedInboxDemoIfRequested } from './inbox-demo-seed.js';
 import { pulseRouter } from './routes/pulse.js';
 import { pulseLayoutPlanRouter } from './routes/pulse-layout-plan.js';
@@ -263,6 +265,10 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   app.use(helpRouter);
   app.use(versionsRouter);
   app.use(imgBlockReportRouter);
+  // SSE before the main inbox router so the more specific
+  // `/inbox/:id/events` route resolves before any catch-all paths
+  // in the inbox router try to claim it.
+  app.use(inboxEventsRouter);
   app.use(inboxRouter);
   app.use(toolsRouter);
   app.use(nodesRouter);
@@ -500,6 +506,12 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     layoutHintsStore,
     blockedImgHostsStore,
     inboxStore,
+    // Streaming pub/sub for inbox conversation events. Powers the SSE
+    // endpoint at GET /inbox/:id/events. Always instantiated — even
+    // when inboxStore is unavailable the bus is a cheap empty Map,
+    // and routes that don't have a store will short-circuit before
+    // touching it.
+    inboxEventBus: new InboxEventBus(),
     integrationsStore,
     plannerTelemetryStore,
     plannerLoopStepLogStore,

--- a/packages/dashboard/src/lib/inbox-event-bus.test.ts
+++ b/packages/dashboard/src/lib/inbox-event-bus.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { InboxEventBus, type InboxBufferedEvent } from './inbox-event-bus.js';
+
+describe('InboxEventBus', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('publishes events with monotonic ids per channel', () => {
+    const bus = new InboxEventBus();
+    const e1 = bus.publish('m1', { type: 'state', data: { phase: 'thinking' } });
+    const e2 = bus.publish('m1', { type: 'state', data: { phase: 'responding' } });
+    const e3 = bus.publish('m2', { type: 'state', data: { phase: 'thinking' } });
+    expect(e1.id).toBe(1);
+    expect(e2.id).toBe(2);
+    // Different channels get independent counters.
+    expect(e3.id).toBe(1);
+  });
+
+  it('subscribers receive live publishes synchronously', () => {
+    const bus = new InboxEventBus();
+    const received: InboxBufferedEvent[] = [];
+    bus.subscribe('m1', (ev) => received.push(ev));
+    bus.publish('m1', { type: 'a', data: {} });
+    bus.publish('m1', { type: 'b', data: {} });
+    expect(received.map((e) => e.type)).toEqual(['a', 'b']);
+  });
+
+  it('unsubscribe stops the listener from receiving further publishes', () => {
+    const bus = new InboxEventBus();
+    const received: string[] = [];
+    const unsub = bus.subscribe('m1', (ev) => received.push(ev.type));
+    bus.publish('m1', { type: 'a', data: {} });
+    unsub();
+    bus.publish('m1', { type: 'b', data: {} });
+    expect(received).toEqual(['a']);
+  });
+
+  it('late subscriber with sinceId gets replayed buffered events', () => {
+    const bus = new InboxEventBus();
+    bus.publish('m1', { type: 'a', data: {} });
+    bus.publish('m1', { type: 'b', data: {} });
+    bus.publish('m1', { type: 'c', data: {} });
+    const replayed: number[] = [];
+    bus.subscribe('m1', (ev) => replayed.push(ev.id), 1);
+    // Should replay events with id > 1 → ids 2 and 3.
+    expect(replayed).toEqual([2, 3]);
+  });
+
+  it('sinceId without a matching event returns nothing replayed', () => {
+    const bus = new InboxEventBus();
+    bus.publish('m1', { type: 'a', data: {} });
+    const replayed: number[] = [];
+    bus.subscribe('m1', (ev) => replayed.push(ev.id), 5);
+    expect(replayed).toEqual([]);
+  });
+
+  it('ring buffer trims oldest events at overflow', () => {
+    const bus = new InboxEventBus({ ringSize: 3 });
+    for (let i = 0; i < 5; i++) bus.publish('m1', { type: 'x', data: { i } });
+    const buffer = bus.bufferSnapshot('m1');
+    expect(buffer.map((e) => e.id)).toEqual([3, 4, 5]);
+    // A reconnecting client that missed nothing-but-old events would
+    // still get all 3 buffered ones.
+    const replayed: number[] = [];
+    bus.subscribe('m1', (ev) => replayed.push(ev.id), 0);
+    expect(replayed).toEqual([3, 4, 5]);
+  });
+
+  it('lastEventId reflects the highest id in the ring buffer', () => {
+    const bus = new InboxEventBus();
+    expect(bus.lastEventId('m1')).toBeUndefined();
+    bus.publish('m1', { type: 'a', data: {} });
+    bus.publish('m1', { type: 'b', data: {} });
+    expect(bus.lastEventId('m1')).toBe(2);
+  });
+
+  it('idle GC drops a channel after the configured timeout when no listeners remain', () => {
+    const bus = new InboxEventBus({ idleGcMs: 1000 });
+    const unsub = bus.subscribe('m1', () => { /* noop */ });
+    bus.publish('m1', { type: 'a', data: {} });
+    expect(bus.channelCount()).toBe(1);
+    unsub();
+    // Not yet — timer is pending.
+    expect(bus.channelCount()).toBe(1);
+    vi.advanceTimersByTime(1000);
+    expect(bus.channelCount()).toBe(0);
+  });
+
+  it('a new subscriber within the GC window cancels the timer', () => {
+    const bus = new InboxEventBus({ idleGcMs: 1000 });
+    const unsub1 = bus.subscribe('m1', () => { /* noop */ });
+    unsub1();
+    vi.advanceTimersByTime(500);
+    // Reconnect before the timer fires.
+    const received: number[] = [];
+    bus.subscribe('m1', (ev) => received.push(ev.id));
+    vi.advanceTimersByTime(1000);
+    expect(bus.channelCount()).toBe(1);
+    // And it still works.
+    bus.publish('m1', { type: 'a', data: {} });
+    expect(received).toEqual([1]);
+  });
+
+  it('dropChannel removes the channel immediately', () => {
+    const bus = new InboxEventBus();
+    bus.publish('m1', { type: 'a', data: {} });
+    expect(bus.channelCount()).toBe(1);
+    bus.dropChannel('m1');
+    expect(bus.channelCount()).toBe(0);
+    // Listener count is 0 even though it never had one.
+    expect(bus.listenerCount('m1')).toBe(0);
+  });
+
+  it('a throwing listener does not starve other listeners', () => {
+    const bus = new InboxEventBus();
+    const received: string[] = [];
+    bus.subscribe('m1', () => { throw new Error('bad listener'); });
+    bus.subscribe('m1', (ev) => received.push(ev.type));
+    bus.publish('m1', { type: 'a', data: {} });
+    expect(received).toEqual(['a']);
+  });
+
+  it('publish to a channel with no subscribers still buffers for later replay', () => {
+    const bus = new InboxEventBus();
+    bus.publish('m1', { type: 'a', data: {} });
+    bus.publish('m1', { type: 'b', data: {} });
+    const replayed: string[] = [];
+    bus.subscribe('m1', (ev) => replayed.push(ev.type), 0);
+    expect(replayed).toEqual(['a', 'b']);
+  });
+
+  it('multiple subscribers each receive each event exactly once', () => {
+    const bus = new InboxEventBus();
+    const a: number[] = [];
+    const b: number[] = [];
+    bus.subscribe('m1', (ev) => a.push(ev.id));
+    bus.subscribe('m1', (ev) => b.push(ev.id));
+    bus.publish('m1', { type: 'x', data: {} });
+    bus.publish('m1', { type: 'y', data: {} });
+    expect(a).toEqual([1, 2]);
+    expect(b).toEqual([1, 2]);
+  });
+
+  it('unsubscribe is idempotent', () => {
+    const bus = new InboxEventBus();
+    const received: number[] = [];
+    const unsub = bus.subscribe('m1', (ev) => received.push(ev.id));
+    unsub();
+    unsub();
+    bus.publish('m1', { type: 'a', data: {} });
+    expect(received).toEqual([]);
+  });
+});

--- a/packages/dashboard/src/lib/inbox-event-bus.ts
+++ b/packages/dashboard/src/lib/inbox-event-bus.ts
@@ -1,0 +1,204 @@
+/**
+ * In-memory pub/sub for inbox conversation events. Powers the SSE
+ * endpoint at `GET /inbox/:id/events`, replacing the existing 1.5s
+ * fragment polling for active conversations.
+ *
+ * Design:
+ *  - One channel per inbox messageId, lazily created on first publish
+ *    or subscribe.
+ *  - Each channel maintains a small ring buffer (RING_SIZE events) so
+ *    a reconnecting EventSource client carrying a Last-Event-ID
+ *    header can catch up the events it missed during the disconnect
+ *    without rebuilding state from `/fragment`.
+ *  - Per-channel monotonic event id. The composite SSE id surfaced to
+ *    the client is `messageId:N` so a client that switches between
+ *    modals can't accidentally replay events from a different thread.
+ *  - When the last subscriber leaves a channel, a GC timer fires
+ *    after IDLE_GC_MS. A new subscriber within the window cancels
+ *    the timer so the buffer survives a quick reconnect.
+ *
+ * Decoupling: this module knows nothing about Express or SSE wire
+ * format. The route layer reads + serialises.
+ */
+
+/** Event shape published by the runtime. `data` is JSON-serialised by the route. */
+export interface InboxEvent {
+  /** Event type — matches the SSE `event:` field on the wire. */
+  type: string;
+  /** Payload object. Shape varies per event type. */
+  data: Record<string, unknown>;
+}
+
+/** Internal envelope held in the ring buffer; includes the channel id. */
+export interface InboxBufferedEvent extends InboxEvent {
+  /** Channel-local sequence number, monotonic from 1. */
+  id: number;
+  /** Wall-clock ms-since-epoch the publish happened. Used for GC + debug. */
+  at: number;
+}
+
+export type InboxEventListener = (event: InboxBufferedEvent) => void;
+
+interface Channel {
+  /** Newest events at the END of the array. Trimmed to RING_SIZE on push. */
+  buffer: InboxBufferedEvent[];
+  /** Next id to assign. Starts at 1; never reset. */
+  nextId: number;
+  listeners: Set<InboxEventListener>;
+  /** Pending GC timer when the channel has no listeners. */
+  gcTimer: ReturnType<typeof setTimeout> | null;
+}
+
+export interface InboxEventBusOptions {
+  /** Per-channel ring buffer size. Default 50 — enough for a few minutes of token streaming + lifecycle. */
+  ringSize?: number;
+  /**
+   * Idle time in ms before a channel with no listeners is GC'd. Default
+   * 5 minutes. Long enough to survive a tab switch / tunnel reconnect
+   * without losing replay history, short enough that an abandoned tab
+   * doesn't leak buffers forever.
+   */
+  idleGcMs?: number;
+}
+
+export class InboxEventBus {
+  private readonly channels = new Map<string, Channel>();
+  private readonly ringSize: number;
+  private readonly idleGcMs: number;
+
+  constructor(opts: InboxEventBusOptions = {}) {
+    this.ringSize = opts.ringSize ?? 50;
+    this.idleGcMs = opts.idleGcMs ?? 5 * 60_000;
+  }
+
+  /**
+   * Publish a single event to a message's channel. Assigns the next
+   * sequence id, appends to the ring buffer (trimming the oldest if
+   * over RING_SIZE), and synchronously notifies every current
+   * listener. Listener throws are caught so one bad subscriber can't
+   * starve the rest.
+   */
+  publish(messageId: string, event: InboxEvent): InboxBufferedEvent {
+    const ch = this.getOrCreate(messageId);
+    const buffered: InboxBufferedEvent = {
+      ...event,
+      id: ch.nextId++,
+      at: Date.now(),
+    };
+    ch.buffer.push(buffered);
+    if (ch.buffer.length > this.ringSize) {
+      ch.buffer.splice(0, ch.buffer.length - this.ringSize);
+    }
+    for (const fn of ch.listeners) {
+      try { fn(buffered); } catch { /* swallow — telemetry path, never break a publisher */ }
+    }
+    return buffered;
+  }
+
+  /**
+   * Subscribe to a message's channel. The listener is invoked
+   * synchronously for every subsequent publish on this channel.
+   *
+   * `sinceId` (optional) replays buffered events with `id > sinceId`
+   * BEFORE adding the listener — used by the SSE route to honor a
+   * client's `Last-Event-ID` header. Replays are best-effort: events
+   * trimmed from the ring buffer are silently lost.
+   *
+   * Returns an unsubscribe function. Idempotent — calling it twice
+   * is a no-op.
+   */
+  subscribe(messageId: string, fn: InboxEventListener, sinceId?: number): () => void {
+    const ch = this.getOrCreate(messageId);
+    // Cancel any pending GC — we have a live subscriber again.
+    if (ch.gcTimer) {
+      clearTimeout(ch.gcTimer);
+      ch.gcTimer = null;
+    }
+    // Replay anything newer than the caller's checkpoint. Done BEFORE
+    // adding the listener so a publish racing the subscribe doesn't
+    // arrive twice.
+    if (typeof sinceId === 'number') {
+      for (const ev of ch.buffer) {
+        if (ev.id > sinceId) {
+          try { fn(ev); } catch { /* swallow */ }
+        }
+      }
+    }
+    ch.listeners.add(fn);
+
+    let removed = false;
+    return () => {
+      if (removed) return;
+      removed = true;
+      ch.listeners.delete(fn);
+      if (ch.listeners.size === 0) this.scheduleGc(messageId, ch);
+    };
+  }
+
+  /** Return the most recent event id on the channel, or undefined if none. */
+  lastEventId(messageId: string): number | undefined {
+    const ch = this.channels.get(messageId);
+    if (!ch || ch.buffer.length === 0) return undefined;
+    return ch.buffer[ch.buffer.length - 1].id;
+  }
+
+  /** Inspection helper for tests + diagnostics. */
+  bufferSnapshot(messageId: string): readonly InboxBufferedEvent[] {
+    return this.channels.get(messageId)?.buffer ?? [];
+  }
+
+  /** Listener count for a channel — diagnostics + tests. */
+  listenerCount(messageId: string): number {
+    return this.channels.get(messageId)?.listeners.size ?? 0;
+  }
+
+  /** Channel count — useful to assert GC ran. */
+  channelCount(): number {
+    return this.channels.size;
+  }
+
+  /**
+   * Force-clear a channel. Used by tests and by the route on inbox
+   * message dismissal — once a message is terminal, no more events
+   * will ever fire on it, so the buffer can drop now rather than
+   * waiting on the idle timer.
+   */
+  dropChannel(messageId: string): void {
+    const ch = this.channels.get(messageId);
+    if (!ch) return;
+    if (ch.gcTimer) clearTimeout(ch.gcTimer);
+    ch.listeners.clear();
+    this.channels.delete(messageId);
+  }
+
+  /** Drop ALL channels. Used on dashboard shutdown. */
+  dropAll(): void {
+    for (const ch of this.channels.values()) {
+      if (ch.gcTimer) clearTimeout(ch.gcTimer);
+      ch.listeners.clear();
+    }
+    this.channels.clear();
+  }
+
+  private getOrCreate(messageId: string): Channel {
+    let ch = this.channels.get(messageId);
+    if (!ch) {
+      ch = { buffer: [], nextId: 1, listeners: new Set(), gcTimer: null };
+      this.channels.set(messageId, ch);
+    }
+    return ch;
+  }
+
+  private scheduleGc(messageId: string, ch: Channel): void {
+    if (ch.gcTimer) clearTimeout(ch.gcTimer);
+    ch.gcTimer = setTimeout(() => {
+      // Double-check at fire time: a new subscriber may have arrived.
+      if (ch.listeners.size > 0) return;
+      this.channels.delete(messageId);
+    }, this.idleGcMs);
+    // Don't keep the Node process alive just to GC empty channels.
+    if (typeof ch.gcTimer === 'object' && ch.gcTimer && 'unref' in ch.gcTimer) {
+      (ch.gcTimer as { unref: () => void }).unref();
+    }
+  }
+}

--- a/packages/dashboard/src/routes/inbox-events.test.ts
+++ b/packages/dashboard/src/routes/inbox-events.test.ts
@@ -137,7 +137,7 @@ describe('GET /inbox/:id/events (SSE)', () => {
           data += chunk.toString('utf-8');
           // Once we've seen our pre-published event, close the
           // connection so the test doesn't hang.
-          if (data.includes('event: state')) res.destroy();
+          if (data.includes('event: state')) (res as unknown as { destroy: () => void }).destroy();
         });
         res.on('close', () => cb(null, data));
         res.on('error', () => cb(null, data));
@@ -170,7 +170,7 @@ describe('GET /inbox/:id/events (SSE)', () => {
         let data = '';
         res.on('data', (chunk: Buffer) => {
           data += chunk.toString('utf-8');
-          if (data.includes('event: c')) res.destroy();
+          if (data.includes('event: c')) (res as unknown as { destroy: () => void }).destroy();
         });
         res.on('close', () => cb(null, data));
         res.on('error', () => cb(null, data));

--- a/packages/dashboard/src/routes/inbox-events.test.ts
+++ b/packages/dashboard/src/routes/inbox-events.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Smoke tests for the SSE endpoint at GET /inbox/:id/events.
+ *
+ * Supertest doesn't fully stream open connections, but we can drive
+ * the route, read the initial frames, and verify wire format +
+ * auth + 404 handling. Full end-to-end (with multiple events
+ * flowing) is exercised by live dogfood — see PR #403 description.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import request from 'supertest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AgentStore,
+  InboxStore,
+  LocalProvider,
+  MemorySecretsStore,
+  RunStore,
+  buildLoopbackAllowlist,
+  loadAgents,
+} from '@some-useful-agents/core';
+import { buildDashboardApp } from '../index.js';
+import type { DashboardContext } from '../context.js';
+import { SESSION_COOKIE } from '../auth-middleware.js';
+import { MemorySecretsSession } from '../secrets-session.js';
+import { InboxEventBus } from '../lib/inbox-event-bus.js';
+
+const TOKEN = 'a'.repeat(64);
+const PORT = 3994;
+const COOKIE = `${SESSION_COOKIE}=${TOKEN}`;
+
+let dir: string;
+let provider: LocalProvider;
+let runStore: RunStore;
+let agentStore: AgentStore;
+let inboxStore: InboxStore;
+let inboxEventBus: InboxEventBus;
+
+async function makeApp() {
+  dir = mkdtempSync(join(tmpdir(), 'sua-sse-'));
+  const dbPath = join(dir, 'runs.db');
+  const agentsDir = join(dir, 'agents', 'local');
+  mkdirSync(agentsDir, { recursive: true });
+
+  const secretsStore = new MemorySecretsStore();
+  runStore = new RunStore(dbPath);
+  agentStore = new AgentStore(dbPath);
+  inboxStore = new InboxStore(dbPath);
+  inboxEventBus = new InboxEventBus({ idleGcMs: 60_000 });
+  provider = new LocalProvider(dbPath, secretsStore);
+  await provider.initialize();
+
+  const ctx: DashboardContext = {
+    token: TOKEN,
+    allowlist: buildLoopbackAllowlist(PORT),
+    port: PORT,
+    provider,
+    runStore,
+    agentStore,
+    loadAgents: () => loadAgents({ directories: [agentsDir] }),
+    secretsStore,
+    secretsSession: new MemorySecretsSession({ backing: secretsStore }),
+    tokenPath: join(dir, 'mcp-token'),
+    retentionDays: 30,
+    dbPath,
+    secretsPath: join(dir, 'secrets.enc'),
+    rotateToken: () => 'r'.repeat(64),
+    inboxStore,
+    inboxEventBus,
+    allowUntrustedShell: new Set(),
+    activeRuns: new Map(),
+    dataDir: dir,
+    dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
+  };
+  return buildDashboardApp(ctx);
+}
+
+afterEach(async () => {
+  if (provider) {
+    const start = Date.now();
+    while ((provider as unknown as { running?: { size: number } }).running?.size && Date.now() - start < 2000) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    await provider.shutdown();
+  }
+  if (inboxEventBus) inboxEventBus.dropAll();
+  try { runStore?.close(); } catch { /* ignore */ }
+  try { agentStore?.close(); } catch { /* ignore */ }
+  try { inboxStore?.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('GET /inbox/:id/events (SSE)', () => {
+  it('returns 404 when the inbox message does not exist', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .get('/inbox/ghost/events')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE);
+    expect(res.status).toBe(404);
+  });
+
+  it('requires auth (no cookie → 401)', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .get('/inbox/anything/events')
+      .set('Host', `127.0.0.1:${PORT}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('opens with the SSE content-type and an initial open frame', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    // Pre-publish a single event so the response body has something
+    // to flush. Supertest's response object closes once the body is
+    // received, which on a real stream would be open-ended — but our
+    // initial padding + the buffered event get flushed together.
+    inboxEventBus.publish(m.id, { type: 'state', data: { phase: 'idle' } });
+
+    // Use a short timeout so the test doesn't hang on the keep-alive
+    // stream. We're only here to verify wire format. Last-Event-ID
+    // of `:0` forces the route to replay every buffered event — a
+    // fresh client wouldn't see the pre-published event otherwise
+    // (which is correct production behavior — they'd hit /fragment
+    // for the snapshot, then subscribe for new events).
+    const req = request(app)
+      .get(`/inbox/${m.id}/events`)
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE)
+      .set('Last-Event-ID', `${m.id}:0`)
+      .buffer(true)
+      .parse((res, cb) => {
+        let data = '';
+        res.on('data', (chunk: Buffer) => {
+          data += chunk.toString('utf-8');
+          // Once we've seen our pre-published event, close the
+          // connection so the test doesn't hang.
+          if (data.includes('event: state')) res.destroy();
+        });
+        res.on('close', () => cb(null, data));
+        res.on('error', () => cb(null, data));
+      });
+    const res = await req;
+    expect(res.headers['content-type']).toContain('text/event-stream');
+    expect(res.headers['cache-control']).toContain('no-cache');
+    const body = res.body as string;
+    expect(body).toContain(': open');
+    expect(body).toContain(`id: ${m.id}:1`);
+    expect(body).toContain('event: state');
+    expect(body).toContain('"phase":"idle"');
+  });
+
+  it('replays buffered events newer than Last-Event-ID', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    // Publish 3 events; client claims to have seen up to id 1.
+    inboxEventBus.publish(m.id, { type: 'a', data: {} });
+    inboxEventBus.publish(m.id, { type: 'b', data: {} });
+    inboxEventBus.publish(m.id, { type: 'c', data: {} });
+
+    const req = request(app)
+      .get(`/inbox/${m.id}/events`)
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', COOKIE)
+      .set('Last-Event-ID', `${m.id}:1`)
+      .buffer(true)
+      .parse((res, cb) => {
+        let data = '';
+        res.on('data', (chunk: Buffer) => {
+          data += chunk.toString('utf-8');
+          if (data.includes('event: c')) res.destroy();
+        });
+        res.on('close', () => cb(null, data));
+        res.on('error', () => cb(null, data));
+      });
+    const res = await req;
+    const body = res.body as string;
+    // Replays b (id 2) and c (id 3) only — a (id 1) is gone.
+    expect(body).not.toContain('event: a');
+    expect(body).toContain('event: b');
+    expect(body).toContain('event: c');
+    expect(body).toContain(`id: ${m.id}:2`);
+    expect(body).toContain(`id: ${m.id}:3`);
+  });
+});

--- a/packages/dashboard/src/routes/inbox-events.ts
+++ b/packages/dashboard/src/routes/inbox-events.ts
@@ -1,0 +1,125 @@
+/**
+ * SSE endpoint for inbox conversation streams.
+ *
+ *   GET /inbox/:id/events
+ *
+ * Replaces the existing 1.5s fragment poll for active conversations.
+ * The route subscribes the client to its message's channel on
+ * `InboxEventBus`, replays any buffered events newer than the
+ * client's `Last-Event-ID` header (set automatically by EventSource
+ * on reconnect), then keeps the connection open and writes each
+ * subsequent event as an SSE frame.
+ *
+ * Auth: the dashboard's standard `requireAuth` middleware already
+ * sits above the inbox router. EventSource cannot set custom headers
+ * but DOES send cookies on same-origin requests, so the session
+ * cookie auth path works unchanged.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { getContext } from '../context.js';
+import type { InboxBufferedEvent } from '../lib/inbox-event-bus.js';
+
+export const inboxEventsRouter: Router = Router();
+
+/** ping comment every 15s — keeps proxies + tabs from idle-closing. */
+const HEARTBEAT_MS = 15_000;
+
+/**
+ * Serialise one event as an SSE frame.
+ *
+ * Format:
+ *   id: <messageId>:<seq>
+ *   event: <type>
+ *   data: <JSON>
+ *   \n
+ *
+ * The `id` field is what the browser echoes back on reconnect via
+ * `Last-Event-ID`. Composite `messageId:seq` so a client switching
+ * between modal threads can't accidentally restore the wrong
+ * channel's checkpoint.
+ */
+function serialiseEvent(messageId: string, ev: InboxBufferedEvent): string {
+  return `id: ${messageId}:${ev.id}\n`
+    + `event: ${ev.type}\n`
+    + `data: ${JSON.stringify(ev.data)}\n\n`;
+}
+
+/**
+ * Parse the `Last-Event-ID` header. The browser sends back whatever
+ * id we last wrote, e.g. `m1:7`. Anything that doesn't match the
+ * current messageId is treated as no checkpoint (client reconnected
+ * after switching threads).
+ */
+function parseSinceId(req: Request, messageId: string): number | undefined {
+  const raw = req.get('last-event-id');
+  if (!raw) return undefined;
+  const colon = raw.lastIndexOf(':');
+  if (colon < 0) return undefined;
+  const prefix = raw.slice(0, colon);
+  if (prefix !== messageId) return undefined;
+  const n = Number(raw.slice(colon + 1));
+  if (!Number.isFinite(n) || n < 0) return undefined;
+  return n;
+}
+
+inboxEventsRouter.get('/inbox/:id/events', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  if (!ctx.inboxEventBus) {
+    res.status(503).type('text/plain').send('inbox event bus not configured');
+    return;
+  }
+  if (!ctx.inboxStore || !ctx.inboxStore.get(id)) {
+    res.status(404).type('text/plain').send('inbox message not found');
+    return;
+  }
+
+  // SSE headers. `X-Accel-Buffering: no` disables buffering on nginx
+  // / reverse proxies that might otherwise hold our writes until the
+  // response ends. `Cache-Control: no-transform` keeps middleboxes
+  // from gzip-buffering the stream.
+  res.status(200);
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache, no-transform');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no');
+  // Flush the headers immediately so the browser knows the stream is
+  // open. flushHeaders is on http.ServerResponse in Node 18+.
+  if (typeof (res as { flushHeaders?: () => void }).flushHeaders === 'function') {
+    (res as { flushHeaders: () => void }).flushHeaders();
+  }
+
+  // Initial padding: 2KB of comment lines defeats early-buffering
+  // intermediaries that hold the first chunk until they've seen
+  // enough bytes. Cheap insurance, otherwise mostly invisible.
+  res.write(':' + ' '.repeat(2048) + '\n\n');
+  res.write(`: open ${new Date().toISOString()}\n\n`);
+
+  // Heartbeat to keep the connection live. Comment lines are ignored
+  // by EventSource but reset proxy/idle-timeout clocks.
+  const heartbeat = setInterval(() => {
+    try { res.write(`: ping ${Date.now()}\n\n`); } catch { /* socket gone */ }
+  }, HEARTBEAT_MS);
+  if (typeof (heartbeat as unknown as { unref?: () => void }).unref === 'function') {
+    (heartbeat as unknown as { unref: () => void }).unref();
+  }
+
+  // Subscribe (with optional replay). The listener writes each event
+  // synchronously. We wrap in try/catch so a socket that died between
+  // ticks doesn't crash the publisher loop.
+  const sinceId = parseSinceId(req, id);
+  const unsubscribe = ctx.inboxEventBus.subscribe(id, (ev) => {
+    try { res.write(serialiseEvent(id, ev)); } catch { /* socket gone — cleanup runs on close */ }
+  }, sinceId);
+
+  // On client disconnect: stop heartbeat + unsubscribe. `close` fires
+  // for both clean tab-close and dropped sockets. `aborted` covers
+  // some older proxies that close without a FIN.
+  const cleanup = () => {
+    clearInterval(heartbeat);
+    unsubscribe();
+  };
+  req.on('close', cleanup);
+  req.on('aborted', cleanup);
+});

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -117,6 +117,23 @@ const MAX_ACTIONS_PER_MESSAGE = 10;
 /** Truncate the sub-agent run output that's stored in action meta. */
 const ACTION_RESULT_PREVIEW_LIMIT = 500;
 
+/**
+ * Thin wrapper around `ctx.inboxEventBus.publish`. Swallows errors so
+ * a misbehaving subscriber can't break a route. Bus presence is
+ * optional — the inbox surface works without it (modal falls back to
+ * the 1.5s fragment poll).
+ */
+function publishInboxEvent(
+  ctx: ReturnType<typeof getContext>,
+  messageId: string,
+  type: string,
+  data: Record<string, unknown>,
+): void {
+  if (!ctx.inboxEventBus) return;
+  try { ctx.inboxEventBus.publish(messageId, { type, data }); }
+  catch { /* telemetry path — never break a route */ }
+}
+
 function parseSort(req: Request): { sort: InboxSortKey; dir: InboxSortDir } {
   const sortRaw = typeof req.query.sort === 'string' ? req.query.sort : '';
   const dirRaw = typeof req.query.dir === 'string' ? req.query.dir : '';
@@ -297,14 +314,24 @@ inboxRouter.post('/inbox/:id/respond', (req: Request, res: Response) => {
     res.redirect(303, `${detailUrl}?error=${encodeURIComponent('Reply is too long (max 8 KB).')}`);
     return;
   }
+  let userResponse;
   try {
-    ctx.inboxStore.addResponse(id, 'user', bodyRaw);
+    userResponse = ctx.inboxStore.addResponse(id, 'user', bodyRaw);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (isAjax(req)) { res.status(500).end(); return; }
     res.redirect(303, `${detailUrl}?error=${encodeURIComponent(`Reply failed: ${msg}`)}`);
     return;
   }
+  // Publish to the SSE bus so any modal subscribed to this thread
+  // sees the persisted user reply within a network RTT. The fragment
+  // poll fallback still works for clients that haven't subscribed.
+  publishInboxEvent(ctx, id, 'message:created', {
+    responseId: userResponse.id,
+    role: 'user',
+    body: bodyRaw,
+    createdAt: userResponse.createdAt,
+  });
   // Auto-fire triage. Fire-and-forget; the modal polls /fragment for
   // the response. The conversation thread itself signals "in progress"
   // via the user-reply-within-30s heuristic in isTriagePending.
@@ -327,7 +354,13 @@ inboxRouter.post('/inbox/:id/triage', (req: Request, res: Response) => {
   // shows what the operator just did. The triage agent receives the
   // updated CONVERSATION and responds.
   try {
-    ctx.inboxStore.addResponse(id, 'user', '(Asked triage to take another look.)');
+    const marker = ctx.inboxStore.addResponse(id, 'user', '(Asked triage to take another look.)');
+    publishInboxEvent(ctx, id, 'message:created', {
+      responseId: marker.id,
+      role: 'user',
+      body: marker.body,
+      createdAt: marker.createdAt,
+    });
   } catch { /* swallow */ }
   void runTriageAgent(ctx, id).catch(() => { /* swallow */ });
   if (isAjax(req)) { res.status(204).end(); return; }
@@ -447,6 +480,12 @@ inboxRouter.post('/inbox/:id/actions/:rid/run', async (req: Request, res: Respon
     res.redirect(303, `${detailUrl}?ok=${encodeURIComponent('Already in progress.')}`);
     return;
   }
+  publishInboxEvent(ctx, id, 'action:status', {
+    responseId: rid,
+    status: 'running',
+    agentId: meta.agentId,
+    startedAt,
+  });
 
   if (isAjax(req)) { res.status(204).end(); }
   // Fire-and-forget; the modal polls /fragment for state.
@@ -498,6 +537,12 @@ inboxRouter.post('/inbox/:id/actions/:rid/skip', (req: Request, res: Response) =
     res.redirect(303, `${detailUrl}?ok=${encodeURIComponent('Action is no longer pending.')}`);
     return;
   }
+  publishInboxEvent(ctx, id, 'action:status', {
+    responseId: rid,
+    status: 'skipped',
+    agentId: meta.agentId,
+    endedAt: skippedMeta.endedAt,
+  });
   if (isAjax(req)) { res.status(204).end(); return; }
   res.redirect(303, `${detailUrl}?ok=${encodeURIComponent('Skipped.')}`);
 });
@@ -794,15 +839,25 @@ async function runProposedAction(
   // contract; the actual write happens here.
   if (ROUTE_HANDLED_AGENTS.has(meta.agentId)) {
     const result = await executeRouteHandledAgent(ctx, messageId, meta);
+    const endedAt = Date.now();
     ctx.inboxStore.updateResponse(response.id, {
       metaJson: JSON.stringify({
         ...meta,
         status: result.status,
         startedAt,
-        endedAt: Date.now(),
+        endedAt,
         resultSummary: result.summary,
         refusalReason: result.refusalReason,
       }),
+    });
+    publishInboxEvent(ctx, messageId, 'action:status', {
+      responseId: response.id,
+      status: result.status,
+      agentId: meta.agentId,
+      startedAt,
+      endedAt,
+      resultSummary: result.summary,
+      refusalReason: result.refusalReason,
     });
     maybeRefireTriage(ctx, messageId);
     return;
@@ -810,13 +865,22 @@ async function runProposedAction(
 
   const subAgent = ctx.agentStore.getAgent(meta.agentId);
   if (!subAgent) {
+    const endedAt = Date.now();
+    const refusalReason = `Agent "${meta.agentId}" is not installed.`;
     ctx.inboxStore.updateResponse(response.id, {
       metaJson: JSON.stringify({
         ...meta,
         status: 'failed',
-        endedAt: Date.now(),
-        refusalReason: `Agent "${meta.agentId}" is not installed.`,
+        endedAt,
+        refusalReason,
       }),
+    });
+    publishInboxEvent(ctx, messageId, 'action:status', {
+      responseId: response.id,
+      status: 'failed',
+      agentId: meta.agentId,
+      endedAt,
+      refusalReason,
     });
     return;
   }
@@ -838,16 +902,31 @@ async function runProposedAction(
     const targetAgentId = parentMessage?.agentId;
     if (targetAgentId && !ctx.agentStore.getAgent(targetAgentId)) {
       const reason = `Can't dispatch agent-analyzer — the target agent "${targetAgentId}" is not installed in this catalog. Install it (e.g. from agents/examples or via the Agents → Import page) and try again.`;
+      const endedAt = Date.now();
       ctx.inboxStore.updateResponse(response.id, {
         metaJson: JSON.stringify({
           ...meta,
           status: 'failed',
           startedAt,
-          endedAt: Date.now(),
+          endedAt,
           refusalReason: reason,
         }),
       });
-      ctx.inboxStore.addResponse(messageId, 'system', reason);
+      publishInboxEvent(ctx, messageId, 'action:status', {
+        responseId: response.id,
+        status: 'failed',
+        agentId: meta.agentId,
+        startedAt,
+        endedAt,
+        refusalReason: reason,
+      });
+      const sysReply = ctx.inboxStore.addResponse(messageId, 'system', reason);
+      publishInboxEvent(ctx, messageId, 'message:created', {
+        responseId: sysReply.id,
+        role: 'system',
+        body: reason,
+        createdAt: sysReply.createdAt,
+      });
       maybeRefireTriage(ctx, messageId);
       return;
     }
@@ -891,16 +970,27 @@ async function runProposedAction(
     nextStatus = 'failed';
     refusalReason = err instanceof Error ? err.message : String(err);
   }
+  const endedAt = Date.now();
   ctx.inboxStore.updateResponse(response.id, {
     metaJson: JSON.stringify({
       ...meta,
       status: nextStatus,
       startedAt,
-      endedAt: Date.now(),
+      endedAt,
       runId,
       resultSummary,
       refusalReason,
     }),
+  });
+  publishInboxEvent(ctx, messageId, 'action:status', {
+    responseId: response.id,
+    status: nextStatus,
+    agentId: meta.agentId,
+    startedAt,
+    endedAt,
+    runId,
+    resultSummary,
+    refusalReason,
   });
 
   // After agent-analyzer completes successfully, look for a
@@ -1055,12 +1145,19 @@ function maybeAutoProposeEditorAction(
     inputs: { AGENT_ID: message.agentId, NEW_YAML: proposedYaml },
     rationale: `Apply the YAML fix that agent-analyzer produced.`,
   };
-  ctx.inboxStore.addResponse(
+  const editorResp = ctx.inboxStore.addResponse(
     messageId,
     'action',
     action.rationale!,
     JSON.stringify(action),
   );
+  publishInboxEvent(ctx, messageId, 'action:created', {
+    responseId: editorResp.id,
+    agentId: action.agentId,
+    rationale: action.rationale,
+    inputs: action.inputs,
+    createdAt: editorResp.createdAt,
+  });
 }
 
 function allActionsResolved(
@@ -1140,6 +1237,12 @@ async function runTriageAgent(
   }
   const triage = ctx.agentStore.getAgent(TRIAGE_AGENT_ID);
   if (!triage) return;
+
+  // SSE: announce the thinking phase so connected clients can show
+  // the witty waiting label immediately, without waiting for the
+  // 1.5s poll heuristic to flip the indicator on.
+  publishInboxEvent(ctx, messageId, 'triage:started', {});
+  publishInboxEvent(ctx, messageId, 'state', { phase: 'thinking', since: Date.now() });
 
   // Build conversation snapshot for the prompt. For action-role rows,
   // include the structured status so the model can see what already
@@ -1233,18 +1336,31 @@ async function runTriageAgent(
     }
     const rec = typeof parsed.recommendation === 'string' ? parsed.recommendation.trim() : '';
     if (!rec || rec.length < 10 || rec.length > 2000) {
-      ctx.inboxStore.addResponse(messageId, 'system', 'Triage agent recommendation failed validation.');
+      const sysReply = ctx.inboxStore.addResponse(messageId, 'system', 'Triage agent recommendation failed validation.');
+      publishInboxEvent(ctx, messageId, 'message:created', {
+        responseId: sysReply.id, role: 'system', body: sysReply.body, createdAt: sysReply.createdAt,
+      });
       return;
     }
     const verifyHint = typeof parsed.verifyHint === 'string' && parsed.verifyHint.trim()
       ? parsed.verifyHint.trim()
       : undefined;
-    ctx.inboxStore.addResponse(
+    const triageReply = ctx.inboxStore.addResponse(
       messageId,
       'triage',
       rec,
       verifyHint ? JSON.stringify({ verifyHint }) : undefined,
     );
+    // The canonical "triage finished" signal. Clients use this to
+    // replace any in-progress typewriter bubble (PR 4) with the
+    // persisted entry.
+    publishInboxEvent(ctx, messageId, 'triage:complete', {
+      responseId: triageReply.id,
+      role: 'triage',
+      body: rec,
+      verifyHint,
+      createdAt: triageReply.createdAt,
+    });
 
     // Parse + persist any proposed actions (only when allowlist is
     // non-empty). Refusals (out-of-allowlist or malformed) get a
@@ -1259,7 +1375,14 @@ async function runTriageAgent(
       for (const action of toInsert) {
         const body = action.rationale
           ?? `Run agent \`${action.agentId}\`.`;
-        ctx.inboxStore.addResponse(messageId, 'action', body, JSON.stringify(action));
+        const actionResp = ctx.inboxStore.addResponse(messageId, 'action', body, JSON.stringify(action));
+        publishInboxEvent(ctx, messageId, 'action:created', {
+          responseId: actionResp.id,
+          agentId: action.agentId,
+          rationale: action.rationale,
+          inputs: action.inputs,
+          createdAt: actionResp.createdAt,
+        });
       }
       const notes: string[] = [];
       for (const r of rejected) {
@@ -1269,18 +1392,26 @@ async function runTriageAgent(
         notes.push(`Skipped ${overflow} additional proposed action${overflow === 1 ? '' : 's'} — message has reached the per-thread action cap (${MAX_ACTIONS_PER_MESSAGE}).`);
       }
       if (notes.length > 0) {
-        ctx.inboxStore.addResponse(messageId, 'system', notes.join('\n'));
+        const sysReply = ctx.inboxStore.addResponse(messageId, 'system', notes.join('\n'));
+        publishInboxEvent(ctx, messageId, 'message:created', {
+          responseId: sysReply.id, role: 'system', body: sysReply.body, createdAt: sysReply.createdAt,
+        });
       }
     }
 
     try {
       ctx.inboxStore.updateStatus(messageId, 'awaiting_user', { recommendation: rec, triageRunId: runId });
     } catch { /* ignore */ }
+    publishInboxEvent(ctx, messageId, 'state', { phase: 'done', since: Date.now() });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     process.stderr.write(`[inbox-triage] run failed: ${msg}\n${(err as Error)?.stack ?? ''}\n`);
     try {
-      ctx.inboxStore.addResponse(messageId, 'system', `Triage agent crashed: ${msg}`);
+      const sysReply = ctx.inboxStore.addResponse(messageId, 'system', `Triage agent crashed: ${msg}`);
+      publishInboxEvent(ctx, messageId, 'message:created', {
+        responseId: sysReply.id, role: 'system', body: sysReply.body, createdAt: sysReply.createdAt,
+      });
     } catch { /* ignore */ }
+    publishInboxEvent(ctx, messageId, 'state', { phase: 'done', since: Date.now() });
   }
 }

--- a/packages/dashboard/src/views/inbox-modal.js.ts
+++ b/packages/dashboard/src/views/inbox-modal.js.ts
@@ -34,6 +34,18 @@ export const INBOX_MODAL_JS = `
   // dag-executor + run-store insertion is racy with our 200ms wait.
   var keepPollingUntil = 0;
 
+  // SSE state. eventSource carries the active connection; sseAliveAt
+  // records the last event (or open) timestamp so the watchdog can
+  // detect a silent disconnect and fall back to the fragment poll.
+  var eventSource = null;
+  var sseAliveAt = 0;
+  var sseWatchdog = null;
+  // Watchdog cadence: if we haven't seen any SSE message (data or
+  // heartbeat comment) within this window, force a fragment refresh
+  // to recover gracefully. Heartbeats fire every 15s server-side,
+  // so 20s is comfortable headroom.
+  var SSE_WATCHDOG_MS = 20000;
+
   function open() {
     modal.hidden = false;
     modal.classList.add('is-open');
@@ -47,6 +59,91 @@ export const INBOX_MODAL_JS = `
     seenMsgIds = Object.create(null);
     keepPollingUntil = 0;
     stopPoll();
+    closeEventSource();
+  }
+
+  function closeEventSource() {
+    if (eventSource) {
+      try { eventSource.close(); } catch (_) { /* noop */ }
+      eventSource = null;
+    }
+    if (sseWatchdog) { clearInterval(sseWatchdog); sseWatchdog = null; }
+    sseAliveAt = 0;
+  }
+
+  /**
+   * Open an EventSource for the current thread. Each handled event
+   * triggers a fragment refresh — the SSE notification is the "wake
+   * up, something changed" signal; the canonical state still comes
+   * from /fragment so we never have to incrementally diff DOM here.
+   * (PR 3+4 will start rendering tokens directly.)
+   *
+   * If EventSource isn't available (very old browsers) or the
+   * endpoint returns an error, we silently fall through to the
+   * 1.5s fragment poll. Same behavior on SSE disconnect via the
+   * watchdog below.
+   */
+  function openEventSource(messageId) {
+    closeEventSource();
+    if (typeof EventSource === 'undefined') return;
+    var es;
+    try {
+      es = new EventSource('/inbox/' + encodeURIComponent(messageId) + '/events');
+    } catch (_) { return; }
+    eventSource = es;
+    sseAliveAt = Date.now();
+
+    es.addEventListener('open', function () { sseAliveAt = Date.now(); });
+    es.addEventListener('error', function () {
+      // EventSource auto-reconnects with Last-Event-ID; we just note
+      // the disconnect so the watchdog can decide whether to fall
+      // back to the poll.
+      sseAliveAt = sseAliveAt || Date.now();
+    });
+
+    // Generic handler for all our custom event types. The data
+    // payload is JSON; for now we just trigger a refresh because the
+    // fragment already renders the canonical state. PR 4 will start
+    // patching DOM incrementally for triage:token events.
+    var onAnyEvent = function () {
+      sseAliveAt = Date.now();
+      // Only one event per animation frame to avoid stacking refreshes
+      // when several events arrive in the same tick.
+      scheduleSseRefresh();
+    };
+    [
+      'state', 'triage:started', 'triage:token', 'triage:complete',
+      'action:created', 'action:status', 'message:created',
+    ].forEach(function (t) { es.addEventListener(t, onAnyEvent); });
+
+    // Watchdog: if the channel goes silent past the threshold (no
+    // heartbeat or data), we suspect the connection died below the
+    // EventSource layer (proxy timeout, sleeping tab). Fall back to
+    // the fragment poll until the next real event arrives.
+    if (sseWatchdog) clearInterval(sseWatchdog);
+    sseWatchdog = setInterval(function () {
+      if (!eventSource || currentId !== messageId) return;
+      if (Date.now() - sseAliveAt > SSE_WATCHDOG_MS) {
+        refresh();
+        sseAliveAt = Date.now();
+      }
+    }, 5000);
+    if (sseWatchdog && typeof sseWatchdog === 'object' && 'unref' in sseWatchdog) {
+      sseWatchdog.unref && sseWatchdog.unref();
+    }
+  }
+
+  var sseRefreshRaf = null;
+  function scheduleSseRefresh() {
+    if (sseRefreshRaf) return;
+    sseRefreshRaf = requestAnimationFrame(function () {
+      sseRefreshRaf = null;
+      // The "userIsInteracting" check inside refresh() still applies
+      // — if the operator is typing in a non-empty textarea or has a
+      // selection, the swap is skipped (their state is preserved)
+      // until the next event or the watchdog forces through.
+      refresh();
+    });
   }
 
   function stopPoll() {
@@ -232,6 +329,10 @@ export const INBOX_MODAL_JS = `
     content.innerHTML = '<p class="dim" style="margin:0;padding:var(--space-4) 0;text-align:center;">Loading…</p>';
     open();
     refresh();
+    // Open the SSE connection AFTER the initial fragment fetch so
+    // the first render isn't racing the stream. Each subsequent
+    // event triggers an incremental refresh.
+    openEventSource(id);
   }
 
   // Row click → modal. Chevron click is checked first and toggles the


### PR DESCRIPTION
## Summary

**Plan path B, PR 2 of 4** (see `~/.claude/plans/shimmering-sprouting-brooks.md`).

Replaces the 1.5s fragment poll for active conversations with a server-sent-events stream. Action card status transitions and triage replies now land at network RTT instead of poll cadence. The fragment poll stays as a fallback when SSE is unavailable, disconnects, or sits silent for >20s.

## Architecture

### Event bus (`packages/dashboard/src/lib/inbox-event-bus.ts`)

In-memory pub/sub keyed by `messageId`. Each channel keeps a 50-event ring buffer for `Last-Event-ID` replay; a 5-minute idle GC drops abandoned channels when the last subscriber leaves. Listener errors are swallowed so one bad subscriber can't starve the rest.

### SSE endpoint (`GET /inbox/:id/events`)

Standard SSE headers (`text/event-stream`, `Cache-Control: no-cache, no-transform`, `X-Accel-Buffering: no`), 2KB initial padding to defeat proxy buffering, 15s heartbeat comments. Honors `Last-Event-ID` for reconnect catch-up. Auth: cookie-based (EventSource sends same-origin cookies automatically).

Wire format:
```
id: <messageId>:<seq>
event: <type>
data: <JSON>
```

### Publish hooks (`packages/dashboard/src/routes/inbox.ts`)

| Lifecycle point | Event |
|---|---|
| User reply persisted | `message:created` |
| `runTriageAgent` starts | `triage:started` + `state(thinking)` |
| Triage reply persisted | `triage:complete` + `state(done)` |
| Proposed action card persisted | `action:created` |
| Action transitions (running, skipped, completed, failed, refused) | `action:status` |
| Triage system notes (refusals, crashes) | `message:created` |

### Client (`inbox-modal.js.ts`)

Opens an `EventSource` per modal in `openFor`, listens to every event type, and schedules a single `refresh()` per animation frame on any event — the SSE notification is the wake-up signal; canonical state still comes from `/fragment` (PR 4 will switch to incremental DOM patches for `triage:token` events).

A 20s watchdog forces a fragment refresh if no events or heartbeats arrive, recovering gracefully when SSE proxies misbehave or tabs sleep.

## Test plan

- [x] `npm run build` clean.
- [x] `npx vitest run` — **1841 pass / 3 skipped** (+18 from baseline).
- [x] **14 bus tests**: publish/subscribe semantics, ring buffer overflow, Last-Event-ID replay, idle GC + cancel-on-reconnect, throwing-listener isolation, multi-subscriber fan-out, idempotent unsubscribe.
- [x] **4 SSE route tests**: 404 on missing message, 401 without cookie, wire format on initial open, `Last-Event-ID` replay (only events with id > checkpoint).
- [x] **Live end-to-end**: `curl -N` against the SSE endpoint while POSTing to `/inbox/:id/triage`. Confirmed `message:created` → `triage:started` → `state(thinking)` arrive with the correct `id: <messageId>:<seq>` / `event: <type>` / `data: <JSON>` framing, plus the open frame + padding.

## Plan progress

- ✅ PR 1 — witty waiting labels + indicator/composer fixes (#402)
- ✅ PR 2 — **SSE endpoint + structured event bus** (this PR)
- ⬜ PR 3 — per-token capture from claude CLI (`output_chunk` events through to `triage:token`)
- ⬜ PR 4 — typewriter UI (incremental DOM patching for streaming bubble)

🤖 Generated with [Claude Code](https://claude.com/claude-code)