### PR TITLE
fix(dashboard): triage stop button no longer double-posts an unfriendly note

### DIFF
--- a/.changeset/triage-cancel-friendly-message.md
+++ b/.changeset/triage-cancel-friendly-message.md
@@ -1,0 +1,29 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+fix(dashboard): triage stop button no longer double-posts an unfriendly "did not complete" note
+
+Race after PR #425: the cancel route posted "Triage stopped by
+operator." and force-finalized the run, but `runTriageAgent`'s
+continuation kept running and saw the executor's terminal status
+(either `'failed'` or `'cancelled'` depending on who won the race to
+update the row). It then added a second, scary system message like
+`Triage agent did not complete (failed). Failed at node "triage"
+(timeout)`. Operator saw two messages back-to-back, the second
+implying something broke when nothing did.
+
+`runTriageAgent` now short-circuits both the continuation AND the
+catch-block whenever `abortController.signal.aborted` is set — that
+bit is the load-bearing operator-intent signal regardless of which
+status the run row ended up at. Also added a defensive
+`run?.status === 'cancelled'` check for the rare case where a
+sibling tab hit `POST /runs/:id/cancel` while triage was waiting.
+
+The cancel-route system message was also reworded from "Triage
+stopped by operator." to "Triage agent cancelled." per the
+operator's preference.

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -1041,10 +1041,10 @@ describe('POST /inbox/:id/triage/cancel', () => {
     const after = runStore.getRun(fakeRunId);
     expect(after?.status).toBe('cancelled');
 
-    // A "Triage stopped by operator." system note now lives on the thread.
+    // A friendly cancellation note now lives on the thread.
     const responses = inboxStore.listResponses(m.id);
     const sys = responses.find((r) => r.role === 'system');
-    expect(sys?.body).toContain('Triage stopped');
+    expect(sys?.body).toBe('Triage agent cancelled.');
   });
 
   it('is idempotent: no in-flight controller returns 204 with "Nothing to cancel"', async () => {

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -552,7 +552,7 @@ inboxRouter.post('/inbox/:id/triage/cancel', async (req: Request, res: Response)
   // sees what happened without polling. The next user reply will
   // re-fire triage normally.
   try {
-    const sysReply = ctx.inboxStore.addResponse(id, 'system', 'Triage stopped by operator.');
+    const sysReply = ctx.inboxStore.addResponse(id, 'system', 'Triage agent cancelled.');
     publishInboxEvent(ctx, id, 'message:created', {
       responseId: sysReply.id, role: 'system', body: sysReply.body, createdAt: sysReply.createdAt,
     });
@@ -1640,7 +1640,20 @@ async function runTriageAgent(
     const finished = await runPromise;
     void finished;
 
+    // Operator-cancelled via the stop button? Bail without adding the
+    // unfriendly "did not complete" continuation — the cancel route
+    // already posted "Triage stopped by operator." and finalized the
+    // run. Hits BOTH races: the executor returning 'failed' before
+    // the cancel route force-updates to 'cancelled', and the executor
+    // returning 'cancelled' cleanly. Either way, the signal-aborted
+    // bit is the load-bearing operator-intent signal.
+    if (abortController.signal.aborted) return;
+
     const run = runId ? ctx.runStore.getRun(runId) : null;
+    // Also catch the case where the run row itself ended up cancelled
+    // (e.g. /runs/:id/cancel hit by a sibling tab while we were
+    // waiting) — same friendly silence.
+    if (run?.status === 'cancelled') return;
     if (!run || run.status !== 'completed' || !run.result) {
       ctx.inboxStore.addResponse(
         messageId,
@@ -1777,14 +1790,21 @@ async function runTriageAgent(
     } catch { /* ignore */ }
     publishInboxEvent(ctx, messageId, 'state', { phase: 'done', since: Date.now() });
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`[inbox-triage] run failed: ${msg}\n${(err as Error)?.stack ?? ''}\n`);
-    try {
-      const sysReply = ctx.inboxStore.addResponse(messageId, 'system', `Triage agent crashed: ${msg}`);
-      publishInboxEvent(ctx, messageId, 'message:created', {
-        responseId: sysReply.id, role: 'system', body: sysReply.body, createdAt: sysReply.createdAt,
-      });
-    } catch { /* ignore */ }
+    // Operator-cancelled exceptions look like crashes here (the
+    // abort signal surfaces as a thrown error inside the executor).
+    // Skip the "Triage agent crashed" system note — the cancel route
+    // already posted "Triage stopped by operator." and the state:done
+    // event below still fires so the modal clears its pending UI.
+    if (!abortController.signal.aborted) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[inbox-triage] run failed: ${msg}\n${(err as Error)?.stack ?? ''}\n`);
+      try {
+        const sysReply = ctx.inboxStore.addResponse(messageId, 'system', `Triage agent crashed: ${msg}`);
+        publishInboxEvent(ctx, messageId, 'message:created', {
+          responseId: sysReply.id, role: 'system', body: sysReply.body, createdAt: sysReply.createdAt,
+        });
+      } catch { /* ignore */ }
+    }
     publishInboxEvent(ctx, messageId, 'state', { phase: 'done', since: Date.now() });
   } finally {
     // Clear the abort-controller registry entries for this run.


### PR DESCRIPTION
## Bug
After clicking the stop button (#425), the operator saw **two** system messages back-to-back:

1. \`Triage stopped by operator.\` (from the cancel route)
2. \`Triage agent did not complete (failed). Failed at node \"triage\" (timeout)\` (from \`runTriageAgent\`'s continuation)

Your report: *\"should be friendlier, like 'Triage agent canceled'\"*.

## Root cause
The cancel route force-finalized the run row to \`cancelled\` and posted the friendly note. But \`runTriageAgent\` was still awaiting its own promise — when the executor's signal aborted, the node failed with \`timeout\` and the run row briefly read \`failed\` before the cancel route's fallback rewrote it. The continuation saw whichever status won the race and appended its own (unfriendly) message.

## Fix
\`runTriageAgent\` now checks \`abortController.signal.aborted\` in both the success-continuation and the catch-block. When the operator cancelled, we skip the unfriendly system note entirely — the cancel route already posted the friendly one. Same logic also detects the rare case where a sibling tab hit \`POST /runs/:id/cancel\` while triage was waiting (via \`run.status === 'cancelled'\`).

Also reworded the friendly note from \"Triage stopped by operator.\" → \"Triage agent cancelled.\" per the operator's preference.

## Test plan
- [x] \`npm run build\` clean
- [x] \`npx vitest run packages/core packages/dashboard packages/mcp-server\` — 1835 passing
- [ ] Live: post a slow reply → click stop → confirm the thread shows exactly ONE system message reading \"Triage agent cancelled.\" (no \"did not complete\" follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)