### PR TITLE
feat(inbox): auto-rename manual threads from first reply + fix Add tile leave-site prompt

### DIFF
--- a/.changeset/inbox-title-from-first-reply-and-add-tile-beforeunload.md
+++ b/.changeset/inbox-title-from-first-reply-and-add-tile-beforeunload.md
@@ -1,0 +1,24 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+feat(inbox): auto-rename "New conversation" threads from first reply
+
+When the operator posts the first reply on a manual-source thread that
+still carries the default `"New conversation"` title, the route now
+replaces the title with a single-line, ellipsized version of the body
+(up to 60 chars). Threads created with an explicit title are
+preserved; subsequent replies never re-rename; non-manual sources are
+untouched.
+
+fix(dashboard): Add tile click no longer triggers Chrome "Leave site?"
+guard. The agent-card click handler in `add-tile-modal.js.ts` called
+`form.submit()` directly, which bypasses the form's `submit` event —
+so `widget-layout.js`'s edit-mode beforeunload guard never got a
+chance to clear `intentionalNav` and Chrome's generic dialog stacked
+on top of the legit POST. Switched to `form.requestSubmit()` (same
+fix pattern as the inbox Cmd/Ctrl+Enter handler).

--- a/packages/core/src/inbox-store.ts
+++ b/packages/core/src/inbox-store.ts
@@ -552,6 +552,21 @@ export class InboxStore {
   }
 
   /**
+   * Rename a message. Used by the dashboard to replace the default
+   * "New conversation" placeholder with a title derived from the
+   * operator's first reply. Title is required (the column is NOT
+   * NULL); caller is responsible for truncating to the operator-
+   * friendly limit (~60 chars).
+   */
+  updateTitle(id: string, title: string): void {
+    if (!title) throw new Error('InboxStore.updateTitle: title is required');
+    const result = this.db.prepare(
+      'UPDATE inbox_messages SET title = ? WHERE id = ?',
+    ).run(title, id);
+    if (result.changes === 0) throw new Error(`InboxStore.updateTitle: no message with id "${id}"`);
+  }
+
+  /**
    * Append a conversation entry to a message. Roles:
    *   `user`   — operator reply via the dashboard or CLI
    *   `triage` — triage agent recommendation / follow-up

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -258,6 +258,49 @@ describe('POST /inbox/:id/respond', () => {
     expect(big.status).toBe(400);
     expect(inboxStore.listResponses(m.id)).toEqual([]);
   });
+
+  it('first reply on a default-titled manual thread renames the title from the body', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 'New conversation', body: '(empty)' });
+    await request(app)
+      .post(`/inbox/${m.id}/respond`).type('form').send({ body: 'Help me build a trivia agent that asks questions and tracks scores' })
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    const after = inboxStore.get(m.id)!;
+    expect(after.title).toBe('Help me build a trivia agent that asks questions and tracks…');
+    expect(after.title.length).toBeLessThanOrEqual(60);
+  });
+
+  it('first reply preserves an operator-set title', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 'Trivia agent design', body: '(empty)' });
+    await request(app)
+      .post(`/inbox/${m.id}/respond`).type('form').send({ body: 'whatever' })
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(inboxStore.get(m.id)!.title).toBe('Trivia agent design');
+  });
+
+  it('second reply does not overwrite a previously-derived title', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 'New conversation', body: '(empty)' });
+    await request(app)
+      .post(`/inbox/${m.id}/respond`).type('form').send({ body: 'first reply' })
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    const afterFirst = inboxStore.get(m.id)!.title;
+    expect(afterFirst).toBe('first reply');
+    await request(app)
+      .post(`/inbox/${m.id}/respond`).type('form').send({ body: 'second reply with very different words' })
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(inboxStore.get(m.id)!.title).toBe('first reply');
+  });
+
+  it('does not rename non-manual sources even when they happen to use the default title', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'run-failure', title: 'New conversation', body: 'b' });
+    await request(app)
+      .post(`/inbox/${m.id}/respond`).type('form').send({ body: 'investigating' })
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(inboxStore.get(m.id)!.title).toBe('New conversation');
+  });
 });
 
 describe('GET /inbox with filters', () => {

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -66,6 +66,34 @@ const PENDING_USER_REPLY_WINDOW_MS = 30_000;
  * LAST_RUN_OUTPUT, mirroring the analyze route at
  * `run-now-build.ts:415`.
  */
+/**
+ * Default title for a freshly-created manual thread. POST /inbox/new
+ * uses this when the client doesn't supply a title; POST /respond
+ * watches for it so the first reply on the thread can replace the
+ * placeholder with something derived from the operator's actual words.
+ */
+const DEFAULT_NEW_CONVERSATION_TITLE = 'New conversation';
+
+/**
+ * Max characters in an auto-derived title. The inbox-list grid is
+ * tight enough that anything past this gets ellipsized anyway, so we
+ * truncate at the route layer with a trailing ellipsis instead of
+ * relying on CSS overflow alone.
+ */
+const TITLE_FROM_BODY_MAX = 60;
+
+/**
+ * Squash a freeform reply body into a single-line title. Replaces
+ * whitespace runs (incl. newlines) with single spaces, trims, and
+ * truncates with an ellipsis past TITLE_FROM_BODY_MAX. Returns the
+ * original (trimmed) body when it's already short enough.
+ */
+function deriveTitleFromBody(body: string): string {
+  const single = body.replace(/\s+/g, ' ').trim();
+  if (single.length <= TITLE_FROM_BODY_MAX) return single;
+  return single.slice(0, TITLE_FROM_BODY_MAX - 1).trimEnd() + '…';
+}
+
 const TRIAGE_SUB_AGENT_ALLOWLIST: readonly string[] = [
   'agent-analyzer',
   'agent-editor',
@@ -320,7 +348,7 @@ inboxRouter.post('/inbox/new', (req: Request, res: Response) => {
     return;
   }
   const titleRaw = typeof req.body?.title === 'string' ? req.body.title.trim() : '';
-  const title = titleRaw.length > 0 ? titleRaw.slice(0, 200) : 'New conversation';
+  const title = titleRaw.length > 0 ? titleRaw.slice(0, 200) : DEFAULT_NEW_CONVERSATION_TITLE;
   // body is required by the store; manual-source threads start blank,
   // so we seed with a small placeholder that's overwritten the moment
   // the operator's first /respond lands.
@@ -391,6 +419,20 @@ inboxRouter.post('/inbox/:id/respond', (req: Request, res: Response) => {
     if (isAjax(req)) { res.status(500).end(); return; }
     res.redirect(303, `${detailUrl}?error=${encodeURIComponent(`Reply failed: ${msg}`)}`);
     return;
+  }
+  // First reply on a manual-source thread still carrying the default
+  // "New conversation" title? Auto-rename from the body so /inbox stops
+  // showing a wall of identical row titles. Only triggers when there
+  // were zero prior responses (this reply is the first), so subsequent
+  // edits don't keep rewriting the title from each reply.
+  const messageNow = ctx.inboxStore.get(id);
+  if (messageNow
+    && messageNow.source === 'manual'
+    && messageNow.title === DEFAULT_NEW_CONVERSATION_TITLE
+    && ctx.inboxStore.listResponses(id).filter((r) => r.id !== userResponse.id).length === 0) {
+    try {
+      ctx.inboxStore.updateTitle(id, deriveTitleFromBody(bodyRaw));
+    } catch { /* ignore — title update is best-effort */ }
   }
   // Publish to the SSE bus so any modal subscribed to this thread
   // sees the persisted user reply within a network RTT. The fragment

--- a/packages/dashboard/src/views/add-tile-modal.js.ts
+++ b/packages/dashboard/src/views/add-tile-modal.js.ts
@@ -165,11 +165,17 @@ export const ADD_TILE_MODAL_JS = `
       var hiddenAgent = document.getElementById('add-tile-agent-id');
       // Only agent cards (with data-agent-id) submit the form; the
       // "Create new" tiles have their own handlers above and are skipped.
+      // Use requestSubmit() so the submit event fires — widget-layout.js
+      // listens for it and clears its edit-mode beforeunload guard. Bare
+      // form.submit() bypasses that listener and triggers Chrome's
+      // generic "Leave site?" dialog on top of the legit navigation.
       var cards = modal.querySelectorAll('.add-tile-card[data-agent-id]');
       for (var c = 0; c < cards.length; c++) {
         cards[c].addEventListener('click', function () {
           hiddenAgent.value = this.getAttribute('data-agent-id') || '';
-          if (hiddenAgent.value) form.submit();
+          if (!hiddenAgent.value) return;
+          if (form.requestSubmit) form.requestSubmit();
+          else form.submit();
         });
       }
 


### PR DESCRIPTION
Two unrelated UX fixes you asked for in the same message.

## 1. Manual-thread title from first reply

Today every \"+ New conversation\" thread is hardcoded to title \`New conversation\` because the client POSTs to \`/inbox/new\` with no title, and the server defaults to that literal. The result is a queue full of identically-titled rows that's hard to scan.

This PR: when the first user reply lands on a manual thread whose title is still the default, the route renames it to a single-line, ellipsized version of the body (≤60 chars). Specifically:

- Only manual-source threads (run-failure / permission-request / cadence stay untouched).
- Only when the title still equals the default.
- Only on the *first* reply — subsequent replies never re-rename.
- Threads created with an explicit title are preserved.

New \`InboxStore.updateTitle\` helper. 4 new route tests cover all the gates.

## 2. Add tile triggers Chrome \"Leave site?\" dialog

Screenshot reproduced on \`/dashboards/<id>\` in edit mode: clicking an agent card in the Add tile modal triggers Chrome's generic \`beforeunload\` dialog (\"Changes you made may not be saved\") stacked on top of the legit POST.

Root cause: the click handler in [add-tile-modal.js.ts:172](packages/dashboard/src/views/add-tile-modal.js.ts#L172) called \`form.submit()\` directly. Programmatic \`.submit()\` does NOT fire the form's \`submit\` event, which is exactly what \`widget-layout.js.ts\` listens for to flip its edit-mode \`beforeunload\` guard's \`intentionalNav = true\` (line ~514). So the guard kept thinking this was accidental navigation.

Fix: \`form.requestSubmit()\` instead of \`form.submit()\` — same pattern as the inbox Cmd+Enter handler from #411. Audited all other \`form.submit()\` sites in the dashboard; rest are either explicitly inside \`intentionalNav = true\` blocks or on pages without the edit-mode guard.

## Test plan
- [x] \`npm run build\` clean
- [x] \`npx vitest run packages/dashboard\` — 476 passed (4 new)
- [ ] Live: \"+ New conversation\" → type \"Help me build a trivia agent\" → submit → row title in /inbox reflects the body.
- [ ] Live: enter dashboard edit mode → Add tile → click an agent → no Chrome dialog; navigates straight to live dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)