### PR TITLE
feat(dashboard): inbox flat sortable list + right-side actions + activity-strip preview

### DIFF
--- a/.changeset/inbox-view-flat-sortable-and-activity-preview.md
+++ b/.changeset/inbox-view-flat-sortable-and-activity-preview.md
@@ -1,0 +1,73 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox queue: flat sortable list + right-side actions + activity-strip
+preview.
+
+PR 2 of 2 in the queue UX pass (PR 1 was #407: store-layer sort +
+last-activity). Replaces the priority-segmented layout with one
+flat list under a sticky sortable column header, reorders the row
+so star + chevron sit on the right next to the metadata they
+modify, and rebuilds the expanded preview as an activity strip
+showing the actual conversation signal.
+
+**Flat list.** Drops `renderGroup` and the priority-group cards.
+The priority dot stays on each row — that's the urgency cue at a
+glance. The (sorted) row order carries the rest.
+
+**Sticky sortable header.** Five column links — Priority · Title ·
+Agent · Status · Age — each render as a sort link that flips
+direction on click. The active column shows a `↑` / `↓` arrow;
+inactive columns are clickable but show no arrow. URL drives the
+sort state (`?sort=X&dir=Y`); active filters (`q` / `starred` /
+`tag`) are preserved through clicks. The chevron + star columns
+get no label.
+
+**Row layout reorder.** Operator feedback: "the grid row left side
+doesn't make sense - think it should be right side." Star and
+chevron move to the right. New grid template
+(`12px 1fr auto auto auto 24px 24px`): priority dot + title (+
+inline tags) on the left, agent · status · age · star · chevron
+on the right. Drops the `—` placeholder for missing agents —
+empty space reads as "no agent" without adding ink. The
+left-edge amber accent for `awaiting_user` stays.
+
+**Activity-strip preview** replaces the body-only excerpt:
+
+  1. Latest non-action response (triage / user / system) with
+     avatar + role + first ~160 chars (word-boundary truncation).
+  2. Pending-actions summary chip when triage proposed actions:
+     `▸ 1 proposed action: agent-catalog-search`.
+  3. Context payload disclosure (only when present).
+  4. Tag chips move from the title cell into the preview.
+  5. Right-aligned footer: Open thread → · Source label.
+
+Empty cases: manual conversation with no replies shows an italic
+"No replies yet. Open the thread to start the conversation." with
+the Open thread CTA. The `(empty)` body sentinel from the store's
+NOT NULL workaround is suppressed (mirrors the modal's filter at
+inbox-detail.ts:135). Rows with no responses but a real body fall
+back to a body excerpt (~320 chars).
+
+**Route preview payload.** `GET /inbox` computes per-row
+`{latestResponse, proposedActions}` in one pass per row via
+`listResponses(m.id)` — cheap at the default ≤200 row page size.
+Walks responses from newest to oldest with an early exit once both
+signals are captured. If pagination grows the row count
+materially, fold into a bulk store helper that joins
+`inbox_responses` once.
+
+**Mobile fallback.** At <720px the priority + agent columns
+collapse on both the row and the sticky header. The chevron and
+star stay on the right so operators can still triage on phones.
+
+1873 tests pass (no behavior tests added — pure markup +
+ordering). Dogfooded live with `SUA_INBOX_DEMO=1`: flat list
+rendered, sort links navigated to the right URL with the right
+arrow indicator, activity-strip preview showed the system reply
++ proposed-action chip + Open thread footer.

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -2855,79 +2855,72 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
   flex-direction: column;
   gap: var(--space-3);
 }
-.inbox-list__group {
-  display: flex;
-  flex-direction: column;
+/* ---------- Inbox queue (flat, sortable) ----------
+ * The priority-group cards are gone. One flat list with a sticky
+ * sortable header. Each row reads content-left, metadata + actions-
+ * right: priority dot + title + tags on the left; agent · status ·
+ * age · star · chevron on the right.
+ *
+ * Grid template (shared by .inbox-list__header and .inbox-row2):
+ *   priority  title              agent  status  age   star  chevron
+ *   12px      1fr                auto   auto    auto  24px  24px
+ */
+.inbox-list {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   overflow: hidden;
 }
-.inbox-list__group-head {
-  padding: var(--space-1) var(--space-3);
-  display: flex;
+.inbox-list__header {
+  display: grid;
+  grid-template-columns: 12px 1fr auto auto auto 24px 24px;
   align-items: center;
-  gap: var(--space-2);
-  color: var(--color-text-muted);
-}
-.inbox-list__group-label {
-  font-size: var(--font-size-sm);
-  font-weight: var(--weight-medium);
-  color: var(--color-text);
-}
-.inbox-list__group-count {
+  gap: var(--space-3);
+  padding: var(--space-1) var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg);
+  position: sticky;
+  top: 0;
+  z-index: 1;
   font-size: var(--font-size-xs);
   color: var(--color-text-muted);
-  font-weight: var(--weight-medium);
 }
+.inbox-list__sort {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: inherit;
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: var(--weight-semibold);
+  padding: 2px 0;
+}
+.inbox-list__sort:hover { color: var(--color-text); }
+.inbox-list__sort--active { color: var(--color-text); }
+.inbox-list__sort-arrow {
+  font-size: 10px;
+  line-height: 1;
+}
+.inbox-list__header-title { justify-self: start; }
+
 .inbox-row2 {
   display: grid;
-  /* Merged the prior age + status columns into a single signal cell
-   * on the right (badge + age, grouped). Keeps the row scanable as
-   * one signal instead of two unrelated chips. */
-  grid-template-columns: 24px 24px 70px 88px 1fr auto;
+  grid-template-columns: 12px 1fr auto auto auto 24px 24px;
   align-items: center;
-  gap: var(--space-2);
+  gap: var(--space-3);
   padding: var(--space-2) var(--space-3);
   border-bottom: 1px solid var(--color-border);
   cursor: pointer;
   transition: background 80ms ease-out;
 }
-/* Right-side signal cell: status badge leading + age trailing.
- * Loud variant for awaiting_user (the only row that needs a click)
- * is driven by the badge variant set in the view. */
-.inbox-row2__signal {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  justify-self: end;
-  font-size: var(--font-size-xs);
-}
-.inbox-row2__signal .inbox-row2__age {
-  white-space: nowrap;
-}
-/* Subtle left-edge accent for the row that needs a click — the badge
- * already says "Your turn" but operators tend to scan the rail line
- * for color, so we mirror the cue at the row level too. */
+.inbox-row2:last-child { border-bottom: 0; }
+.inbox-row2:hover { background: var(--color-surface-raised); }
+/* Subtle left-edge accent for the row that needs a click — mirrors
+ * the loud "Your turn" badge in a color cue for the row itself. */
 .inbox-row2[data-inbox-status="awaiting_user"] {
   box-shadow: inset 3px 0 0 var(--color-warn, #f59e0b);
 }
-.inbox-row2:last-child { border-bottom: 0; }
-.inbox-row2:hover { background: var(--color-surface-raised); }
-.inbox-row2__chevron {
-  background: transparent;
-  border: 0;
-  color: var(--color-text-muted);
-  cursor: pointer;
-  font-size: var(--font-size-sm);
-  width: 24px;
-  height: 24px;
-  padding: 0;
-  border-radius: var(--radius-sm);
-  transition: transform 120ms ease-out;
-}
-.inbox-row2__chevron:hover { color: var(--color-text); background: var(--color-surface); }
-.inbox-row2__chevron[aria-expanded="true"] { transform: rotate(90deg); color: var(--color-text); }
 .inbox-row2__title {
   font-size: var(--font-size-sm);
   font-weight: var(--weight-medium);
@@ -2945,62 +2938,134 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
   color: var(--color-text-muted);
+  justify-self: end;
+  white-space: nowrap;
+}
+.inbox-row2__status {
+  justify-self: end;
+  white-space: nowrap;
 }
 .inbox-row2__age {
   font-size: var(--font-size-xs);
   color: var(--color-text-muted);
+  justify-self: end;
+  white-space: nowrap;
 }
+.inbox-row2__chevron {
+  background: transparent;
+  border: 0;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border-radius: var(--radius-sm);
+  transition: transform 120ms ease-out;
+  justify-self: end;
+}
+.inbox-row2__chevron:hover { color: var(--color-text); background: var(--color-surface); }
+.inbox-row2__chevron[aria-expanded="true"] { transform: rotate(90deg); color: var(--color-text); }
+
+/* Expanded preview — activity strip replaces the body-only excerpt.
+ * Avatar + role + first ~160 chars of the latest non-action
+ * response. Pending-actions summary chip. Tags + Open thread CTA
+ * + source label in a right-aligned footer. */
 .inbox-row2__preview {
   grid-column: 1 / -1;
   background: var(--color-surface-raised);
   border-top: 1px solid var(--color-border);
-  padding: var(--space-3) var(--space-3);
+  padding: var(--space-3);
   display: none;
 }
 .inbox-row2--expanded .inbox-row2__preview { display: block; }
 .inbox-row2--expanded { background: var(--color-surface-raised); }
-.inbox-row2__preview-body {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-muted);
-  margin: 0 0 var(--space-3);
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  max-height: 8rem;
-  overflow: hidden;
-  position: relative;
-}
-.inbox-row2__preview-tail {
+.inbox-row2__activity {
   display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-  margin-bottom: var(--space-3);
+  gap: var(--space-3);
+  align-items: flex-start;
+  margin-bottom: var(--space-2);
 }
-.inbox-row2__preview-msg {
+.inbox-row2__activity-body { flex: 1; min-width: 0; }
+.inbox-row2__activity-meta {
   display: flex;
+  align-items: baseline;
   gap: var(--space-2);
   font-size: var(--font-size-xs);
-  align-items: baseline;
+  margin-bottom: 2px;
 }
-.inbox-row2__preview-msg-role {
+.inbox-row2__activity-role {
   font-weight: var(--weight-semibold);
-  color: var(--color-text-muted);
-  min-width: 50px;
-  text-transform: uppercase;
-  font-size: 10px;
-  letter-spacing: 0.06em;
 }
-.inbox-row2__preview-actions {
+.inbox-row2__activity-excerpt {
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  line-height: 1.5;
+  word-wrap: break-word;
+}
+.inbox-row2__body-excerpt {
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  margin: 0 0 var(--space-2);
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  line-height: 1.5;
+}
+.inbox-row2__no-activity {
+  font-style: italic;
+  font-size: var(--font-size-sm);
+  margin: 0 0 var(--space-2);
+}
+.inbox-row2__action-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  margin: 0 0 var(--space-2);
+}
+.inbox-row2__action-summary-icon { color: var(--color-text-muted); }
+.inbox-row2__context {
+  font-size: var(--font-size-xs);
+  margin: 0 0 var(--space-2);
+}
+.inbox-row2__context summary {
+  cursor: pointer;
+  color: var(--color-text-muted);
+}
+.inbox-row2__context pre {
+  font-size: var(--font-size-xs);
+  margin: var(--space-2) 0 0;
+  padding: var(--space-2);
+  background: var(--color-bg);
+  border-radius: var(--radius-sm);
+  overflow-x: auto;
+  max-height: 10rem;
+}
+.inbox-row2__preview-tags {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.inbox-row2__preview-footer {
   display: flex;
+  align-items: center;
   gap: var(--space-2);
+  flex-wrap: wrap;
+}
+.inbox-row2__preview-footer-spacer { flex: 1; }
+.inbox-row2__preview-source {
+  font-size: var(--font-size-xs);
 }
 
-/* Mobile fallback: simpler column set. Keep the signal cell on the
- * right so operators still see "Your turn" on phones. */
+/* Mobile fallback: collapse the priority and agent columns. The
+ * sticky header drops its corresponding cells so the labels stay
+ * aligned. */
 @media (max-width: 720px) {
-  .inbox-row2 { grid-template-columns: 24px 24px 1fr auto; }
-  .inbox-row2__priority,
-  .inbox-row2__source { display: none; }
-  .inbox-row2__signal .inbox-row2__age { display: none; }
+  .inbox-list__header,
+  .inbox-row2 { grid-template-columns: 12px 1fr auto auto 24px 24px; }
+  .inbox-row2__agent,
+  .inbox-list__header > [role="columnheader"]:nth-child(4) { display: none; }
 }
 
 /* ---------- Modal timeline ---------- */

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -166,13 +166,61 @@ inboxRouter.get('/inbox', (req: Request, res: Response) => {
   const statusQ = typeof req.query.status === 'string' ? req.query.status : '';
   const archiveView: 'dismissed' | 'resolved' | undefined =
     statusQ === 'dismissed' ? 'dismissed' : statusQ === 'resolved' ? 'resolved' : undefined;
+  const { sort, dir } = parseSort(req);
+  // Coerce the dashboard's broader InboxSortKey union (which still
+  // carries the legacy 'source' option for back-compat) to the
+  // store's sort vocabulary. Anything the store doesn't know falls
+  // back to its default (priority semantics).
+  const STORE_SORT_KEYS: ReadonlySet<string> = new Set(['priority', 'status', 'age', 'title', 'agent']);
+  const storeSort = STORE_SORT_KEYS.has(sort) ? (sort as 'priority' | 'status' | 'age' | 'title' | 'agent') : 'priority';
   const rows = ctx.inboxStore ? ctx.inboxStore.list({
     q: q || undefined,
     starred: starred || undefined,
     tag: tag || undefined,
     status: archiveView,
+    sort: storeSort,
+    dir,
   }) : [];
   const allTags = ctx.inboxStore ? ctx.inboxStore.listAllTags() : [];
+  // Compute per-row preview payloads in a single pass. Each call to
+  // listResponses is a single SQLite roundtrip; for the default
+  // page-size (≤200 rows) the cost is negligible. If pagination
+  // grows the row count materially, fold this into a bulk store
+  // helper that joins inbox_responses once.
+  const previewPayloads = new Map<string, import('../views/inbox-list.js').InboxRowPreviewPayload>();
+  if (ctx.inboxStore && rows.length > 0) {
+    for (const r of rows) {
+      const responses = ctx.inboxStore.listResponses(r.id);
+      let latestResponse: { role: 'user' | 'triage' | 'system' | 'action'; body: string; createdAt: number } | undefined;
+      let proposedCount = 0;
+      let firstProposedAgentId: string | undefined;
+      // Walk from newest to oldest. listResponses returns ascending
+      // by created_at, so iterate in reverse.
+      for (let i = responses.length - 1; i >= 0; i--) {
+        const resp = responses[i];
+        if (resp.role !== 'action' && !latestResponse) {
+          latestResponse = { role: resp.role, body: resp.body, createdAt: resp.createdAt };
+        }
+        if (resp.role === 'action') {
+          const meta = parseActionMeta(resp);
+          if (meta?.status === 'proposed') {
+            proposedCount += 1;
+            if (!firstProposedAgentId) firstProposedAgentId = meta.agentId;
+          }
+        }
+        // Early exit once we have both signals.
+        if (latestResponse && proposedCount > 0) break;
+      }
+      previewPayloads.set(r.id, {
+        latestResponse: latestResponse && latestResponse.role !== 'action'
+          ? { role: latestResponse.role, body: latestResponse.body, createdAt: latestResponse.createdAt }
+          : undefined,
+        proposedActions: proposedCount > 0
+          ? { count: proposedCount, firstAgentId: firstProposedAgentId }
+          : undefined,
+      });
+    }
+  }
   // terminalCount drives the "Inbox cleared" empty-state + the "View
   // N dismissed / resolved" archive-footer link. Only computed for
   // the active view — the archive view has its own header.
@@ -184,13 +232,13 @@ inboxRouter.get('/inbox', (req: Request, res: Response) => {
       terminalCount = dismissed.length + resolved.length;
     } catch { /* swallow — empty count is harmless */ }
   }
-  const { sort, dir } = parseSort(req);
   res.type('html').send(renderInboxList({
     rows, sort, dir, flash: parseFlash(req),
     filter: { q, starred, tag },
     allTags,
     terminalCount,
     archiveView,
+    previewPayloads,
   }));
 });
 

--- a/packages/dashboard/src/views/inbox-list.ts
+++ b/packages/dashboard/src/views/inbox-list.ts
@@ -1,4 +1,4 @@
-import type { InboxMessage, InboxPriority, InboxSource, InboxStatus } from '@some-useful-agents/core';
+import type { InboxMessage, InboxPriority, InboxResponseRole, InboxSource, InboxStatus } from '@some-useful-agents/core';
 import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { formatAge } from './components.js';
@@ -47,6 +47,34 @@ export interface InboxListOptions {
    * changes. The list itself comes from the route's filtered query.
    */
   archiveView?: 'dismissed' | 'resolved';
+  /**
+   * Per-row preview payload, keyed by message id. Powers the
+   * activity-strip preview in the row's expanded state — latest
+   * conversation excerpt + count of proposed action cards. The
+   * route computes these in one pass when rendering the list to
+   * avoid N+1 from the view side. Rows without an entry get the
+   * legacy "no replies yet" empty preview.
+   */
+  previewPayloads?: Map<string, InboxRowPreviewPayload>;
+}
+
+/** Compact preview-strip payload for one row. See renderRow. */
+export interface InboxRowPreviewPayload {
+  /** Most recent non-action response, or undefined when none exists. */
+  latestResponse?: {
+    role: InboxResponseRole;
+    body: string;
+    createdAt: number;
+  };
+  /**
+   * Count + first-agent summary of proposed action cards on the
+   * thread. Drives the "1 proposed action: agent-X" pill in the
+   * preview strip.
+   */
+  proposedActions?: {
+    count: number;
+    firstAgentId?: string;
+  };
 }
 
 export const INBOX_DEFAULT_SORT: { sort: InboxSortKey; dir: InboxSortDir } = {
@@ -62,7 +90,7 @@ const SOURCE_LABEL: Record<InboxSource, string> = {
 };
 
 const PRIORITY_LABEL: Record<InboxPriority, string> = {
-  high: 'High priority',
+  high: 'High',
   medium: 'Medium',
   low: 'Low',
 };
@@ -72,6 +100,28 @@ const PRIORITY_BADGE: Record<InboxPriority, string> = {
   medium: 'badge--info',
   low: 'badge--muted',
 };
+
+/**
+ * Role labels for the activity-strip preview. Matches the modal's
+ * ROLE_LABEL in inbox-detail.ts but kept local to avoid an import
+ * cycle. Action role intentionally omitted — the activity strip
+ * excludes action-card responses; pending actions get their own
+ * summary chip.
+ */
+const PREVIEW_ROLE_LABEL: Partial<Record<InboxResponseRole, string>> = {
+  user: 'You',
+  triage: 'Triage',
+  system: 'System',
+};
+
+const PREVIEW_ROLE_AVATAR: Partial<Record<InboxResponseRole, string>> = {
+  user: 'You',
+  triage: 'Tri',
+  system: 'Sys',
+};
+
+/** Max characters in the preview's activity-excerpt body before truncating. */
+const PREVIEW_EXCERPT_CAP = 160;
 
 /**
  * Human labels for the inbox-status enum. The raw snake_case values
@@ -153,13 +203,14 @@ export function renderInboxList(opts: InboxListOptions): string {
 
   const starredAll = rows.filter((r) => r.starred);
   const suggestions = archiveView ? [] : buildSuggestions(rows);
+  const previewPayloads = opts.previewPayloads ?? new Map<string, InboxRowPreviewPayload>();
 
   const filterBar = renderFilterBar(filter, allTags);
   const suggestBanner = archiveView
     ? renderArchiveHeader(archiveView, rows.length)
     : renderSuggestBanner(suggestions, rows.length, terminalCount);
   const rail = renderRail(starredAll);
-  const main = renderMain(rows);
+  const main = renderMain(rows, opts.sort, opts.dir, filter, previewPayloads);
   const archiveLink = !archiveView && terminalCount > 0
     ? html`
       <div class="inbox-archive-footer">
@@ -356,7 +407,7 @@ function renderRail(starred: InboxMessage[]): SafeHtml {
   `;
 }
 
-function renderMain(rows: InboxMessage[]): SafeHtml {
+function renderMain(rows: InboxMessage[], sort: InboxSortKey, dir: InboxSortDir, filter: { q: string; starred: boolean; tag: string }, previewPayloads: Map<string, InboxRowPreviewPayload>): SafeHtml {
   if (rows.length === 0) {
     return html`
       <div class="card" style="padding: var(--space-6); text-align: center; color: var(--color-text-muted);">
@@ -367,43 +418,80 @@ function renderMain(rows: InboxMessage[]): SafeHtml {
       </div>
     `;
   }
-
-  const groups: Record<InboxPriority, InboxMessage[]> = { high: [], medium: [], low: [] };
-  for (const r of rows) groups[r.priority].push(r);
-  for (const k of ['high', 'medium', 'low'] as InboxPriority[]) {
-    groups[k].sort((a, b) => (b.starred ? 1 : 0) - (a.starred ? 1 : 0) || b.createdAt - a.createdAt);
-  }
-
-  const sections = (['high', 'medium', 'low'] as InboxPriority[])
-    .filter((p) => groups[p].length > 0)
-    .map((p) => renderGroup(p, groups[p]));
-
-  return html`<div class="inbox-list">${sections as unknown as SafeHtml[]}</div>`;
-}
-
-function renderGroup(priority: InboxPriority, rows: InboxMessage[]): SafeHtml {
-  // Group header uses the same priority dot as the rows, so the
-  // color cue is shared between the group label and each row's
-  // priority indicator — single design language.
+  // Flat sortable list. The priority-group cards are gone — the
+  // priority dot on each row + the (sorted) order carry the
+  // urgency cue without the structural overhead.
   return html`
-    <section class="inbox-list__group" data-priority="${priority}">
-      <header class="inbox-list__group-head">
-        <span class="inbox-modal__priority inbox-modal__priority--${priority}"></span>
-        <span class="inbox-list__group-label">${PRIORITY_LABEL[priority]}</span>
-        <span class="inbox-list__group-count">${rows.length}</span>
-      </header>
-      ${rows.map((m) => renderRow(m)) as unknown as SafeHtml[]}
-    </section>
+    <div class="inbox-list" role="table">
+      ${renderListHeader(sort, dir, filter)}
+      ${rows.map((m) => renderRow(m, previewPayloads.get(m.id))) as unknown as SafeHtml[]}
+    </div>
   `;
 }
 
-function renderRow(m: InboxMessage): SafeHtml {
+/**
+ * Sticky column header for the flat list. Each column is a sort link
+ * that flips direction on click; the active column shows an arrow
+ * indicator. The grid template mirrors the row's so the labels sit
+ * directly above their cells.
+ *
+ * The chevron and star columns get no label (they're per-row
+ * affordances, not data dimensions).
+ */
+function renderListHeader(sort: InboxSortKey, dir: InboxSortDir, filter: { q: string; starred: boolean; tag: string }): SafeHtml {
+  const link = (key: InboxSortKey, label: string, defaultDir: InboxSortDir = 'desc'): SafeHtml => {
+    const isActive = sort === key;
+    // Active column: click flips direction. Inactive: jump to the
+    // column's natural direction (desc for priority/age/status,
+    // asc for title/agent so the alphabetical sort feels intuitive).
+    const nextDir: InboxSortDir = isActive ? (dir === 'desc' ? 'asc' : 'desc') : defaultDir;
+    const params = new URLSearchParams();
+    params.set('sort', key);
+    params.set('dir', nextDir);
+    if (filter.q) params.set('q', filter.q);
+    if (filter.starred) params.set('starred', '1');
+    if (filter.tag) params.set('tag', filter.tag);
+    const href = `/inbox?${params.toString()}`;
+    const arrow = isActive
+      ? (dir === 'desc' ? html`<span class="inbox-list__sort-arrow" aria-hidden="true">↓</span>` : html`<span class="inbox-list__sort-arrow" aria-hidden="true">↑</span>`)
+      : html``;
+    return html`<a class="inbox-list__sort ${isActive ? 'inbox-list__sort--active' : ''}" href="${href}" data-inbox-row-stop>${label}${arrow}</a>`;
+  };
+  return html`
+    <div class="inbox-list__header" role="row">
+      <span></span>
+      <span role="columnheader">${link('priority', 'Priority', 'asc')}</span>
+      <span role="columnheader" class="inbox-list__header-title">${link('title', 'Title', 'asc')}</span>
+      <span role="columnheader">${link('agent', 'Agent', 'asc')}</span>
+      <span role="columnheader">${link('status', 'Status', 'asc')}</span>
+      <span role="columnheader">${link('age', 'Age', 'desc')}</span>
+      <span></span>
+      <span></span>
+    </div>
+  `;
+}
+
+/**
+ * One row in the flat list.
+ *
+ * Left side: priority dot + title (+ inline tag chips).
+ * Right side: agent · status · age · star · chevron.
+ *
+ * Operators read content on the left and act on the right — the
+ * star and chevron sit next to the metadata that informs their
+ * decisions. Removed the "—" placeholder for missing agents: empty
+ * space reads as "no agent" without adding ink.
+ *
+ * The expanded preview replaces the old body-only excerpt with an
+ * activity strip that shows the most recent triage/user/system
+ * reply + a pending-actions summary. See renderPreview.
+ */
+function renderRow(m: InboxMessage, preview: InboxRowPreviewPayload | undefined): SafeHtml {
   const tagChips = m.tags.length === 0
     ? html``
     : html`<span class="inbox-row2__tags">${m.tags.map((t) => html`<span class="inbox-tag-chip">${t}</span>`) as unknown as SafeHtml[]}</span>`;
-  // Agent + run link rendered inline like the modal's meta row:
-  // `agent-id · run abc12345`. Both links share the .inbox-modal__link
-  // styling so hover/focus behavior is identical.
+  // Agent + run link, rendered only when present. Mono is reserved
+  // for ids; the cell is empty (zero-width) when no agent.
   const agentRunCell = (m.agentId || m.runId)
     ? html`
       <span class="inbox-row2__agent">
@@ -412,43 +500,132 @@ function renderRow(m: InboxMessage): SafeHtml {
         ${m.runId ? html`<a href="/runs/${m.runId}" class="inbox-modal__link mono" data-inbox-row-stop>${m.runId.slice(0, 8)}</a>` : html``}
       </span>
     `
-    : html`<span class="inbox-row2__agent dim">—</span>`;
+    : html`<span class="inbox-row2__agent" aria-hidden="true"></span>`;
+  // Age cell uses lastActivityAt when present; falls back to
+  // createdAt for rows where the store didn't compute the join
+  // (e.g. single-message reads). The hover title shows both so the
+  // operator can disambiguate "old thread, recently bumped" vs
+  // "old thread, untouched."
+  const ageAt = m.lastActivityAt ?? m.createdAt;
+  const ageTitle = m.lastActivityAt && m.lastActivityAt !== m.createdAt
+    ? `created ${formatAge(new Date(m.createdAt).toISOString())} · last activity ${formatAge(new Date(m.lastActivityAt).toISOString())}`
+    : `created ${formatAge(new Date(m.createdAt).toISOString())}`;
   return html`
-    <div class="inbox-row2" data-inbox-row-id="${m.id}" id="row-${m.id}">
-      <button type="button" class="inbox-row2__chevron" data-inbox-row-chevron
-        aria-label="Toggle preview" aria-expanded="false">›</button>
+    <div class="inbox-row2" data-inbox-row-id="${m.id}" id="row-${m.id}" role="row" data-inbox-status="${m.status}">
+      <span class="inbox-modal__priority inbox-modal__priority--${m.priority}" title="${m.priority} priority"></span>
+      <span class="inbox-row2__title" role="cell">
+        <a href="/inbox/${m.id}" data-inbox-row-link class="inbox-row2__title-text">${m.title}</a>
+        ${tagChips}
+      </span>
+      ${agentRunCell}
+      <span class="inbox-row2__status" role="cell">
+        <span class="badge ${STATUS_BADGE[m.status]}">${STATUS_LABEL[m.status]}</span>
+      </span>
+      <span class="inbox-row2__age dim" role="cell" title="${ageTitle}">${formatAge(new Date(ageAt).toISOString())}</span>
       <form method="POST" action="/inbox/${m.id}/star" data-inbox-row-stop data-inbox-star-form style="margin: 0;">
         <input type="hidden" name="starred" value="${m.starred ? '0' : '1'}">
         <button type="submit" class="inbox-star ${m.starred ? 'inbox-star--on' : ''}" aria-label="${m.starred ? 'Unstar' : 'Star'}">★</button>
       </form>
-      <span class="inbox-modal__priority inbox-modal__priority--${m.priority}" title="${m.priority} priority"></span>
-      ${agentRunCell}
-      <span class="inbox-row2__title">
-        <a href="/inbox/${m.id}" data-inbox-row-link class="inbox-row2__title-text">${m.title}</a>
-        ${tagChips}
-      </span>
-      <span class="inbox-row2__signal" data-inbox-status="${m.status}">
-        <span class="badge ${STATUS_BADGE[m.status]}">${STATUS_LABEL[m.status]}</span>
-        <span class="inbox-row2__age dim">${formatAge(new Date(m.createdAt).toISOString())}</span>
-      </span>
+      <button type="button" class="inbox-row2__chevron" data-inbox-row-chevron
+        aria-label="Toggle preview" aria-expanded="false">›</button>
 
-      <div class="inbox-row2__preview" data-inbox-row-preview>
-        <div class="inbox-row2__preview-body">${m.body}</div>
-        ${m.contextJson ? html`
-          <details>
-            <summary style="cursor: pointer; font-size: var(--font-size-xs); color: var(--color-text-muted);">Context payload</summary>
-            <pre class="mono" style="font-size: var(--font-size-xs); margin: var(--space-2) 0 0; overflow-x: auto; max-height: 10rem;">${tryPretty(m.contextJson)}</pre>
-          </details>
-        ` : html``}
-        <div class="inbox-row2__preview-actions">
-          <a href="/inbox/${m.id}" class="btn btn--sm btn--primary" data-inbox-row-link>Open thread</a>
-          <span class="dim" style="font-size: var(--font-size-xs); align-self: center;">
-            ${SOURCE_LABEL[m.source]}
-          </span>
+      ${renderPreview(m, preview)}
+    </div>
+  `;
+}
+
+/**
+ * Expanded preview — the "activity strip." Replaces the old
+ * body-only excerpt with the actual conversation signal:
+ *
+ *   1. Latest non-action response (triage / user / system) with
+ *      avatar + role + first ~160 chars.
+ *   2. Pending-actions summary when triage has proposed something.
+ *   3. Context payload disclosure (only when present).
+ *   4. Tag chips moved here from the collapsed row.
+ *   5. Right-aligned footer: Open thread → · Source · age.
+ *
+ * Empty cases:
+ *   - Manual conversation with no replies → italic "No replies yet"
+ *     hint + Open thread CTA. The "(empty)" body sentinel from the
+ *     store's NOT NULL workaround is suppressed (mirrors the modal
+ *     fragment renderer in inbox-detail.ts).
+ *   - Body that isn't "(empty)" but no responses → fall back to the
+ *     legacy body excerpt so producers that seed real body text
+ *     still get a useful preview.
+ */
+function renderPreview(m: InboxMessage, preview: InboxRowPreviewPayload | undefined): SafeHtml {
+  const latest = preview?.latestResponse;
+  const proposed = preview?.proposedActions;
+  const trimmedBody = m.body.trim();
+  const hasMeaningfulBody = trimmedBody.length > 0 && trimmedBody !== '(empty)';
+
+  const activityBlock = latest
+    ? html`
+      <div class="inbox-row2__activity">
+        <span class="inbox-msg__avatar inbox-msg__avatar--${latest.role}">${PREVIEW_ROLE_AVATAR[latest.role] ?? latest.role.slice(0, 3)}</span>
+        <div class="inbox-row2__activity-body">
+          <div class="inbox-row2__activity-meta">
+            <span class="inbox-row2__activity-role">${PREVIEW_ROLE_LABEL[latest.role] ?? latest.role}</span>
+            <span class="dim">${formatAge(new Date(latest.createdAt).toISOString())}</span>
+          </div>
+          <div class="inbox-row2__activity-excerpt">${excerpt(latest.body, PREVIEW_EXCERPT_CAP)}</div>
         </div>
+      </div>
+    `
+    : hasMeaningfulBody
+      ? html`<div class="inbox-row2__body-excerpt">${excerpt(m.body, PREVIEW_EXCERPT_CAP * 2)}</div>`
+      : html`<div class="inbox-row2__no-activity dim">No replies yet. Open the thread to start the conversation.</div>`;
+
+  const actionsBlock = proposed && proposed.count > 0
+    ? html`
+      <div class="inbox-row2__action-summary">
+        <span class="inbox-row2__action-summary-icon" aria-hidden="true">▸</span>
+        ${proposed.count} proposed action${proposed.count === 1 ? '' : 's'}${proposed.firstAgentId ? html`: <span class="mono">${proposed.firstAgentId}</span>` : html``}
+      </div>
+    `
+    : html``;
+
+  const contextBlock = m.contextJson
+    ? html`
+      <details class="inbox-row2__context">
+        <summary>Context payload</summary>
+        <pre class="mono">${tryPretty(m.contextJson)}</pre>
+      </details>
+    `
+    : html``;
+
+  const tagsBlock = m.tags.length > 0
+    ? html`
+      <div class="inbox-row2__preview-tags">
+        ${m.tags.map((t) => html`<span class="inbox-tag-chip">${t}</span>`) as unknown as SafeHtml[]}
+      </div>
+    `
+    : html``;
+
+  return html`
+    <div class="inbox-row2__preview" data-inbox-row-preview>
+      ${activityBlock}
+      ${actionsBlock}
+      ${contextBlock}
+      <div class="inbox-row2__preview-footer">
+        ${tagsBlock}
+        <span class="inbox-row2__preview-footer-spacer"></span>
+        <a href="/inbox/${m.id}" class="btn btn--sm btn--primary" data-inbox-row-link>Open thread →</a>
+        <span class="dim inbox-row2__preview-source">${SOURCE_LABEL[m.source]}</span>
       </div>
     </div>
   `;
+}
+
+/** Truncate to N chars at a word boundary; appends ellipsis when cut. */
+function excerpt(raw: string, cap: number): string {
+  const s = raw.trim();
+  if (s.length <= cap) return s;
+  const cut = s.slice(0, cap);
+  const lastSpace = cut.lastIndexOf(' ');
+  const trimmed = lastSpace > cap * 0.6 ? cut.slice(0, lastSpace) : cut;
+  return trimmed + '…';
 }
 
 function tryPretty(raw: string): string {


### PR DESCRIPTION
## Summary

**Queue UX pass, PR 2 of 2** (PR 1 was #407 — store-layer sort + last-activity). Replaces the priority-segmented layout with one flat list under a sticky sortable column header, reorders the row so star + chevron sit on the right next to the metadata they modify, and rebuilds the expanded preview as an activity strip showing the actual conversation signal.

Plan at \`~/.claude/plans/shimmering-sprouting-brooks.md\`.

## Changes

### Flat list

Drops \`renderGroup\` and the priority-group cards. The priority dot stays on each row — that's the urgency cue at a glance. The (sorted) row order carries the rest.

### Sticky sortable header

Five column links — **Priority · Title · Agent · Status · Age** — each render as a sort link that flips direction on click. The active column shows a \`↑\` / \`↓\` arrow; inactive columns are clickable but show no arrow. URL drives the sort state (\`?sort=X&dir=Y\`); active filters (\`q\` / \`starred\` / \`tag\`) are preserved through clicks. The chevron + star columns get no label.

### Row reorder per operator feedback

> *"the grid row left side doesn't make sense - think it should be right side."*

Star and chevron move to the right. New grid template (\`12px 1fr auto auto auto 24px 24px\`):

| Left | Right |
|---|---|
| priority dot · title (+ inline tags) | agent · status · age · star · chevron |

Drops the \`—\` placeholder for missing agents — empty space reads as "no agent" without adding ink. The left-edge amber accent for \`awaiting_user\` stays.

### Activity-strip preview

Replaces the body-only excerpt with:

1. **Latest non-action response** (triage / user / system) with avatar + role + first ~160 chars (word-boundary truncation).
2. **Pending-actions summary chip** when triage proposed actions: \`▸ 1 proposed action: agent-catalog-search\`.
3. **Context payload disclosure** (only when present).
4. **Tag chips** move from the title cell into the preview.
5. **Right-aligned footer**: \`Open thread →\` · Source label.

Empty cases:

- Manual conversation with no replies → italic *"No replies yet. Open the thread to start the conversation."* + \`Open thread →\` CTA. The \`(empty)\` body sentinel from the store's NOT NULL workaround is suppressed (mirrors the modal's filter at [inbox-detail.ts:135](packages/dashboard/src/views/inbox-detail.ts#L135)).
- Rows with no responses but a real body fall back to a body excerpt (~320 chars).

### Route preview payload

\`GET /inbox\` computes per-row \`{latestResponse, proposedActions}\` in one pass per row via \`listResponses(m.id)\` — cheap at the default ≤200 row page size. Walks responses from newest to oldest with an early exit once both signals are captured.

### Mobile fallback

At <720px the priority + agent columns collapse on both the row and the sticky header. The chevron and star stay on the right so operators can still triage on phones.

## Test plan

- [x] \`npm run build\` clean.
- [x] \`npx vitest run\` — **1873 pass / 3 skipped** (no behavior tests added — pure markup + ordering).
- [x] **Live dogfood** with \`SUA_INBOX_DEMO=1\`:
  - Flat list renders without priority-group cards.
  - Sticky header shows all 5 sort links; default active is **PRIORITY ↑**.
  - Click chevron → activity strip renders: \`SYS · System · 1h ago · "Skipped 1 additional proposed action..."\` + \`▸ 1 proposed action: agent-catalog-search\` chip + \`Open thread → · Manual\` footer.
  - Navigate to \`?sort=age&dir=desc\` → header flips to **AGE ↓** as the active column; other columns calm; rows reorder by activity desc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)