### PR TITLE
fix(core,dashboard): apple-foundation-models reaches the schema + every UI dropdown

### DIFF
--- a/.changeset/apple-fm-provider-misses.md
+++ b/.changeset/apple-fm-provider-misses.md
@@ -1,0 +1,38 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+fix(core,dashboard): apple-foundation-models reaches the schema + every UI dropdown
+
+Follow-up to #416. The provider was added to the LlmProvider union and
+spawner registry, but five other sites still hardcoded only
+`['claude', 'codex']`:
+
+- **agent-v2-schema.ts** — Zod `z.enum(['claude', 'codex'])` on the
+  agent-level and node-level `provider` fields. Any agent YAML with
+  `provider: apple-foundation-models` would fail schema validation
+  before reaching the executor. Now driven by `PROVIDER_IDS` so new
+  providers register through one place.
+- **dashboard/routes/versions.ts** — `VALID_PROVIDERS` set + the
+  agent-llm save handler's `'claude' | 'codex'` cast both refused the
+  new provider. Now sourced from `LLM_PROVIDERS`; error message
+  enumerates the full set.
+- **dashboard/views/agent-detail/config.ts** — the per-agent LLM
+  defaults card's provider select listed only claude + codex. Apple
+  FM was reachable via per-node pin (llm-options.ts) but the
+  agent-default UI couldn't pick it.
+- **core/node-catalog.ts** — `llm-prompt` / `claude-code` node docs
+  said `'claude' | 'codex'` in the type string and "Run an LLM
+  (Claude or Codex)" in the description.
+- **dashboard/views/settings-llm.ts** — intro paragraph still claimed
+  "Rate limits, auth failures, and other errors stay on the same
+  provider" after PR #415 expanded `shouldFallback` to include both.
+  Now reflects the post-#415 policy.
+
+No new tests — existing 1785-test suite covers the schema + route
+paths via the bundled apple-foundationmodels-prompt agent and the
+node-spawner tests added in #416.

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -17,8 +17,21 @@
 import { z } from 'zod';
 import { validateScheduleInterval, CronInvalidError, CronTooFrequentError } from './cron-validator.js';
 import { extractInputReferences, SENSITIVE_ENV_NAMES } from './input-resolver.js';
+import { PROVIDER_IDS } from './llm-providers.js';
 import { inputSpecSchema, outputSpecSchema } from './schema.js';
 import { outputWidgetSchema } from './output-widget-schema.js';
+
+/**
+ * Zod enum over every registered LLM provider id. Sourced from
+ * `PROVIDER_IDS` so new providers automatically validate through the
+ * agent + node `provider` fields without a schema edit. The double
+ * cast (`as [string, ...string[]]`) is required because
+ * `PROVIDER_IDS` is typed as `readonly LlmProvider[]` and z.enum needs
+ * a non-empty mutable-tuple type.
+ */
+const providerEnumSchema = z.enum(
+  PROVIDER_IDS as unknown as [typeof PROVIDER_IDS[number], ...typeof PROVIDER_IDS[number][]],
+);
 
 const AGENT_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
 const NODE_ID_RE = /^[a-z0-9][a-z0-9_-]*$/;
@@ -98,7 +111,7 @@ export const agentNodeSchema = z.object({
   model: z.string().optional(),
   maxTurns: z.number().int().positive().optional(),
   allowedTools: z.array(z.string()).optional(),
-  provider: z.enum(['claude', 'codex']).optional(),
+  provider: providerEnumSchema.optional(),
 
   // file-write node fields (top-level for ergonomics; desugar to toolInputs at dispatch).
   path: z.string().optional(),
@@ -194,7 +207,7 @@ export const agentV2Schema = z.object({
     imgSrc: z.array(z.string().regex(/^(\*\.)?[a-z0-9]([a-z0-9.-]*[a-z0-9])?$/, 'imgSrc hosts must be lowercase host names, optional leading "*." for wildcard subdomains')).optional(),
   }).optional(),
 
-  provider: z.enum(['claude', 'codex']).optional(),
+  provider: providerEnumSchema.optional(),
   model: z.string().optional(),
 
   inputs: z.record(

--- a/packages/core/src/node-catalog.ts
+++ b/packages/core/src/node-catalog.ts
@@ -80,10 +80,10 @@ export const NODE_CATALOG: Record<NodeType, NodeContract> = {
 
   'llm-prompt': {
     type: 'llm-prompt',
-    description: 'Run an LLM (Claude or Codex) with a prompt. Optional tool access via allowedTools. Alias: claude-code.',
+    description: 'Run an LLM (Claude, Codex, or Apple Foundation Models) with a prompt. Optional tool access via allowedTools. Alias: claude-code.',
     inputs: [
       { name: 'prompt', type: 'string', required: true, description: 'Prompt text. References inputs via {{inputs.X}}, upstreams via {{upstream.<id>.result}}.' },
-      { name: 'provider', type: "'claude' | 'codex'", description: 'Which CLI to spawn. Defaults to the agent-level provider, then to claude.' },
+      { name: 'provider', type: "'claude' | 'codex' | 'apple-foundation-models'", description: 'Which CLI to spawn. Defaults to the agent-level provider, then to claude.' },
       { name: 'model', type: 'string', description: 'Override the default model for this node only.' },
       { name: 'maxTurns', type: 'number', description: 'Cap on tool-use turns. Default 5.' },
       { name: 'allowedTools', type: 'string[]', description: 'Tools the LLM may call. Built-ins: file-read, file-write, Edit, Write, web-search, etc. MCP tools when configured.' },
@@ -113,10 +113,10 @@ export const NODE_CATALOG: Record<NodeType, NodeContract> = {
 
   'claude-code': {
     type: 'claude-code',
-    description: 'Run an LLM (Claude or Codex) with a prompt. Optional tool access via allowedTools.',
+    description: 'Run an LLM (Claude, Codex, or Apple Foundation Models) with a prompt. Optional tool access via allowedTools.',
     inputs: [
       { name: 'prompt', type: 'string', required: true, description: 'Prompt text. References inputs via {{inputs.X}}, upstreams via {{upstream.<id>.result}}.' },
-      { name: 'provider', type: "'claude' | 'codex'", description: 'Which CLI to spawn. Defaults to the agent-level provider, then to claude.' },
+      { name: 'provider', type: "'claude' | 'codex' | 'apple-foundation-models'", description: 'Which CLI to spawn. Defaults to the agent-level provider, then to claude.' },
       { name: 'model', type: 'string', description: 'Override the default model for this node only.' },
       { name: 'maxTurns', type: 'number', description: 'Cap on tool-use turns. Default 5.' },
       { name: 'allowedTools', type: 'string[]', description: 'Tools the LLM may call. Built-ins: file-read, file-write, Edit, Write, web-search, etc. MCP tools when configured.' },

--- a/packages/dashboard/src/routes/versions.ts
+++ b/packages/dashboard/src/routes/versions.ts
@@ -1,7 +1,7 @@
 import { Router, type Request, type Response } from 'express';
 import { getContext } from '../context.js';
 import { renderVersionsList, renderVersionDetail } from '../views/versions.js';
-import { validateScheduleInterval, CronInvalidError, CronTooFrequentError } from '@some-useful-agents/core';
+import { validateScheduleInterval, CronInvalidError, CronTooFrequentError, LLM_PROVIDERS, type LlmProvider } from '@some-useful-agents/core';
 
 /**
  * Version history + rollback routes for v2 DAG agents.
@@ -281,7 +281,7 @@ versionsRouter.post('/agents/:id/schedule', (req: Request, res: Response) => {
   }
 });
 
-const VALID_PROVIDERS = new Set(['claude', 'codex']);
+const VALID_PROVIDERS: ReadonlySet<string> = new Set(LLM_PROVIDERS);
 
 /**
  * POST /agents/:id/llm — update agent-level provider and model defaults.
@@ -296,7 +296,7 @@ versionsRouter.post('/agents/:id/llm', (req: Request, res: Response) => {
   const model = typeof body.model === 'string' ? body.model.trim() : '';
 
   if (provider && !VALID_PROVIDERS.has(provider)) {
-    res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent('Invalid provider. Must be claude or codex.')}`);
+    res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent(`Invalid provider. Must be one of: ${LLM_PROVIDERS.join(', ')}.`)}`);
     return;
   }
 
@@ -307,7 +307,7 @@ versionsRouter.post('/agents/:id/llm', (req: Request, res: Response) => {
   }
 
   // Check for no-op.
-  const newProvider = (provider || undefined) as 'claude' | 'codex' | undefined;
+  const newProvider = (provider || undefined) as LlmProvider | undefined;
   const newModel = model || undefined;
   if (agent.provider === newProvider && agent.model === newModel) {
     res.redirect(303, `/agents/${encodeURIComponent(id)}/config?flash=${encodeURIComponent('LLM defaults unchanged.')}`);

--- a/packages/dashboard/src/views/agent-detail/config.ts
+++ b/packages/dashboard/src/views/agent-detail/config.ts
@@ -256,6 +256,7 @@ export async function renderAgentConfig(args: AgentDetailArgs): Promise<string> 
         <select name="provider" id="llm-provider" class="form-field" style="flex: 1; padding: var(--space-1) var(--space-2); font-size: var(--font-size-sm);">
           ${providerOption('claude', agent.provider)}
           ${providerOption('codex', agent.provider)}
+          ${providerOption('apple-foundation-models', agent.provider)}
         </select>
       </div>
       <div style="display: flex; gap: var(--space-2); align-items: center;">

--- a/packages/dashboard/src/views/settings-llm.ts
+++ b/packages/dashboard/src/views/settings-llm.ts
@@ -131,12 +131,13 @@ export function renderSettingsLlm(args: SettingsLlmArgs): SafeHtml {
     <section class="settings-section">
       <h2 class="mt-0">LLM provider waterfall</h2>
       <p class="dim">
-        An ordered chain of CLI providers. The first entry is the
+        An ordered chain of LLM providers. The first entry is the
         <strong>primary</strong> — every <code>llm-prompt</code> node calls
-        into it by default. On recognized failures (credit / quota /
-        binary-missing / hard-timeout), the runtime walks the rest of the
-        chain in order until one succeeds. Rate limits, auth failures, and
-        other errors stay on the same provider.
+        into it by default. On recognized failures (binary missing,
+        timeout, quota / credit exhausted, auth required, or rate
+        limited) the runtime walks the rest of the chain in order
+        until one succeeds. Unclassified errors stay on the same
+        provider so real bugs surface instead of being masked.
       </p>
       <p class="dim">
         When an agent or node pins its own provider, that provider runs


### PR DESCRIPTION
Follow-up to #416. While #416 added \`apple-foundation-models\` to the \`LlmProvider\` union and the spawner registry, **five other sites still hardcoded only \`['claude', 'codex']\`**:

| # | Site | Effect of the miss |
|---|------|--------------------|
| 1 | [\`agent-v2-schema.ts\`](packages/core/src/agent-v2-schema.ts) (2 lines) | Any agent YAML with \`provider: apple-foundation-models\` failed Zod schema validation before reaching the executor |
| 2 | [\`dashboard/routes/versions.ts\`](packages/dashboard/src/routes/versions.ts) | \`POST /agents/:id/llm\` refused the provider with \"Must be claude or codex.\" |
| 3 | [\`dashboard/views/agent-detail/config.ts\`](packages/dashboard/src/views/agent-detail/config.ts) | The agent-default LLM card's provider select listed only claude + codex |
| 4 | [\`core/node-catalog.ts\`](packages/core/src/node-catalog.ts) | \`llm-prompt\` / \`claude-code\` node docs still said \`'claude' \\| 'codex'\` |
| 5 | [\`dashboard/views/settings-llm.ts\`](packages/dashboard/src/views/settings-llm.ts) | Intro copy still claimed rate-limited / auth-required errors don't fall back (false after PR #415) |

## Changes
- Introduced a shared \`providerEnumSchema\` in \`agent-v2-schema.ts\` that derives from \`PROVIDER_IDS\` — adding a new provider is now a one-place change.
- \`versions.ts\` now reads \`LLM_PROVIDERS\` (the already-exported alias of \`PROVIDER_IDS\`); the error message enumerates the full set.
- \`config.ts\` adds a third \`<option>\` to the agent-default provider select.
- \`node-catalog.ts\` updates the type string and description on both node types.
- \`settings-llm.ts\` rewrites the intro to match PR #415's expanded fallback policy.

## Test plan
- [x] \`npm run build\` clean
- [x] \`npx vitest run packages/core packages/dashboard\` — 1785 passed, 3 skipped (matches baseline)
- [ ] Live: open \`/agents/<id>/config\` and confirm \"apple-foundation-models\" appears in the provider dropdown
- [ ] Live: save an agent with provider set to apple-foundation-models — should succeed instead of returning the \"Must be claude or codex\" flash
- [ ] Live: \`/settings/llm\` intro paragraph reads correctly post-#415

🤖 Generated with [Claude Code](https://claude.com/claude-code)