### PR TITLE
feat(dashboard,mcp): honor configured run provider (--provider local|temporal)

### DIFF
--- a/.changeset/temporal-provider-wiring.md
+++ b/.changeset/temporal-provider-wiring.md
@@ -1,0 +1,20 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Dashboard and MCP server honor the configured run provider.
+
+`sua dashboard start` and `sua mcp start` now accept `--provider <local|temporal>`
+(also respecting `SUA_PROVIDER` and `sua.config.json`) and route "Run now" /
+run-submission through that provider instead of always using the local one. The
+selected provider is shown in the startup banner, and an unreachable Temporal
+server fails fast with a clear hint instead of hanging. New operator guide at
+`docs/temporal.md` covers running Temporal in Docker and monitoring it via the
+Temporal Web UI.
+
+Note: this routes v1 single-node agents through Temporal; multi-node (v2 DAG)
+agents still run in-process. Executing v2 DAGs on Temporal is planned next.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
 ## Docs map
-- **User-facing docs**: [docs/](docs/) — quickstart, agents, flows, tools, mcp, output-widgets, templating, dashboard, build-from-goal, security
+- **User-facing docs**: [docs/](docs/) — quickstart, agents, flows, tools, mcp, output-widgets, templating, dashboard, build-from-goal, temporal, security
 - **Architecture decisions**: [docs/adr/](docs/adr/) — MADR-lite records for load-bearing choices
 - **Changelog**: [CHANGELOG.md](CHANGELOG.md) (produced by `changeset version` at release time)
 - **Roadmap**: [ROADMAP.md](ROADMAP.md)

--- a/docs/temporal.md
+++ b/docs/temporal.md
@@ -1,0 +1,194 @@
+# Running on Temporal
+
+`some-useful-agents` can run agents two ways:
+
+- **`local`** (default) — runs execute in-process inside whatever started them
+  (the CLI, the dashboard daemon, the MCP server). Zero infrastructure.
+- **`temporal`** — single-node agent runs are submitted to a [Temporal](https://temporal.io)
+  server as durable workflows and executed by a worker process. You get
+  durability, the Temporal Web UI, and retry/visibility primitives.
+
+This page is the operator guide: start Temporal in Docker, point `sua` at it,
+run a worker, and monitor it.
+
+> **Scope note (current release).** Only **v1 single-node agents** route through
+> Temporal today — the path behind "Run now" and `sua agent run`. **v2 DAG
+> agents** (anything multi-node: triage, build-from-goal, layout-planner, and
+> most agents built in the dashboard) run **in-process via `executeAgentDag`
+> regardless of the provider.** So with Temporal enabled, the Temporal Web UI
+> shows your v1 runs only; multi-node agents won't appear there yet. Making v2
+> DAGs execute as Temporal workflows is planned (Phase B) — see
+> `ROADMAP.md` / the Temporal wiring plan.
+
+## Architecture: server in Docker, worker on the host
+
+The Temporal **server** runs in Docker. The **worker** runs on your host —
+*not* in Docker — because the worker spawns `bash` and `claude` and needs your
+PATH, dev tools, and credentials. Putting the worker in a container would mean
+mounting `~/.claude` and your keys into it, which defeats the sandbox. This
+split is recorded in [ADR-0004](adr/0004-temporal-worker-on-host.md).
+
+```
+┌─────────────────────── Docker ───────────────────────┐
+│  temporal (server)  :7233   ◄── gRPC                  │
+│  temporal-db (postgres)     persists workflow history │
+│  temporal-ui        :8233   ◄── browser monitoring    │
+└───────────────────────────────────────────────────────┘
+            ▲                         ▲
+            │ submit workflow         │ poll task queue
+   ┌────────┴────────┐       ┌────────┴──────────────────┐
+   │ sua dashboard / │       │  sua worker start         │
+   │ mcp / agent run │       │  (HOST process: shell +   │
+   │ (provider=temporal)     │   claude + secrets)       │
+   └─────────────────┘       └───────────────────────────┘
+```
+
+## 1. Start the Temporal stack
+
+The repo ships a [`docker-compose.yml`](../docker-compose.yml) with three
+services:
+
+| Service | Port | Purpose |
+| --- | --- | --- |
+| `temporal` | `7233` | Temporal server (gRPC) — what `sua` and the worker connect to |
+| `temporal-db` | `127.0.0.1:5432` | Postgres backing workflow history |
+| `temporal-ui` | `8233` → container `8080` | Temporal Web UI for monitoring |
+
+```bash
+docker compose up -d
+```
+
+Confirm it's healthy:
+
+```bash
+docker compose ps          # all three Up; temporal-db (healthy)
+docker compose logs -f temporal   # watch server logs
+```
+
+The Web UI is now at **http://localhost:8233**. It will be empty until you run
+something.
+
+## 2. Point `sua` at Temporal
+
+Three ways, in precedence order (highest wins):
+
+1. **Per-command flag:** `--provider temporal` on `sua dashboard start`,
+   `sua mcp start`, or `sua agent run`.
+2. **Environment:** `SUA_PROVIDER=temporal`.
+3. **Config file** (`sua.config.json` in the working directory):
+
+   ```json
+   {
+     "provider": "temporal",
+     "temporalAddress": "localhost:7233",
+     "temporalNamespace": "default",
+     "temporalTaskQueue": "sua-agents"
+   }
+   ```
+
+`temporalAddress` / `temporalNamespace` / `temporalTaskQueue` default to
+`localhost:7233` / `default` / `sua-agents` — the values the bundled compose
+file uses, so you usually don't set them.
+
+When a server or command starts with the Temporal provider it says so in its
+banner (`Run-now provider: temporal (needs \`sua worker start\`)`), and it fails
+fast with a clear message if the Temporal server is unreachable rather than
+hanging.
+
+## 3. Start a worker on the host
+
+Nothing runs until a worker is polling the task queue. In a separate terminal:
+
+```bash
+sua worker start
+# Address:    localhost:7233
+# Namespace:  default
+# Task queue: sua-agents
+# ✓ Worker connected. Listening for agent runs...
+```
+
+Leave it running (Ctrl-C stops it). For a long-lived setup, wrap it in
+`launchd` / `systemd`, or run it under `sua daemon` if you manage services that
+way.
+
+> If you submit a Temporal run with **no worker** polling, the run sits
+> `pending` — the Temporal server has accepted the workflow but nothing is
+> executing it. Start a worker and it picks up immediately.
+
+## 4. Run something
+
+Either of these now goes through Temporal:
+
+```bash
+# CLI:
+sua agent run hello-world --provider temporal
+
+# Dashboard: start it on Temporal, then use "Run now" on a v1 agent:
+sua dashboard start --provider temporal
+```
+
+## 5. Monitor
+
+### Temporal Web UI — http://localhost:8233
+
+The primary monitoring surface.
+
+- **Workflows list** — every submitted run. `sua` names workflows
+  `sua-run-<runId>`, so you can match them to rows in the dashboard `/runs`
+  page and to `sua agent status`.
+- **Status** — Running / Completed / Failed / Cancelled / Terminated.
+- **Workflow detail → History** — the full event log: when the activity
+  started, its input, result, retries, and any failure stack. This is where you
+  look when a run failed and you want to know *why*.
+- **Task queues** — open the `sua-agents` task queue to confirm a worker is
+  registered (a "pollers" entry). No pollers = no worker running = runs stay
+  pending.
+
+### Command line
+
+```bash
+# List recent workflows from inside the server container:
+docker exec sua-temporal temporal workflow list
+
+# Inspect one run's full history:
+docker exec sua-temporal temporal workflow show --workflow-id sua-run-<runId>
+
+# Is a worker registered on the queue? (look for pollers)
+docker exec sua-temporal temporal task-queue describe --task-queue sua-agents
+```
+
+`sua` also mirrors run status into its local SQLite store, so
+`sua agent status [runId]`, `sua agent logs <runId>`, and the dashboard
+`/runs` page reflect Temporal runs without opening the UI.
+
+### Health at a glance
+
+```bash
+docker compose ps                       # containers up + db healthy
+docker exec sua-temporal temporal operator cluster health   # server reachable
+```
+
+## Stopping and resetting
+
+```bash
+docker compose stop      # stop containers, keep workflow history
+docker compose down      # remove containers, keep the postgres volume
+docker compose down -v   # remove containers AND wipe all workflow history
+```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `Could not start the temporal provider: ... ECONNREFUSED` | Temporal server not up | `docker compose up -d`, then retry |
+| Runs stuck `pending` forever | No worker polling the queue | `sua worker start` in another terminal |
+| Worker: `Worker failed: ... connection refused` | Server not up / wrong address | Start the stack; check `temporalAddress` |
+| Web UI loads but is empty | No runs yet, or you only ran **v2 DAG agents** (which don't route through Temporal yet) | Run a v1 agent, or see the scope note above |
+| UI can't reach server | `temporal-ui` env `TEMPORAL_ADDRESS` wrong | It's `temporal:7233` (container DNS), already set in compose |
+
+## See also
+
+- [ADR-0004 — Temporal worker runs on host, not Docker](adr/0004-temporal-worker-on-host.md)
+- [docker-compose.yml](../docker-compose.yml)
+- [docs/security.md](SECURITY.md) — trust boundaries are enforced at the agent
+  layer, which is why host execution is acceptable

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -1,7 +1,8 @@
 import { Command } from 'commander';
 import { startDashboardServer } from '@some-useful-agents/dashboard';
 import { getMcpTokenPath, readMcpToken } from '@some-useful-agents/core';
-import { loadConfig, getAgentDirs, getDbPath, getSecretsPath, getVariablesPath, getLlmSettingsPath, getRetentionDays, getDashboardBaseUrl } from '../config.js';
+import { loadConfig, getAgentDirs, getDbPath, getSecretsPath, getVariablesPath, getLlmSettingsPath, getRetentionDays, getDashboardBaseUrl, resolveProvider } from '../config.js';
+import { createProvider } from '../provider-factory.js';
 import * as ui from '../ui.js';
 
 function collectName(value: string, previous: string[]): string[] {
@@ -40,6 +41,11 @@ dashboardCommand
   .option('--port <port>', 'Port to listen on', '3000')
   .option('--host <host>', 'Bind host (default 127.0.0.1)', '127.0.0.1')
   .option(
+    '--provider <kind>',
+    'Run-now backend: "local" (default) or "temporal". Overrides config/SUA_PROVIDER. ' +
+      'Temporal requires the server (docker compose up -d) and a worker (sua worker start).',
+  )
+  .option(
     '--allow-untrusted-shell <name>',
     'Pre-allow a community shell agent to be triggered from the dashboard (repeatable)',
     collectName,
@@ -61,7 +67,7 @@ The dashboard runs foreground; Ctrl-C stops it. Daemonization is out
 of scope for this release — wrap in launchd / systemd if you need it.
 `,
   )
-  .action(async (options: { port: string; host: string; allowUntrustedShell: string[] }) => {
+  .action(async (options: { port: string; host: string; provider?: string; allowUntrustedShell: string[] }) => {
     const port = Number.parseInt(options.port, 10);
     if (!Number.isFinite(port) || port < 1 || port > 65535) {
       ui.fail(`Invalid port "${options.port}".`);
@@ -70,6 +76,28 @@ of scope for this release — wrap in launchd / systemd if you need it.
 
     const config = loadConfig();
     const dirs = getAgentDirs(config);
+    const allowUntrustedShell = new Set(options.allowUntrustedShell);
+
+    // Build the run-now provider up front so a misconfigured or unreachable
+    // Temporal server fails before we bind the HTTP listener. resolveProvider
+    // validates the kind; createProvider connects (Temporal) or opens the
+    // SQLite store (local).
+    const providerKind = resolveProvider(config, options.provider);
+    let provider;
+    try {
+      provider = await createProvider(config, {
+        providerOverride: options.provider,
+        allowUntrustedShell,
+      });
+    } catch (err) {
+      const msg = (err as Error).message;
+      ui.fail(`Could not start the ${providerKind} provider: ${msg}`);
+      if (providerKind === 'temporal' && /ECONNREFUSED|connection refused/i.test(msg)) {
+        console.error(ui.dim(`\nIs Temporal running? Start it with: ${ui.cmd('docker compose up -d')}`));
+        console.error(ui.dim(`Then start a worker in another terminal: ${ui.cmd('sua worker start')}`));
+      }
+      process.exit(1);
+    }
 
     let handle;
     try {
@@ -82,8 +110,9 @@ of scope for this release — wrap in launchd / systemd if you need it.
         variablesPath: getVariablesPath(config),
         llmSettingsPath: getLlmSettingsPath(config),
         retentionDays: getRetentionDays(config),
-        allowUntrustedShell: new Set(options.allowUntrustedShell),
+        allowUntrustedShell,
         dashboardBaseUrl: getDashboardBaseUrl(config),
+        provider,
       });
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === 'EADDRINUSE') {
@@ -116,6 +145,8 @@ of scope for this release — wrap in launchd / systemd if you need it.
     ui.banner(
       `Dashboard running on ${options.host}:${port}`,
       [
+        `Run-now provider: ${providerKind}${providerKind === 'temporal' ? ' (needs `sua worker start`)' : ''}`,
+        ``,
         `One-time sign-in URL:`,
         handle.authUrl,
         ``,

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -6,7 +6,8 @@ import {
   readMcpToken,
   rotateMcpToken,
 } from '@some-useful-agents/core';
-import { loadConfig, getAgentDirs, getDbPath, getSecretsPath } from '../config.js';
+import { loadConfig, getAgentDirs, getDbPath, getSecretsPath, resolveProvider } from '../config.js';
+import { createProvider } from '../provider-factory.js';
 import * as ui from '../ui.js';
 
 export const mcpCommand = new Command('mcp')
@@ -20,6 +21,11 @@ mcpCommand
     '--host <host>',
     'Bind host (default 127.0.0.1; set 0.0.0.0 only if you genuinely need LAN exposure)',
   )
+  .option(
+    '--provider <kind>',
+    'Run backend: "local" (default) or "temporal". Overrides config/SUA_PROVIDER. ' +
+      'Temporal requires the server (docker compose up -d) and a worker (sua worker start).',
+  )
   .action(async (options) => {
     const config = loadConfig();
     const port = options.port ? parseInt(options.port, 10) : config.mcpPort;
@@ -28,16 +34,33 @@ mcpCommand
     const dbPath = getDbPath(config);
     const tokenPath = getMcpTokenPath();
     const { token } = ensureMcpToken(tokenPath);
+    const providerKind = resolveProvider(config, options.provider);
+
+    // Build the run provider up front so an unreachable Temporal server fails
+    // before we advertise the MCP endpoint.
+    let provider;
+    try {
+      provider = await createProvider(config, { providerOverride: options.provider });
+    } catch (err) {
+      const msg = (err as Error).message;
+      ui.fail(`Could not start the ${providerKind} provider: ${msg}`);
+      if (providerKind === 'temporal' && /ECONNREFUSED|connection refused/i.test(msg)) {
+        console.error(ui.dim(`\nIs Temporal running? Start it with: ${ui.cmd('docker compose up -d')}`));
+        console.error(ui.dim(`Then start a worker in another terminal: ${ui.cmd('sua worker start')}`));
+      }
+      process.exit(1);
+    }
 
     // Dynamic import to avoid loading MCP deps when not needed
     const { startMcpServer } = await import('@some-useful-agents/mcp-server');
 
     ui.banner('Starting MCP server', [
-      `Host:   ${host}`,
-      `Port:   ${port}`,
-      `Agents: ${dirs.all.join(', ')}`,
-      `DB:     ${dbPath}`,
-      `Token:  ${tokenPath}`,
+      `Host:     ${host}`,
+      `Port:     ${port}`,
+      `Provider: ${providerKind}${providerKind === 'temporal' ? ' (needs `sua worker start`)' : ''}`,
+      `Agents:   ${dirs.all.join(', ')}`,
+      `DB:       ${dbPath}`,
+      `Token:    ${tokenPath}`,
     ]);
 
     if (host !== '127.0.0.1' && host !== '::1' && host !== 'localhost') {
@@ -71,6 +94,7 @@ mcpCommand
       dbPath,
       secretsPath: getSecretsPath(config),
       tokenPath,
+      provider,
     });
   });
 

--- a/packages/dashboard/src/context.ts
+++ b/packages/dashboard/src/context.ts
@@ -1,4 +1,4 @@
-import type { LocalProvider, RunStore, SecretsStore, AgentDefinition, AgentStore, ToolStore, VariablesStore, LlmSettingsStore, PacksStore, DashboardsStore, LayoutHintsStore, BlockedImgHostsStore, InboxStore, IntegrationsStore, PlannerTelemetryStore, PlannerLoopStepLogStore, PlannerMemoryStore, AgentMemoryStore } from '@some-useful-agents/core';
+import type { Provider, RunStore, SecretsStore, AgentDefinition, AgentStore, ToolStore, VariablesStore, LlmSettingsStore, PacksStore, DashboardsStore, LayoutHintsStore, BlockedImgHostsStore, InboxStore, IntegrationsStore, PlannerTelemetryStore, PlannerLoopStepLogStore, PlannerMemoryStore, AgentMemoryStore } from '@some-useful-agents/core';
 import type { SecretsSession } from './secrets-session.js';
 import type { InboxEventBus } from './lib/inbox-event-bus.js';
 
@@ -14,8 +14,13 @@ export interface DashboardContext {
   allowlist: Set<string>;
   /** Expected Host header's port (for loopback checks). */
   port: number;
-  /** Provider used to submit "Run now" POSTs. */
-  provider: LocalProvider;
+  /**
+   * Provider used to submit "Run now" POSTs (v1 single-node agents) and to
+   * cancel runs. Defaults to LocalProvider; the CLI injects a TemporalProvider
+   * when started with `--provider temporal`. v2 DAG agents bypass this and run
+   * in-process via executeAgentDag regardless of provider (see ADR-0013).
+   */
+  provider: Provider;
   /** Run store reader for /runs and /runs/:id. */
   runStore: RunStore;
   /**

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -28,6 +28,7 @@ import {
   buildLoopbackAllowlist,
   reapOrphanedRuns,
   type SecretsStore,
+  type Provider,
   type RunStatus,
   getSchedulerStatus,
 } from '@some-useful-agents/core';
@@ -101,8 +102,13 @@ export interface StartDashboardOptions {
   dashboardBaseUrl?: string;
   /** Optional SecretsStore override (tests). */
   secretsStore?: SecretsStore;
-  /** Optional LocalProvider override (tests). */
-  provider?: LocalProvider;
+  /**
+   * Provider that backs "Run now" + run cancellation. Defaults to a
+   * LocalProvider over `dbPath`. The CLI injects a TemporalProvider here when
+   * `sua dashboard start --provider temporal` is used; tests inject a
+   * LocalProvider directly.
+   */
+  provider?: Provider;
   /** Optional RunStore override (tests). */
   runStore?: RunStore;
   /** Optional AgentStore override (tests). */
@@ -356,10 +362,16 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
   // mode makes concurrent handles safe.
   const agentStore = opts.agentStore ?? new AgentStore(opts.dbPath);
   const secretsStore = opts.secretsStore ?? new EncryptedFileStore(opts.secretsPath);
-  const provider = opts.provider ?? new LocalProvider(opts.dbPath, secretsStore, {
-    allowUntrustedShell: opts.allowUntrustedShell,
-  });
-  await provider.initialize();
+  // An injected provider (the CLI's createProvider, or a test's) arrives
+  // already initialized — re-initializing a TemporalProvider would open a
+  // second client connection. Only initialize the fallback we construct here.
+  let provider = opts.provider;
+  if (!provider) {
+    provider = new LocalProvider(opts.dbPath, secretsStore, {
+      allowUntrustedShell: opts.allowUntrustedShell,
+    });
+    await provider.initialize();
+  }
 
   const secretsSession = new EncryptedFileSecretsSession(opts.secretsPath);
   // Tool store shares the same DB path. WAL mode makes concurrent handles safe.

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -11,6 +11,7 @@ import {
   VariablesStore,
   ensureMcpToken,
   getMcpTokenPath,
+  type Provider,
 } from '@some-useful-agents/core';
 import {
   buildLoopbackAllowlist,
@@ -39,6 +40,12 @@ export interface McpServerOptions {
    * if it does not exist.
    */
   tokenPath?: string;
+  /**
+   * Provider that backs the run/list/cancel MCP tools. Defaults to a
+   * LocalProvider over `dbPath`. The CLI injects a TemporalProvider here when
+   * `sua mcp start --provider temporal` is used.
+   */
+  provider?: Provider;
 }
 
 interface SessionEntry {
@@ -101,8 +108,13 @@ export async function startMcpServer(options: McpServerOptions): Promise<McpServ
   }
 
   const secretsStore = new EncryptedFileStore(options.secretsPath);
-  const provider = new LocalProvider(options.dbPath, secretsStore);
-  await provider.initialize();
+  // An injected provider (the CLI's createProvider) arrives already
+  // initialized; only initialize the fallback we construct here.
+  let provider = options.provider;
+  if (!provider) {
+    provider = new LocalProvider(options.dbPath, secretsStore);
+    await provider.initialize();
+  }
 
   // Dashboard-managed agents live in the SQLite DB, not on the filesystem.
   // Open dedicated handles here so the list/run tools see the full

--- a/packages/mcp-server/src/server.test.ts
+++ b/packages/mcp-server/src/server.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { Provider, Run, RunRequest } from '@some-useful-agents/core';
 import { startMcpServer } from './index.js';
 
 /**
@@ -100,6 +101,74 @@ describe('MCP server multi-session', () => {
     const body = (await health.json()) as { status: string; sessions: number };
     expect(body.status).toBe('ok');
     expect(body.sessions).toBe(2);
+  });
+});
+
+/**
+ * Phase A of Temporal wiring: the CLI builds the provider (via createProvider)
+ * and injects it. An injected provider arrives already initialized, so the
+ * server must NOT re-initialize it — re-initializing a TemporalProvider would
+ * open a second client connection. Verify the injected provider is the one the
+ * server uses and that initialize() is not called on it.
+ */
+describe('MCP server provider injection', () => {
+  let dataDir: string;
+  let tokenPath: string;
+  let secretsPath: string;
+  let serverHandle: { port: number; shutdown: () => Promise<void> } | undefined;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'sua-mcp-prov-'));
+    tokenPath = join(dataDir, 'mcp-token');
+    writeFileSync(tokenPath, 't'.repeat(64));
+    chmodSync(tokenPath, 0o600);
+    secretsPath = join(dataDir, 'secrets.enc');
+  });
+
+  afterEach(async () => {
+    if (serverHandle) {
+      await serverHandle.shutdown();
+      serverHandle = undefined;
+    }
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it('uses an injected provider without re-initializing it', async () => {
+    let initializeCalls = 0;
+    let shutdownCalls = 0;
+    const injected: Provider = {
+      name: 'stub',
+      async initialize() { initializeCalls++; },
+      async shutdown() { shutdownCalls++; },
+      async submitRun(_req: RunRequest): Promise<Run> {
+        return { id: 'stub-run', agentName: 'x', status: 'completed', startedAt: '2026-01-01T00:00:00Z', triggeredBy: 'mcp' };
+      },
+      async getRun(): Promise<Run | null> { return null; },
+      async listRuns(): Promise<Run[]> { return []; },
+      async cancelRun(): Promise<void> {},
+      async getRunLogs(): Promise<string> { return ''; },
+    };
+
+    serverHandle = await startMcpServer({
+      port: 0,
+      host: '127.0.0.1',
+      agentDirs: [dataDir],
+      dbPath: join(dataDir, 'runs.db'),
+      secretsPath,
+      tokenPath,
+      provider: injected,
+    });
+
+    // Server booted on the injected provider; the CLI already initialized it,
+    // so the server left it alone.
+    expect(initializeCalls).toBe(0);
+    const health = await fetch(`http://127.0.0.1:${serverHandle.port}/health`);
+    expect(health.status).toBe(200);
+
+    await serverHandle.shutdown();
+    serverHandle = undefined;
+    // The server owns teardown of whatever provider it was handed.
+    expect(shutdownCalls).toBe(1);
   });
 });
 


### PR DESCRIPTION
## What

The dashboard and MCP server hardcoded `LocalProvider`, ignoring `provider` in `sua.config.json` / `SUA_PROVIDER`. This is Phase A of wiring Temporal as a real option: make both surfaces honor the configured provider, and add the deploy switch.

- Widen `provider` type `LocalProvider` -> `Provider` in the dashboard context and MCP options.
- The CLI builds the provider via `createProvider` and injects it. An injected provider arrives already initialized, so the server skips re-init (a second `TemporalProvider.initialize` would open a duplicate client connection).
- `sua dashboard start` and `sua mcp start` gain `--provider <local|temporal>` (overrides config/`SUA_PROVIDER`). Both build the provider up front so an unreachable Temporal server **fails fast with a hint** instead of hanging, and show the active provider in the startup banner.
- New operator guide `docs/temporal.md`: Docker stack, config precedence, `sua worker start`, and monitoring via the Temporal Web UI + CLI.

## Scope / caveat

This routes **v1 single-node agents** through the chosen provider. **v2 DAG agents** (triage, build-from-goal, layout-planner, most dashboard-built agents) still run **in-process** via `executeAgentDag` and do not yet touch Temporal — so the Temporal UI shows v1 runs only. Executing v2 DAGs on Temporal is the next phase (durable, resumable orchestration); plan tracked locally.

## Test

- New injection test in `packages/mcp-server/src/server.test.ts` verifies an injected provider is used and not re-initialized, and is shut down by the server.
- Clean rebuild + full suite: **1911 passed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)