### PR TITLE
feat(dashboard,examples): triage dispatches agent-builder with auto-injected catalogs

### DIFF
--- a/.changeset/triage-agent-builder.md
+++ b/.changeset/triage-agent-builder.md
@@ -1,0 +1,46 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+feat(dashboard,examples): triage dispatches agent-builder with auto-injected catalogs
+
+Closes the gap flagged in PR #411: when the operator asks triage to
+"build me an X agent" and no installed agent matches a prior catalog-
+search, triage now proposes an `agent-builder` action instead of
+telling the operator to run `/build` themselves.
+
+### What landed
+
+- `agent-builder` is now in `TRIAGE_SUB_AGENT_ALLOWLIST`,
+  `TRIAGE_AUTO_APPROVE_AGENTS`, and `SYSTEM_AGENT_IDS`. The proposal
+  auto-runs on emit (no operator click), the commitment chip pulses
+  through the run, and catalog-search hides it from results so it
+  isn't recommended as a generic match.
+- New `enrichAgentBuilderInputs` helper in `routes/inbox.ts` injects
+  `AVAILABLE_TOOLS` (formatted tool catalog) + `DISCOVERY_CATALOG`
+  (built via `buildDiscoveryCatalog` from agent + tool + template +
+  dashboard + pack stores). Mirrors the `/agents/new` "Build from
+  goal" flow's input shape so triage-dispatched builds see the same
+  context as the dashboard button path.
+- `inbox-triage.yaml` prompt now documents `agent-builder` under the
+  Agent guide:
+  - Pass `GOAL` verbatim from the operator's request.
+  - `FOCUS` is opt-in for genuine constraints only.
+  - Auto-injection is called out so triage doesn't try to thread the
+    catalogs through `inputs`.
+  - Order-of-operations rule: propose `agent-catalog-search` FIRST
+    when the operator names a topic, then propose `agent-builder`
+    only after a confirmed miss (or when the operator explicitly
+    asked for a fresh build).
+- Added an `agent-builder` example to the OUTPUT FORMAT block with
+  the right `commitmentSummary` shape ("drafting trivia-night
+  agent").
+
+After restart, triage stops bouncing operators to `/build` for
+"build me an agent" requests — Layer 2 auto-approves the proposal,
+the chip pulses while it runs, and Layer 3 wraps with a summary the
+operator can act on.

--- a/agents/examples/inbox-triage.yaml
+++ b/agents/examples/inbox-triage.yaml
@@ -279,6 +279,28 @@ nodes:
         exist — you don't see the catalog, but the search agent
         does.
 
+      - `agent-builder` → the operator wants to BUILD a new agent
+        ("draft me an agent that …", "build a trivia-night agent",
+        "create one that pulls X and posts Y"). Pass `GOAL` = the
+        operator's full request, verbatim and unedited; pass `FOCUS`
+        only when the conversation has produced a SPECIFIC additional
+        constraint (e.g. the operator said "shell-only, no LLM
+        nodes", "schedule it daily", "use the cocktail-db API"). When
+        no constraint surfaced, omit `FOCUS` entirely or pass an
+        empty string. The dashboard auto-injects `AVAILABLE_TOOLS`
+        and `DISCOVERY_CATALOG`, so you don't thread either.
+        commitmentSummary should be the verb-led "drafting <NAME>
+        agent" form (e.g. "drafting trivia-night agent").
+
+        ORDER OF OPERATIONS when the operator asks for an agent on a
+        topic: PROPOSE `agent-catalog-search` FIRST to check for an
+        existing one. If catalog-search returns no installed match,
+        the FOLLOW-UP turn proposes `agent-builder` to draft a new
+        one. Do NOT propose both in the same turn — `agent-builder`
+        only runs after a confirmed miss. The exception: when the
+        operator EXPLICITLY says "build a new one" or "I want a
+        fresh one" — propose builder directly.
+
       If `ALLOWED_SUB_AGENTS` is empty OR no action would help, omit
       `actions` entirely (or send an empty array). Text-only
       recommendations are perfectly fine.
@@ -328,6 +350,27 @@ nodes:
             "agentId": "agent-catalog-search",
             "inputs": { "QUERY": "trivia — generate trivia questions, host a quiz, or answer trivia" },
             "rationale": "Search the installed catalog for any agent that already covers trivia."
+          }
+        ]
+      }
+      </plan>
+
+      Example proposing agent-builder (operator explicitly asked to
+      build a new agent, OR a prior agent-catalog-search returned no
+      matches). Pass GOAL verbatim. The dashboard injects the tool
+      catalog + discovery context, so `inputs` stays tiny:
+
+      <plan>
+      {
+        "messageId": "{{inputs.MESSAGE_ID}}",
+        "recommendation": "I'll draft the trivia-night agent now — it'll generate questions, host a quiz, and track scores.",
+        "commitmentSummary": "drafting trivia-night agent",
+        "actions": [
+          {
+            "type": "run-agent",
+            "agentId": "agent-builder",
+            "inputs": { "GOAL": "Build a trivia-night agent that asks questions, accepts answers, and tracks scores using the Open Trivia DB API." },
+            "rationale": "Draft a complete agent YAML from the operator's goal."
           }
         ]
       }

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -26,17 +26,22 @@ import { Router, type Request, type Response } from 'express';
 import { readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import {
+  buildDiscoveryCatalog,
   exportAgent,
   executeAgentDag,
   extractPlanJson,
+  listBuiltinTools,
   parseAgent,
   type RunStatus,
   type InboxActionMeta,
   type InboxActionStatus,
   type InboxResponse,
+  type ToolDefinition,
 } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 import { buildLlmSettingsSnapshot } from '../lib/llm-settings-snapshot.js';
+import { formatToolCatalog } from './run-now-build.js';
+import { TEMPLATE_REGISTRY } from '../views/pulse-templates.js';
 import {
   renderInboxList,
   type InboxSortKey,
@@ -98,6 +103,7 @@ const TRIAGE_SUB_AGENT_ALLOWLIST: readonly string[] = [
   'agent-analyzer',
   'agent-editor',
   'agent-catalog-search',
+  'agent-builder',
 ];
 
 /**
@@ -119,6 +125,7 @@ const TRIAGE_AUTO_APPROVE_AGENTS: ReadonlySet<string> = new Set([
   'agent-analyzer',
   'agent-editor',
   'agent-catalog-search',
+  'agent-builder',
 ]);
 
 /**
@@ -134,6 +141,7 @@ const SYSTEM_AGENT_IDS: ReadonlySet<string> = new Set([
   'agent-analyzer',
   'agent-editor',
   'agent-catalog-search',
+  'agent-builder',
 ]);
 
 /**
@@ -859,6 +867,47 @@ function enrichAgentCatalogSearchInputs(
 }
 
 /**
+ * Inject `AVAILABLE_TOOLS` + `DISCOVERY_CATALOG` into agent-builder
+ * inputs. Both are required by `agents/examples/agent-builder.yaml`'s
+ * design node; the operator-facing "Build from goal" flow at
+ * `run-now-build.ts:340-348` already supplies them and we mirror its
+ * input shape here so a triage-dispatched agent-builder run sees the
+ * same catalog the dashboard's button-driven flow does.
+ *
+ * Preserves any caller-supplied values (triage occasionally passes a
+ * narrowed FOCUS; never the registries). Falls back to whatever the
+ * stores expose — empty strings are acceptable inputs and the agent
+ * gracefully degrades when a catalog is missing.
+ */
+function enrichAgentBuilderInputs(
+  ctx: ReturnType<typeof getContext>,
+  inputs: Record<string, string>,
+): Record<string, string> {
+  const out: Record<string, string> = { ...inputs };
+  try {
+    const builtins = listBuiltinTools();
+    let userTools: ToolDefinition[] = [];
+    try {
+      if (ctx.toolStore) userTools = ctx.toolStore.listTools();
+    } catch { /* store not available */ }
+    const allTools = [...builtins, ...userTools];
+    if (!out.AVAILABLE_TOOLS) {
+      out.AVAILABLE_TOOLS = formatToolCatalog(allTools);
+    }
+    if (!out.DISCOVERY_CATALOG) {
+      out.DISCOVERY_CATALOG = buildDiscoveryCatalog({
+        agents: ctx.agentStore.listAgents(),
+        tools: allTools,
+        templateRegistry: TEMPLATE_REGISTRY,
+        dashboards: ctx.dashboardsStore?.listDashboards(),
+        packs: ctx.packsStore?.listPacks(),
+      });
+    }
+  } catch { /* swallow — agent-builder validates inputs and will fail loudly */ }
+  return out;
+}
+
+/**
  * Distilled version of run-now-build.ts's run-output collector:
  * grab the latest completed run's result + the latest failed run's
  * error/output, cap at 3000 chars. Empty string when neither exists.
@@ -1058,6 +1107,8 @@ async function runProposedAction(
     effectiveInputs = enrichAgentAnalyzerInputs(ctx, targetAgentId, meta.inputs);
   } else if (meta.agentId === 'agent-catalog-search') {
     effectiveInputs = enrichAgentCatalogSearchInputs(ctx, meta.inputs);
+  } else if (meta.agentId === 'agent-builder') {
+    effectiveInputs = enrichAgentBuilderInputs(ctx, meta.inputs);
   }
 
   let runId: string | undefined;


### PR DESCRIPTION
## Summary
Closes the gap flagged in [#411](https://github.com/gregmeyer/some-useful-agents/pull/411) and called out in the user's recent \"triage is fighting me\" report: when the operator asks triage to *build* an agent and no installed match exists, triage now proposes an \`agent-builder\` action instead of telling them to use \`/build\`.

## What landed

**1. Allowlist + auto-approve.**
- \`agent-builder\` added to [\`TRIAGE_SUB_AGENT_ALLOWLIST\`](packages/dashboard/src/routes/inbox.ts#L69), [\`TRIAGE_AUTO_APPROVE_AGENTS\`](packages/dashboard/src/routes/inbox.ts#L119), and [\`SYSTEM_AGENT_IDS\`](packages/dashboard/src/routes/inbox.ts#L133).
- The proposal auto-runs on emit, the Layer 1 commitment chip pulses while it runs, and Layer 3 fires a wrap-up triage turn on completion.
- \`agent-catalog-search\` hides it from result sets (system-agent filter).

**2. Auto-injection of \`AVAILABLE_TOOLS\` + \`DISCOVERY_CATALOG\`.**
- New \`enrichAgentBuilderInputs\` helper in [\`routes/inbox.ts\`](packages/dashboard/src/routes/inbox.ts) parallel to \`enrichAgentAnalyzerInputs\`. Imports \`listBuiltinTools\`, \`buildDiscoveryCatalog\`, \`formatToolCatalog\`, and \`TEMPLATE_REGISTRY\` — same primitives the \`/agents/new\` \"Build from goal\" flow uses ([\`run-now-build.ts:340-348\`](packages/dashboard/src/routes/run-now-build.ts#L340-L348)).
- Triage-dispatched builds now see the same catalog the button-driven flow does.

**3. Prompt guidance.**
- [\`agents/examples/inbox-triage.yaml\`](agents/examples/inbox-triage.yaml) gains an \`agent-builder\` section in the Agent guide:
  - Pass \`GOAL\` verbatim from the operator's request.
  - \`FOCUS\` only when a specific constraint has surfaced in conversation.
  - Auto-injection called out so triage doesn't thread the catalogs.
  - **Order-of-operations rule:** propose \`agent-catalog-search\` FIRST when the operator names a topic; only propose \`agent-builder\` after a confirmed miss, or when the operator explicitly asks for a fresh build.
- New OUTPUT FORMAT example with the right \`commitmentSummary\` shape (\"drafting trivia-night agent\").

## Test plan
- [x] \`npm run build\` clean
- [x] \`npx vitest run packages/core packages/dashboard packages/mcp-server\` — **1832 passing**, 3 skipped (baseline unchanged)
- [ ] Live: post \"build me a trivia-night agent that asks questions and tracks scores\" to a manual inbox thread → triage proposes catalog-search → returns no match → triage's follow-up proposes agent-builder → auto-runs → operator sees the drafted YAML in the wrap-up summary.

## Composition with prior work
This is the last piece of the triage-follow-through arc:
- [#411](https://github.com/gregmeyer/some-useful-agents/pull/411) — commitment chip + prompt rule against prose-only promises.
- [#412](https://github.com/gregmeyer/some-useful-agents/pull/412) — trusted sub-agent auto-approve.
- [#413](https://github.com/gregmeyer/some-useful-agents/pull/413) — turn budget cap (5).
- [#418](https://github.com/gregmeyer/some-useful-agents/pull/418) — per-agent allowedSubAgents UI (lets operators add ad-hoc agents to triage's allowlist).
- **This PR** — agent-builder ships in the default allowlist with auto-injected context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)