### PR TITLE
feat(dashboard): inbox streaming — typewriter UI for triage replies

### DIFF
--- a/.changeset/inbox-typewriter-ui.md
+++ b/.changeset/inbox-typewriter-ui.md
@@ -1,0 +1,47 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox streaming: typewriter UI for triage replies.
+
+Plan path B, PR 4 of 4 — completes the streaming work. Triage's
+reply now paints into a live bubble as the LLM streams text,
+replacing the prior "wall of text materializes at LLM finish"
+moment with a ChatGPT-style incremental reveal.
+
+**Modal JS** (`packages/dashboard/src/views/inbox-modal.js.ts`)
+listens for three new SSE event types:
+
+- `triage:started` — creates a streaming bubble with the Tri avatar
+  and a "Writing…" meta label. The server-rendered thinking
+  indicator is removed so the operator doesn't see "Triage agent
+  is thinking…" sitting above the live reply.
+- `triage:token` — appends `chunk` to the bubble's text. Chunks
+  accumulate into a string queue and flush once per animation
+  frame via `requestAnimationFrame` so a burst of tokens doesn't
+  thrash layout. Uses `appendChild(createTextNode(...))` — never
+  innerHTML — so any "<" or "&" in the model output renders as
+  text, not markup. Auto-scrolls only when the operator was
+  already near the bottom (preserves their reading position).
+- `triage:complete` — clears `data-streaming`, sets
+  `data-settled="1"`. The blinking caret hides; the canonical
+  fragment refresh that follows (via the existing onAnyEvent
+  scheduler) replaces the bubble with the persisted entry,
+  no flicker.
+
+**CSS** (`packages/dashboard/src/assets/screens.css`) adds the
+streaming caret — a black-vertical-rectangle pseudo-element after
+`.inbox-msg__text`, blinking at 900ms via `inbox-stream-caret`
+keyframes. Settled state hides it.
+
+Live-verified end-to-end: posted a reply, watched
+`bubble-text-len=582 streaming=true` at t=9s and
+`settled=true` at t=10s with the screenshot showing the bubble
+mid-write (avatar + "Writing…" meta + visible streamed text
+ending in `<plan>` `{`).
+
+1850 tests pass (no test changes — pure runtime behavior).

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -2142,6 +2142,34 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
 .inbox-msg[data-pending] .inbox-msg__text {
   font-style: italic;
 }
+
+/* Streaming triage bubble (PR 4 of the streaming UX work). Created
+ * by inbox-modal.js on the first `triage:token` SSE event, replaced
+ * by the canonical fragment after `triage:complete`. The caret
+ * pseudo-element is the ChatGPT-style blinking cursor that marks
+ * the live writing edge. */
+.inbox-msg[data-streaming] {
+  animation: inbox-msg-in 140ms ease-out;
+}
+.inbox-msg[data-streaming] .inbox-msg__text::after {
+  content: '\25AE'; /* black vertical rectangle — narrow + tall, reads as a caret */
+  display: inline-block;
+  margin-left: 1px;
+  color: var(--color-accent, currentColor);
+  animation: inbox-stream-caret 900ms steps(1, end) infinite;
+  font-weight: bold;
+}
+.inbox-msg[data-settled] .inbox-msg__text::after {
+  /* Hide the caret once triage:complete fires — the canonical
+   * fragment refresh will replace this bubble outright, but in the
+   * brief gap the operator shouldn't see a still-blinking cursor on
+   * a finished message. */
+  display: none;
+}
+@keyframes inbox-stream-caret {
+  0%, 49%   { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
 /* Copy-message affordance on each conversation turn. Sits in the
  * meta row next to the timestamp. Invisible until row hover so the
  * conversation stays clean during reading; pops in when the

--- a/packages/dashboard/src/views/inbox-modal.js.ts
+++ b/packages/dashboard/src/views/inbox-modal.js.ts
@@ -101,19 +101,58 @@ export const INBOX_MODAL_JS = `
       sseAliveAt = sseAliveAt || Date.now();
     });
 
-    // Generic handler for all our custom event types. The data
-    // payload is JSON; for now we just trigger a refresh because the
-    // fragment already renders the canonical state. PR 4 will start
-    // patching DOM incrementally for triage:token events.
+    // Generic handler: any event keeps the watchdog happy and pulls
+    // a fresh fragment so the canonical state renders. Specific
+    // triage:* event handlers below run BEFORE this — they patch the
+    // DOM incrementally for the typewriter reveal, so a refresh
+    // happening right after wouldn't be jarring (it's a no-op when
+    // the fragment matches the streamed content).
     var onAnyEvent = function () {
       sseAliveAt = Date.now();
-      // Only one event per animation frame to avoid stacking refreshes
-      // when several events arrive in the same tick.
       scheduleSseRefresh();
     };
+
+    // triage:started — create the streaming bubble immediately so
+    // there's no gap between the witty waiting label and the first
+    // token. The bubble is replaced wholesale when the fragment
+    // refresh fires after triage:complete.
+    es.addEventListener('triage:started', function () {
+      sseAliveAt = Date.now();
+      ensureStreamingBubble();
+    });
+    // triage:token — append the text chunk to the streaming bubble.
+    // textContent (not innerHTML) keeps the operator-visible text
+    // free of any HTML interpretation; the canonical fragment is
+    // server-rendered with the same escaping rules.
+    es.addEventListener('triage:token', function (ev) {
+      sseAliveAt = Date.now();
+      var bubble = ensureStreamingBubble();
+      if (!bubble) return;
+      var data;
+      try { data = JSON.parse(ev.data); } catch (_) { return; }
+      var chunk = data && data.chunk;
+      if (!chunk) return;
+      appendStreamingText(bubble, String(chunk));
+    });
+    // triage:complete — keep the bubble in place; the watchdog or
+    // the canonical fragment refresh (scheduled by onAnyEvent for
+    // message:created → fired on triage's addResponse) will swap in
+    // the persisted entry so we don't double-render.
+    es.addEventListener('triage:complete', function () {
+      sseAliveAt = Date.now();
+      // Mark "settled" — drop the streaming caret so the bubble looks
+      // like a normal finished message between now and the fragment
+      // refresh replacing it.
+      var bubble = content.querySelector('[data-streaming-bubble]');
+      if (bubble) {
+        bubble.removeAttribute('data-streaming');
+        bubble.setAttribute('data-settled', '1');
+      }
+      scheduleSseRefresh();
+    });
+
     [
-      'state', 'triage:started', 'triage:token', 'triage:complete',
-      'action:created', 'action:status', 'message:created',
+      'state', 'action:created', 'action:status', 'message:created',
     ].forEach(function (t) { es.addEventListener(t, onAnyEvent); });
 
     // Watchdog: if the channel goes silent past the threshold (no
@@ -143,6 +182,98 @@ export const INBOX_MODAL_JS = `
       // selection, the swap is skipped (their state is preserved)
       // until the next event or the watchdog forces through.
       refresh();
+    });
+  }
+
+  /**
+   * Create the streaming triage bubble if it doesn't already exist.
+   * Returns the .inbox-msg__text element where chunks get appended.
+   * Idempotent — multiple triage:started events on a single turn
+   * (rare) reuse the same bubble.
+   *
+   * The thinking indicator (rendered server-side based on the
+   * isTriagePending heuristic) is removed when the bubble lands so
+   * the operator doesn't see "Triage agent is thinking..." sitting
+   * above the streaming reply.
+   */
+  function ensureStreamingBubble() {
+    var existing = content.querySelector('[data-streaming-bubble]');
+    if (existing) return existing.querySelector('.inbox-msg__text');
+
+    var ul = content.querySelector('ul.inbox-timeline');
+    if (!ul) {
+      var section = content.querySelector('.inbox-modal__timeline-section');
+      if (!section) return null;
+      var emptyP = section.querySelector('p.dim');
+      if (emptyP && emptyP.parentNode) emptyP.parentNode.removeChild(emptyP);
+      ul = document.createElement('ul');
+      ul.className = 'inbox-timeline';
+      section.appendChild(ul);
+    }
+    // Remove the server-rendered thinking indicator if present —
+    // the streaming bubble takes its place.
+    var thinking = content.querySelector('.inbox-thinking[data-triage-pending]');
+    if (thinking && thinking.parentNode) thinking.parentNode.removeChild(thinking);
+
+    var li = document.createElement('li');
+    li.className = 'inbox-timeline__entry';
+    var msg = document.createElement('div');
+    msg.className = 'inbox-msg inbox-msg--new';
+    msg.setAttribute('data-streaming', '1');
+    msg.setAttribute('data-streaming-bubble', '1');
+    var avatar = document.createElement('div');
+    avatar.className = 'inbox-msg__avatar inbox-msg__avatar--triage';
+    avatar.textContent = 'Tri';
+    var body = document.createElement('div');
+    body.className = 'inbox-msg__body';
+    var meta = document.createElement('div');
+    meta.className = 'inbox-msg__meta';
+    var name = document.createElement('span');
+    name.className = 'inbox-msg__meta-name';
+    name.textContent = 'Triage agent';
+    var age = document.createElement('span');
+    age.textContent = 'Writing…';
+    meta.appendChild(name);
+    meta.appendChild(age);
+    var text = document.createElement('div');
+    text.className = 'inbox-msg__text';
+    body.appendChild(meta);
+    body.appendChild(text);
+    msg.appendChild(avatar);
+    msg.appendChild(body);
+    li.appendChild(msg);
+    ul.appendChild(li);
+    requestAnimationFrame(function () {
+      content.scrollTop = content.scrollHeight;
+    });
+    return text;
+  }
+
+  // Append text to the streaming bubble. Throttled to one DOM write
+  // per animation frame so a burst of tokens doesn't tank layout.
+  // Pending chunks accumulate in a string queue and flush on rAF.
+  var pendingStreamText = '';
+  var pendingStreamRaf = null;
+  function appendStreamingText(textEl, chunk) {
+    pendingStreamText += chunk;
+    if (pendingStreamRaf) return;
+    pendingStreamRaf = requestAnimationFrame(function () {
+      pendingStreamRaf = null;
+      var flush = pendingStreamText;
+      pendingStreamText = '';
+      // Re-query the element in case the DOM was swapped between
+      // when the chunk arrived and when this rAF fired.
+      var el = content.querySelector('[data-streaming-bubble] .inbox-msg__text');
+      if (!el) return;
+      // textContent appends — explicitly avoid innerHTML so an
+      // accidental "<" or "&" in the model's output renders as-is
+      // instead of breaking the markup.
+      el.appendChild(document.createTextNode(flush));
+      // Auto-scroll while streaming, but only if the operator was
+      // already near the bottom — don't yank them away from reading
+      // earlier history.
+      var nearBottom = content.scrollHeight - content.scrollTop - content.clientHeight < 80;
+      if (nearBottom) content.scrollTop = content.scrollHeight;
     });
   }
 


### PR DESCRIPTION
## Summary

**Plan path B, PR 4 of 4** — completes the streaming work shipped in #402 (waiting labels) + #403 (SSE event bus) + #404 (per-token capture).

Triage's reply now paints into a live bubble as the LLM streams text, replacing the prior wall-of-text-materializes-at-LLM-finish moment with a ChatGPT-style incremental reveal.

## What changed

**Modal JS** (\`packages/dashboard/src/views/inbox-modal.js.ts\`) listens for three SSE event types and patches DOM incrementally:

- **\`triage:started\`** → creates a streaming bubble with the Tri avatar + \"Writing…\" meta. Server-rendered thinking indicator is removed so the operator doesn't see *\"Triage agent is thinking…\"* sitting above the live reply.
- **\`triage:token\`** → appends \`chunk\` to the bubble's text. Chunks accumulate into a string queue and flush once per animation frame via \`requestAnimationFrame\` so a burst of tokens doesn't thrash layout. Uses \`appendChild(createTextNode(...))\` — never \`innerHTML\` — so any \`<\` or \`&\` in the model output renders as text. Auto-scrolls only when the operator was already near the bottom.
- **\`triage:complete\`** → clears \`data-streaming\`, sets \`data-settled=\"1\"\`. The canonical fragment refresh that follows (via the existing onAnyEvent scheduler) replaces the bubble with the persisted entry, no flicker.

**CSS** (\`packages/dashboard/src/assets/screens.css\`) adds the streaming caret — a black-vertical-rectangle pseudo-element after \`.inbox-msg__text\`, blinking at 900ms via \`inbox-stream-caret\` keyframes. Settled state hides it.

## Test plan

- [x] \`npm run build\` clean.
- [x] \`npx vitest run\` — **1850 pass / 3 skipped** (no test changes; pure runtime DOM behavior).
- [x] **Live end-to-end** with claude as waterfall primary: posted a reply, sampled DOM state every 1s:
  ```
  t=1-8s: no-bubble                              (claude still thinking)
  t=9s:   bubble-text-len=582 streaming=true     (caret blinking)
  t=10s:  bubble-text-len=582 streaming=false settled=true
  ```
  Screenshot captures the bubble mid-write with avatar + \"Writing…\" meta + visible streamed text.

## Notes

- Per-token streaming is **claude-only** today. Codex \`parseProgress\` still returns null (out of scope per the plan). With codex as primary, the modal falls through to the original flow: thinking indicator → fragment refresh on \`triage:complete\`. No regression.
- Effort estimate for codex parallel: **~1.5hr including tests**. Same shape as #404 (use \`codex exec --json\`, emit \`output_chunk\` on \`item.completed\` agent_message events). Codex emits one big chunk rather than per-token deltas, so the reveal is \"whole reply arrives ~5s before complete\" rather than ChatGPT-style — still a UX win.

## Plan progress

- ✅ PR 1 — witty waiting labels + bug fixes (#402)
- ✅ PR 2 — SSE event bus + EventSource client (#403)
- ✅ PR 3 — per-token capture from Claude CLI (#404)
- ✅ PR 4 — **typewriter UI** (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)