### PR TITLE
feat(core,dashboard): inbox streaming — per-token capture from Claude CLI

### DIFF
--- a/.changeset/inbox-token-streaming.md
+++ b/.changeset/inbox-token-streaming.md
@@ -1,0 +1,44 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox streaming: per-token capture from Claude CLI to SSE bus.
+
+Plan path B, PR 3 of 4. Extends the SSE pipeline so triage replies
+stream text chunks live instead of materializing all at once when
+the DAG completes. PR 4 will hang the typewriter reveal off these
+events.
+
+**Core change.** `claudeSpawner.parseProgress`
+(`packages/core/src/node-spawner.ts`) now inspects the `content`
+array of every `assistant` event from the `--output-format stream-json`
+output. Each text chunk emits an `output_chunk` SpawnProgress with
+the actual text in `message`. Tool-use content still produces
+`tool_use` events. Empty assistant events fall back to `turn_start`
+("Claude is responding…") so the UI keeps an alive signal.
+
+**Decoupling hook.** New optional `DagExecutorDeps.inboxOnProgress`
+forwarder. The dag-executor's existing progress collector
+synchronously calls it (alongside the DB `progressJson` write)
+with `{nodeId, progress}`. Errors swallowed so a misbehaving
+adapter can't break a run. Core knows nothing about the bus.
+
+**Dashboard adapter.** `runTriageAgent` passes an `inboxOnProgress`
+that filters `output_chunk` and republishes as `triage:token`
+SSE events with `{nodeId, chunk, at}` payload.
+
+Live-verified: with claude as the waterfall primary, posting to
+/inbox/:id/triage produced a `triage:token` event over the SSE
+stream with the assistant's full plan JSON chunk before the
+`triage:complete` event fired. Codex still doesn't stream per-token
+(parseProgress returns null) — out of scope for this PR; future
+work can wire it in the same shape.
+
+8 new parseProgress unit tests covering text deltas, tool-use,
+text+tool-use priority, empty assistant events, empty text deltas,
+result events, top-level tool_use, unknown event types. 1850 tests
+pass (+9).

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -106,6 +106,16 @@ export interface DagExecutorDeps {
    */
   llmSettings?: import('./node-spawner.js').LlmSettingsSnapshot;
   /**
+   * Optional per-event forwarder used by the dashboard's inbox SSE
+   * stream. Fires once per `SpawnProgress` event with the agent +
+   * node context. Decoupled from core: dag-executor doesn't know
+   * about the inbox event bus; the dashboard registers an adapter
+   * that filters by node and republishes to the bus as
+   * `triage:token` / `tool_use` etc. Errors are swallowed by the
+   * adapter so a misbehaving subscriber can't break a run.
+   */
+  inboxOnProgress?: (event: { nodeId: string; progress: import('./node-spawner.js').SpawnProgress }) => void;
+  /**
    * Optional dashboard URL prefix used by the notify dispatcher to embed
    * a "view run in dashboard" link in Slack messages. When absent, the
    * link is omitted; the notify still fires.
@@ -738,6 +748,11 @@ export async function executeAgentDag(
 
     // Progress collector: accumulates SpawnProgress events and writes
     // them to the DB so the dashboard can poll for turn status.
+    // Additionally forwards each event to the optional inbox SSE
+    // adapter (`deps.inboxOnProgress`) — that's what the dashboard
+    // hangs per-token triage:token events off of, for the typewriter
+    // reveal in PR 4. The adapter is responsible for filtering by
+    // node and swallowing its own errors.
     const progressEvents: SpawnProgress[] = [];
     const onProgress = (event: SpawnProgress) => {
       progressEvents.push(event);
@@ -745,6 +760,12 @@ export async function executeAgentDag(
       deps.runStore.updateNodeExecution(runId, node.id, {
         progressJson: JSON.stringify(progressEvents),
       });
+      // Best-effort fan-out to the inbox SSE bus. Never let an
+      // adapter exception break a live run.
+      if (deps.inboxOnProgress) {
+        try { deps.inboxOnProgress({ nodeId: node.id, progress: event }); }
+        catch { /* swallow */ }
+      }
     };
 
     // PR C (orphan-kill): persist the child's pid + wall-clock start time

--- a/packages/core/src/node-spawner.test.ts
+++ b/packages/core/src/node-spawner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildProviderChain, classifyLlmFailure, type SpawnResult } from './node-spawner.js';
+import { buildProviderChain, claudeSpawner, classifyLlmFailure, type SpawnResult } from './node-spawner.js';
 
 function r(partial: Partial<SpawnResult>): SpawnResult {
   return {
@@ -94,6 +94,89 @@ describe('buildProviderChain (waterfall)', () => {
 
   it('supports a 3-provider chain — pin still goes first, rest follows in order', () => {
     expect(buildProviderChain('codex', ['claude', 'gemini', 'codex'])).toEqual(['codex', 'claude', 'gemini']);
+  });
+});
+
+describe('claudeSpawner.parseProgress (per-token output_chunk)', () => {
+  // The Claude CLI's --output-format stream-json emits one JSON line
+  // per event. Assistant events carry a content array with text
+  // and/or tool_use items. PR 4 of the streaming UX work uses the
+  // output_chunk events to drive the typewriter reveal.
+
+  it('returns null for non-JSON lines', () => {
+    expect(claudeSpawner.parseProgress('')).toBeNull();
+    expect(claudeSpawner.parseProgress('hello world')).toBeNull();
+    expect(claudeSpawner.parseProgress('[not, json]')).toBeNull();
+  });
+
+  it('emits output_chunk with the text delta on an assistant text event', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: 'Hello, world!' }] },
+    });
+    const p = claudeSpawner.parseProgress(line);
+    expect(p).not.toBeNull();
+    expect(p?.type).toBe('output_chunk');
+    expect(p?.message).toBe('Hello, world!');
+  });
+
+  it('emits tool_use when an assistant event has tool_use content (no text)', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: { content: [{ type: 'tool_use', name: 'Read', input: {} }] },
+    });
+    const p = claudeSpawner.parseProgress(line);
+    expect(p?.type).toBe('tool_use');
+  });
+
+  it('prefers text over tool_use when both are present in one assistant event', () => {
+    // The first text chunk drives the typewriter; the tool_use is
+    // surfaced via the next event in the stream.
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: { content: [
+        { type: 'text', text: 'Let me check.' },
+        { type: 'tool_use', name: 'Read' },
+      ] },
+    });
+    const p = claudeSpawner.parseProgress(line);
+    expect(p?.type).toBe('output_chunk');
+    expect(p?.message).toBe('Let me check.');
+  });
+
+  it('falls back to turn_start for an assistant event with empty content', () => {
+    const line = JSON.stringify({ type: 'assistant', message: { content: [] } });
+    const p = claudeSpawner.parseProgress(line);
+    expect(p?.type).toBe('turn_start');
+  });
+
+  it('skips empty text deltas (no message.length === 0 events)', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: '' }] },
+    });
+    const p = claudeSpawner.parseProgress(line);
+    // Empty text → no useful chunk → falls through to the generic
+    // turn_start so the UI knows the model is alive.
+    expect(p?.type).toBe('turn_start');
+  });
+
+  it('emits turn_complete with the turn count on a result event', () => {
+    const line = JSON.stringify({ type: 'result', num_turns: 3 });
+    const p = claudeSpawner.parseProgress(line);
+    expect(p?.type).toBe('turn_complete');
+    expect(p?.turn).toBe(3);
+  });
+
+  it('emits tool_use on a top-level tool_use event', () => {
+    const line = JSON.stringify({ type: 'tool_use', name: 'Grep' });
+    const p = claudeSpawner.parseProgress(line);
+    expect(p?.type).toBe('tool_use');
+  });
+
+  it('returns null for unrecognized event types', () => {
+    const line = JSON.stringify({ type: 'system' });
+    expect(claudeSpawner.parseProgress(line)).toBeNull();
   });
 });
 

--- a/packages/core/src/node-spawner.ts
+++ b/packages/core/src/node-spawner.ts
@@ -174,14 +174,46 @@ export const claudeSpawner: LlmSpawner = {
     if (!line.startsWith('{')) return null;
     try {
       const event = JSON.parse(line);
+      // Assistant events carry an array of content items: `{type:'text', text:'...'}`
+      // for the model's writing, `{type:'tool_use', ...}` when it calls a tool.
+      // Each `assistant` event from the stream-json output represents a chunk
+      // (the CLI streams in sub-message intervals). Per-token reveal in the
+      // dashboard hangs off these text chunks.
       if (event.type === 'assistant') {
+        const content = event.message?.content;
+        if (Array.isArray(content)) {
+          // Prefer the FIRST text chunk we find. If a single assistant
+          // event interleaves text + tool_use the tool_use case still
+          // fires via the dedicated branch below.
+          for (const c of content) {
+            if (c && c.type === 'text' && typeof c.text === 'string' && c.text.length > 0) {
+              return {
+                timestamp: new Date().toISOString(),
+                type: 'output_chunk',
+                message: c.text,
+              };
+            }
+          }
+          // Tool-use without text: surface that explicitly so the
+          // dashboard's witty-label loop can flip to the action-running
+          // phase rather than show the triage thinking phase.
+          if (content.some((c: { type?: string }) => c && c.type === 'tool_use')) {
+            return {
+              timestamp: new Date().toISOString(),
+              type: 'tool_use',
+              message: 'Using a tool...',
+            };
+          }
+        }
+        // Empty assistant event (rare, but handle gracefully) — keep
+        // the old "thinking" signal so the UI knows something happened.
         return {
           timestamp: new Date().toISOString(),
           type: 'turn_start',
           message: 'Claude is responding...',
         };
       }
-      if (event.type === 'tool_use' || (event.type === 'assistant' && event.message?.content?.some?.((c: { type: string }) => c.type === 'tool_use'))) {
+      if (event.type === 'tool_use') {
         return {
           timestamp: new Date().toISOString(),
           type: 'tool_use',

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -1283,6 +1283,20 @@ async function runTriageAgent(
         variablesStore: ctx.variablesStore,
         dataRoot: ctx.agentStore.dataRoot,
         llmSettings: buildLlmSettingsSnapshot(ctx),
+        // Forward token-level progress from the triage LLM node to
+        // the SSE bus. Filtered to output_chunk so we don't spam
+        // clients with turn_start / tool_use markers (those still
+        // land in progressJson via the DB path). Other progress
+        // types remain DB-only.
+        inboxOnProgress: ({ nodeId, progress }) => {
+          if (progress.type !== 'output_chunk') return;
+          if (!progress.message) return;
+          publishInboxEvent(ctx, messageId, 'triage:token', {
+            nodeId,
+            chunk: progress.message,
+            at: Date.now(),
+          });
+        },
       },
     );
     // Capture the runId once it lands. Race the executor to avoid


### PR DESCRIPTION
## Summary

**Plan path B, PR 3 of 4** (see \`~/.claude/plans/shimmering-sprouting-brooks.md\`).

Extends the SSE pipeline shipped in #403 so triage replies stream text chunks live instead of materializing all at once when the DAG completes. PR 4 hangs the typewriter reveal off these new events.

## Core change

**\`claudeSpawner.parseProgress\`** (\`packages/core/src/node-spawner.ts\`) now inspects the \`content\` array of every \`assistant\` event from \`--output-format stream-json\`. Each text chunk emits an \`output_chunk\` SpawnProgress with the actual text in \`message\`. Tool-use content still produces \`tool_use\` events. Empty assistant events fall back to \`turn_start\` so the UI keeps an alive signal.

## Decoupling hook

New optional **\`DagExecutorDeps.inboxOnProgress\`** forwarder. The dag-executor's existing progress collector synchronously calls it (alongside the DB \`progressJson\` write) with \`{nodeId, progress}\`. Errors swallowed so a misbehaving adapter can't break a run. **Core knows nothing about the inbox bus** — the adapter lives in the dashboard.

## Dashboard adapter

\`runTriageAgent\` passes an \`inboxOnProgress\` that filters \`output_chunk\` and republishes as \`triage:token\` SSE events with \`{nodeId, chunk, at}\` payload.

## Test plan

- [x] \`npm run build\` clean.
- [x] \`npx vitest run\` — **1850 pass / 3 skipped** (+9 from baseline).
- [x] **8 new parseProgress unit tests**: text deltas, tool-use, text+tool-use priority, empty assistant content fallback, empty text delta fallback, result events with turn count, top-level tool_use, unknown event types, non-JSON lines.
- [x] **Live end-to-end**: promoted claude to waterfall primary, opened \`curl -N\` on the SSE endpoint, POSTed to \`/inbox/:id/triage\`. Observed:
  ```
  event counts:
    2 event: state
    1 event: triage:started
    1 event: triage:token       ← NEW
    1 event: triage:complete
    1 event: message:created
    1 event: action:created
  ```
  The \`triage:token\` event carried the assistant's full plan JSON chunk BEFORE \`triage:complete\` fired.

## Codex caveat (out of scope)

Codex \`parseProgress\` still returns null — out of scope per the plan. With codex as primary, the SSE stream skips straight from \`triage:started\` to \`triage:complete\` (no \`triage:token\` events). Future PR can add codex per-token in the same shape; the plumbing is generic.

## Plan progress

- ✅ PR 1 — witty waiting labels + indicator/composer fixes (#402)
- ✅ PR 2 — SSE event bus + EventSource client (#403)
- ✅ PR 3 — **per-token capture from Claude CLI** (this PR)
- ⬜ PR 4 — typewriter UI (incremental DOM patching for streaming bubble)

🤖 Generated with [Claude Code](https://claude.com/claude-code)