### PR TITLE
feat(dashboard): cap consecutive auto-triage turns at 5

### DIFF
--- a/.changeset/inbox-triage-turn-budget.md
+++ b/.changeset/inbox-triage-turn-budget.md
@@ -1,0 +1,33 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+feat(dashboard): cap consecutive auto-triage turns at 5
+
+Closes the runaway-loop risk Layer 2 introduced. The existing
+`maybeRefireTriage` (which already re-invokes triage after each
+sub-agent action resolves) now counts consecutive `triage` responses
+since the most recent `user` reply. When that count hits 5, instead of
+firing another triage turn we post a system note ("Auto-follow-up
+paused after 5 consecutive triage turns. Reply or dismiss to continue."),
+flip the thread to `awaiting_user`, and stop. The operator's next
+reply resets the counter so fresh user input always gets a fresh
+budget.
+
+Layer 3 of the triage follow-through plan
+(`~/.claude/plans/triage-follow-through.md`). The other half of Layer 3
+— passing sub-agent results to the follow-up triage turn — was already
+in place: `runTriageAgent`'s CONVERSATION snapshot includes each action's
+status and `resultSummary` (lines 1319-1328), so triage already sees
+what came back without any new input plumbing.
+
+Closes the "did you finish?" pain end-to-end:
+- Layer 1 (#411) — triage emits structured commitments; chip surfaces
+  pending work in the modal header.
+- Layer 2 (#412) — trusted sub-agent proposals auto-approve to running.
+- Layer 3 (this) — sub-agent completion re-invokes triage to summarize,
+  capped at 5 turns to prevent runaways.

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -1075,15 +1075,74 @@ async function runProposedAction(
   maybeRefireTriage(ctx, messageId);
 }
 
+/**
+ * Maximum number of consecutive auto-fired triage turns between
+ * operator interventions. Each completed sub-agent action triggers a
+ * triage refire (so triage can summarize what came back); if triage
+ * then proposes another auto-approved action that completes, that's
+ * another refire, etc. The cap prevents a runaway loop when triage
+ * keeps proposing actions on its own. Reset when the operator posts
+ * a user response.
+ *
+ * 5 is a comfortable headroom for analyzer → editor → catalog-search
+ * chains while still catching pathological loops within a few turns.
+ */
+const MAX_AUTO_TRIAGE_TURNS = 5;
+
+/**
+ * Count the number of `triage` responses since the most recent `user`
+ * response (or message creation if no user reply yet). Drives the
+ * auto-refire cap — the operator hitting Reply resets the counter so
+ * fresh user input always gets a fresh budget.
+ */
+function countConsecutiveTriageTurns(
+  ctx: ReturnType<typeof getContext>,
+  messageId: string,
+): number {
+  if (!ctx.inboxStore) return 0;
+  const responses = ctx.inboxStore.listResponses(messageId);
+  let count = 0;
+  for (let i = responses.length - 1; i >= 0; i -= 1) {
+    const r = responses[i];
+    if (r.role === 'user') break;
+    if (r.role === 'triage') count += 1;
+  }
+  return count;
+}
+
 /** Hoisted from the end of `runProposedAction` so route-handled and
- *  DAG-dispatched paths share the same re-fire trigger. */
+ *  DAG-dispatched paths share the same re-fire trigger.
+ *
+ *  Layer 3 of the triage follow-through plan: when a sub-agent action
+ *  completes and resolves all outstanding actions on the thread,
+ *  re-invoke triage so it can summarize the result and either propose
+ *  the next step, mark `awaiting_user`, or mark resolved. The
+ *  CONVERSATION snapshot already includes each action's status +
+ *  resultSummary, so triage sees what came back without any new
+ *  input plumbing.
+ *
+ *  The cap (MAX_AUTO_TRIAGE_TURNS) prevents runaway loops. When hit,
+ *  we post a system note + mark the thread awaiting_user so the
+ *  operator can decide whether to continue. */
 function maybeRefireTriage(
   ctx: ReturnType<typeof getContext>,
   messageId: string,
 ): void {
-  if (allActionsResolved(ctx, messageId) && atLeastOneActionExecuted(ctx, messageId)) {
-    void runTriageAgent(ctx, messageId).catch(() => { /* swallow */ });
+  if (!ctx.inboxStore) return;
+  if (!(allActionsResolved(ctx, messageId) && atLeastOneActionExecuted(ctx, messageId))) return;
+  if (countConsecutiveTriageTurns(ctx, messageId) >= MAX_AUTO_TRIAGE_TURNS) {
+    const note = `Auto-follow-up paused after ${MAX_AUTO_TRIAGE_TURNS} consecutive triage turns. Reply or dismiss to continue.`;
+    const sysReply = ctx.inboxStore.addResponse(messageId, 'system', note);
+    publishInboxEvent(ctx, messageId, 'message:created', {
+      responseId: sysReply.id, role: 'system', body: sysReply.body, createdAt: sysReply.createdAt,
+    });
+    try {
+      ctx.inboxStore.updateStatus(messageId, 'awaiting_user');
+    } catch { /* ignore */ }
+    publishInboxEvent(ctx, messageId, 'state', { phase: 'done', since: Date.now() });
+    return;
   }
+  void runTriageAgent(ctx, messageId).catch(() => { /* swallow */ });
 }
 
 /**


### PR DESCRIPTION
## Summary

**Layer 3 of the triage follow-through plan** (`~/.claude/plans/triage-follow-through.md`). Closes the runaway-loop risk Layer 2 introduced. With auto-approve now firing trusted actions immediately, a triage turn could in principle propose another auto-approve action, complete, refire triage, propose again, ad infinitum. This PR adds the cap.

## What was already in place
`maybeRefireTriage` (line ~1080 of `routes/inbox.ts`) already re-invokes triage when all actions resolve, and `runTriageAgent`'s CONVERSATION snapshot (lines 1319-1328) already includes each action's `status` and `resultSummary`. So the "sub-agent completion → triage summarizes" loop was wired before this PR — there was just no brake on it.

## What this PR adds
- New `MAX_AUTO_TRIAGE_TURNS = 5` const.
- New `countConsecutiveTriageTurns(ctx, messageId)` helper: walks responses newest-first, stops at the first `user` response, counts intervening `triage` responses. The operator's reply resets the counter so fresh user input always gets a fresh budget.
- `maybeRefireTriage` checks the count before refiring. When the cap hits, instead of another triage turn we post a system note ("Auto-follow-up paused after 5 consecutive triage turns. Reply or dismiss to continue."), flip the thread to `awaiting_user`, and stop.

## Closes the "did you finish?" pain end-to-end
- Layer 1 (#411) — triage emits structured commitments; chip surfaces pending work in the modal header.
- Layer 2 (#412) — trusted sub-agent proposals auto-approve to running.
- **Layer 3 (this)** — sub-agent completion re-invokes triage to summarize, capped at 5 turns to prevent runaways.

## Test plan
- [x] `npm run build` clean
- [x] `npx vitest run packages/dashboard` — 472 passed (one initial flake was the unrelated `secrets-session` race; clean on re-run).
- [ ] Live verification of the chained loop: a triage reply that proposes `agent-catalog-search` should auto-fire, complete, and trigger a follow-up triage turn that summarizes the search results. Beyond 5 chained turns we should see the auto-pause note.

## Carry-forward
- **Layer 4 (clock for genuinely external waits)** is deferred per the plan — most waits that aren't sub-agent runs are rare enough that they don't need automated infrastructure yet.
- Cap value (5) is currently a const; a future PR can make it per-thread or operator-configurable if real usage shows 5 is too tight (or too loose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)