### PR TITLE
feat(dashboard,examples): inbox triage honors a provider hint when dispatching agent-builder

### DIFF
--- a/.changeset/triage-builder-provider-hint.md
+++ b/.changeset/triage-builder-provider-hint.md
@@ -1,0 +1,34 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+feat(dashboard,examples): inbox triage honors a provider hint when dispatching agent-builder
+
+When the operator says "build it on apple" (or names any provider in
+the conversation), the inbox-triage prompt now emits an optional
+`PROVIDER` field in the action's `inputs` map. The route extracts it
+as a provider pin, strips it from the agent inputs (so input-
+resolution doesn't reject an undeclared key), and applies the pin to
+every llm-prompt node in the agent-builder agent via the
+`applyProviderPin` helper exported from build-orchestrator.
+
+Mirrors PR #422's "Build from goal" provider picker but driven from
+the conversation instead of a UI control. The global fallback chain
+in `/settings/llm` still applies on classified failures — the pin
+says "try this first," not "use only this."
+
+Triage prompt updates:
+- Maps loose phrasings: "apple" / "on-device" / "foundation models"
+  → `apple-foundation-models`; "claude" → `claude`; "codex" /
+  "openai" → `codex`.
+- Hard rule: omit `PROVIDER` entirely when the operator didn't name
+  a provider. Never invent the hint.
+- New OUTPUT FORMAT example shows the shape.
+
+The validator drops PROVIDER if the operator didn't supply one or if
+the value isn't in `LLM_PROVIDERS`, so a malformed hint silently
+falls back to the system default chain.

--- a/agents/examples/inbox-triage.yaml
+++ b/agents/examples/inbox-triage.yaml
@@ -292,6 +292,18 @@ nodes:
         commitmentSummary should be the verb-led "drafting <NAME>
         agent" form (e.g. "drafting trivia-night agent").
 
+        OPTIONAL `PROVIDER` input: when the operator EXPLICITLY names
+        an LLM provider for the build ("build it on apple", "use
+        codex", "with claude", "on apple foundation models"), include
+        `PROVIDER` in the action inputs with one of these exact
+        values: `claude`, `codex`, `apple-foundation-models`. Map
+        loose phrasings: "apple" / "on-device" / "foundation models"
+        → `apple-foundation-models`; "claude" → `claude`; "codex" /
+        "openai" → `codex`. When the operator did NOT mention a
+        provider, OMIT `PROVIDER` entirely — the dashboard's system
+        default chain (from /settings/llm) takes over. Never invent
+        a provider hint the operator didn't ask for.
+
         ORDER OF OPERATIONS when the operator asks for an agent on a
         topic: PROPOSE `agent-catalog-search` FIRST to check for an
         existing one. If catalog-search returns no installed match,
@@ -371,6 +383,29 @@ nodes:
             "agentId": "agent-builder",
             "inputs": { "GOAL": "Build a trivia-night agent that asks questions, accepts answers, and tracks scores using the Open Trivia DB API." },
             "rationale": "Draft a complete agent YAML from the operator's goal."
+          }
+        ]
+      }
+      </plan>
+
+      Example proposing agent-builder with an explicit provider hint
+      (operator said "build it on apple" — only include PROVIDER when
+      the operator actually named a provider):
+
+      <plan>
+      {
+        "messageId": "{{inputs.MESSAGE_ID}}",
+        "recommendation": "I'll draft the trivia-night agent on Apple Foundation Models.",
+        "commitmentSummary": "drafting trivia-night agent on apple",
+        "actions": [
+          {
+            "type": "run-agent",
+            "agentId": "agent-builder",
+            "inputs": {
+              "GOAL": "Build a trivia-night agent that asks questions, accepts answers, and tracks scores using the Open Trivia DB API.",
+              "PROVIDER": "apple-foundation-models"
+            },
+            "rationale": "Draft the agent pinned to the on-device Apple model."
           }
         ]
       }

--- a/packages/dashboard/src/routes/build-orchestrator.ts
+++ b/packages/dashboard/src/routes/build-orchestrator.ts
@@ -184,7 +184,7 @@ async function kickoffAgentRun(args: {
  *
  * Non-LLM nodes (shell, file-write, control flow) are unchanged.
  */
-function applyProviderPin(agent: Agent, providerPin: LlmProvider): Agent {
+export function applyProviderPin(agent: Agent, providerPin: LlmProvider): Agent {
   return {
     ...agent,
     nodes: agent.nodes.map((node) => (isLlmPromptType(node.type) ? { ...node, provider: providerPin } : node)),

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -32,6 +32,8 @@ import {
   extractPlanJson,
   listBuiltinTools,
   parseAgent,
+  LLM_PROVIDERS,
+  type LlmProvider,
   type RunStatus,
   type InboxActionMeta,
   type InboxActionStatus,
@@ -41,6 +43,7 @@ import {
 import { getContext } from '../context.js';
 import { buildLlmSettingsSnapshot } from '../lib/llm-settings-snapshot.js';
 import { formatToolCatalog } from './run-now-build.js';
+import { applyProviderPin } from './build-orchestrator.js';
 import { TEMPLATE_REGISTRY } from '../views/pulse-templates.js';
 import {
   renderInboxList,
@@ -884,6 +887,11 @@ function enrichAgentBuilderInputs(
   inputs: Record<string, string>,
 ): Record<string, string> {
   const out: Record<string, string> = { ...inputs };
+  // PROVIDER is a routing hint, not an agent input — it gets converted
+  // to a per-node pin in extractAgentBuilderProviderPin. Drop it here
+  // so executeAgentDag's input-resolution doesn't reject it as an
+  // undeclared key.
+  delete out.PROVIDER;
   try {
     const builtins = listBuiltinTools();
     let userTools: ToolDefinition[] = [];
@@ -905,6 +913,20 @@ function enrichAgentBuilderInputs(
     }
   } catch { /* swallow — agent-builder validates inputs and will fail loudly */ }
   return out;
+}
+
+/**
+ * Pull a provider pin off an agent-builder action's inputs. Triage may
+ * include `PROVIDER` when the operator names one explicitly ("build
+ * it on apple", "use codex"); we strip it from the agent inputs in
+ * `enrichAgentBuilderInputs` and apply it as a per-node pin on the
+ * cloned agent before dispatch. Invalid / unknown values are ignored
+ * so the system default chain still kicks in.
+ */
+function extractAgentBuilderProviderPin(inputs: Record<string, string>): LlmProvider | undefined {
+  const raw = typeof inputs.PROVIDER === 'string' ? inputs.PROVIDER.trim() : '';
+  if (!raw) return undefined;
+  return (LLM_PROVIDERS as readonly string[]).includes(raw) ? (raw as LlmProvider) : undefined;
 }
 
 /**
@@ -1111,6 +1133,17 @@ async function runProposedAction(
     effectiveInputs = enrichAgentBuilderInputs(ctx, meta.inputs);
   }
 
+  // Provider pin from triage's action inputs. agent-builder is the
+  // only consumer today — operator says "build it on apple" and triage
+  // emits PROVIDER=apple-foundation-models. The pin runs first in the
+  // waterfall; the global fallback chain still applies on classified
+  // failures. Strip is already handled inside enrichAgentBuilderInputs.
+  let dispatchAgent = subAgent;
+  if (meta.agentId === 'agent-builder') {
+    const providerPin = extractAgentBuilderProviderPin(meta.inputs);
+    if (providerPin) dispatchAgent = applyProviderPin(subAgent, providerPin);
+  }
+
   let runId: string | undefined;
   let nextStatus: InboxActionStatus = 'failed';
   let resultSummary: string | undefined;
@@ -1118,7 +1151,7 @@ async function runProposedAction(
   let fullResult = '';
   try {
     const run = await executeAgentDag(
-      subAgent,
+      dispatchAgent,
       {
         triggeredBy: 'dashboard',
         inputs: effectiveInputs,


### PR DESCRIPTION
When the operator says \"build it on apple\" (or names any provider in the conversation), the inbox-triage prompt now emits an optional \`PROVIDER\` field in the action's \`inputs\` map. The route extracts it as a provider pin, strips it from the agent inputs (so input-resolution doesn't reject an undeclared key), and applies the pin to every llm-prompt node in the agent-builder agent via the \`applyProviderPin\` helper exported from build-orchestrator.

Mirrors PR [#422](https://github.com/gregmeyer/some-useful-agents/pull/422)'s \"Build from goal\" provider picker, but driven from the conversation instead of a UI control. The global fallback chain in \`/settings/llm\` still applies on classified failures — the pin says \"try this first,\" not \"use only this.\"

## Triage prompt updates
- Maps loose phrasings: \"apple\" / \"on-device\" / \"foundation models\" → \`apple-foundation-models\`; \"claude\" → \`claude\`; \"codex\" / \"openai\" → \`codex\`.
- **Hard rule:** omit \`PROVIDER\` entirely when the operator didn't name a provider. Never invent the hint.
- New OUTPUT FORMAT example shows the shape.

## Route handling
- New \`extractAgentBuilderProviderPin\` helper validates against \`LLM_PROVIDERS\`; unknown values fall back to system default.
- \`enrichAgentBuilderInputs\` now deletes \`inputs.PROVIDER\` before passing to \`executeAgentDag\` (it's a routing hint, not an agent input).
- \`runProposedAction\` applies the pin via \`applyProviderPin\` before dispatching when the agent is \`agent-builder\` and a valid hint is present.

## Test plan
- [x] \`npm run build\` clean
- [x] \`npx vitest run packages/core packages/dashboard packages/mcp-server\` — 1832 passing
- [ ] Live: post \"build me a trivia agent on apple\" → triage emits PROVIDER=apple-foundation-models → drafter runs pinned to Apple FM (also unblocks the dispatch path post-#423 once that ESM-require fix lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)