### PR TITLE
fix(dashboard): escape backslashes inside INBOX_MODAL_JS template literal

### DIFF
--- a/.changeset/inbox-modal-template-literal-escapes.md
+++ b/.changeset/inbox-modal-template-literal-escapes.md
@@ -1,0 +1,23 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+fix(dashboard): escape backslashes inside INBOX_MODAL_JS template literal
+
+PR #409's `extractRecommendationFromStream` used un-doubled backslash escapes
+(`'\\'`, `'\n'`, `\s`) inside the `INBOX_MODAL_JS` backtick template literal.
+Template processing collapsed each `\\` → `\` at module-load time, producing
+invalid served JavaScript: `'\'` was an unterminated string and `'\n'`/`'\t'`/
+`'\r'` placed literal control characters inside single-quoted strings. The
+browser threw a parse error during the inline IIFE, so every click delegate
+in the inbox modal layer silently failed to attach — chevron toggle, row →
+modal click, rail collapse, suggest banner, copy button, new conversation,
+modal close.
+
+Doubled the backslashes in source so they survive template processing and
+produce valid JS in the served output. No behavior change to the parser
+itself.

--- a/packages/dashboard/src/views/inbox-modal.js.ts
+++ b/packages/dashboard/src/views/inbox-modal.js.ts
@@ -296,19 +296,19 @@ export const INBOX_MODAL_JS = `
    * The caller falls back to raw text in that case.
    */
   function extractRecommendationFromStream(buffer) {
-    var startMatch = buffer.match(/"recommendation"\s*:\s*"/);
+    var startMatch = buffer.match(/"recommendation"\\s*:\\s*"/);
     if (!startMatch) return null;
     var i = startMatch.index + startMatch[0].length;
     var out = '';
     while (i < buffer.length) {
       var c = buffer.charCodeAt(i);
-      if (c === 92 /* \\ */ && i + 1 < buffer.length) {
+      if (c === 92 && i + 1 < buffer.length) {
         var nextCh = buffer[i + 1];
-        if (nextCh === 'n') out += '\n';
-        else if (nextCh === 't') out += '\t';
-        else if (nextCh === 'r') out += '\r';
+        if (nextCh === 'n') out += '\\n';
+        else if (nextCh === 't') out += '\\t';
+        else if (nextCh === 'r') out += '\\r';
         else if (nextCh === '"') out += '"';
-        else if (nextCh === '\\') out += '\\';
+        else if (nextCh === '\\\\') out += '\\\\';
         else if (nextCh === '/') out += '/';
         else if (nextCh === 'u' && i + 5 < buffer.length) {
           var hex = buffer.slice(i + 2, i + 6);
@@ -322,7 +322,7 @@ export const INBOX_MODAL_JS = `
           out += nextCh;
         }
         i += 2;
-      } else if (c === 34 /* " */) {
+      } else if (c === 34 /* dquote */) {
         // Closing quote — recommendation field is complete.
         break;
       } else {


### PR DESCRIPTION
## Summary
- PR #409's `extractRecommendationFromStream` parser landed with un-doubled backslash escapes (`'\\'`, `'\n'`, `'\t'`, `'\r'`, regex `\s`) **inside the `INBOX_MODAL_JS` backtick template literal**. Template processing collapsed every `\\` to a single `\` at module-load time, producing invalid served JavaScript: `'\'` was an unterminated string and `'\n'`/`'\t'`/`'\r'` embedded literal control chars inside single-quoted strings.
- The browser threw a parse error during the inline IIFE, so **every click delegate in the inbox modal layer silently failed to attach** — chevron toggle, row→modal click, rail collapse, suggest banner, copy button, new-conversation, modal close. The inbox queue looked fine but was completely inert.
- Fix doubles every backslash that needs to survive template-literal processing: `\\s` → `\\\\s`, `'\n'` → `'\\n'`, `'\\'` → `'\\\\'`, etc. Confirmed served JS now contains valid `/\s/`, `'\n'`, `'\t'`, `'\r'`, `'\\'`.

## Repro before fix
- Open `/inbox` with at least one row.
- Click the chevron → row does not expand. Click row title → modal does not open, link does not navigate (`preventDefault` is the only thing that fires, then `openFor` never runs because the click delegate never attached).
- DevTools shows `Uncaught SyntaxError` from the inline `<script>` somewhere inside `extractRecommendationFromStream`.

## Test plan
- [x] `curl /inbox | sed -n '/extractRecommendationFromStream/,/return out/p'` shows valid escape sequences.
- [x] Live browser: chevron click expands the row; title link click opens the modal in-place; rail collapse toggle works.
- [x] `npx vitest run packages/dashboard` — 472 passed.
- [ ] Triage reply still strips the `<plan>` envelope from the streaming bubble (PR #409's behavior) — verify post-merge with a real triage send.

## Note on regression coverage
The IIFE was only callable in a real browser, so this slipped past Node-side tests. Worth adding a follow-up regression guard that does `new Function(INBOX_MODAL_JS)()` (or `vm.Script(INBOX_MODAL_JS)`) in a test to catch future template-literal escaping bugs at unit-test time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)