### PR TITLE
feat(dashboard): stop button on the triage thinking indicator

### DIFF
--- a/.changeset/triage-stop-button.md
+++ b/.changeset/triage-stop-button.md
@@ -1,0 +1,42 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+feat(dashboard): stop button on the triage thinking indicator
+
+While triage is in flight, the modal's "Triage agent is thinking…"
+indicator now ships with a square stop button on the right edge.
+Clicking it aborts the underlying DAG run, kills any spawned LLM
+processes, marks the run cancelled, posts a system note ("Triage
+stopped by operator."), and re-enables the composer so the operator
+can send a new message immediately.
+
+Implementation:
+
+- New `inboxTriageAbortControllers: Map<messageId, { runId, controller }>`
+  on `DashboardContext`. `runTriageAgent` now pre-generates the runId
+  (via `randomUUID`), creates an `AbortController`, registers in both
+  `activeRuns` (by runId) and `inboxTriageAbortControllers` (by
+  messageId), and passes the abort signal into `executeAgentDag`.
+  Cleared on completion in a `finally` block so even crashes don't
+  leave stale entries.
+- New `POST /inbox/:id/triage/cancel` route: looks up the controller
+  by message id, aborts it, calls `provider.cancelRun` as belt-and-
+  suspenders, and force-finalizes the run + node executions if the
+  executor didn't get to its own teardown before the response. Idempotent
+  — missing entries (run already finished, dashboard restarted)
+  return 204 with "Nothing to cancel."
+- View update in `inbox-detail.ts`: the thinking indicator now
+  contains a `<form data-inbox-modal-form>` posting to the cancel
+  route. Reuses the modal's existing submit interceptor so the
+  fragment refresh after cancel is the same path tags / star / reply
+  already use.
+- New `.inbox-thinking__stop` CSS: 28×28 square with a small filled
+  square icon, hover state, sits at the end of the thinking row.
+- 3 new route tests: abort + cleanup (entries removed, run flipped to
+  cancelled, system note inserted), idempotent no-op on a thread
+  with no in-flight triage, 404 on unknown id.

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -2257,6 +2257,39 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
   opacity: 0;
   transform: translateY(-2px);
 }
+.inbox-thinking__body { flex: 1; min-width: 0; }
+/* Stop button — square icon next to the pulsing dots. Killing the
+ * in-flight triage hits POST /inbox/:id/triage/cancel which aborts
+ * the DAG executor and unblocks the composer for the operator's
+ * next reply. Visually parks at the right edge of the indicator row
+ * so it shares space with the dots without crowding the label. */
+.inbox-thinking__stop-form { margin: 0; flex-shrink: 0; }
+.inbox-thinking__stop {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transition: background 80ms ease-out, color 80ms ease-out, border-color 80ms ease-out;
+}
+.inbox-thinking__stop:hover {
+  color: var(--color-text);
+  background: var(--color-surface-raised);
+  border-color: var(--color-border-strong, var(--color-border));
+}
+.inbox-thinking__stop-icon {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  background: currentColor;
+  border-radius: 1px;
+}
 
 /* Inbox list: data-inbox-row-id rows get a row-hover affordance so
  * users see the click target. Title link inherits the row hover. */

--- a/packages/dashboard/src/context.ts
+++ b/packages/dashboard/src/context.ts
@@ -162,6 +162,16 @@ export interface DashboardContext {
    */
   activeRuns: Map<string, AbortController>;
   /**
+   * Active inbox-triage runs, keyed by inbox message id. Lets POST
+   * /inbox/:id/triage/cancel find the run-in-flight for a thread
+   * without scanning the runs table: the route launches triage and
+   * registers the pre-generated runId + abort controller here; the
+   * cancel route aborts the controller (which also cascades into
+   * activeRuns + the runStore). Cleared on completion. Only one
+   * triage run per message at a time — re-entering replaces.
+   */
+  inboxTriageAbortControllers: Map<string, { runId: string; controller: AbortController }>;
+  /**
    * Data directory path. Used by the health endpoint to read the scheduler
    * heartbeat file and report scheduler status.
    */

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -90,6 +90,7 @@ command: echo from-the-internet
     rotateToken: overrides.rotateToken ?? (() => 'r'.repeat(64)),
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
+    inboxTriageAbortControllers: new Map(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -519,6 +519,7 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     agentMemoryStore,
     allowUntrustedShell: opts.allowUntrustedShell ?? new Set(),
     activeRuns: new Map(),
+    inboxTriageAbortControllers: new Map(),
     dataDir: dirname(opts.dbPath),
     dashboardBaseUrl: (opts.dashboardBaseUrl ?? `http://${host}:${opts.port}`).replace(/\/$/, ''),
   };

--- a/packages/dashboard/src/routes/build-commit.test.ts
+++ b/packages/dashboard/src/routes/build-commit.test.ts
@@ -75,6 +75,7 @@ async function makeApp() {
     dashboardsStore,
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
+    inboxTriageAbortControllers: new Map(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/routes/dashboard-layout-plan-commit.test.ts
+++ b/packages/dashboard/src/routes/dashboard-layout-plan-commit.test.ts
@@ -95,6 +95,7 @@ async function makeApp() {
     layoutHintsStore,
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
+    inboxTriageAbortControllers: new Map(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/routes/dashboards-edit.test.ts
+++ b/packages/dashboard/src/routes/dashboards-edit.test.ts
@@ -75,6 +75,7 @@ async function makeApp() {
     dashboardsStore,
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
+    inboxTriageAbortControllers: new Map(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/routes/dashboards.test.ts
+++ b/packages/dashboard/src/routes/dashboards.test.ts
@@ -76,6 +76,7 @@ async function makeApp() {
     layoutHintsStore,
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
+    inboxTriageAbortControllers: new Map(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/routes/img-block-report.test.ts
+++ b/packages/dashboard/src/routes/img-block-report.test.ts
@@ -74,6 +74,7 @@ async function makeApp() {
     blockedImgHostsStore,
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
+    inboxTriageAbortControllers: new Map(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/routes/inbox-events.test.ts
+++ b/packages/dashboard/src/routes/inbox-events.test.ts
@@ -71,6 +71,7 @@ async function makeApp() {
     inboxEventBus,
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
+    inboxTriageAbortControllers: new Map(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -69,6 +69,7 @@ async function makeApp() {
     inboxStore,
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
+    inboxTriageAbortControllers: new Map(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };
@@ -1003,6 +1004,69 @@ describe('POST /inbox/:id/triage', () => {
     expect(r1.status).toBe(303);
     const r2 = await request(app).post('/inbox/nope/triage').set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
     expect(r2.status).toBe(404);
+  });
+});
+
+describe('POST /inbox/:id/triage/cancel', () => {
+  it('aborts the registered controller and clears the in-flight entry', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+
+    // Simulate an in-flight triage run: register a controller + a
+    // runStore row in `running` state, then POST cancel.
+    const fakeRunId = 'triage-fake-run-id';
+    const controller = new AbortController();
+    runStore.createRun({
+      id: fakeRunId, agentName: 'inbox-triage', status: 'running',
+      startedAt: new Date().toISOString(), triggeredBy: 'dashboard',
+    });
+    const app2 = app as unknown as { locals: { activeRuns: Map<string, AbortController>; inboxTriageAbortControllers: Map<string, { runId: string; controller: AbortController }> } };
+    app2.locals.activeRuns.set(fakeRunId, controller);
+    app2.locals.inboxTriageAbortControllers.set(m.id, { runId: fakeRunId, controller });
+
+    let aborted = false;
+    controller.signal.addEventListener('abort', () => { aborted = true; });
+
+    const res = await request(app)
+      .post(`/inbox/${m.id}/triage/cancel`)
+      .set('X-Requested-With', 'fetch')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(204);
+
+    expect(aborted).toBe(true);
+    expect(app2.locals.inboxTriageAbortControllers.has(m.id)).toBe(false);
+    expect(app2.locals.activeRuns.has(fakeRunId)).toBe(false);
+
+    // Run row was force-finalized as cancelled.
+    const after = runStore.getRun(fakeRunId);
+    expect(after?.status).toBe('cancelled');
+
+    // A "Triage stopped by operator." system note now lives on the thread.
+    const responses = inboxStore.listResponses(m.id);
+    const sys = responses.find((r) => r.role === 'system');
+    expect(sys?.body).toContain('Triage stopped');
+  });
+
+  it('is idempotent: no in-flight controller returns 204 with "Nothing to cancel"', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const res = await request(app)
+      .post(`/inbox/${m.id}/triage/cancel`)
+      .set('X-Requested-With', 'fetch')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(204);
+    // No system message inserted for a no-op cancel.
+    const responses = inboxStore.listResponses(m.id);
+    expect(responses.find((r) => r.role === 'system')).toBeUndefined();
+  });
+
+  it('404 (AJAX) for unknown message id', async () => {
+    const app = await makeApp();
+    const res = await request(app)
+      .post('/inbox/nope/triage/cancel')
+      .set('X-Requested-With', 'fetch')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(404);
   });
 
   it('auto-refreshes a stale inbox-triage agent from the bundled YAML', async () => {

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -23,6 +23,7 @@
  */
 
 import { Router, type Request, type Response } from 'express';
+import { randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import {
@@ -484,6 +485,87 @@ inboxRouter.post('/inbox/:id/triage', (req: Request, res: Response) => {
   void runTriageAgent(ctx, id).catch(() => { /* swallow */ });
   if (isAjax(req)) { res.status(204).end(); return; }
   res.redirect(303, `${detailUrl}?ok=${encodeURIComponent('Triage agent invoked.')}`);
+});
+
+/**
+ * POST /inbox/:id/triage/cancel — short-circuit an in-flight triage
+ * run. Looks up the registered AbortController via
+ * `ctx.inboxTriageAbortControllers` (keyed by message id), aborts the
+ * DAG executor's signal, calls into `provider.cancelRun` as a belt-
+ * and-suspenders for v1 paths, and force-finalizes the run row +
+ * node executions if the executor didn't get to those teardown
+ * steps before the response returns.
+ *
+ * Idempotent: a missing entry (run already finished, or the dashboard
+ * was restarted) returns 204 / "Nothing to cancel" without erroring.
+ * The operator sees the indicator clear via the `state:done` SSE
+ * event that the runTriageAgent finally-block (or this route's
+ * fallback finalization) publishes.
+ */
+inboxRouter.post('/inbox/:id/triage/cancel', async (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const detailUrl = `/inbox/${encodeURIComponent(id)}`;
+  if (!ctx.inboxStore || !ctx.inboxStore.get(id)) {
+    if (isAjax(req)) { res.status(404).end(); return; }
+    res.redirect(303, `/inbox?error=${encodeURIComponent('Message not found.')}`);
+    return;
+  }
+  const entry = ctx.inboxTriageAbortControllers.get(id);
+  if (!entry) {
+    if (isAjax(req)) { res.status(204).end(); return; }
+    res.redirect(303, `${detailUrl}?ok=${encodeURIComponent('Nothing to cancel.')}`);
+    return;
+  }
+  ctx.inboxTriageAbortControllers.delete(id);
+  ctx.activeRuns.delete(entry.runId);
+  try { entry.controller.abort(); } catch { /* ignore */ }
+  // Provider cancel — belt-and-suspenders for v1 paths and any
+  // pid-tracked child processes the executor spawned.
+  try { await ctx.provider.cancelRun(entry.runId); } catch { /* ignore */ }
+  // Force-finalize the run + any node executions still flagged
+  // running, in case the executor's normal teardown didn't fire
+  // before the request returns. Mirrors POST /runs/:id/cancel.
+  try {
+    const run = ctx.runStore.getRun(entry.runId);
+    if (run && (run.status === 'running' || run.status === 'pending')) {
+      const completedAt = new Date().toISOString();
+      ctx.runStore.updateRun(entry.runId, {
+        status: 'cancelled' as RunStatus,
+        completedAt,
+        error: 'Cancelled by user.',
+      });
+      const nodeExecs = ctx.runStore.listNodeExecutions(entry.runId);
+      for (const exec of nodeExecs) {
+        if (exec.status === 'running' || exec.status === 'pending') {
+          ctx.runStore.updateNodeExecution(entry.runId, exec.nodeId, {
+            status: 'cancelled',
+            errorCategory: 'cancelled',
+            completedAt,
+            error: 'Cancelled by user.',
+          });
+        }
+      }
+    }
+  } catch { /* ignore */ }
+  // Surface the cancellation in the conversation so the operator
+  // sees what happened without polling. The next user reply will
+  // re-fire triage normally.
+  try {
+    const sysReply = ctx.inboxStore.addResponse(id, 'system', 'Triage stopped by operator.');
+    publishInboxEvent(ctx, id, 'message:created', {
+      responseId: sysReply.id, role: 'system', body: sysReply.body, createdAt: sysReply.createdAt,
+    });
+  } catch { /* ignore */ }
+  publishInboxEvent(ctx, id, 'state', { phase: 'done', since: Date.now() });
+  // Move the thread to awaiting_user so the modal's pending state
+  // clears and the composer re-enables.
+  try {
+    ctx.inboxStore.updateStatus(id, 'awaiting_user');
+  } catch { /* ignore */ }
+
+  if (isAjax(req)) { res.status(204).end(); return; }
+  res.redirect(303, `${detailUrl}?ok=${encodeURIComponent('Triage stopped.')}`);
 });
 
 /**
@@ -1495,7 +1577,26 @@ async function runTriageAgent(
 
   const allowlist = getSubAgentAllowlist(ctx);
 
-  let runId: string | undefined;
+  // Pre-generate the runId + AbortController so the cancel route
+  // (/inbox/:id/triage/cancel) can find and abort the in-flight run
+  // without scanning the runs table. Replace any prior in-flight
+  // triage controller for this message — last writer wins, the
+  // older run's abort will run to completion safely.
+  const runId: string = randomUUID();
+  const abortController = new AbortController();
+  ctx.activeRuns.set(runId, abortController);
+  ctx.inboxTriageAbortControllers.set(messageId, { runId, controller: abortController });
+  // Set the triageRunId on the message immediately so the
+  // run-detail page and the inbox modal can both point at the
+  // in-flight run. We refresh the status post-run anyway.
+  try {
+    ctx.inboxStore.updateStatus(
+      messageId,
+      message.status === 'open' ? 'triaged' : message.status,
+      { triageRunId: runId },
+    );
+  } catch { /* ignore — message may have been dismissed mid-flight */ }
+
   try {
     const runPromise = executeAgentDag(
       triage,
@@ -1511,6 +1612,8 @@ async function runTriageAgent(
           CONVERSATION: conversation,
           ALLOWED_SUB_AGENTS: allowlist.join(', '),
         },
+        runId,
+        signal: abortController.signal,
       },
       {
         runStore: ctx.runStore,
@@ -1534,27 +1637,6 @@ async function runTriageAgent(
         },
       },
     );
-    // Capture the runId once it lands. Race the executor to avoid
-    // blocking the auto-fire path; the conversation-based pending
-    // heuristic carries us through if this misses.
-    await Promise.race([runPromise, new Promise((r) => setTimeout(r, 250))]);
-    const { rows } = ctx.runStore.queryRuns({
-      agentName: TRIAGE_AGENT_ID,
-      statuses: ['running', 'completed', 'failed', 'pending'] as RunStatus[],
-      limit: 1,
-      offset: 0,
-    });
-    const recent = rows[0];
-    if (recent) {
-      runId = recent.id;
-      try {
-        ctx.inboxStore.updateStatus(
-          messageId,
-          message.status === 'open' ? 'triaged' : message.status,
-          { triageRunId: runId },
-        );
-      } catch { /* ignore — message may have been dismissed mid-flight */ }
-    }
     const finished = await runPromise;
     void finished;
 
@@ -1704,5 +1786,16 @@ async function runTriageAgent(
       });
     } catch { /* ignore */ }
     publishInboxEvent(ctx, messageId, 'state', { phase: 'done', since: Date.now() });
+  } finally {
+    // Clear the abort-controller registry entries for this run.
+    // Cancel-route already deletes activeRuns when it fires; this
+    // covers the normal-completion path. Use ?-checks because a
+    // re-entry would have already replaced the entry with a fresh
+    // controller pointing at a newer runId.
+    ctx.activeRuns.delete(runId);
+    const existing = ctx.inboxTriageAbortControllers.get(messageId);
+    if (existing && existing.runId === runId) {
+      ctx.inboxTriageAbortControllers.delete(messageId);
+    }
   }
 }

--- a/packages/dashboard/src/routes/metrics-planner.test.ts
+++ b/packages/dashboard/src/routes/metrics-planner.test.ts
@@ -58,6 +58,7 @@ async function makeApp(): Promise<ReturnType<typeof buildDashboardApp>> {
     plannerTelemetryStore,
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
+    inboxTriageAbortControllers: new Map(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/routes/packs.test.ts
+++ b/packages/dashboard/src/routes/packs.test.ts
@@ -63,6 +63,7 @@ async function makeApp() {
     dashboardsStore,
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
+    inboxTriageAbortControllers: new Map(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/routes/pulse-layout-plan-commit.test.ts
+++ b/packages/dashboard/src/routes/pulse-layout-plan-commit.test.ts
@@ -87,6 +87,7 @@ async function makeApp() {
     layoutHintsStore,
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
+    inboxTriageAbortControllers: new Map(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/routes/pulse-toggle.test.ts
+++ b/packages/dashboard/src/routes/pulse-toggle.test.ts
@@ -84,6 +84,7 @@ async function makeApp(initial: { pulseVisible?: boolean }) {
     dashboardsStore,
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
+    inboxTriageAbortControllers: new Map(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/routes/schedule-edit.test.ts
+++ b/packages/dashboard/src/routes/schedule-edit.test.ts
@@ -73,6 +73,7 @@ async function makeApp(opts: { schedule?: string; allowHighFrequency?: boolean }
     dashboardsStore,
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
+    inboxTriageAbortControllers: new Map(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/routes/tools-used-by.test.ts
+++ b/packages/dashboard/src/routes/tools-used-by.test.ts
@@ -86,6 +86,7 @@ async function makeApp() {
     dashboardsStore,
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
+    inboxTriageAbortControllers: new Map(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/views/inbox-detail.ts
+++ b/packages/dashboard/src/views/inbox-detail.ts
@@ -191,7 +191,7 @@ export function renderInboxDetailFragment(opts: InboxDetailOptions): SafeHtml {
       ${responses.length === 0 && !triagePending
         ? html`<p class="dim" style="font-size: var(--font-size-sm); margin: 0 0 var(--space-2);">No replies yet. Use the composer below — the triage agent will join automatically.</p>`
         : html`<ul class="inbox-timeline">${timeline as unknown as SafeHtml[]}</ul>`}
-      ${triagePending ? renderThinkingIndicator() : html``}
+      ${triagePending ? renderThinkingIndicator(message.id) : html``}
     </section>
   `;
 
@@ -564,19 +564,31 @@ function formatDuration(meta: InboxActionMeta): string {
   return `${(ms / 1000).toFixed(1)}s`;
 }
 
-/** Pulsing-dots "Triage agent is thinking…" indicator. */
-function renderThinkingIndicator(): SafeHtml {
+/** Pulsing-dots "Triage agent is thinking…" indicator with a stop button. */
+function renderThinkingIndicator(messageId: string): SafeHtml {
   // data-thinking-phase lets the modal JS pick the right label set
   // when it rotates copy underneath the dots. The default seed text
   // is a sensible label so users with JS disabled (or before the
   // rotation loop fires) still see something coherent.
+  //
+  // Stop button posts to /inbox/:id/triage/cancel; the route aborts
+  // the in-flight DAG run, marks it cancelled, and publishes a
+  // state:done SSE so the modal clears the pending state. The
+  // composer's `disabled` attribute drops off via the same fragment
+  // refresh path the rest of the modal uses.
   return html`
     <div class="inbox-thinking" data-triage-pending="1" data-thinking-phase="triage">
       <div class="inbox-thinking__avatar">Tri</div>
-      <div>
+      <div class="inbox-thinking__body">
         <span class="inbox-thinking__label" data-thinking-label>Triage agent is thinking</span>
         <span class="inbox-thinking__dots"><span></span><span></span><span></span></span>
       </div>
+      <form method="POST" action="/inbox/${messageId}/triage/cancel"
+        data-inbox-modal-form data-inbox-triage-stop="1" class="inbox-thinking__stop-form">
+        <button type="submit" class="inbox-thinking__stop" aria-label="Stop triage">
+          <span aria-hidden="true" class="inbox-thinking__stop-icon"></span>
+        </button>
+      </form>
     </div>
   `;
 }

--- a/packages/dashboard/src/views/not-found.test.ts
+++ b/packages/dashboard/src/views/not-found.test.ts
@@ -61,6 +61,7 @@ async function makeApp() {
     dashboardsStore,
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
+    inboxTriageAbortControllers: new Map(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };


### PR DESCRIPTION
While triage is in flight, the modal's \"Triage agent is thinking…\" indicator now ships with a square stop button on the right edge. Clicking it aborts the underlying DAG run, kills any spawned LLM processes, marks the run cancelled, posts a system note (\"Triage stopped by operator.\"), and re-enables the composer so the operator can send a new message immediately.

## Implementation

- **`DashboardContext`** gains an `inboxTriageAbortControllers: Map<messageId, { runId, controller }>` so the cancel route finds the in-flight run without scanning the runs table.
- **`runTriageAgent`** now pre-generates the runId via `randomUUID`, creates an `AbortController`, registers in both `activeRuns` (by runId — same map POST /runs/:id/cancel uses) and `inboxTriageAbortControllers` (by messageId), and passes the abort signal into `executeAgentDag`. Cleared on completion in a `finally` block so even crashes don't leak entries.
- **New route**: `POST /inbox/:id/triage/cancel` aborts the controller, calls `provider.cancelRun` as belt-and-suspenders, and force-finalizes the run + node executions if the executor's normal teardown didn't fire before the response. Idempotent.
- **View**: thinking indicator wraps a `<form data-inbox-modal-form>` posting to the cancel route. Reuses the existing modal submit interceptor for the optimistic fragment refresh.
- **CSS**: new `.inbox-thinking__stop` — 28×28 square with a filled square icon, hover state.
- **3 new tests** cover abort + cleanup, idempotent no-op, 404.

## How the operator experiences it

1. Post a reply → triage starts → \"Triage agent is thinking…\" indicator + stop button appears.
2. Click stop → indicator vanishes, system note lands (\"Triage stopped by operator.\"), composer re-enables.
3. Type next message → send → triage re-fires normally on the new conversation snapshot (which now includes the system note).

## Test plan
- [x] \`npm run build\` clean
- [x] \`npx vitest run packages/core packages/dashboard packages/mcp-server\` — **1835 passing** (+3 over baseline)
- [ ] Live: post a slow reply → click stop → confirm indicator clears, system note shows, composer re-enables, run-detail page shows the cancelled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)