### PR TITLE
feat(core): apple-foundation-models LLM provider (on-device, system option)

### DIFF
--- a/.changeset/apple-foundation-models-provider.md
+++ b/.changeset/apple-foundation-models-provider.md
@@ -1,0 +1,51 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+feat(core): apple-foundation-models LLM provider (on-device, system option)
+
+Adds `apple-foundation-models` as a third LLM provider alongside
+`claude` and `codex`. Runs entirely on-device via Apple's
+`SystemLanguageModel` / `FoundationModels` framework — no API key, no
+network. macOS 26+ with Xcode CLT (`xcrun`) required.
+
+**How it works:** A tiny Swift runner ships embedded in
+`packages/core/src/apple-foundationmodels-runner.ts`. On first use
+(`ensureAppleRunner`) we write the source to `~/.sua/runners/`,
+compile with `xcrun swiftc -parse-as-library`, and cache the binary +
+a source-hash sidecar. Subsequent invocations hit the cache. On non-
+macOS hosts or hosts without `xcrun`, the bootstrap returns
+`unsupported` without raising and the LLM waterfall falls through to
+the next provider.
+
+**Spawner shape:** The runner reads `PROMPT` + `SYSTEM_PROMPT` from
+its environment (not stdin or argv) and prints a single JSON line
+`{ status, response_text, model_name, error_message }`. The new
+`LlmSpawner` fields `resolveBinary`, `buildEnv`, `promptEnvVar`,
+`classifyResult`, and `simulateStream` are all opt-in extensions that
+keep the claude / codex spawners unchanged. `status: "unavailable" |
+"unsupported"` map to `binary_missing` so the waterfall falls through
+to the next provider when the host can't actually run the model.
+
+**Simulated streaming.** Apple FM has no native token-delta stream,
+but the dashboard's typewriter UX expects `output_chunk` events.
+After a successful run the spawner chunks the response text into
+~30-char pieces and emits synthetic `output_chunk` events at ~8 ms
+intervals (capped at ~1.5 s total). Same code path as real streaming
+on the client.
+
+**System agent.** The existing `apple-foundationmodels-prompt` user
+agent (which compiles Swift + runs the binary directly via shell
+nodes) is now bundled in `agents/examples/` as a system agent so it
+ships with sua. It demos the underlying mechanics; new agents can
+just set `provider: apple-foundation-models` on any `llm-prompt`
+node and skip the boilerplate.
+
+**Dashboard:** Per-node provider select (`llm-options.ts`) and the
+`/settings/llm` chain editor (`settings-llm.ts`) now list the new
+provider. Probe results show "reachable" on macOS hosts that compile
+the runner, "unavailable" elsewhere.

--- a/agents/examples/apple-foundationmodels-prompt.yaml
+++ b/agents/examples/apple-foundationmodels-prompt.yaml
@@ -1,0 +1,413 @@
+id: apple-foundationmodels-prompt
+name: Apple FoundationModels Prompt
+description: Run a prompt through Apple's on-device Foundation Models stack via Swift and return a structured response for local agent workflows.
+status: active
+source: examples
+mcp: true
+inputs:
+  PROMPT:
+    type: string
+    description: The user prompt to send to the local Apple model.
+  SYSTEM_PROMPT:
+    type: string
+    default: ""
+    description: Optional system instructions for the session.
+  TIMEOUT_SECONDS:
+    type: number
+    default: 60
+    description: Maximum seconds to allow the local Swift runner to execute.
+  MAX_PREVIEW_CHARS:
+    type: number
+    default: 160
+    description: Maximum prompt characters to expose in prompt_preview.
+outputs:
+  status:
+    type: string
+  response_text:
+    type: string
+  model_name:
+    type: string
+  error_message:
+    type: string
+  elapsed_ms:
+    type: number
+  prompt_chars:
+    type: number
+  system_prompt_used:
+    type: boolean
+  prompt_preview:
+    type: string
+  summary_text:
+    type: string
+nodes:
+  - id: write_runner
+    type: shell
+    command: |
+      set -euo pipefail
+
+      mkdir -p "$STATE_DIR"
+      script_path="$STATE_DIR/apple_foundationmodels_prompt.swift"
+
+      cat > "$script_path" <<'SWIFT'
+      import Foundation
+      #if canImport(FoundationModels)
+      import FoundationModels
+      #endif
+
+      struct Output: Codable {
+          let status: String
+          let response_text: String
+          let model_name: String
+          let error_message: String?
+      }
+
+      func emit(_ output: Output) {
+          let encoder = JSONEncoder()
+          if let data = try? encoder.encode(output),
+             let text = String(data: data, encoding: .utf8) {
+              print(text)
+          } else {
+              print("{\"status\":\"error\",\"response_text\":\"\",\"model_name\":\"apple-foundationmodels\",\"error_message\":\"Failed to encode output\"}")
+          }
+      }
+
+      @main
+      struct Runner {
+          static func main() async {
+              let env = ProcessInfo.processInfo.environment
+              let prompt = (env["PROMPT"] ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+              let systemPrompt = (env["SYSTEM_PROMPT"] ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+
+              guard !prompt.isEmpty else {
+                  emit(Output(status: "error", response_text: "", model_name: "apple-foundationmodels", error_message: "PROMPT is required"))
+                  return
+              }
+
+              #if canImport(FoundationModels)
+              if #available(macOS 26.0, iOS 26.0, *) {
+                  guard SystemLanguageModel.default.isAvailable else {
+                      emit(Output(status: "unavailable", response_text: "", model_name: "apple-foundationmodels", error_message: "Apple Foundation Models is not available on this device"))
+                      return
+                  }
+
+                  do {
+                      let session = systemPrompt.isEmpty
+                          ? LanguageModelSession()
+                          : LanguageModelSession(instructions: systemPrompt)
+                      let response = try await session.respond(to: prompt)
+                      emit(Output(status: "ok", response_text: String(describing: response.content), model_name: "apple-foundationmodels", error_message: nil))
+                  } catch {
+                      emit(Output(status: "error", response_text: "", model_name: "apple-foundationmodels", error_message: String(describing: error)))
+                  }
+              } else {
+                  emit(Output(status: "unsupported", response_text: "", model_name: "apple-foundationmodels", error_message: "Requires Apple OS with Foundation Models support"))
+              }
+              #else
+              emit(Output(status: "unsupported", response_text: "", model_name: "apple-foundationmodels", error_message: "FoundationModels framework is not available in this Swift toolchain"))
+              #endif
+          }
+      }
+      SWIFT
+
+      if [ ! -s "$script_path" ]; then
+        echo '{"script_path":"","error":"Failed to write Swift runner"}' >&2
+        exit 1
+      fi
+
+      printf '{"script_path":"%s"}\n' "$script_path"
+  - id: run_prompt
+    type: shell
+    command: |
+      set -euo pipefail
+
+      if [ -z "${PROMPT:-}" ]; then
+        echo '{"status":"error","response_text":"","model_name":"apple-foundationmodels","error_message":"PROMPT is required","elapsed_ms":0}'
+        exit 0
+      fi
+
+      if [ -z "${TIMEOUT_SECONDS:-}" ]; then
+        echo '{"status":"error","response_text":"","model_name":"apple-foundationmodels","error_message":"TIMEOUT_SECONDS is required","elapsed_ms":0}'
+        exit 0
+      fi
+
+      python3 - "$TIMEOUT_SECONDS" <<'PY'
+      import sys
+
+      try:
+          timeout = float(sys.argv[1])
+      except Exception:
+          print('{"status":"error","response_text":"","model_name":"apple-foundationmodels","error_message":"TIMEOUT_SECONDS must be numeric","elapsed_ms":0}')
+          sys.exit(0)
+
+      if timeout <= 0:
+          print('{"status":"error","response_text":"","model_name":"apple-foundationmodels","error_message":"TIMEOUT_SECONDS must be greater than 0","elapsed_ms":0}')
+          sys.exit(0)
+      PY
+
+      start_ms=$(python3 - <<'PY'
+      import time
+      print(int(time.time() * 1000))
+      PY
+      )
+
+      runner_json=$(python3 - "$TIMEOUT_SECONDS" "$STATE_DIR/foundationmodels_raw.json" "$STATE_DIR/foundationmodels.stderr" "$STATE_DIR/apple_foundationmodels_runner" <<'PY'
+      import json
+      import os
+      import subprocess
+      import sys
+
+      timeout = int(float(sys.argv[1]))
+      raw_path = sys.argv[2]
+      err_path = sys.argv[3]
+      bin_path = sys.argv[4]
+
+      try:
+          upstream = json.loads(os.environ["UPSTREAM_WRITE_RUNNER_RESULT"])
+          script_path = upstream["script_path"]
+      except Exception as exc:
+          print(json.dumps({
+              "status": "error",
+              "response_text": "",
+              "model_name": "apple-foundationmodels",
+              "error_message": f"Failed to read script_path from write_runner: {exc}"
+          }))
+          sys.exit(0)
+
+      if not script_path:
+          print(json.dumps({
+              "status": "error",
+              "response_text": "",
+              "model_name": "apple-foundationmodels",
+              "error_message": "Swift runner path is empty"
+          }))
+          sys.exit(0)
+
+      if not os.path.exists(script_path):
+          print(json.dumps({
+              "status": "error",
+              "response_text": "",
+              "model_name": "apple-foundationmodels",
+              "error_message": "Swift runner file is missing"
+          }))
+          sys.exit(0)
+
+      try:
+          compile_proc = subprocess.run(
+              ["xcrun", "swiftc", "-parse-as-library", script_path, "-o", bin_path],
+              capture_output=True,
+              text=True,
+              timeout=timeout
+          )
+          if compile_proc.returncode != 0:
+              print(json.dumps({
+                  "status": "error",
+                  "response_text": "",
+                  "model_name": "apple-foundationmodels",
+                  "error_message": (compile_proc.stderr or compile_proc.stdout or f"Swift compile failed with code {compile_proc.returncode}").strip()
+              }))
+              sys.exit(0)
+
+          with open(raw_path, "w", encoding="utf-8") as out, open(err_path, "w", encoding="utf-8") as err:
+              proc = subprocess.run(
+                  [bin_path],
+                  stdout=out,
+                  stderr=err,
+                  text=True,
+                  timeout=timeout,
+                  env=os.environ.copy()
+              )
+          if proc.returncode != 0:
+              with open(err_path, "r", encoding="utf-8") as f:
+                  stderr = f.read().strip()
+              print(json.dumps({
+                  "status": "error",
+                  "response_text": "",
+                  "model_name": "apple-foundationmodels",
+                  "error_message": stderr or f"Swift runner exited with code {proc.returncode}"
+              }))
+              sys.exit(0)
+      except subprocess.TimeoutExpired:
+          print(json.dumps({
+              "status": "error",
+              "response_text": "",
+              "model_name": "apple-foundationmodels",
+              "error_message": f"Timed out after {timeout} seconds"
+          }))
+          sys.exit(0)
+      except FileNotFoundError as exc:
+          print(json.dumps({
+              "status": "error",
+              "response_text": "",
+              "model_name": "apple-foundationmodels",
+              "error_message": f"Required tool not found: {exc}"
+          }))
+          sys.exit(0)
+      except Exception as exc:
+          print(json.dumps({
+              "status": "error",
+              "response_text": "",
+              "model_name": "apple-foundationmodels",
+              "error_message": f"Runner launch failed: {exc}"
+          }))
+          sys.exit(0)
+
+      try:
+          with open(raw_path, "r", encoding="utf-8") as f:
+              text = f.read().strip()
+          data = json.loads(text) if text else None
+      except Exception:
+          data = None
+
+      if not isinstance(data, dict):
+          with open(err_path, "r", encoding="utf-8") as f:
+              stderr = f.read().strip()
+          data = {
+              "status": "error",
+              "response_text": "",
+              "model_name": "apple-foundationmodels",
+              "error_message": stderr or "Swift runner produced invalid JSON"
+          }
+
+      print(json.dumps(data))
+      PY
+      )
+
+      end_ms=$(python3 - <<'PY'
+      import time
+      print(int(time.time() * 1000))
+      PY
+      )
+
+      python3 - "$runner_json" "$start_ms" "$end_ms" <<'PY'
+      import json
+      import sys
+
+      try:
+          data = json.loads(sys.argv[1])
+      except Exception as exc:
+          data = {
+              "status": "error",
+              "response_text": "",
+              "model_name": "apple-foundationmodels",
+              "error_message": f"Failed to parse runner JSON: {exc}"
+          }
+
+      start_ms = int(sys.argv[2])
+      end_ms = int(sys.argv[3])
+      data["elapsed_ms"] = max(0, end_ms - start_ms)
+      print(json.dumps(data))
+      PY
+    dependsOn:
+      - write_runner
+  - id: finalize
+    type: shell
+    command: |
+      set -euo pipefail
+      python3 - <<'PY'
+      import json
+      import os
+
+      prompt = os.environ.get("PROMPT", "")
+      system_prompt = os.environ.get("SYSTEM_PROMPT", "")
+      max_preview_chars = int(float(os.environ.get("MAX_PREVIEW_CHARS", "160") or "160"))
+      preview = prompt[:max_preview_chars] + ("..." if len(prompt) > max_preview_chars else "")
+
+      try:
+          data = json.loads(os.environ["UPSTREAM_RUN_PROMPT_RESULT"])
+      except Exception as exc:
+          data = {
+              "status": "error",
+              "response_text": "",
+              "model_name": "apple-foundationmodels",
+              "error_message": f"Failed to parse runner output: {exc}",
+              "elapsed_ms": 0
+          }
+
+      error_message = data.get("error_message") or ""
+      response_text = data.get("response_text", "") or ""
+      summary_text = error_message if error_message else response_text[:240]
+
+      final = {
+          "status": data.get("status", "error"),
+          "response_text": response_text,
+          "model_name": data.get("model_name", "apple-foundationmodels"),
+          "error_message": error_message,
+          "elapsed_ms": int(data.get("elapsed_ms", 0) or 0),
+          "prompt_chars": len(prompt),
+          "system_prompt_used": bool(system_prompt.strip()),
+          "prompt_preview": preview,
+          "summary_text": summary_text
+      }
+
+      print(json.dumps(final))
+      PY
+    dependsOn:
+      - run_prompt
+signal:
+  title: Apple Prompt
+  template: text-headline
+  mapping:
+    headline: status
+    body: summary_text
+  size: 2x1
+  accent: blue
+outputWidget:
+  type: dashboard
+  fields:
+    - name: elapsed_ms
+      label: Latency ms
+      type: metric
+    - name: status
+      label: Status
+      type: badge
+    - name: model_name
+      label: Model
+      type: stat
+    - name: prompt_chars
+      label: Prompt chars
+      type: stat
+    - name: response_text
+      label: Response
+      type: text
+    - name: system_prompt_used
+      label: System prompt
+      type: stat
+    - name: prompt_preview
+      label: Prompt preview
+      type: code
+    - name: error_message
+      label: Error
+      type: text
+  controls:
+    - type: replay
+      label: Run again
+      inputs:
+        - PROMPT
+        - SYSTEM_PROMPT
+        - TIMEOUT_SECONDS
+    - type: field-toggle
+      label: Show
+      fields:
+        - prompt_preview
+        - error_message
+      default: hidden
+    - type: view-switch
+      label: View
+      views:
+        - id: summary
+          fields:
+            - elapsed_ms
+            - status
+            - model_name
+            - prompt_chars
+            - response_text
+        - id: debug
+          fields:
+            - elapsed_ms
+            - status
+            - model_name
+            - prompt_chars
+            - system_prompt_used
+            - prompt_preview
+            - error_message
+      default: summary

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -16,6 +16,7 @@
 import type { AgentInputSpec, AgentOutputSpec } from './types.js';
 import type { AgentCapabilities } from './agent-capabilities.js';
 import type { AgentSource } from './agent-loader.js';
+import type { LlmProvider } from './llm-providers.js';
 
 export type AgentStatus = 'active' | 'paused' | 'archived' | 'draft';
 
@@ -238,7 +239,7 @@ export interface AgentNode {
    * Determines which CLI binary and argument format the spawner uses.
    * Shell nodes ignore this field.
    */
-  provider?: 'claude' | 'codex';
+  provider?: LlmProvider;
 
   // Common per-node
   timeout?: number;
@@ -348,7 +349,7 @@ export interface Agent {
   version: number;
 
   /** Default LLM provider for all claude-code nodes. Nodes can override. */
-  provider?: 'claude' | 'codex';
+  provider?: LlmProvider;
   /** Default model for all claude-code nodes. Nodes can override. */
   model?: string;
 
@@ -513,7 +514,7 @@ export interface AgentVersion {
  */
 export interface AgentVersionDag {
   id: string;
-  provider?: 'claude' | 'codex';
+  provider?: LlmProvider;
   model?: string;
   /**
    * Per-agent opt-out of the scheduler's frequency cap. When true, sub-minute

--- a/packages/core/src/apple-foundationmodels-runner.test.ts
+++ b/packages/core/src/apple-foundationmodels-runner.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Apple Foundation Models runner bootstrap tests.
+ *
+ * Coverage:
+ *   - Non-macOS hosts return `unsupported` without raising.
+ *   - On macOS with xcrun (real-CLI gated), `ensureAppleRunner` produces
+ *     a binary at the cache path and reports `ready` on cache hit.
+ *
+ * Tests gate on `process.platform === 'darwin'` AND `xcrun` being on
+ * PATH — same fixture pattern as `llm-invoker.test.ts` so hosts without
+ * Xcode tools skip cleanly instead of hard-failing CI.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  APPLE_RUNNER_SWIFT_SOURCE,
+  appleRunnerBinaryPath,
+  appleRunnerVersionString,
+  appleRunnersDir,
+  ensureAppleRunner,
+} from './apple-foundationmodels-runner.js';
+
+function xcrunAvailable(): boolean {
+  try {
+    execFileSync('xcrun', ['--version'], { stdio: ['ignore', 'pipe', 'ignore'] });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('appleRunnersDir / appleRunnerBinaryPath', () => {
+  it('honors SUA_APPLE_RUNNERS_DIR override', () => {
+    const prev = process.env.SUA_APPLE_RUNNERS_DIR;
+    process.env.SUA_APPLE_RUNNERS_DIR = '/tmp/sua-runners-test';
+    try {
+      expect(appleRunnersDir()).toBe('/tmp/sua-runners-test');
+      expect(appleRunnerBinaryPath()).toBe('/tmp/sua-runners-test/apple_foundationmodels');
+    } finally {
+      if (prev === undefined) delete process.env.SUA_APPLE_RUNNERS_DIR;
+      else process.env.SUA_APPLE_RUNNERS_DIR = prev;
+    }
+  });
+
+  it('exports a stable version string', () => {
+    expect(appleRunnerVersionString()).toMatch(/^apple-foundationmodels-runner /);
+  });
+
+  it('embeds the canImport(FoundationModels) guard', () => {
+    expect(APPLE_RUNNER_SWIFT_SOURCE).toContain('canImport(FoundationModels)');
+    expect(APPLE_RUNNER_SWIFT_SOURCE).toContain('--version');
+  });
+});
+
+describe('ensureAppleRunner (non-macOS branch)', () => {
+  it('returns status=unsupported on non-macOS', () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    try {
+      const handle = ensureAppleRunner();
+      expect(handle.status).toBe('unsupported');
+      expect(handle.message).toMatch(/macOS-only/);
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    }
+  });
+});
+
+describe('ensureAppleRunner (real compile, macOS-gated)', () => {
+  let tmpDir: string;
+  let prevEnv: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'sua-apple-runner-'));
+    prevEnv = process.env.SUA_APPLE_RUNNERS_DIR;
+    process.env.SUA_APPLE_RUNNERS_DIR = tmpDir;
+  });
+
+  afterEach(() => {
+    if (prevEnv === undefined) delete process.env.SUA_APPLE_RUNNERS_DIR;
+    else process.env.SUA_APPLE_RUNNERS_DIR = prevEnv;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it.skipIf(process.platform !== 'darwin' || !xcrunAvailable())(
+    'compiles the runner on first call and reports cache hit on the second',
+    () => {
+      const first = ensureAppleRunner();
+      expect(first.status).toBe('ready');
+      expect(first.binaryPath).toBe(join(tmpDir, 'apple_foundationmodels'));
+      // Binary should exist + be executable on disk.
+      const stat = statSync(first.binaryPath);
+      expect(stat.isFile()).toBe(true);
+      expect(stat.size).toBeGreaterThan(0);
+
+      // Probe the runner's --version branch to confirm we built the
+      // right Swift source (vs. a foreign binary at the path).
+      const versionOut = execFileSync(first.binaryPath, ['--version'], { encoding: 'utf-8' }).trim();
+      expect(versionOut).toBe(appleRunnerVersionString());
+
+      // Second call hits the source-hash cache; status still ready,
+      // binary unchanged.
+      const second = ensureAppleRunner();
+      expect(second.status).toBe('ready');
+      expect(second.binaryPath).toBe(first.binaryPath);
+    },
+    60_000,
+  );
+
+  it.skipIf(process.platform !== 'darwin' || !xcrunAvailable())(
+    'recompiles when the cached source hash drifts',
+    () => {
+      const first = ensureAppleRunner();
+      expect(first.status).toBe('ready');
+
+      // Corrupt the sidecar hash so the next call sees a mismatch.
+      const hashPath = join(tmpDir, 'apple_foundationmodels.source-hash');
+      writeFileSync(hashPath, 'deadbeef', 'utf-8');
+
+      const second = ensureAppleRunner();
+      expect(second.status).toBe('ready');
+      // After recompile the hash should be back to the real value (≠ deadbeef).
+      // Recreating exactly is harder to assert without rehashing, but we
+      // can confirm the file changed back from the corrupted marker.
+      const after = execFileSync('cat', [hashPath], { encoding: 'utf-8' }).trim();
+      expect(after).not.toBe('deadbeef');
+      expect(after.length).toBe(64); // sha256 hex
+    },
+    60_000,
+  );
+});

--- a/packages/core/src/apple-foundationmodels-runner.ts
+++ b/packages/core/src/apple-foundationmodels-runner.ts
@@ -1,0 +1,229 @@
+/**
+ * Apple Foundation Models runner bootstrap.
+ *
+ * Apple's on-device Foundation Models framework is exposed through the
+ * Swift standard library — no first-party CLI exists. We bridge by
+ * compiling a tiny Swift runner once per host and caching the binary
+ * under `~/.sua/runners/apple_foundationmodels`. The runner reads
+ * `PROMPT` and `SYSTEM_PROMPT` from its environment, calls
+ * `SystemLanguageModel.default` via `LanguageModelSession`, and prints
+ * a single line of JSON describing the outcome:
+ *
+ *   { "status": "ok" | "unavailable" | "unsupported" | "error",
+ *     "response_text": "...",
+ *     "model_name": "apple-foundationmodels",
+ *     "error_message": null | "..." }
+ *
+ * The Swift source embedded here mirrors the user-agent demo at
+ * `data/agent-state/apple-foundationmodels-prompt/apple_foundationmodels_prompt.swift`,
+ * with a `--version` branch added so `detectLlms()` can probe install
+ * status without spinning up a model session.
+ *
+ * Compilation requires `xcrun` (Apple Command Line Tools). On non-macOS
+ * hosts or hosts without `xcrun` we return `status: 'unsupported'` and
+ * the provider chain falls through to the next available provider.
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { chmod600Safe, ensureDir, ensureParentDir } from './fs-utils.js';
+
+const APPLE_RUNNER_VERSION_STRING = 'apple-foundationmodels-runner 1.0.0';
+
+/**
+ * Swift source for the on-device runner. Compiled once and cached at
+ * `~/.sua/runners/apple_foundationmodels` (binary) with a sidecar
+ * `apple_foundationmodels.source-hash` file recording the SHA-256 of
+ * this string. If the source ever changes, `ensureAppleRunner` detects
+ * the hash mismatch and recompiles.
+ */
+export const APPLE_RUNNER_SWIFT_SOURCE = `import Foundation
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+struct Output: Codable {
+    let status: String
+    let response_text: String
+    let model_name: String
+    let error_message: String?
+}
+
+func emit(_ output: Output) {
+    let encoder = JSONEncoder()
+    if let data = try? encoder.encode(output),
+       let text = String(data: data, encoding: .utf8) {
+        print(text)
+    } else {
+        print("{\\"status\\":\\"error\\",\\"response_text\\":\\"\\",\\"model_name\\":\\"apple-foundationmodels\\",\\"error_message\\":\\"Failed to encode output\\"}")
+    }
+}
+
+@main
+struct Runner {
+    static func main() async {
+        let args = CommandLine.arguments
+        if args.contains("--version") {
+            print("${APPLE_RUNNER_VERSION_STRING}")
+            return
+        }
+
+        let env = ProcessInfo.processInfo.environment
+        let prompt = (env["PROMPT"] ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let systemPrompt = (env["SYSTEM_PROMPT"] ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !prompt.isEmpty else {
+            emit(Output(status: "error", response_text: "", model_name: "apple-foundationmodels", error_message: "PROMPT is required"))
+            return
+        }
+
+        #if canImport(FoundationModels)
+        if #available(macOS 26.0, iOS 26.0, *) {
+            guard SystemLanguageModel.default.isAvailable else {
+                emit(Output(status: "unavailable", response_text: "", model_name: "apple-foundationmodels", error_message: "Apple Foundation Models is not available on this device"))
+                return
+            }
+
+            do {
+                let session = systemPrompt.isEmpty
+                    ? LanguageModelSession()
+                    : LanguageModelSession(instructions: systemPrompt)
+                let response = try await session.respond(to: prompt)
+                emit(Output(status: "ok", response_text: String(describing: response.content), model_name: "apple-foundationmodels", error_message: nil))
+            } catch {
+                emit(Output(status: "error", response_text: "", model_name: "apple-foundationmodels", error_message: String(describing: error)))
+            }
+        } else {
+            emit(Output(status: "unsupported", response_text: "", model_name: "apple-foundationmodels", error_message: "Requires Apple OS with Foundation Models support"))
+        }
+        #else
+        emit(Output(status: "unsupported", response_text: "", model_name: "apple-foundationmodels", error_message: "FoundationModels framework is not available in this Swift toolchain"))
+        #endif
+    }
+}
+`;
+
+export interface AppleRunnerHandle {
+  /** Absolute path to the compiled binary. Only meaningful when status === 'ready'. */
+  binaryPath: string;
+  status: 'ready' | 'compile-failed' | 'unsupported';
+  /** Human-readable message when status !== 'ready'. */
+  message?: string;
+}
+
+/**
+ * Where the compiled binary lives. Override via `SUA_APPLE_RUNNERS_DIR`
+ * for tests; production callers should leave it unset so the path stays
+ * stable across invocations on a host.
+ */
+export function appleRunnersDir(): string {
+  return process.env.SUA_APPLE_RUNNERS_DIR ?? join(homedir(), '.sua', 'runners');
+}
+
+export function appleRunnerBinaryPath(): string {
+  return join(appleRunnersDir(), 'apple_foundationmodels');
+}
+
+function appleRunnerSourceHashPath(): string {
+  return join(appleRunnersDir(), 'apple_foundationmodels.source-hash');
+}
+
+function hashSource(): string {
+  return createHash('sha256').update(APPLE_RUNNER_SWIFT_SOURCE).digest('hex');
+}
+
+/**
+ * Ensure the runner is compiled and cached. Idempotent:
+ *   1. If the cached binary exists AND its sidecar hash matches the
+ *      current source hash, return immediately (`status: 'ready'`).
+ *   2. Otherwise, write the source, compile via `xcrun swiftc
+ *      -parse-as-library`, and write the sidecar.
+ *   3. On non-macOS hosts (or hosts where `xcrun` isn't on PATH) return
+ *      `status: 'unsupported'` without raising — the provider waterfall
+ *      treats this as `binary_missing` and falls through.
+ *
+ * Test note: callers can stub `process.platform` / `SUA_APPLE_RUNNERS_DIR`
+ * to exercise the non-macOS branches without an Xcode install.
+ */
+export function ensureAppleRunner(): AppleRunnerHandle {
+  const binaryPath = appleRunnerBinaryPath();
+
+  if (process.platform !== 'darwin') {
+    return {
+      binaryPath,
+      status: 'unsupported',
+      message: 'Apple Foundation Models is macOS-only.',
+    };
+  }
+
+  // xcrun is required to compile. If it's not on PATH, the host doesn't
+  // have Xcode CLI tools installed and we can't build the runner.
+  try {
+    execFileSync('xcrun', ['--version'], { stdio: ['ignore', 'pipe', 'ignore'] });
+  } catch {
+    return {
+      binaryPath,
+      status: 'unsupported',
+      message: 'xcrun not found. Install Apple Command Line Tools (`xcode-select --install`).',
+    };
+  }
+
+  const dir = appleRunnersDir();
+  ensureDir(dir);
+  const sourcePath = join(dir, 'apple_foundationmodels.swift');
+  const hashPath = appleRunnerSourceHashPath();
+  const currentHash = hashSource();
+
+  // Cache hit: binary present, sidecar hash matches, source hasn't drifted.
+  if (existsSync(binaryPath) && existsSync(hashPath)) {
+    try {
+      const cachedHash = readFileSync(hashPath, 'utf-8').trim();
+      if (cachedHash === currentHash) {
+        // Sanity check: binary mtime is at or after the hash file.
+        const binStat = statSync(binaryPath);
+        const hashStat = statSync(hashPath);
+        if (binStat.mtimeMs >= hashStat.mtimeMs - 5_000) {
+          return { binaryPath, status: 'ready' };
+        }
+      }
+    } catch {
+      // Fall through to recompile.
+    }
+  }
+
+  // (Re)compile.
+  ensureParentDir(sourcePath);
+  writeFileSync(sourcePath, APPLE_RUNNER_SWIFT_SOURCE, 'utf-8');
+  chmod600Safe(sourcePath);
+
+  const compile = spawnSync('xcrun', ['swiftc', '-parse-as-library', sourcePath, '-o', binaryPath], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (compile.status !== 0) {
+    const stderr = (compile.stderr ?? '').trim() || (compile.stdout ?? '').trim();
+    return {
+      binaryPath,
+      status: 'compile-failed',
+      message: stderr || `xcrun swiftc exited with code ${compile.status}`,
+    };
+  }
+
+  writeFileSync(hashPath, currentHash, 'utf-8');
+  chmod600Safe(hashPath);
+  return { binaryPath, status: 'ready' };
+}
+
+/**
+ * Stable identifier string the runner prints under `--version`. The
+ * provider `detectLlms()` probe runs `apple_foundationmodels --version`
+ * and compares the trimmed stdout against this value to confirm the
+ * binary on disk matches what we expect (vs. a stale/foreign binary
+ * sitting at the same path).
+ */
+export function appleRunnerVersionString(): string {
+  return APPLE_RUNNER_VERSION_STRING;
+}

--- a/packages/core/src/llm-invoker.ts
+++ b/packages/core/src/llm-invoker.ts
@@ -1,4 +1,5 @@
 import { spawn, execSync } from 'node:child_process';
+import { ensureAppleRunner } from './apple-foundationmodels-runner.js';
 import { PROVIDERS, PROVIDER_IDS, type LlmProvider } from './llm-providers.js';
 
 export interface LlmInvokeOptions {
@@ -16,6 +17,7 @@ export interface LlmInvokeResult {
 export interface LlmAvailability {
   claude: { installed: boolean; version?: string };
   codex: { installed: boolean; version?: string };
+  'apple-foundation-models': { installed: boolean; version?: string };
 }
 
 /** Detect which LLM CLIs are installed on the host. Fast, synchronous. */
@@ -23,10 +25,32 @@ export function detectLlms(): LlmAvailability {
   const result: LlmAvailability = {
     claude: { installed: false },
     codex: { installed: false },
+    'apple-foundation-models': { installed: false },
   };
 
   for (const id of PROVIDER_IDS) {
     const def = PROVIDERS[id];
+
+    // Apple FM goes through the runner bootstrap (compile-on-first-use).
+    // ensureAppleRunner is idempotent + cheap on cache hit. On non-
+    // macOS or hosts without xcrun it returns `unsupported` without
+    // raising; we leave `installed: false` in that case.
+    if (id === 'apple-foundation-models') {
+      const handle = ensureAppleRunner();
+      if (handle.status !== 'ready') continue;
+      try {
+        const v = execSync(
+          `${handle.binaryPath} ${def.versionArgv.join(' ')}`,
+          { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] },
+        ).trim();
+        result[id] = { installed: true, version: v };
+      } catch {
+        // Runner compiled but the version probe failed — treat as
+        // not installed so the chain doesn't try to use it.
+      }
+      continue;
+    }
+
     try {
       const v = execSync(
         `${def.binary} ${def.versionArgv.join(' ')}`,

--- a/packages/core/src/llm-providers.ts
+++ b/packages/core/src/llm-providers.ts
@@ -7,13 +7,18 @@
  * here plus a `LlmProvider` union member.
  */
 
-export type LlmProvider = 'claude' | 'codex';
+export type LlmProvider = 'claude' | 'codex' | 'apple-foundation-models';
 
 export interface ProviderDef {
   id: LlmProvider;
   /** Human-readable name for UI ("Claude Code", "Codex"). */
   displayName: string;
-  /** Binary name resolved against PATH. */
+  /**
+   * Binary name resolved against PATH. For providers that ship a
+   * compiled-on-demand runner (e.g. apple-foundation-models), this is a
+   * sentinel — the spawner resolves the real path lazily via the
+   * runner-bootstrap helper.
+   */
   binary: string;
   /** Argv used by `detectLlms()` to probe install + version. */
   versionArgv: readonly string[];
@@ -35,6 +40,20 @@ export const PROVIDERS: Record<LlmProvider, ProviderDef> = {
     binary: 'codex',
     versionArgv: ['--version'],
     promptArgv: (prompt) => ['exec', '-s', 'read-only', prompt],
+  },
+  // Apple Foundation Models runs on-device via a tiny Swift runner we
+  // compile and cache at ~/.sua/runners/apple_foundationmodels. The
+  // `binary` here is the resolved cache path returned by
+  // ensureAppleRunner(); detectLlms() / invokeLlm() call into the
+  // runner module to bootstrap before invoking. The prompt rides on
+  // env vars (PROMPT, SYSTEM_PROMPT), not argv — promptArgv returns
+  // an empty array and the spawner contributes the env separately.
+  'apple-foundation-models': {
+    id: 'apple-foundation-models',
+    displayName: 'Apple Foundation Models',
+    binary: 'apple_foundationmodels',
+    versionArgv: ['--version'],
+    promptArgv: () => [],
   },
 };
 

--- a/packages/core/src/node-spawner.test.ts
+++ b/packages/core/src/node-spawner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildProviderChain, claudeSpawner, codexSpawner, classifyLlmFailure, shouldFallback, type SpawnResult } from './node-spawner.js';
+import { appleFoundationModelsSpawner, buildProviderChain, claudeSpawner, codexSpawner, classifyLlmFailure, shouldFallback, type SpawnResult } from './node-spawner.js';
 
 function r(partial: Partial<SpawnResult>): SpawnResult {
   return {
@@ -122,6 +122,64 @@ describe('buildProviderChain (waterfall)', () => {
 
   it('supports a 3-provider chain — pin still goes first, rest follows in order', () => {
     expect(buildProviderChain('codex', ['claude', 'gemini', 'codex'])).toEqual(['codex', 'claude', 'gemini']);
+  });
+
+  it('places apple-foundation-models pin at the head, keeping claude/codex as fallbacks', () => {
+    expect(buildProviderChain('apple-foundation-models', ['claude', 'codex']))
+      .toEqual(['apple-foundation-models', 'claude', 'codex']);
+  });
+});
+
+describe('appleFoundationModelsSpawner', () => {
+  it('exposes the env-var prompt contract (PROMPT) and empty argv', () => {
+    expect(appleFoundationModelsSpawner.promptEnvVar).toBe('PROMPT');
+    expect(appleFoundationModelsSpawner.buildArgs({ prompt: 'hi' })).toEqual([]);
+    expect(appleFoundationModelsSpawner.buildEnv?.({ prompt: 'hi there' })).toEqual({ PROMPT: 'hi there' });
+  });
+
+  it('enables simulated streaming so the typewriter UX still fires', () => {
+    expect(appleFoundationModelsSpawner.simulateStream).toBe(true);
+  });
+
+  it('extractResult returns response_text on status=ok and empty string otherwise', () => {
+    const ok = JSON.stringify({ status: 'ok', response_text: 'hello world', model_name: 'apple-foundationmodels' });
+    expect(appleFoundationModelsSpawner.extractResult(ok)).toBe('hello world');
+
+    const unavailable = JSON.stringify({ status: 'unavailable', response_text: '', model_name: 'apple-foundationmodels' });
+    expect(appleFoundationModelsSpawner.extractResult(unavailable)).toBe('');
+
+    const err = JSON.stringify({ status: 'error', response_text: '', model_name: 'apple-foundationmodels', error_message: 'boom' });
+    expect(appleFoundationModelsSpawner.extractResult(err)).toBe('');
+  });
+
+  it('classifyResult maps unavailable/unsupported to binary_missing for fallback', () => {
+    const unavailable = JSON.stringify({ status: 'unavailable' });
+    expect(appleFoundationModelsSpawner.classifyResult?.(
+      { result: unavailable, exitCode: 0, error: '' },
+      unavailable,
+    )).toBe('binary_missing');
+
+    const unsupported = JSON.stringify({ status: 'unsupported' });
+    expect(appleFoundationModelsSpawner.classifyResult?.(
+      { result: unsupported, exitCode: 0, error: '' },
+      unsupported,
+    )).toBe('binary_missing');
+  });
+
+  it('classifyResult maps error to other (does NOT silently fall back on real bugs)', () => {
+    const err = JSON.stringify({ status: 'error', error_message: 'boom' });
+    expect(appleFoundationModelsSpawner.classifyResult?.(
+      { result: err, exitCode: 0, error: '' },
+      err,
+    )).toBe('other');
+  });
+
+  it('classifyResult returns null on status=ok (no override needed)', () => {
+    const ok = JSON.stringify({ status: 'ok', response_text: 'hi' });
+    expect(appleFoundationModelsSpawner.classifyResult?.(
+      { result: ok, exitCode: 0, error: '' },
+      ok,
+    )).toBeNull();
   });
 });
 

--- a/packages/core/src/node-spawner.ts
+++ b/packages/core/src/node-spawner.ts
@@ -131,10 +131,52 @@ export interface LlmSpawnOptions {
  * the final result text.
  */
 export interface LlmSpawner {
-  /** CLI binary name (e.g. 'claude', 'codex'). */
+  /**
+   * CLI binary name (e.g. 'claude', 'codex'). For providers whose
+   * binary path is computed lazily at invocation time, `resolveBinary`
+   * overrides this — the spawner registry's `binary` is still set to a
+   * sensible default for static call sites (logging, error messages).
+   */
   binary: string;
+  /**
+   * Resolve the actual binary path at invocation time. Used by
+   * providers that compile-on-demand (e.g. apple-foundation-models,
+   * which materializes its Swift runner under ~/.sua/runners/ on first
+   * use). When undefined, callers use `binary` directly.
+   *
+   * Returns either a path or a structured `unsupported` signal that the
+   * waterfall treats as `binary_missing` (so the chain falls through to
+   * the next provider without an actual spawn attempt).
+   */
+  resolveBinary?: () => { path: string } | { unsupported: true; reason: string };
   /** Build the CLI argument list. */
   buildArgs(opts: LlmSpawnOptions): string[];
+  /**
+   * Optional env-var contribution. The prompt-on-env-var providers
+   * (apple-foundation-models) use this to surface PROMPT /
+   * SYSTEM_PROMPT alongside the inherited childEnv. Returned keys are
+   * merged INTO the existing childEnv before the spawn — they don't
+   * replace it. When undefined, no extra env is contributed.
+   */
+  buildEnv?: (opts: LlmSpawnOptions) => Record<string, string>;
+  /**
+   * When true, after the process exits successfully the waterfall emits
+   * the extracted result text as a series of synthetic `output_chunk`
+   * progress events (paced ~8ms apart, capped at ~1.5s total) so the
+   * typewriter UI behaves consistently across streaming and non-
+   * streaming providers. Used by apple-foundation-models, which has no
+   * native token-delta stream.
+   */
+  simulateStream?: boolean;
+  /**
+   * If set, the prompt is passed via this env var name instead of
+   * stdin. Providers that read prompts from argv (claude/codex via
+   * stdinInput) leave this unset. The waterfall hands the resolved
+   * prompt to `buildEnv` automatically, but explicit env-name mapping
+   * keeps the interface declarative for future providers that want a
+   * different name.
+   */
+  promptEnvVar?: string;
   /**
    * Parse a line of stdout for progress events. Returns null if the line
    * is not a progress event (e.g. regular output text).
@@ -146,6 +188,14 @@ export interface LlmSpawner {
    * For text mode, this returns stdout as-is.
    */
   extractResult(stdout: string): string;
+  /**
+   * Inspect a fresh `SpawnResult` (after extractResult ran) and return
+   * an override category when the provider's payload encodes failures
+   * inline (e.g. apple-foundation-models writes `status: "unavailable"`
+   * to a JSON line with exit code 0). The waterfall consults this
+   * BEFORE the generic `classifyLlmFailure` text matcher.
+   */
+  classifyResult?: (result: SpawnResult, rawStdout: string) => LlmFailureCategory | null;
 }
 
 // ── Claude spawner ─────────────────────────────────────────────────────
@@ -376,12 +426,112 @@ export const codexSpawner: LlmSpawner = {
   },
 };
 
+// ── Apple Foundation Models spawner ────────────────────────────────────
+
+/**
+ * Apple Foundation Models spawner. Drives the on-device model via a
+ * tiny Swift runner compiled lazily and cached at
+ * `~/.sua/runners/apple_foundationmodels` (see
+ * `apple-foundationmodels-runner.ts`).
+ *
+ * Key differences from claude/codex:
+ *   - Prompt rides on environment variables (PROMPT, SYSTEM_PROMPT),
+ *     not stdin or argv.
+ *   - Output is a single JSON object on stdout: `{ status,
+ *     response_text, model_name, error_message }`. No per-token deltas.
+ *   - The typewriter UX is simulated post-completion via
+ *     `simulateStream: true` so the modal's streaming-bubble path keeps
+ *     working — the runlAttempt loop chunks the extracted text and
+ *     emits synthetic output_chunk events on the same onProgress hook
+ *     real spawners use.
+ *   - `status: "unavailable"` or `"unsupported"` map to `binary_missing`
+ *     via `classifyResult` so the waterfall falls through to the next
+ *     provider.
+ */
+export const appleFoundationModelsSpawner: LlmSpawner = {
+  binary: 'apple_foundationmodels',
+  simulateStream: true,
+  promptEnvVar: 'PROMPT',
+
+  resolveBinary() {
+    // Lazy import to keep this provider out of the cold-path for
+    // non-macOS hosts that never invoke it. The runner module's
+    // ensureAppleRunner() is idempotent and fast on cache hit.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { ensureAppleRunner } = require('./apple-foundationmodels-runner.js') as typeof import('./apple-foundationmodels-runner.js');
+    const handle = ensureAppleRunner();
+    if (handle.status === 'ready') return { path: handle.binaryPath };
+    return { unsupported: true, reason: handle.message ?? 'Apple Foundation Models runner is unavailable.' };
+  },
+
+  buildArgs(_opts: LlmSpawnOptions): string[] {
+    // The runner reads PROMPT + SYSTEM_PROMPT from its environment;
+    // model / maxTurns / allowedTools are ignored (the on-device
+    // framework doesn't expose those knobs).
+    return [];
+  },
+
+  buildEnv(opts: LlmSpawnOptions): Record<string, string> {
+    return { PROMPT: opts.prompt };
+  },
+
+  parseProgress(_line: string): SpawnProgress | null {
+    // Real-time progress isn't available — the runner emits one JSON
+    // line at completion. The simulated streaming hook in
+    // `runLlmAttempt` covers the typewriter UX.
+    return null;
+  },
+
+  extractResult(stdout: string): string {
+    // The runner prints one JSON object on the last non-empty line.
+    const lines = stdout.split('\n').map((l) => l.trim()).filter((l) => l.length > 0);
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i];
+      if (!line.startsWith('{')) continue;
+      try {
+        const obj = JSON.parse(line);
+        if (typeof obj.response_text === 'string' && obj.status === 'ok') {
+          return obj.response_text;
+        }
+        // Non-ok status: surface an empty result; classifyResult will
+        // map the JSON status to a fallback-worthy category so the
+        // waterfall continues to the next provider.
+        return '';
+      } catch { /* skip */ }
+    }
+    return '';
+  },
+
+  classifyResult(result: SpawnResult, rawStdout: string): LlmFailureCategory | null {
+    // Apple's runner can exit 0 yet report failure inline via the JSON
+    // status field. Map unavailable/unsupported to binary_missing so
+    // the waterfall treats the host as if the binary weren't installed
+    // (because functionally — for this prompt on this device — it
+    // isn't usable). 'error' maps to 'other' so real bugs surface.
+    const lines = rawStdout.split('\n').map((l) => l.trim()).filter((l) => l.length > 0);
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i];
+      if (!line.startsWith('{')) continue;
+      try {
+        const obj = JSON.parse(line);
+        if (obj.status === 'unavailable' || obj.status === 'unsupported') {
+          return 'binary_missing';
+        }
+        if (obj.status === 'error') return 'other';
+        if (obj.status === 'ok') return null;
+      } catch { /* skip */ }
+    }
+    return null;
+  },
+};
+
 // ── Spawner registry ───────────────────────────────────────────────────
 
 const SPAWNERS: Record<string, LlmSpawner> = {
   claude: claudeSpawner,
   'claude-text': claudeTextSpawner,
   codex: codexSpawner,
+  'apple-foundation-models': appleFoundationModelsSpawner,
 };
 
 /** Get a spawner by provider name. Defaults to claude stream-json. */
@@ -514,16 +664,48 @@ async function runLlmAttempt(
   onSpawn?: (pid: number, startedAtMs: number) => void,
 ): Promise<SpawnResult> {
   const spawner = getSpawner(provider);
-  const args = spawner.buildArgs({
+  const spawnOpts: LlmSpawnOptions = {
     prompt: resolvedPrompt,
     model: node.model,
     maxTurns: node.maxTurns,
     allowedTools: node.allowedTools,
-  });
-  return spawnProcess(spawner.binary, args, {
+  };
+  const args = spawner.buildArgs(spawnOpts);
+
+  // Lazy-resolve binary path. Providers like apple-foundation-models
+  // compile a runner on first use; the resolver returns either a
+  // ready path or an `unsupported: true` signal we turn into a
+  // synthetic binary_missing failure so the waterfall falls through
+  // without actually trying to spawn a nonexistent executable.
+  let binaryPath = spawner.binary;
+  if (spawner.resolveBinary) {
+    const resolved = spawner.resolveBinary();
+    if ('unsupported' in resolved) {
+      return {
+        result: '',
+        exitCode: 127,
+        error: resolved.reason,
+        category: 'spawn_failure',
+      };
+    }
+    binaryPath = resolved.path;
+  }
+
+  // Merge env. The spawner's buildEnv overrides anything in childEnv
+  // with the same key (so PROMPT etc. land cleanly even if the agent
+  // env happens to collide).
+  const mergedEnv = spawner.buildEnv
+    ? { ...childEnv, ...spawner.buildEnv(spawnOpts) }
+    : childEnv;
+
+  // Providers that read the prompt from env (Apple FM) skip stdin so
+  // the runner doesn't sit waiting for EOF.
+  const stdinInput = spawner.promptEnvVar ? undefined : resolvedPrompt;
+
+  const result = await spawnProcess(binaryPath, args, {
     cwd: node.workingDirectory,
-    env: childEnv,
-    stdinInput: resolvedPrompt,
+    env: mergedEnv,
+    stdinInput,
     timeoutSec: node.timeout ?? 300,
     onProgress: onProgress ? (line) => {
       const event = spawner.parseProgress(line);
@@ -533,6 +715,68 @@ async function runLlmAttempt(
     signal,
     onSpawn,
   });
+
+  // Inline-failure classification (e.g. apple-foundation-models writes
+  // `status: "unavailable"` on a successful exit). When the spawner
+  // reports a fallback-worthy category, override the result so the
+  // waterfall's classifyLlmFailure picks it up.
+  if (spawner.classifyResult && result.exitCode === 0) {
+    const overrideCategory = spawner.classifyResult(result, result.result ?? '');
+    if (overrideCategory === 'binary_missing' || overrideCategory === 'other') {
+      return {
+        ...result,
+        result: '',
+        exitCode: 1,
+        category: overrideCategory === 'binary_missing' ? 'spawn_failure' : result.category,
+        error: result.error ?? 'Provider reported an inline failure status.',
+      };
+    }
+  }
+
+  // Simulated streaming. Non-streaming providers (Apple FM) emit one
+  // synthetic output_chunk burst so the typewriter UX stays consistent.
+  // We only fire chunks when the run succeeded; failure already exits
+  // here and the waterfall falls through.
+  if (spawner.simulateStream && result.exitCode === 0 && onProgress && result.result) {
+    await simulateStreamingChunks(result.result, onProgress, signal);
+  }
+
+  return result;
+}
+
+/**
+ * Synthetic streaming for non-streaming providers. Splits the
+ * extracted text into ~30-char chunks and pacing each by
+ * SIMULATED_STREAM_INTERVAL_MS, capped at SIMULATED_STREAM_MAX_MS total
+ * so long responses don't drag. Emits each chunk on `onProgress` as an
+ * `output_chunk` event — the dashboard's typewriter consumes these
+ * identically to real per-token streams from claude.
+ */
+const SIMULATED_STREAM_INTERVAL_MS = 8;
+const SIMULATED_STREAM_MAX_MS = 1500;
+const SIMULATED_STREAM_MIN_CHUNK = 30;
+
+async function simulateStreamingChunks(
+  text: string,
+  onProgress: (event: SpawnProgress) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (!text) return;
+  // Compute chunk size that keeps total time under MAX_MS.
+  const maxChunks = Math.max(1, Math.floor(SIMULATED_STREAM_MAX_MS / SIMULATED_STREAM_INTERVAL_MS));
+  const chunkSize = Math.max(SIMULATED_STREAM_MIN_CHUNK, Math.ceil(text.length / maxChunks));
+  for (let i = 0; i < text.length; i += chunkSize) {
+    if (signal?.aborted) return;
+    const chunk = text.slice(i, i + chunkSize);
+    onProgress({
+      timestamp: new Date().toISOString(),
+      type: 'output_chunk',
+      message: chunk,
+    });
+    if (i + chunkSize < text.length) {
+      await new Promise<void>((resolve) => setTimeout(resolve, SIMULATED_STREAM_INTERVAL_MS));
+    }
+  }
 }
 
 /**

--- a/packages/dashboard/src/lib/provider-usage.test.ts
+++ b/packages/dashboard/src/lib/provider-usage.test.ts
@@ -17,7 +17,7 @@ describe('computeProviderUsage', () => {
   it('returns one row per provider, even when no agents use them', () => {
     const rows = computeProviderUsage([]);
     const ids = rows.map((r) => r.id).sort();
-    expect(ids).toEqual(['claude', 'codex']);
+    expect(ids).toEqual(['apple-foundation-models', 'claude', 'codex']);
     for (const r of rows) {
       expect(r.agentCount).toBe(0);
       expect(typeof r.installed).toBe('boolean');

--- a/packages/dashboard/src/lib/provider-usage.ts
+++ b/packages/dashboard/src/lib/provider-usage.ts
@@ -29,7 +29,7 @@ function isLlmPromptNode(type: string | undefined): boolean {
  */
 export function computeProviderUsage(agents: Agent[]): ProviderUsageRow[] {
   const availability = detectLlms();
-  const counts: Record<LlmProvider, number> = { claude: 0, codex: 0 };
+  const counts: Record<LlmProvider, number> = { claude: 0, codex: 0, 'apple-foundation-models': 0 };
 
   for (const agent of agents) {
     const agentDefault = (agent.provider ?? 'claude') as LlmProvider;

--- a/packages/dashboard/src/views/llm-options.ts
+++ b/packages/dashboard/src/views/llm-options.ts
@@ -1,4 +1,11 @@
+import type { LlmProvider } from '@some-useful-agents/core';
 import { html, type SafeHtml } from './html.js';
+
+const PROVIDER_OPTIONS: ReadonlyArray<{ id: LlmProvider; label: string }> = [
+  { id: 'claude', label: 'Claude' },
+  { id: 'codex', label: 'Codex' },
+  { id: 'apple-foundation-models', label: 'Apple Foundation Models' },
+];
 
 /**
  * Per-node LLM options for `type: llm-prompt` nodes — provider, model,
@@ -17,7 +24,9 @@ export interface LlmOptionsValues {
 }
 
 export function renderLlmOptions(values: LlmOptionsValues = {}): SafeHtml {
-  const provider = values.provider === 'codex' ? 'codex' : 'claude';
+  const selected: LlmProvider = PROVIDER_OPTIONS.some((o) => o.id === values.provider)
+    ? (values.provider as LlmProvider)
+    : 'claude';
   const model = typeof values.model === 'string' ? values.model : '';
   const maxTurns =
     typeof values.maxTurns === 'number' ? String(values.maxTurns)
@@ -32,10 +41,9 @@ export function renderLlmOptions(values: LlmOptionsValues = {}): SafeHtml {
     <div class="form-field">
       <strong>Provider</strong>
       <select name="provider" class="form-field__input" style="width: auto;">
-        <option value="claude" ${provider !== 'codex' ? 'selected' : ''}>Claude</option>
-        <option value="codex" ${provider === 'codex' ? 'selected' : ''}>Codex</option>
+        ${PROVIDER_OPTIONS.map((opt) => html`<option value="${opt.id}" ${selected === opt.id ? 'selected' : ''}>${opt.label}</option>`) as unknown as SafeHtml[]}
       </select>
-      <span class="form-field__hint">Which LLM CLI runs the prompt. Inherits from the agent if unset.</span>
+      <span class="form-field__hint">Which LLM provider runs the prompt. Inherits from the agent if unset.</span>
     </div>
 
     <div class="form-field">
@@ -62,7 +70,7 @@ export function renderLlmOptions(values: LlmOptionsValues = {}): SafeHtml {
 }
 
 export interface ParsedLlmOptions {
-  provider?: 'claude' | 'codex';
+  provider?: LlmProvider;
   model?: string;
   maxTurns?: number;
   allowedTools?: string[];
@@ -72,8 +80,8 @@ export interface ParsedLlmOptions {
 export function parseLlmOptions(body: Record<string, unknown>): ParsedLlmOptions {
   const result: ParsedLlmOptions = {};
 
-  if (typeof body.provider === 'string' && (body.provider === 'claude' || body.provider === 'codex')) {
-    result.provider = body.provider;
+  if (typeof body.provider === 'string' && PROVIDER_OPTIONS.some((o) => o.id === body.provider)) {
+    result.provider = body.provider as LlmProvider;
   }
 
   if (typeof body.model === 'string' && body.model.trim()) {

--- a/packages/dashboard/src/views/settings-llm.ts
+++ b/packages/dashboard/src/views/settings-llm.ts
@@ -17,6 +17,7 @@ export interface SettingsLlmArgs {
 const PROVIDER_LABEL: Record<LlmProvider, string> = {
   claude: 'Claude (claude CLI)',
   codex: 'Codex (codex CLI)',
+  'apple-foundation-models': 'Apple Foundation Models (on-device)',
 };
 
 export function renderSettingsLlm(args: SettingsLlmArgs): SafeHtml {


### PR DESCRIPTION
**PR B of the LLM fallback + apple-foundation-models plan** (`~/.claude/plans/i-need-help-with-zippy-goose.md`). PR A (#415) landed; this PR adds `apple-foundation-models` as a third LLM provider parallel to `claude` and `codex`. Runs entirely on-device via Apple's `SystemLanguageModel` / `FoundationModels` framework. No API key, no network. macOS 26+ with Xcode CLT (`xcrun`) required.

## How it works

A tiny Swift runner ships embedded in [`apple-foundationmodels-runner.ts`](packages/core/src/apple-foundationmodels-runner.ts). On first use, `ensureAppleRunner`:
1. Writes the source to `~/.sua/runners/apple_foundationmodels.swift`
2. Compiles with `xcrun swiftc -parse-as-library` to `~/.sua/runners/apple_foundationmodels`
3. Writes a SHA-256 source-hash sidecar — subsequent calls hit the cache; if the embedded source ever drifts the runner is recompiled automatically

On non-macOS hosts or hosts without `xcrun`, the bootstrap returns `status: 'unsupported'` without raising and the LLM waterfall falls through.

## Spawner shape

Different from claude / codex:
- **Prompt via env vars** (`PROMPT`, `SYSTEM_PROMPT`) — not stdin or argv
- **Output is a single JSON line** `{ status, response_text, model_name, error_message }`
- **`status: "unavailable" | "unsupported"`** map to `binary_missing` so the waterfall falls through. With PR #415's expanded `shouldFallback` already landed, this gives clean "Apple FM unavailable on this host → claude → codex" behavior.

New opt-in `LlmSpawner` extensions: `resolveBinary` (lazy binary path), `buildEnv` (env-var prompt), `promptEnvVar` (skip stdin), `classifyResult` (inline JSON-status → fallback category), `simulateStream`. Claude / codex spawners are unchanged.

## Simulated streaming

Apple FM has no native token-delta stream, but the dashboard's typewriter UX expects `output_chunk` events. After a successful run the waterfall chunks `response_text` into ~30-char pieces and emits synthetic `output_chunk` events at ~8ms intervals (capped at ~1.5s total). Same client code path as real claude streaming.

## System agent

The existing `apple-foundationmodels-prompt` user agent (which compiles Swift via shell nodes) is now bundled in `agents/examples/apple-foundationmodels-prompt.yaml` as a system agent so it ships with sua. It still demos the underlying mechanics — but for new agents you just set `provider: apple-foundation-models` on any `llm-prompt` node and skip the Swift boilerplate.

## Dashboard

- Per-node provider select in `llm-options.ts` now lists Apple Foundation Models
- `/settings/llm` chain editor shows the new provider with a probe row
- `provider-usage` includes the new id

## Tests

- New [`apple-foundationmodels-runner.test.ts`](packages/core/src/apple-foundationmodels-runner.test.ts) — 6 tests: non-macOS unsupported branch, real-CLI-gated compile + cache hit + hash-drift recompile
- Extended [`node-spawner.test.ts`](packages/core/src/node-spawner.test.ts) — 7 new tests covering the spawner contract (env-var prompt, simulateStream, extractResult on each status, classifyResult mapping, 3-provider chain with Apple FM pin)
- Extended [`provider-usage.test.ts`](packages/dashboard/src/lib/provider-usage.test.ts) — assert the new provider appears in the usage rows
- Full suite: **1785 passing**, 3 skipped (matches baseline + new tests)

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run packages/core packages/dashboard` — 1785 pass
- [ ] Live: visit `/settings/llm` → confirm "Apple Foundation Models (on-device)" appears with a probe row.
- [ ] Live: add it to the chain head; run any agent with no provider pin → confirm it uses Apple FM and the typewriter renders.
- [ ] Live: pin a node to `claude`, kill claude auth, run → confirm it falls back through to Apple FM (PR #415's `auth_required` expansion + this PR's mapping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)