### PR TITLE
feat(core): codex spawner per-event streaming (parallel to PR #404)

### DIFF
--- a/.changeset/codex-per-token-streaming.md
+++ b/.changeset/codex-per-token-streaming.md
@@ -1,0 +1,50 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Codex spawner: per-event streaming parallel to Claude (PR 4.5).
+
+Parallel to PR #404 — extends `codexSpawner` to opt into
+`codex exec --json` and forward the structured event stream into
+the inbox SSE pipeline. Triage replies running on codex now stream
+into the typewriter bubble shipped in PR #405 instead of arriving
+all at once after `addResponse`.
+
+**Changes** in `packages/core/src/node-spawner.ts`:
+
+- `buildArgs` adds `--json` so codex emits a JSONL event stream
+  instead of raw prose.
+- `parseProgress` handles the codex shape (sampled live):
+  - `turn.started` → `turn_start`
+  - `item.completed` with `item.type=agent_message` → `output_chunk`
+    carrying the full `item.text`
+  - `turn.completed` → `turn_complete` with `usage.output_tokens`
+    as the turn-count proxy
+  - Other event types (thread.started, future tool_use, reasoning,
+    etc.) are silently skipped.
+- `extractResult` walks back to the last `agent_message` item and
+  returns its text — `--json` makes stdout JSONL, so the previous
+  identity passthrough would have stored the raw event stream as
+  the run's `result`. Falls back to raw stdout if no
+  agent_message line is found (defensive for future event shapes).
+
+**Caveat (same as PR #404 plan).** Codex emits the full assistant
+text in a single `agent_message` item, not token-by-token deltas
+like claude's `--output-format stream-json`. So the typewriter
+reveal with codex feels like "whole reply arrives ~RTT before
+turn.completed" rather than ChatGPT-style streaming — still a
+visible win over the prior "reply lands at addResponse time"
+behavior, just less dramatic.
+
+**Live-verified end-to-end** with codex as waterfall primary:
+posted a reply, observed `triage:token` event over the SSE stream
+carrying the full plan JSON before `triage:complete`. The dashboard
+typewriter bubble renders the chunk live.
+
+13 new codex unit tests covering buildArgs flags, all parseProgress
+branches, agent_message preference in extractResult, raw-stdout
+fallback. 1863 tests pass (+13).

--- a/packages/core/src/node-spawner.test.ts
+++ b/packages/core/src/node-spawner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildProviderChain, claudeSpawner, classifyLlmFailure, type SpawnResult } from './node-spawner.js';
+import { buildProviderChain, claudeSpawner, codexSpawner, classifyLlmFailure, type SpawnResult } from './node-spawner.js';
 
 function r(partial: Partial<SpawnResult>): SpawnResult {
   return {
@@ -177,6 +177,117 @@ describe('claudeSpawner.parseProgress (per-token output_chunk)', () => {
   it('returns null for unrecognized event types', () => {
     const line = JSON.stringify({ type: 'system' });
     expect(claudeSpawner.parseProgress(line)).toBeNull();
+  });
+});
+
+describe('codexSpawner', () => {
+  // Live sample of codex --json (sampled from running `codex exec --json -s read-only`):
+  //   {"type":"thread.started","thread_id":"…"}
+  //   {"type":"turn.started"}
+  //   {"type":"item.completed","item":{"type":"agent_message","text":"…"}}
+  //   {"type":"turn.completed","usage":{"output_tokens":N,…}}
+
+  it('buildArgs includes --json so we get structured events instead of raw prose', () => {
+    const args = codexSpawner.buildArgs({ prompt: 'hi' });
+    expect(args).toContain('--json');
+    expect(args).toContain('exec');
+    expect(args).toContain('-s');
+    expect(args).toContain('read-only');
+  });
+
+  it('buildArgs threads through the model when set', () => {
+    const args = codexSpawner.buildArgs({ prompt: 'hi', model: 'o3' });
+    const i = args.indexOf('-m');
+    expect(i).toBeGreaterThan(-1);
+    expect(args[i + 1]).toBe('o3');
+  });
+
+  it('parseProgress returns null for non-JSON lines', () => {
+    expect(codexSpawner.parseProgress('')).toBeNull();
+    expect(codexSpawner.parseProgress('not json')).toBeNull();
+  });
+
+  it('parseProgress emits turn_start on turn.started', () => {
+    const p = codexSpawner.parseProgress(JSON.stringify({ type: 'turn.started' }));
+    expect(p?.type).toBe('turn_start');
+  });
+
+  it('parseProgress emits output_chunk with the agent_message text', () => {
+    const line = JSON.stringify({
+      type: 'item.completed',
+      item: { id: 'item_0', type: 'agent_message', text: 'Hello there.' },
+    });
+    const p = codexSpawner.parseProgress(line);
+    expect(p?.type).toBe('output_chunk');
+    expect(p?.message).toBe('Hello there.');
+  });
+
+  it('parseProgress skips empty agent_message text', () => {
+    const line = JSON.stringify({
+      type: 'item.completed',
+      item: { type: 'agent_message', text: '' },
+    });
+    expect(codexSpawner.parseProgress(line)).toBeNull();
+  });
+
+  it('parseProgress ignores non-agent_message item.completed events', () => {
+    // Codex may emit tool_use / file_changes / reasoning items in
+    // future versions — those should not surface as triage:token.
+    const line = JSON.stringify({
+      type: 'item.completed',
+      item: { type: 'tool_use', name: 'shell' },
+    });
+    expect(codexSpawner.parseProgress(line)).toBeNull();
+  });
+
+  it('parseProgress emits turn_complete on turn.completed with output_tokens', () => {
+    const line = JSON.stringify({
+      type: 'turn.completed',
+      usage: { output_tokens: 57, input_tokens: 12934 },
+    });
+    const p = codexSpawner.parseProgress(line);
+    expect(p?.type).toBe('turn_complete');
+    expect(p?.message).toContain('57');
+  });
+
+  it('parseProgress emits turn_complete with a generic message when usage is absent', () => {
+    const p = codexSpawner.parseProgress(JSON.stringify({ type: 'turn.completed' }));
+    expect(p?.type).toBe('turn_complete');
+  });
+
+  it('parseProgress returns null for thread.started + unknown event types', () => {
+    expect(codexSpawner.parseProgress(JSON.stringify({ type: 'thread.started', thread_id: 'x' }))).toBeNull();
+    expect(codexSpawner.parseProgress(JSON.stringify({ type: 'something_new' }))).toBeNull();
+  });
+
+  it('extractResult walks back to the last agent_message and returns its text', () => {
+    const stdout = [
+      JSON.stringify({ type: 'thread.started', thread_id: 'x' }),
+      JSON.stringify({ type: 'turn.started' }),
+      JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'Hello there.' } }),
+      JSON.stringify({ type: 'turn.completed', usage: { output_tokens: 12 } }),
+    ].join('\n');
+    expect(codexSpawner.extractResult(stdout)).toBe('Hello there.');
+  });
+
+  it('extractResult prefers the LAST agent_message when multiple appear in one run', () => {
+    // Multi-turn runs (e.g. when the model emits a tool_use then a
+    // follow-up agent_message) would have several agent_message
+    // items. The final one is the user-visible reply.
+    const stdout = [
+      JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'Intermediate.' } }),
+      JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'Final answer.' } }),
+      JSON.stringify({ type: 'turn.completed' }),
+    ].join('\n');
+    expect(codexSpawner.extractResult(stdout)).toBe('Final answer.');
+  });
+
+  it('extractResult falls back to raw stdout when no agent_message is present', () => {
+    // Defensive: legacy behavior for any future codex output shape
+    // we haven't seen yet — the spawner still hands a string back to
+    // the executor instead of throwing.
+    const stdout = 'plain unstructured fallback';
+    expect(codexSpawner.extractResult(stdout)).toBe(stdout);
   });
 });
 

--- a/packages/core/src/node-spawner.ts
+++ b/packages/core/src/node-spawner.ts
@@ -288,13 +288,92 @@ export const codexSpawner: LlmSpawner = {
     // Prompt rides on stdin (see claudeSpawner note). `codex exec` reads
     // its prompt from stdin when no positional argument is given.
     void opts.prompt;
-    const args = ['exec', '-s', 'read-only'];
+    // --json emits one JSON event per line, mirroring claude's
+    // `--output-format stream-json`. This unlocks the inbox SSE
+    // pipeline: turn.started → output_chunk → turn.completed get
+    // forwarded as triage:started → triage:token → triage:complete.
+    const args = ['exec', '--json', '-s', 'read-only'];
     if (opts.model) args.push('-m', opts.model);
     return args;
   },
 
-  parseProgress(): SpawnProgress | null { return null; },
-  extractResult(stdout: string): string { return stdout; },
+  /**
+   * Codex's --json JSONL shape (sampled live):
+   *   {"type":"thread.started","thread_id":"…"}      ← discarded
+   *   {"type":"turn.started"}                         → turn_start
+   *   {"type":"item.completed","item":{
+   *      "type":"agent_message","text":"…"}}          → output_chunk
+   *   {"type":"turn.completed","usage":{
+   *      "output_tokens": N, …}}                      → turn_complete
+   *
+   * Codex emits the full assistant text in a single agent_message
+   * item rather than streaming token-by-token deltas (the way
+   * claude's --output-format stream-json does). The dashboard's
+   * typewriter still renders incrementally — it just gets one big
+   * chunk arriving ~RTT before turn.completed, which still beats
+   * the prior "whole reply lands at addResponse time" experience.
+   */
+  parseProgress(line: string): SpawnProgress | null {
+    if (!line.startsWith('{')) return null;
+    try {
+      const event = JSON.parse(line);
+      if (event.type === 'turn.started') {
+        return {
+          timestamp: new Date().toISOString(),
+          type: 'turn_start',
+          message: 'Codex is responding...',
+        };
+      }
+      if (event.type === 'item.completed' && event.item?.type === 'agent_message') {
+        const text = typeof event.item.text === 'string' ? event.item.text : '';
+        if (text.length > 0) {
+          return {
+            timestamp: new Date().toISOString(),
+            type: 'output_chunk',
+            message: text,
+          };
+        }
+      }
+      if (event.type === 'turn.completed') {
+        const outTokens = event.usage?.output_tokens;
+        return {
+          timestamp: new Date().toISOString(),
+          type: 'turn_complete',
+          message: typeof outTokens === 'number'
+            ? `Completed (${outTokens} output tokens).`
+            : 'Completed.',
+        };
+      }
+    } catch {
+      // Not valid JSON — skip.
+    }
+    return null;
+  },
+
+  /**
+   * With --json the raw stdout is JSONL, not the model's prose. Walk
+   * to the LAST `item.completed` agent_message and return its text —
+   * matches the contract `claudeSpawner.extractResult` provides
+   * (final prose string for the run record + downstream prompts).
+   * Falls back to the raw stdout for backward compat if no
+   * agent_message line is found.
+   */
+  extractResult(stdout: string): string {
+    const lines = stdout.split('\n');
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i].trim();
+      if (!line.startsWith('{')) continue;
+      try {
+        const event = JSON.parse(line);
+        if (event.type === 'item.completed'
+          && event.item?.type === 'agent_message'
+          && typeof event.item.text === 'string') {
+          return event.item.text;
+        }
+      } catch { /* skip */ }
+    }
+    return stdout;
+  },
 };
 
 // ── Spawner registry ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Parallel to PR #404 — extends \`codexSpawner\` to opt into \`codex exec --json\` and forward the structured event stream into the inbox SSE pipeline. Triage replies running on codex now stream into the typewriter bubble (shipped in #405) instead of arriving all at once after \`addResponse\`.

## Changes

In \`packages/core/src/node-spawner.ts\`:

- **\`buildArgs\`** adds \`--json\` so codex emits a JSONL event stream instead of raw prose.

- **\`parseProgress\`** handles the codex shape (sampled live from \`codex exec --json -s read-only\`):

  | Codex event | SpawnProgress |
  |---|---|
  | \`{\"type\":\"turn.started\"}\` | \`turn_start\` |
  | \`{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"…\"}}\` | \`output_chunk\` (with full text) |
  | \`{\"type\":\"turn.completed\",\"usage\":{\"output_tokens\":N}}\` | \`turn_complete\` (with N as turn proxy) |

  Other event types (\`thread.started\`, future tool_use / reasoning / etc.) silently skipped.

- **\`extractResult\`** walks back to the last \`agent_message\` item and returns its text. \`--json\` makes stdout JSONL, so the previous identity passthrough would have stored the raw event stream as the run's \`result\`. Falls back to raw stdout if no agent_message line is found.

## Caveat (called out in PR #404 plan)

Codex emits the full assistant text in a **single \`agent_message\` item**, not token-by-token deltas like claude's \`--output-format stream-json\`. So the typewriter reveal with codex feels like *"whole reply arrives ~RTT before turn.completed"* rather than ChatGPT-style streaming — still a visible win over the prior *"reply lands at addResponse time"* behavior, just less dramatic.

## Test plan

- [x] \`npm run build\` clean.
- [x] \`npx vitest run\` — **1863 pass / 3 skipped** (+13 from baseline).
- [x] **13 new codex unit tests**: buildArgs flags, --json presence, model threading, all parseProgress branches (turn.started, agent_message text, empty text, non-agent_message item, turn.completed with + without usage, thread.started/unknown skipped), extractResult agent_message walkback, multiple agent_messages preference, raw-stdout fallback.
- [x] **Live end-to-end** with codex as waterfall primary: posted to \`/inbox/:id/triage\` and observed:
  \`\`\`
  event counts:
    2 event: state
    2 event: message:created
    1 event: triage:started
    1 event: triage:token       ← NEW (was 0 before)
    1 event: triage:complete
  \`\`\`
  \`triage:token\` payload carried the full plan JSON chunk before \`triage:complete\` fired.

## Plan progress (streaming pack)

- ✅ PR 1 — witty waiting labels + bug fixes (#402)
- ✅ PR 2 — SSE event bus + EventSource client (#403)
- ✅ PR 3 — per-token capture from Claude CLI (#404)
- ✅ PR 4 — typewriter UI (#405)
- ✅ PR 4.5 — **codex per-event streaming** (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)