### PR TITLE
feat(dashboard): auto-approve trusted sub-agent chain from triage

### DIFF
--- a/.changeset/inbox-auto-approve-trusted-chain.md
+++ b/.changeset/inbox-auto-approve-trusted-chain.md
@@ -1,0 +1,25 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+feat(dashboard): auto-approve trusted sub-agent chain from triage
+
+When triage proposes an action against a known-safe system agent
+(`agent-analyzer`, `agent-editor`, `agent-catalog-search`), the action
+card now transitions straight from `proposed` to `running` without
+waiting for an operator click. Anything outside this set still requires
+manual Run.
+
+The transition uses the same atomic `transitionActionStatus` pattern as
+the manual /run route, so a concurrent operator click no-ops idempotently.
+The Layer 1 commitment chip stays pulsing through the run; on completion,
+the existing `runProposedAction` path publishes the terminal
+`action:status` event exactly as it would after a manual click.
+
+Layer 2 of the triage follow-through plan
+(`~/.claude/plans/triage-follow-through.md`). Layer 3 (sub-agent
+completion re-invokes triage for a wrap-up turn) ships next.

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -73,6 +73,27 @@ const TRIAGE_SUB_AGENT_ALLOWLIST: readonly string[] = [
 ];
 
 /**
+ * Agents whose proposed-action cards are auto-approved when triage
+ * emits them — they kick straight to `running` without waiting for an
+ * operator click. The set is the proven safe chain: analyzer (read-only
+ * diagnosis), editor (writes only the YAML diff already shown in the
+ * card), catalog-search (read-only catalog probe). Anything outside
+ * this set still requires manual Run.
+ *
+ * Operator can still skip an in-flight action via the standard
+ * action-card controls, and the chevron/dismiss flows are unaffected.
+ *
+ * v1 keeps this hardcoded. A future PR can move it to a per-thread or
+ * global override (`data/.sua/inbox-settings.json`) once a non-trivial
+ * subset of operators want different defaults.
+ */
+const TRIAGE_AUTO_APPROVE_AGENTS: ReadonlySet<string> = new Set([
+  'agent-analyzer',
+  'agent-editor',
+  'agent-catalog-search',
+]);
+
+/**
  * Agent ids that are themselves part of the inbox-triage scaffolding —
  * they exist to make triage work, not as candidates to recommend back
  * to the operator. `agent-catalog-search` filters these out of its
@@ -1459,6 +1480,34 @@ async function runTriageAgent(
           inputs: action.inputs,
           createdAt: actionResp.createdAt,
         });
+        // Auto-approve trusted system agents. The proposed -> running
+        // transition is atomic via transitionActionStatus, so a
+        // concurrent operator click on /run no-ops idempotently. The
+        // chip Layer 1 added stays pulsing through the run; on
+        // completion runProposedAction publishes the terminal
+        // action:status event and (when all actions resolve) fires
+        // the follow-up triage turn.
+        if (TRIAGE_AUTO_APPROVE_AGENTS.has(action.agentId)) {
+          const startedAt = Date.now();
+          const runningMeta: InboxActionMeta = { ...action, status: 'running', startedAt };
+          const claimed = ctx.inboxStore.transitionActionStatus(
+            actionResp.id,
+            'proposed',
+            JSON.stringify(runningMeta),
+          );
+          if (claimed) {
+            publishInboxEvent(ctx, messageId, 'action:status', {
+              responseId: actionResp.id,
+              status: 'running',
+              agentId: action.agentId,
+              startedAt,
+            });
+            const claimedResponse = ctx.inboxStore.getResponse(actionResp.id) ?? actionResp;
+            void runProposedAction(ctx, messageId, claimedResponse, runningMeta).catch((err) => {
+              process.stderr.write(`[inbox-triage] auto-approved action ${actionResp.id} crashed: ${(err as Error)?.message ?? err}\n`);
+            });
+          }
+        }
       }
       const notes: string[] = [];
       for (const r of rejected) {


### PR DESCRIPTION
## Summary

**Layer 2 of the triage follow-through plan** (`~/.claude/plans/triage-follow-through.md`). When triage proposes an action against a known-safe system agent, the card now goes straight from `proposed` to `running` instead of sitting there waiting for an operator click. The operator's job becomes review, not approval-clicking.

The auto-approve set is `{agent-analyzer, agent-editor, agent-catalog-search}` — the proven chain. Anything outside (future user agents, anything the operator hasn't validated) still requires manual Run.

## Why
Layer 1 shipped the commitment chip and the prompt rule that says "no prose-only promises." But triage's promises were still landing as `proposed` action cards that sat there until the operator clicked Run. The chip would pulse forever and the operator had to do the same click work as before — the loop wasn't actually closed.

Auto-approve closes it for the safe chain: the analyzer / editor / catalog-search proposals fire immediately, the chip pulses while they run, and the existing `runProposedAction` path publishes the terminal `action:status` event exactly as it would after a manual click.

## Implementation
- New `TRIAGE_AUTO_APPROVE_AGENTS` const set, hardcoded for v1. (A future PR can move it to `data/.sua/inbox-settings.json` once operators want different defaults — not needed yet.)
- After persisting each accepted action in `runTriageAgent`, if its `agentId` is in the auto-approve set:
  1. Build a `running`-state meta and atomically transition via `transitionActionStatus(actionResp.id, 'proposed', ...)`.
  2. Publish `action:status` with `status='running'`.
  3. Fire-and-forget `runProposedAction(...)`.
- A concurrent operator click on the manual `/run` route hits the same atomic transition and no-ops idempotently — no double-fires possible.

## Test plan
- [x] `npm run build` clean
- [x] `npx vitest run packages/dashboard` — 472 passed
- [ ] Live: post a triage reply that proposes `agent-catalog-search`. Card should appear and immediately flip to "Running"; chip should pulse; on completion both should settle.

## Carry-forward
- Layer 3 (sub-agent completion re-invokes triage for a wrap-up turn) is the one that ends the "did you finish?" turn entirely. It uses the same `runProposedAction` completion path this PR exercises, so the test infrastructure I'd add here is better added when Layer 3 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)