### PR TITLE
fix(core): apple-foundation-models spawner uses ESM import, not CJS require

### DIFF
--- a/.changeset/apple-fm-require-import.md
+++ b/.changeset/apple-fm-require-import.md
@@ -1,0 +1,21 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+fix(core): apple-foundation-models spawner uses ESM import, not CJS require
+
+`appleFoundationModelsSpawner.resolveBinary` called `require()` to
+lazily load the runner module. The core package is ESM — `require`
+isn't defined at runtime — so every invocation of the Apple FM
+provider threw `ReferenceError: require is not defined` before
+reaching the runner. Replaced with a static top-of-file
+`import { ensureAppleRunner } from './apple-foundationmodels-runner.js'`.
+
+The "lazy load to keep the cold-path light on non-macOS hosts"
+justification didn't hold up — the runner module imports only
+Node built-ins (child_process, crypto, fs, os, path) that core
+already loads transitively. Eager-loading costs nothing.

--- a/packages/core/src/node-spawner.ts
+++ b/packages/core/src/node-spawner.ts
@@ -13,6 +13,7 @@ import type { Agent, AgentNode, NodeErrorCategory } from './agent-v2-types.js';
 import type { ExecutionResult } from './agent-executor.js';
 import { substituteInputs } from './input-resolver.js';
 import { resolveUpstreamTemplate, resolveVarsTemplate, resolveStateTemplate } from './node-templates.js';
+import { ensureAppleRunner } from './apple-foundationmodels-runner.js';
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -454,11 +455,12 @@ export const appleFoundationModelsSpawner: LlmSpawner = {
   promptEnvVar: 'PROMPT',
 
   resolveBinary() {
-    // Lazy import to keep this provider out of the cold-path for
-    // non-macOS hosts that never invoke it. The runner module's
-    // ensureAppleRunner() is idempotent and fast on cache hit.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { ensureAppleRunner } = require('./apple-foundationmodels-runner.js') as typeof import('./apple-foundationmodels-runner.js');
+    // Static import at the top of the file — the runner module's
+    // dependencies are Node built-ins (child_process, fs, crypto,
+    // os, path), so eager loading costs nothing. The earlier CJS
+    // `require()` here was broken: this package is ESM and `require`
+    // isn't defined at runtime, so every Apple FM invocation threw
+    // ReferenceError before reaching the runner.
     const handle = ensureAppleRunner();
     if (handle.status === 'ready') return { path: handle.binaryPath };
     return { unsupported: true, reason: handle.message ?? 'Apple Foundation Models runner is unavailable.' };


### PR DESCRIPTION
## Bug
\`appleFoundationModelsSpawner.resolveBinary\` in [node-spawner.ts](packages/core/src/node-spawner.ts) called \`require()\` to lazily load the runner module:

\`\`\`ts
resolveBinary() {
  // eslint-disable-next-line @typescript-eslint/no-require-imports
  const { ensureAppleRunner } = require('./apple-foundationmodels-runner.js') as typeof import('./apple-foundationmodels-runner.js');
  ...
}
\`\`\`

The core package is ESM. \`require\` isn't defined at runtime, so every Apple FM invocation threw \`ReferenceError: require is not defined\` before reaching the runner. Match for your bug report: \"the apple llm provider needs a 'require' parameter that is not passed.\"

## Fix
Replaced with a static top-of-file \`import { ensureAppleRunner } from './apple-foundationmodels-runner.js'\`. The earlier \"lazy to keep cold-path light\" justification doesn't survive — the runner module imports only Node built-ins (child_process, crypto, fs, os, path) that core already loads transitively, so eager-loading is free.

## Test plan
- [x] \`npm run build\` clean
- [x] \`npx vitest run packages/core\` — 1309 passing
- [ ] Live: restart dashboard, fire a Build-from-goal with provider pinned to \"Apple Foundation Models\" → confirm it actually invokes the runner instead of throwing \`ReferenceError\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)