### PR TITLE
feat(dashboard): Build from goal honors an optional LLM provider pin

### DIFF
--- a/.changeset/build-from-goal-provider-picker.md
+++ b/.changeset/build-from-goal-provider-picker.md
@@ -1,0 +1,36 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+feat(dashboard): "Build from goal" honors an optional LLM provider pin
+
+The Build-from-goal modal now exposes an "LLM provider" select that
+defaults to "Use system default (waterfall from /settings/llm)" and
+offers every registered provider (claude, codex, apple-foundation-
+models). When the operator picks a provider, the chosen id pins the
+head of the waterfall for every llm-prompt node in the surveyor /
+drafter / designer chain. The global fallback chain still applies on
+classified failures (binary missing, timeout, quota, auth, rate-
+limit) — the pin says "try this first," not "use only this."
+
+Threaded through:
+- `build-from-goal-modal.ts` — new `<select id="build-provider">` with
+  every `LLM_PROVIDERS` entry.
+- `build-from-goal.js.ts` — appends `provider=…` to the POST body.
+- `POST /agents/build` + `POST /agents/draft-one` — validate against
+  `LLM_PROVIDERS`, pass through.
+- `startBuildSession` + `startDraftOneSession` accept `provider`,
+  persist as `session.providerPin`.
+- `kickoffAgentRun` gains a `providerPin` arg; when set, clones the
+  agent and stamps every `llm-prompt` (or legacy `claude-code`) node
+  with the pin via a new `applyProviderPin` helper. Non-LLM nodes
+  (shell, file-write, control flow) are unchanged.
+- Drafter retries + designer kickoff read `session.providerPin` so
+  the pin survives the full build flow.
+
+Unset → existing behavior (each node inherits its declared provider,
+the agent's default, or the global primary).

--- a/packages/dashboard/src/routes/build-orchestrator.ts
+++ b/packages/dashboard/src/routes/build-orchestrator.ts
@@ -24,6 +24,7 @@ import {
   executeAgentDag,
   extractPlanJson,
   extractSurveyJson,
+  isLlmPromptType,
   parseAgent,
   surveySchema,
   draftSchema,
@@ -38,6 +39,7 @@ import {
   type Agent,
   type BuildPlan,
   type Draft,
+  type LlmProvider,
   type Survey,
   type DashboardDesign,
 } from '@some-useful-agents/core';
@@ -65,6 +67,14 @@ interface BuildSession {
   id: string;
   goal: string;
   focus: string;
+  /**
+   * Optional provider pin applied to every llm-prompt node in the
+   * surveyor / drafter / designer chain. Defaults to undefined =
+   * "use the system default chain from /settings/llm." When set, the
+   * pin starts the waterfall but the global fallback chain still
+   * applies on classified failures.
+   */
+  providerPin?: LlmProvider;
   createdAt: number;
 
   phase: SessionPhase;
@@ -124,8 +134,18 @@ async function kickoffAgentRun(args: {
   ctx: Ctx;
   agent: Agent;
   inputs: Record<string, string>;
+  /**
+   * Optional provider pin applied to every llm-prompt node in the
+   * agent before dispatch. When set, the pin runs first in the
+   * waterfall and the global fallback chain still applies on
+   * classified failures (auth, rate-limit, binary-missing, etc. —
+   * see node-spawner.ts:shouldFallback). When unset, each node
+   * inherits its declared provider (or the agent's default, or the
+   * global primary).
+   */
+  providerPin?: LlmProvider;
 }): Promise<string | null> {
-  const { ctx, agent, inputs } = args;
+  const { ctx, agent, inputs, providerPin } = args;
   // Pre-generate the run-id. Eliminates the race in the old code path
   // (which queried runStore for "most-recent run by agentName" — when
   // N parallel kickoffs target the same agent, the query returns the
@@ -133,11 +153,12 @@ async function kickoffAgentRun(args: {
   // polling the same drafter run). Passing runId in via DagExecuteOptions
   // means we know the id without ever needing the query.
   const runId = randomUUID();
+  const effectiveAgent = providerPin ? applyProviderPin(agent, providerPin) : agent;
   // Fire-and-forget: don't await the run completion here; callers poll
   // runStore later. Swallow errors so a startup failure doesn't reject
   // the kickoff promise — the polling path surfaces the failed run.
   executeAgentDag(
-    agent,
+    effectiveAgent,
     {
       triggeredBy: 'dashboard',
       inputs,
@@ -152,6 +173,22 @@ async function kickoffAgentRun(args: {
     },
   ).catch(() => { /* failure surfaces via runStore.getRun(runId).status */ });
   return runId;
+}
+
+/**
+ * Clone an agent with `provider` stamped on every llm-prompt (and
+ * legacy claude-code) node so the operator's build-time pick becomes
+ * the head of the waterfall. The global fallback chain in
+ * /settings/llm still applies on classified failures — the pin is
+ * "try this first," not "use only this."
+ *
+ * Non-LLM nodes (shell, file-write, control flow) are unchanged.
+ */
+function applyProviderPin(agent: Agent, providerPin: LlmProvider): Agent {
+  return {
+    ...agent,
+    nodes: agent.nodes.map((node) => (isLlmPromptType(node.type) ? { ...node, provider: providerPin } : node)),
+  };
 }
 
 // ── Catalog helpers ────────────────────────────────────────────────────
@@ -228,8 +265,9 @@ export async function startBuildSession(args: {
   ctx: Ctx;
   goal: string;
   focus: string;
+  provider?: LlmProvider;
 }): Promise<string | null> {
-  const { ctx, goal, focus } = args;
+  const { ctx, goal, focus, provider } = args;
   gcSessions();
 
   const surveyor = loadExampleAgent(ctx, SURVEYOR_AGENT_ID);
@@ -244,6 +282,7 @@ export async function startBuildSession(args: {
       FOCUS: focus,
       DISCOVERY_CATALOG: discovery,
     },
+    providerPin: provider,
   });
   if (!runId) return null;
 
@@ -252,6 +291,7 @@ export async function startBuildSession(args: {
     id: sessionId,
     goal,
     focus,
+    providerPin: provider,
     createdAt: Date.now(),
     phase: 'survey',
     phaseMessage: 'Surveying your goal...',
@@ -274,8 +314,9 @@ export async function startDraftOneSession(args: {
   purpose: string;
   suggestedName?: string;
   focus: string;
+  provider?: LlmProvider;
 }): Promise<string | null> {
-  const { ctx, purpose, suggestedName, focus } = args;
+  const { ctx, purpose, suggestedName, focus, provider } = args;
   gcSessions();
 
   const drafter = loadExampleAgent(ctx, DRAFTER_AGENT_ID);
@@ -295,6 +336,7 @@ export async function startDraftOneSession(args: {
       AVAILABLE_TOOLS: tools,
       DISCOVERY_CATALOG: discovery,
     },
+    providerPin: provider,
   });
   if (!runId) return null;
 
@@ -307,6 +349,7 @@ export async function startDraftOneSession(args: {
     id: sessionId,
     goal: purpose,
     focus,
+    providerPin: provider,
     createdAt: Date.now(),
     phase: 'drafting',
     phaseMessage: 'Drafting agent...',
@@ -433,6 +476,7 @@ async function advanceSurvey(ctx: Ctx, session: BuildSession): Promise<void> {
         AVAILABLE_TOOLS: tools,
         DISCOVERY_CATALOG: discovery,
       },
+      providerPin: session.providerPin,
     });
     return [`fragment-${i}`, runId] as const;
   });
@@ -606,6 +650,7 @@ async function advanceDrafting(ctx: Ctx, session: BuildSession): Promise<void> {
           AVAILABLE_TOOLS: tools,
           DISCOVERY_CATALOG: discovery,
         },
+        providerPin: session.providerPin,
       });
       return [key, newRunId] as const;
     });
@@ -675,6 +720,7 @@ async function startDesignerStage(ctx: Ctx, session: BuildSession): Promise<void
       AGENT_IDS: allAgentIds.join(', '),
       AGENT_DESCRIPTIONS: JSON.stringify(descriptions),
     },
+    providerPin: session.providerPin,
   });
   if (!runId) {
     fail(session, 'Failed to kick off dashboard-designer.');

--- a/packages/dashboard/src/routes/run-now-build.ts
+++ b/packages/dashboard/src/routes/run-now-build.ts
@@ -13,10 +13,12 @@ import {
   parseAgent,
   buildDiscoveryCatalog,
   buildPlanSchema,
+  LLM_PROVIDERS,
   PlannerLoopRunner,
   defaultCheckImageUrl,
   findSimilarCommittedPlans,
   formatPriorPlansBlock,
+  type LlmProvider,
   type PriorPlanCandidate,
   type BuildPlan,
   type PlanCriticError,
@@ -784,13 +786,17 @@ buildRouter.post('/agents/build', async (req: Request, res: Response) => {
   const body = (req.body ?? {}) as Record<string, unknown>;
   const goal = typeof body.goal === 'string' ? body.goal.trim() : '';
   const focus = typeof body.focus === 'string' ? body.focus.trim() : '';
+  const providerRaw = typeof body.provider === 'string' ? body.provider.trim() : '';
+  const provider = providerRaw && (LLM_PROVIDERS as readonly string[]).includes(providerRaw)
+    ? (providerRaw as LlmProvider)
+    : undefined;
 
   if (!goal) {
     res.json({ ok: false, error: 'Goal is required.' });
     return;
   }
 
-  const sessionId = await startBuildSession({ ctx, goal, focus });
+  const sessionId = await startBuildSession({ ctx, goal, focus, provider });
   if (!sessionId) {
     res.json({
       ok: false,
@@ -827,13 +833,17 @@ buildRouter.post('/agents/draft-one', async (req: Request, res: Response) => {
     ? body.suggestedName.trim()
     : undefined;
   const focus = typeof body.focus === 'string' ? body.focus.trim() : '';
+  const providerRaw = typeof body.provider === 'string' ? body.provider.trim() : '';
+  const provider = providerRaw && (LLM_PROVIDERS as readonly string[]).includes(providerRaw)
+    ? (providerRaw as LlmProvider)
+    : undefined;
 
   if (!purpose) {
     res.json({ ok: false, error: 'purpose is required.' });
     return;
   }
 
-  const sessionId = await startDraftOneSession({ ctx, purpose, suggestedName, focus });
+  const sessionId = await startDraftOneSession({ ctx, purpose, suggestedName, focus, provider });
   if (!sessionId) {
     res.json({
       ok: false,

--- a/packages/dashboard/src/views/build-from-goal-modal.ts
+++ b/packages/dashboard/src/views/build-from-goal-modal.ts
@@ -12,6 +12,7 @@
  * the page body. Both the home page and the agents list page use this.
  */
 
+import { LLM_PROVIDERS, type LlmProvider } from '@some-useful-agents/core';
 import { html, unsafeHtml, type SafeHtml } from './html.js';
 
 export interface BuildFromGoalModalOptions {
@@ -19,7 +20,19 @@ export interface BuildFromGoalModalOptions {
   availableDashboards?: Array<{ id: string; name: string }>;
   /** If set, the existing-dashboard radio is pre-selected and this id is pre-chosen in the dropdown. */
   defaultDashboardId?: string;
+  /**
+   * Provider ids the runtime knows about. When unset, the picker shows
+   * only "System default" — useful for older daemons that don't pass
+   * the list through. Caller normally sources from `PROVIDER_IDS`.
+   */
+  availableProviders?: readonly LlmProvider[];
 }
+
+const PROVIDER_LABEL: Record<LlmProvider, string> = {
+  claude: 'Claude (claude CLI)',
+  codex: 'Codex (codex CLI)',
+  'apple-foundation-models': 'Apple Foundation Models (on-device)',
+};
 
 export function buildFromGoalButton(opts: { variant?: 'primary' | 'ghost' } = {}): SafeHtml {
   const cls = opts.variant === 'primary' ? 'btn btn--primary btn--sm' : 'btn btn--sm';
@@ -69,10 +82,19 @@ export function buildFromGoalModal(opts: BuildFromGoalModalOptions = {}): SafeHt
             <textarea id="build-goal" rows="3" placeholder="e.g. a daily morning dashboard with HN top stories, today's weather, and my notes folder"
               style="padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm); resize: vertical;"></textarea>
           </label>
-          <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-4);">
+          <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-3);">
             <strong style="font-size: var(--font-size-sm);">Constraints <span class="dim" style="font-weight: var(--weight-regular);">(optional)</span></strong>
             <input id="build-focus" type="text" placeholder="e.g. use shell nodes only, schedule daily at 9am"
               style="padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm);">
+          </label>
+          <label style="display: flex; flex-direction: column; gap: var(--space-1); margin-bottom: var(--space-4);">
+            <strong style="font-size: var(--font-size-sm);">LLM provider <span class="dim" style="font-weight: var(--weight-regular);">(optional)</span></strong>
+            <select id="build-provider" class="input"
+              style="padding: var(--space-2) var(--space-3); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-sm);">
+              <option value="" selected>Use system default (waterfall from /settings/llm)</option>
+              ${(opts.availableProviders ?? LLM_PROVIDERS).map((p) => html`<option value="${p}">${PROVIDER_LABEL[p] ?? p}</option>`) as unknown as SafeHtml[]}
+            </select>
+            <span class="dim" style="font-size: var(--font-size-xs);">Pins this build's planner/drafter/designer to the chosen provider. On failure the global fallback chain still applies.</span>
           </label>
           <div style="display: flex; gap: var(--space-2); justify-content: flex-end;">
             <button type="button" class="btn btn--ghost btn--sm" data-close-build="1">Cancel</button>

--- a/packages/dashboard/src/views/build-from-goal.js.ts
+++ b/packages/dashboard/src/views/build-from-goal.js.ts
@@ -50,19 +50,23 @@ export const BUILD_FROM_GOAL_JS = `
     // (the original goal field is gone from the DOM by then).
     var lastGoal = '';
     var lastFocus = '';
+    var lastProvider = '';
 
     submitBtn.addEventListener('click', function () {
       var goalEl = document.getElementById('build-goal');
       var focusEl = document.getElementById('build-focus');
+      var providerEl = document.getElementById('build-provider');
       var goal = goalEl ? goalEl.value.trim() : '';
       if (!goal) { goalEl && goalEl.focus(); return; }
       var focus = focusEl ? focusEl.value.trim() : '';
-      runPlanner(goal, focus);
+      var provider = providerEl ? String(providerEl.value || '').trim() : '';
+      runPlanner(goal, focus, provider);
     });
 
-    function runPlanner(goal, focus) {
+    function runPlanner(goal, focus, provider) {
       lastGoal = goal;
       lastFocus = focus;
+      lastProvider = provider || '';
       var t0 = Date.now();
       var cancelled = false;
       var pollTimer = null;
@@ -103,7 +107,9 @@ export const BUILD_FROM_GOAL_JS = `
       fetch('/agents/build', {
         method: 'POST', credentials: 'same-origin',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: 'goal=' + encodeURIComponent(goal) + (focus ? '&focus=' + encodeURIComponent(focus) : ''),
+        body: 'goal=' + encodeURIComponent(goal)
+          + (focus ? '&focus=' + encodeURIComponent(focus) : '')
+          + (provider ? '&provider=' + encodeURIComponent(provider) : ''),
       })
       .then(function (r) { return r.json(); })
       .then(function (startData) {
@@ -337,7 +343,7 @@ export const BUILD_FROM_GOAL_JS = `
             var ansEl = document.getElementById('build-answers');
             var ans = ansEl ? ansEl.value.trim() : '';
             if (!ans) { ansEl && ansEl.focus(); return; }
-            runPlanner(lastGoal + '\\n\\nClarifications: ' + ans, lastFocus);
+            runPlanner(lastGoal + '\\n\\nClarifications: ' + ans, lastFocus, lastProvider);
           });
         }
       }


### PR DESCRIPTION
The \"Build from goal\" modal now lets the operator optionally pin a specific LLM provider for the build flow. Defaults to \"Use system default (waterfall from /settings/llm)\" so the existing behavior is unchanged.

## Why

You asked: *\"I'd like the LLM provider to be respected when we build so that it takes system default but asks me which provider optionally do I want to use, e.g. I might want to try building on apple instead of codex or claude.\"*

Now you can. Pick \"Apple Foundation Models (on-device)\" in the modal and the surveyor + drafter(s) + designer all run pinned to it. The global fallback chain still kicks in if Apple FM returns a fallback-worthy failure (binary missing, unavailable, etc.) — the pin says \"try this first,\" not \"use only this.\"

## Threaded through

| File | What |
|---|---|
| [\`build-from-goal-modal.ts\`](packages/dashboard/src/views/build-from-goal-modal.ts) | New \`<select id=\"build-provider\">\`. Default \"Use system default\" + every \`LLM_PROVIDERS\` entry. |
| [\`build-from-goal.js.ts\`](packages/dashboard/src/views/build-from-goal.js.ts) | Appends \`provider=…\` to the POST body. Preserves the choice across the clarifications-retry path. |
| [\`POST /agents/build\`](packages/dashboard/src/routes/run-now-build.ts) + [\`POST /agents/draft-one\`](packages/dashboard/src/routes/run-now-build.ts) | Validate \`body.provider\` against \`LLM_PROVIDERS\`, pass through. |
| [\`startBuildSession\` + \`startDraftOneSession\`](packages/dashboard/src/routes/build-orchestrator.ts) | Accept \`provider\`, persist as \`session.providerPin\`. |
| [\`kickoffAgentRun\`](packages/dashboard/src/routes/build-orchestrator.ts) | New \`providerPin\` arg. When set, clones the agent via a new \`applyProviderPin\` helper that stamps every \`llm-prompt\` (and legacy \`claude-code\`) node with the pin. Non-LLM nodes are unchanged. |
| Drafter retries + designer kickoff | Read \`session.providerPin\` so the pin survives the entire build flow. |

## Test plan

- [x] \`npm run build\` clean
- [x] \`npx vitest run packages/core packages/dashboard packages/mcp-server\` — **1832 passing**, 3 skipped (baseline unchanged)
- [ ] Live: open \"Build from goal\" → confirm the new LLM provider select appears with three options + \"Use system default\".
- [ ] Live: pick \"Apple Foundation Models\" + submit \"build a tiny shell agent that prints the time\" → watch /runs to confirm the surveyor + drafter run pinned to apple-foundation-models (the dashboard's run-detail shows \`usedProvider\` per node).
- [ ] Live: pick \"Codex\", submit any goal → drafter dispatches via codex.
- [ ] Live: leave it on \"Use system default\" → behaves exactly as before (uses the head of \`/settings/llm\`).

## Follow-ups

- The inbox-triage \`agent-builder\` dispatch path (PR #421) still uses the global default. Threading a per-action provider pin through inbox → agent-builder is a separate change, gated by a triage prompt update so triage can extract \"build it on apple\" hints from the operator. Skipping for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)