### PR TITLE
feat(dashboard): concurrent-triage guard — one in-flight turn per thread + don't auto-fire on pending actions

### DIFF
--- a/.changeset/triage-concurrent-guard.md
+++ b/.changeset/triage-concurrent-guard.md
@@ -1,0 +1,46 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+feat(dashboard): concurrent-triage guard — one in-flight turn per thread + don't auto-fire on pending actions
+
+Plan item #4 from
+`~/.claude/plans/triage-followups-2026-05-30.md`. Two races closed:
+
+**(a) Two triage runs racing on the same thread.** When triage was
+already running and an operator reply arrived (or a sibling tab hit
+`/triage`), `runTriageAgent` happily started a second run. Two replies
+would land out-of-order; message-status updates raced.
+
+`runTriageAgent` now checks `ctx.inboxTriageAbortControllers.has(messageId)`
+at the top and defers re-entry by adding the message to a new
+`ctx.inboxTriagePendingRefires` Set. The in-flight run's `finally`
+block drains the pending refire via `setImmediate` after clearing
+its own controller — so the operator's reply still gets a triage
+turn, just sequential instead of concurrent. The drain is gated on
+`!signal.aborted` so operator-cancelled runs don't auto-restart.
+
+**(b) Triage auto-firing while a proposed action is pending.** When
+triage proposed an action and the operator replied before the action
+ran, `POST /inbox/:id/respond` would auto-fire triage anyway —
+triage would then propose ANOTHER action or comment on the pending
+one. The action also might auto-approve and run concurrently with
+the fresh triage turn.
+
+`POST /respond` now skips the auto-fire when any action on the
+thread is in `proposed` or `running` state. The user reply is still
+recorded; the post-action `maybeRefireTriage` (which fires when all
+actions resolve) gives triage the full picture in one turn instead
+of two. Operator can still hit "Ask triage" explicitly to force a
+turn.
+
+**Set membership is idempotent** — N stacked re-entries collapse to
+one queued refire. The in-flight run only sees CONVERSATION as of
+its start time, so the queued refire ensures every reply gets a
+response.
+
+Tests: 4 new route tests cover (a)+(b). Full suite: 1839 passing.

--- a/packages/dashboard/src/context.ts
+++ b/packages/dashboard/src/context.ts
@@ -172,6 +172,14 @@ export interface DashboardContext {
    */
   inboxTriageAbortControllers: Map<string, { runId: string; controller: AbortController }>;
   /**
+   * Message ids whose latest `runTriageAgent` call was deferred
+   * because an earlier triage run was still in flight. After the
+   * earlier run finishes, the `finally` block fires a fresh triage
+   * turn so the operator's later reply doesn't sit silently. Membership
+   * is idempotent — multiple deferred calls collapse to one re-fire.
+   */
+  inboxTriagePendingRefires: Set<string>;
+  /**
    * Data directory path. Used by the health endpoint to read the scheduler
    * heartbeat file and report scheduler status.
    */

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -91,6 +91,7 @@ command: echo from-the-internet
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
     inboxTriageAbortControllers: new Map(),
+    inboxTriagePendingRefires: new Set(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -520,6 +520,7 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     allowUntrustedShell: opts.allowUntrustedShell ?? new Set(),
     activeRuns: new Map(),
     inboxTriageAbortControllers: new Map(),
+    inboxTriagePendingRefires: new Set(),
     dataDir: dirname(opts.dbPath),
     dashboardBaseUrl: (opts.dashboardBaseUrl ?? `http://${host}:${opts.port}`).replace(/\/$/, ''),
   };

--- a/packages/dashboard/src/routes/build-commit.test.ts
+++ b/packages/dashboard/src/routes/build-commit.test.ts
@@ -76,6 +76,7 @@ async function makeApp() {
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
     inboxTriageAbortControllers: new Map(),
+    inboxTriagePendingRefires: new Set(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/routes/dashboard-layout-plan-commit.test.ts
+++ b/packages/dashboard/src/routes/dashboard-layout-plan-commit.test.ts
@@ -96,6 +96,7 @@ async function makeApp() {
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
     inboxTriageAbortControllers: new Map(),
+    inboxTriagePendingRefires: new Set(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/routes/dashboards-edit.test.ts
+++ b/packages/dashboard/src/routes/dashboards-edit.test.ts
@@ -76,6 +76,7 @@ async function makeApp() {
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
     inboxTriageAbortControllers: new Map(),
+    inboxTriagePendingRefires: new Set(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/routes/dashboards.test.ts
+++ b/packages/dashboard/src/routes/dashboards.test.ts
@@ -77,6 +77,7 @@ async function makeApp() {
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
     inboxTriageAbortControllers: new Map(),
+    inboxTriagePendingRefires: new Set(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/routes/img-block-report.test.ts
+++ b/packages/dashboard/src/routes/img-block-report.test.ts
@@ -75,6 +75,7 @@ async function makeApp() {
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
     inboxTriageAbortControllers: new Map(),
+    inboxTriagePendingRefires: new Set(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/routes/inbox-events.test.ts
+++ b/packages/dashboard/src/routes/inbox-events.test.ts
@@ -72,6 +72,7 @@ async function makeApp() {
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
     inboxTriageAbortControllers: new Map(),
+    inboxTriagePendingRefires: new Set(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -70,6 +70,7 @@ async function makeApp() {
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
     inboxTriageAbortControllers: new Map(),
+    inboxTriagePendingRefires: new Set(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };
@@ -1068,7 +1069,116 @@ describe('POST /inbox/:id/triage/cancel', () => {
       .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
     expect(res.status).toBe(404);
   });
+});
 
+describe('Concurrent-triage guard (POST /respond)', () => {
+  it('does NOT auto-fire triage when a proposed action is pending', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    inboxStore.addResponse(m.id, 'action', 'rationale', JSON.stringify({
+      kind: 'action',
+      status: 'proposed',
+      agentId: 'agent-analyzer',
+      inputs: { FOCUS: 'why' },
+      rationale: 'rationale',
+    }));
+
+    const app2 = app as unknown as { locals: { inboxTriageAbortControllers: Map<string, unknown> } };
+    expect(app2.locals.inboxTriageAbortControllers.has(m.id)).toBe(false);
+
+    await request(app)
+      .post(`/inbox/${m.id}/respond`)
+      .type('form').send({ body: 'follow-up reply' })
+      .set('X-Requested-With', 'fetch')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+
+    // Give the fire-and-forget a tick to land if it were going to.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(app2.locals.inboxTriageAbortControllers.has(m.id)).toBe(false);
+
+    // The user reply still landed on the thread.
+    const userReplies = inboxStore.listResponses(m.id).filter((r) => r.role === 'user');
+    expect(userReplies.map((r) => r.body)).toEqual(['follow-up reply']);
+  });
+
+  it('does NOT auto-fire triage when a running action is pending', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    inboxStore.addResponse(m.id, 'action', 'rationale', JSON.stringify({
+      kind: 'action',
+      status: 'running',
+      agentId: 'agent-analyzer',
+      inputs: { FOCUS: 'why' },
+      rationale: 'rationale',
+      startedAt: Date.now(),
+    }));
+
+    const app2 = app as unknown as { locals: { inboxTriageAbortControllers: Map<string, unknown> } };
+    await request(app)
+      .post(`/inbox/${m.id}/respond`)
+      .type('form').send({ body: 'follow-up reply' })
+      .set('X-Requested-With', 'fetch')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(app2.locals.inboxTriageAbortControllers.has(m.id)).toBe(false);
+  });
+
+  it('still records the user reply when triage is skipped', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    inboxStore.addResponse(m.id, 'action', 'rationale', JSON.stringify({
+      kind: 'action',
+      status: 'proposed',
+      agentId: 'agent-analyzer',
+      inputs: {},
+      rationale: 'r',
+    }));
+
+    const res = await request(app)
+      .post(`/inbox/${m.id}/respond`)
+      .type('form').send({ body: 'guarded reply' })
+      .set('X-Requested-With', 'fetch')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(204);
+    const userReplies = inboxStore.listResponses(m.id).filter((r) => r.role === 'user');
+    expect(userReplies.map((r) => r.body)).toEqual(['guarded reply']);
+  });
+
+  it('runTriageAgent re-entry queues a pending refire (idempotent)', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+
+    // Seed an in-flight triage controller manually — simulates the
+    // first reply still being processed when a second reply comes in.
+    const app2 = app as unknown as { locals: {
+      inboxTriageAbortControllers: Map<string, { runId: string; controller: AbortController }>;
+      inboxTriagePendingRefires: Set<string>;
+    } };
+    const controller = new AbortController();
+    app2.locals.inboxTriageAbortControllers.set(m.id, { runId: 'inflight', controller });
+
+    // Trigger the explicit /triage path (which also goes through
+    // runTriageAgent). With the in-flight controller present, the
+    // guard should add this message to the pending refire set
+    // instead of starting a second triage run.
+    await request(app)
+      .post(`/inbox/${m.id}/triage`)
+      .set('X-Requested-With', 'fetch')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(app2.locals.inboxTriagePendingRefires.has(m.id)).toBe(true);
+
+    // Hitting it again is idempotent — set membership doesn't grow.
+    await request(app)
+      .post(`/inbox/${m.id}/triage`)
+      .set('X-Requested-With', 'fetch')
+      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(app2.locals.inboxTriagePendingRefires.size).toBe(1);
+  });
+});
+
+describe('Stale inbox-triage refresh', () => {
   it('auto-refreshes a stale inbox-triage agent from the bundled YAML', async () => {
     // Regression for the stage-direction recurrence: PR #398 added
     // auto-refresh for the SUB-agent allowlist (analyzer/editor/

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -452,10 +452,26 @@ inboxRouter.post('/inbox/:id/respond', (req: Request, res: Response) => {
     body: bodyRaw,
     createdAt: userResponse.createdAt,
   });
-  // Auto-fire triage. Fire-and-forget; the modal polls /fragment for
-  // the response. The conversation thread itself signals "in progress"
-  // via the user-reply-within-30s heuristic in isTriagePending.
-  void runTriageAgent(ctx, id).catch(() => { /* logged in helper */ });
+  // Auto-fire triage UNLESS a proposed-or-running action is pending
+  // on this thread. The prior action either is awaiting an operator
+  // click (proposed) or is mid-execution (running); auto-firing
+  // triage now would race against the action's lifecycle and could
+  // pile up redundant proposals. The follow-up triage turn that
+  // `maybeRefireTriage` schedules at action-completion picks up the
+  // operator's reply (it lives in the same CONVERSATION snapshot)
+  // so nothing is lost. Operator can still hit "Ask triage"
+  // explicitly when they want a fresh turn now.
+  const responsesNow = ctx.inboxStore.listResponses(id);
+  const actionPending = responsesNow.some((r) => {
+    const m = parseActionMeta(r);
+    return m && (m.status === 'proposed' || m.status === 'running');
+  });
+  if (!actionPending) {
+    // Fire-and-forget; the modal polls /fragment for the response.
+    // The conversation thread itself signals "in progress" via the
+    // user-reply-within-30s heuristic in isTriagePending.
+    void runTriageAgent(ctx, id).catch(() => { /* logged in helper */ });
+  }
 
   if (isAjax(req)) { res.status(204).end(); return; }
   res.redirect(303, `${detailUrl}?ok=${encodeURIComponent('Reply added.')}`);
@@ -1539,6 +1555,20 @@ async function runTriageAgent(
   const message = ctx.inboxStore.get(messageId);
   if (!message) return;
 
+  // Concurrent-triage guard. PR #425 added an in-flight controller
+  // registry; if one already exists, an earlier triage run is mid-
+  // flight and a second concurrent run would race against the
+  // first's response + the message-status updates. The deferred
+  // call lands in `inboxTriagePendingRefires`; the in-flight run's
+  // `finally` block schedules a fresh triage turn after it clears
+  // its own controller, so any reply the operator posted while
+  // triage was thinking still gets a response. Operator can hit the
+  // stop button to abandon the prior run if they want fresh.
+  if (ctx.inboxTriageAbortControllers.has(messageId)) {
+    ctx.inboxTriagePendingRefires.add(messageId);
+    return;
+  }
+
   // Auto-install + auto-refresh inbox-triage from the bundled YAML.
   // Pre-PR #399 this only handled the install case — operators who
   // installed inbox-triage before PR #395's VOICE-section update kept
@@ -1796,6 +1826,18 @@ async function runTriageAgent(
     const existing = ctx.inboxTriageAbortControllers.get(messageId);
     if (existing && existing.runId === runId) {
       ctx.inboxTriageAbortControllers.delete(messageId);
+    }
+    // Drain a pending re-fire (queued while this run was holding the
+    // guard). Use setImmediate so the new run starts AFTER the
+    // current frame's state mutations settle and any SSE listeners
+    // see this run's `state:done` before the next one's
+    // `triage:started`. The cancel-aborted path skips the drain —
+    // operator-cancelled means "stop responding," not "queue up the
+    // next turn."
+    if (!abortController.signal.aborted && ctx.inboxTriagePendingRefires.delete(messageId)) {
+      setImmediate(() => {
+        runTriageAgent(ctx, messageId).catch(() => { /* swallow */ });
+      });
     }
   }
 }

--- a/packages/dashboard/src/routes/metrics-planner.test.ts
+++ b/packages/dashboard/src/routes/metrics-planner.test.ts
@@ -59,6 +59,7 @@ async function makeApp(): Promise<ReturnType<typeof buildDashboardApp>> {
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
     inboxTriageAbortControllers: new Map(),
+    inboxTriagePendingRefires: new Set(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/routes/packs.test.ts
+++ b/packages/dashboard/src/routes/packs.test.ts
@@ -64,6 +64,7 @@ async function makeApp() {
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
     inboxTriageAbortControllers: new Map(),
+    inboxTriagePendingRefires: new Set(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/routes/pulse-layout-plan-commit.test.ts
+++ b/packages/dashboard/src/routes/pulse-layout-plan-commit.test.ts
@@ -88,6 +88,7 @@ async function makeApp() {
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
     inboxTriageAbortControllers: new Map(),
+    inboxTriagePendingRefires: new Set(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/routes/pulse-toggle.test.ts
+++ b/packages/dashboard/src/routes/pulse-toggle.test.ts
@@ -85,6 +85,7 @@ async function makeApp(initial: { pulseVisible?: boolean }) {
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
     inboxTriageAbortControllers: new Map(),
+    inboxTriagePendingRefires: new Set(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/routes/schedule-edit.test.ts
+++ b/packages/dashboard/src/routes/schedule-edit.test.ts
@@ -74,6 +74,7 @@ async function makeApp(opts: { schedule?: string; allowHighFrequency?: boolean }
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
     inboxTriageAbortControllers: new Map(),
+    inboxTriagePendingRefires: new Set(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/routes/tools-used-by.test.ts
+++ b/packages/dashboard/src/routes/tools-used-by.test.ts
@@ -87,6 +87,7 @@ async function makeApp() {
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
     inboxTriageAbortControllers: new Map(),
+    inboxTriagePendingRefires: new Set(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };

--- a/packages/dashboard/src/views/not-found.test.ts
+++ b/packages/dashboard/src/views/not-found.test.ts
@@ -62,6 +62,7 @@ async function makeApp() {
     allowUntrustedShell: new Set(),
     activeRuns: new Map(),
     inboxTriageAbortControllers: new Map(),
+    inboxTriagePendingRefires: new Set(),
     dataDir: dir,
     dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
   };


### PR DESCRIPTION
Closes plan item #4 in `~/.claude/plans/triage-followups-2026-05-30.md`. Two distinct races fixed.

## (a) Two triage runs racing on the same thread

When triage was already running and an operator reply arrived (or a sibling tab hit \`/triage\`), \`runTriageAgent\` happily started a second run. Two responses would land out-of-order; message-status updates raced.

**Fix:** \`runTriageAgent\` now checks \`ctx.inboxTriageAbortControllers.has(messageId)\` at the top and defers re-entry by adding the message to a new \`ctx.inboxTriagePendingRefires\` Set. The in-flight run's \`finally\` block drains the pending refire via \`setImmediate\` after clearing its own controller — so the operator's reply still gets a triage turn, just sequential instead of concurrent. Drain is gated on \`!signal.aborted\` so operator-cancelled runs don't auto-restart.

## (b) Triage auto-firing while a proposed action is pending

When triage proposed an action and the operator replied before the action ran, \`POST /inbox/:id/respond\` would auto-fire triage anyway — triage would then propose ANOTHER action or comment on the pending one. The action also might auto-approve (post-#412) and run concurrently with the fresh triage turn.

**Fix:** \`POST /respond\` now skips the auto-fire when any action on the thread is in \`proposed\` or \`running\` state. The user reply is still recorded; the post-action \`maybeRefireTriage\` (which fires when all actions resolve) gives triage the full picture in one turn instead of two. Operator can still hit \"Ask triage\" explicitly to force a turn.

## Idempotency
Set membership for \`inboxTriagePendingRefires\` is naturally idempotent — N stacked re-entries collapse to one queued refire. The in-flight run only sees CONVERSATION as of its start time, so the queued refire ensures every reply gets a response (even if multiple replies stacked while triage was busy).

## Test plan
- [x] \`npm run build\` clean
- [x] \`npx vitest run packages/core packages/dashboard packages/mcp-server\` — **1839 passing** (+4 over baseline)
- [ ] Live: send two rapid replies → confirm only one triage turn runs at a time, and the second response addresses both replies.
- [ ] Live: trigger an analyzer/editor proposed action, send a reply while it's pending → confirm triage doesn't fire until the action resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)