### PR TITLE
feat: record usedWorkflowProvider (local|temporal) on runs and nodes

### DIFF
--- a/.changeset/used-workflow-provider.md
+++ b/.changeset/used-workflow-provider.md
@@ -1,0 +1,16 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Record which execution backend ran each run.
+
+Runs and node executions now carry a `usedWorkflowProvider` field
+(`local` | `temporal`) so you can tell where work actually ran. This is a
+distinct axis from the LLM provider (`usedProvider`, claude/codex/apple). The
+local and Temporal providers stamp it at submit time; v2 DAG runs record
+`local`. The runs list shows a `temporal` chip for Temporal runs and the run
+detail page shows a Backend row. Legacy rows read back as local.

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -636,6 +636,12 @@ export interface NodeExecutionRecord {
    * size stays bounded.
    */
   attemptedProviders?: string;
+  /**
+   * Execution backend that ran this node: `'local'` (in-process) or
+   * `'temporal'` (worker activity). Different axis from `usedProvider`
+   * above, which is the LLM provider. Undefined on legacy rows ↔ `local`.
+   */
+  usedWorkflowProvider?: string;
 }
 
 /**

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -253,6 +253,9 @@ export async function executeAgentDag(
     parentNodeId: options.parentNodeId,
     retryOfRunId: options.retryOf?.originalRunId,
     attempt: options.retryOf?.attempt,
+    // v2 DAGs execute in-process today. B1b will set this to 'temporal' per
+    // node when spawns route through a Temporal activity.
+    usedWorkflowProvider: 'local',
   });
 
   const outputs = new Map<string, NodeOutput>();

--- a/packages/core/src/local-provider.ts
+++ b/packages/core/src/local-provider.ts
@@ -57,6 +57,7 @@ export class LocalProvider implements Provider {
       status: 'running',
       startedAt: new Date().toISOString(),
       triggeredBy: request.triggeredBy,
+      usedWorkflowProvider: 'local',
     };
 
     this.store.createRun(run);

--- a/packages/core/src/run-store.test.ts
+++ b/packages/core/src/run-store.test.ts
@@ -108,6 +108,13 @@ describe('RunStore', () => {
     expect(retrieved!.exitCode).toBe(0);
   });
 
+  it('round-trips usedWorkflowProvider; undefined when unset (legacy/local)', () => {
+    store.createRun(makeRun({ id: 'r-temporal', usedWorkflowProvider: 'temporal' }));
+    store.createRun(makeRun({ id: 'r-default' }));
+    expect(store.getRun('r-temporal')!.usedWorkflowProvider).toBe('temporal');
+    expect(store.getRun('r-default')!.usedWorkflowProvider).toBeUndefined();
+  });
+
   it.skipIf(platform() === 'win32')('chmods the DB file to 0o600 on create', () => {
     const mode = statSync(TEST_DB).mode & 0o777;
     expect(mode).toBe(0o600);
@@ -281,6 +288,21 @@ describe('RunStore node_executions', () => {
     expect(got!.nodeId).toBe('fetch');
     expect(got!.status).toBe('running');
     expect(got!.errorCategory).toBeUndefined();
+  });
+
+  it('round-trips usedWorkflowProvider on a node execution', () => {
+    store.createNodeExecution({
+      runId: 'r-x', nodeId: 'fetch', workflowVersion: 1,
+      status: 'completed', startedAt: new Date().toISOString(),
+      usedWorkflowProvider: 'temporal',
+    });
+    expect(store.getNodeExecution('r-x', 'fetch')!.usedWorkflowProvider).toBe('temporal');
+    // A node written without the field reads back undefined (legacy/local).
+    store.createNodeExecution({
+      runId: 'r-x', nodeId: 'parse', workflowVersion: 1,
+      status: 'completed', startedAt: new Date().toISOString(),
+    });
+    expect(store.getNodeExecution('r-x', 'parse')!.usedWorkflowProvider).toBeUndefined();
   });
 
   it('persists errorCategory on failed rows', () => {

--- a/packages/core/src/run-store.ts
+++ b/packages/core/src/run-store.ts
@@ -180,6 +180,14 @@ export class RunStore {
     if (!runCols.has('attempt')) {
       this.db.exec(`ALTER TABLE runs ADD COLUMN attempt INTEGER NOT NULL DEFAULT 1`);
     }
+
+    // Workflow (execution backend) provider: which provider executed this run
+    // — 'local' (in-process) or 'temporal' (worker). Distinct from the LLM
+    // provider axis (node_executions.usedProvider). Nullable; NULL ↔ legacy/
+    // local. See ~/.claude/plans/temporal-wiring.md (B1a).
+    if (!runCols.has('usedworkflowprovider')) {
+      this.db.exec(`ALTER TABLE runs ADD COLUMN usedWorkflowProvider TEXT`);
+    }
     this.db.exec(`
       CREATE INDEX IF NOT EXISTS idx_runs_retry_of
         ON runs(retry_of_run_id) WHERE retry_of_run_id IS NOT NULL;
@@ -228,6 +236,14 @@ export class RunStore {
     if (!execCols.has('attemptedproviders')) {
       this.db.exec(`ALTER TABLE node_executions ADD COLUMN attemptedProviders TEXT`);
     }
+
+    // Workflow (execution backend) provider per node: 'local' | 'temporal'.
+    // Different axis from `usedProvider` above, which is the LLM provider
+    // (claude/codex/apple) — read that as the "LLM provider". This one records
+    // where the node's work actually ran. Nullable; NULL ↔ legacy/local.
+    if (!execCols.has('usedworkflowprovider')) {
+      this.db.exec(`ALTER TABLE node_executions ADD COLUMN usedWorkflowProvider TEXT`);
+    }
   }
 
   /**
@@ -247,8 +263,8 @@ export class RunStore {
     const stmt = this.db.prepare(`
       INSERT INTO runs (id, agentName, status, startedAt, completedAt, result, exitCode, error, triggeredBy,
                         workflow_id, workflow_version, replayed_from_run_id, replayed_from_node_id,
-                        parent_run_id, parent_node_id, retry_of_run_id, attempt)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        parent_run_id, parent_node_id, retry_of_run_id, attempt, usedWorkflowProvider)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     stmt.run(
       run.id, run.agentName, run.status, run.startedAt,
@@ -258,6 +274,7 @@ export class RunStore {
       run.replayedFromRunId ?? null, run.replayedFromNodeId ?? null,
       run.parentRunId ?? null, run.parentNodeId ?? null,
       run.retryOfRunId ?? null, run.attempt ?? 1,
+      run.usedWorkflowProvider ?? null,
     );
   }
 
@@ -412,8 +429,8 @@ export class RunStore {
         startedAt, completedAt, result, exitCode, error,
         inputsJson, upstreamInputsJson, outputsJson, progressJson,
         stateBytesBefore, stateBytesAfter, childPid, childStartedAtMs,
-        usedProvider, attemptedProviders
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        usedProvider, attemptedProviders, usedWorkflowProvider
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     stmt.run(
       record.runId, record.nodeId, record.workflowVersion, record.status,
@@ -425,6 +442,7 @@ export class RunStore {
       record.stateBytesBefore ?? null, record.stateBytesAfter ?? null,
       record.childPid ?? null, record.childStartedAtMs ?? null,
       record.usedProvider ?? null, record.attemptedProviders ?? null,
+      record.usedWorkflowProvider ?? null,
     );
   }
 
@@ -432,7 +450,7 @@ export class RunStore {
     runId: string,
     nodeId: string,
     updates: Partial<Pick<NodeExecutionRecord,
-      'status' | 'errorCategory' | 'completedAt' | 'result' | 'exitCode' | 'error' | 'inputsJson' | 'upstreamInputsJson' | 'outputsJson' | 'progressJson' | 'stateBytesBefore' | 'stateBytesAfter' | 'childPid' | 'childStartedAtMs' | 'usedProvider' | 'attemptedProviders'
+      'status' | 'errorCategory' | 'completedAt' | 'result' | 'exitCode' | 'error' | 'inputsJson' | 'upstreamInputsJson' | 'outputsJson' | 'progressJson' | 'stateBytesBefore' | 'stateBytesAfter' | 'childPid' | 'childStartedAtMs' | 'usedProvider' | 'attemptedProviders' | 'usedWorkflowProvider'
     >>,
   ): void {
     const fields: string[] = [];
@@ -453,6 +471,7 @@ export class RunStore {
     if (updates.childStartedAtMs !== undefined) { fields.push('childStartedAtMs = ?'); values.push(updates.childStartedAtMs); }
     if (updates.usedProvider !== undefined) { fields.push('usedProvider = ?'); values.push(updates.usedProvider); }
     if (updates.attemptedProviders !== undefined) { fields.push('attemptedProviders = ?'); values.push(updates.attemptedProviders); }
+    if (updates.usedWorkflowProvider !== undefined) { fields.push('usedWorkflowProvider = ?'); values.push(updates.usedWorkflowProvider); }
     if (fields.length === 0) return;
 
     values.push(runId, nodeId);
@@ -524,6 +543,7 @@ export class RunStore {
       parentNodeId: (row.parent_node_id as string | null) ?? undefined,
       retryOfRunId: (row.retry_of_run_id as string | null) ?? undefined,
       attempt: typeof row.attempt === 'number' ? row.attempt : 1,
+      usedWorkflowProvider: (row.usedWorkflowProvider as string | null) ?? undefined,
     };
   }
 
@@ -549,6 +569,7 @@ export class RunStore {
       childStartedAtMs: (row.childStartedAtMs as number | null) ?? undefined,
       usedProvider: (row.usedProvider as string | null) ?? undefined,
       attemptedProviders: (row.attemptedProviders as string | null) ?? undefined,
+      usedWorkflowProvider: (row.usedWorkflowProvider as string | null) ?? undefined,
     };
   }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -115,6 +115,13 @@ export interface Run {
    */
   retryOfRunId?: string;
   attempt?: number;
+  /**
+   * Which execution backend ran this: `'local'` (in-process) or `'temporal'`
+   * (durable worker). Distinct from the LLM provider axis
+   * (`NodeExecutionRecord.usedProvider`). NULL/undefined on legacy rows ↔
+   * treat as `local`.
+   */
+  usedWorkflowProvider?: string;
 }
 
 export interface RunRequest {

--- a/packages/dashboard/src/views/components.test.ts
+++ b/packages/dashboard/src/views/components.test.ts
@@ -1,5 +1,18 @@
 import { describe, it, expect } from 'vitest';
-import { formatExitCode, stripEnclosingCodeFence } from './components.js';
+import { formatExitCode, stripEnclosingCodeFence, workflowProviderBadge } from './components.js';
+import { render } from './html.js';
+
+describe('workflowProviderBadge', () => {
+  it('renders a chip only for temporal', () => {
+    expect(render(workflowProviderBadge('temporal'))).toContain('temporal');
+    expect(render(workflowProviderBadge('temporal'))).toContain('badge');
+  });
+
+  it('renders nothing for local or undefined (color stays rare)', () => {
+    expect(render(workflowProviderBadge('local'))).toBe('');
+    expect(render(workflowProviderBadge(undefined))).toBe('');
+  });
+});
 
 describe('formatExitCode', () => {
   it('renders a plain exit code', () => {

--- a/packages/dashboard/src/views/components.ts
+++ b/packages/dashboard/src/views/components.ts
@@ -28,6 +28,16 @@ export function sourceBadge(source: string): SafeHtml {
 }
 
 /**
+ * Execution-backend badge. Only renders for runs that ran on Temporal — the
+ * default (local / undefined) is the common case and gets no chip, keeping
+ * color rare and meaningful per DESIGN.md. Returns empty html for local.
+ */
+export function workflowProviderBadge(provider?: string): SafeHtml {
+  if (provider !== 'temporal') return html``;
+  return html`<span class="badge badge--info" title="Ran on the Temporal worker backend">temporal</span>`;
+}
+
+/**
  * Strip a single enclosing Markdown code fence. LLM nodes routinely wrap their
  * whole output in ```json … ``` (or ```), which renders as literal backticks in
  * the stdout frame. When the entire (trimmed) text is one fenced block, return

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -175,6 +175,7 @@ export function renderRunDetail(opts: RunDetailOptions): string {
           <dt>Duration</dt><dd>${formatDuration(run.startedAt, run.completedAt)}</dd>
           <dt>Exit code</dt><dd class="mono">${formatExitCode(run.exitCode) || html`<span class="dim">—</span>`}</dd>
           <dt>Triggered by</dt><dd>${run.triggeredBy}</dd>
+          <dt>Backend</dt><dd class="mono">${run.usedWorkflowProvider ?? 'local'}</dd>
           ${replayedFrom}
           ${retryOf}
         </dl>

--- a/packages/dashboard/src/views/runs-list.ts
+++ b/packages/dashboard/src/views/runs-list.ts
@@ -3,7 +3,7 @@ import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
 import { sectionTabs } from './section-tabs.js';
-import { statusBadge, formatDuration, formatAge } from './components.js';
+import { statusBadge, formatDuration, formatAge, workflowProviderBadge } from './components.js';
 
 export interface RunsListOptions {
   rows: Run[];
@@ -39,7 +39,7 @@ export function renderRunsList(opts: RunsListOptions): string {
   const runRows = rows.map((r) => html`
     <tr>
       <td><a href="/runs/${r.id}" class="mono">${r.id.slice(0, 8)}</a></td>
-      <td><a href="/agents/${r.agentName}">${r.agentName}</a></td>
+      <td><a href="/agents/${r.agentName}">${r.agentName}</a> ${workflowProviderBadge(r.usedWorkflowProvider)}</td>
       <td>${statusBadge(r.status)}</td>
       <td class="dim">${formatAge(r.startedAt)}</td>
       <td class="dim">${formatDuration(r.startedAt, r.completedAt)}</td>

--- a/packages/temporal-provider/src/provider.ts
+++ b/packages/temporal-provider/src/provider.ts
@@ -58,6 +58,7 @@ export class TemporalProvider implements Provider {
       status: 'pending',
       startedAt: new Date().toISOString(),
       triggeredBy: request.triggeredBy,
+      usedWorkflowProvider: 'temporal',
     };
     this.store.createRun(run);
 


### PR DESCRIPTION
## What

B1a of the Temporal Phase B plan: stamp **which execution backend** ran each run and node, so operators (and, later, the triage agent) can tell where work actually executed.

- New `usedWorkflowProvider` column (`local` | `temporal`) on **both** `runs` and `node_executions`. Nullable; NULL ↔ legacy/local. Threaded through `createRun` / `createNodeExecution` / `updateNodeExecution` and the row mappers.
- Stamp sites: `LocalProvider` → `local`, `TemporalProvider` (v1) → `temporal`, v2 DAG executor → `local` (B1b will set it per-node when spawns route through a Temporal activity).
- Dashboard: a `temporal` chip on the runs list (only for Temporal runs — local is the default and gets no chip, keeping color rare per DESIGN.md) and a **Backend** row on the run detail page.

## Why this naming

There are two provider axes and they were colliding. `node_executions.usedProvider` is the **LLM** provider (claude/codex/apple). This new field is the **execution backend** (local/temporal). Keeping them as distinct columns (`usedProvider` vs `usedWorkflowProvider`) avoids overloading one column with two meanings. Renaming the existing one to `usedLLMProvider` is noted as a future cleanup in the plan.

## Test

- Round-trip tests for `usedWorkflowProvider` on runs and node executions (set + undefined-when-unset).
- Badge component test: chip renders only for `temporal`, empty for `local`/undefined.
- Clean rebuild + full suite: **1913 passed, 3 skipped**.

This is the small, independent first step; B1b (node-level Temporal activities + live progress) and B1c (failure → inbox conversation) build on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)