### PR TITLE
feat(core): widen the node-spawn seam for pluggable execution backends

### DIFF
--- a/.changeset/spawn-seam-widening.md
+++ b/.changeset/spawn-seam-widening.md
@@ -1,0 +1,16 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Make the DAG node-spawn seam pluggable for alternate execution backends.
+
+`SpawnNodeFn` now receives the same `onProgress` / `signal` / `onSpawn`
+callbacks the in-process spawner gets, and `SpawnResult` carries an optional
+`usedWorkflowProvider` a backend self-reports. The executor copies that onto the
+node execution row and rolls it up to the run. This is the seam a Temporal-
+backed node executor plugs into; behavior is unchanged for the default
+in-process path.

--- a/packages/core/src/dag-executor.test.ts
+++ b/packages/core/src/dag-executor.test.ts
@@ -2136,3 +2136,45 @@ describe('executeAgentDag — agent wall-clock timeout (Agent.timeoutSec)', () =
     expect(execs.find((e) => e.nodeId === 'b')!.status).toBe('cancelled');
   });
 });
+
+describe('executeAgentDag spawn backend seam (B1b)', () => {
+  it('passes onProgress + signal to an injected spawnNode and stamps usedWorkflowProvider', async () => {
+    let sawOnProgress = false;
+    let sawSignal = false;
+    const backend: DagExecutorDeps['spawnNode'] = async (_node, _env, _opts, onProgress, signal) => {
+      sawOnProgress = typeof onProgress === 'function';
+      sawSignal = signal instanceof AbortSignal;
+      // A backend self-reports where it ran; the executor copies it onto the row.
+      return { result: 'done', exitCode: 0, usedWorkflowProvider: 'temporal' };
+    };
+
+    const run = await executeAgentDag(
+      makeAgent(),
+      { triggeredBy: 'cli' },
+      { runStore, spawnNode: backend },
+    );
+
+    // The widened seam hands the injected backend the same callbacks the real
+    // spawner gets — without these, a Temporal backend couldn't stream or cancel.
+    expect(sawOnProgress).toBe(true);
+    expect(sawSignal).toBe(true);
+
+    // The backend's self-reported execution provider lands on the node row and
+    // rolls up to the run.
+    const execs = runStore.listNodeExecutions(run.id);
+    expect(execs.find((e) => e.nodeId === 'main')!.usedWorkflowProvider).toBe('temporal');
+    expect(runStore.getRun(run.id)!.usedWorkflowProvider).toBe('temporal');
+  });
+
+  it('leaves usedWorkflowProvider as local when the backend does not report temporal', async () => {
+    const run = await executeAgentDag(
+      makeAgent(),
+      { triggeredBy: 'cli' },
+      { runStore, spawnNode: cannedSpawner({ main: { exitCode: 0, result: 'ok' } }) },
+    );
+    // Created as 'local'; no node reported temporal, so it stays local.
+    expect(runStore.getRun(run.id)!.usedWorkflowProvider).toBe('local');
+    const execs = runStore.listNodeExecutions(run.id);
+    expect(execs.find((e) => e.nodeId === 'main')!.usedWorkflowProvider).toBeUndefined();
+  });
+});

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -261,6 +261,9 @@ export async function executeAgentDag(
   const outputs = new Map<string, NodeOutput>();
   const order = topologicalSort(agent.nodes);
   let firstFailure: { nodeId: string; category: NodeErrorCategory } | undefined;
+  // Roll-up of the per-node execution backend: if any node ran on Temporal,
+  // the run-level usedWorkflowProvider is promoted from its created 'local'.
+  let ranOnTemporal = false;
   let flowEnded = false;
   const skippedNodes = new Set<string>();
 
@@ -938,9 +941,7 @@ export async function executeAgentDag(
             model: node.model ?? agent.model,
           };
           const spawnOpts = { agentId: agent.id, agentSource: agent.source, allowUntrustedShell: deps.allowUntrustedShell, llmSettings: deps.llmSettings };
-          const spawnResult = spawnFn === spawnNodeReal
-            ? await spawnNodeReal(synthNode, env, spawnOpts, onProgress, effectiveSignal, onSpawn)
-            : await spawnFn(synthNode, env, spawnOpts);
+          const spawnResult = await spawnFn(synthNode, env, spawnOpts, onProgress, effectiveSignal, onSpawn);
           result = spawnResult;
           structuredOutput = buildToolOutput(spawnResult.result);
         }
@@ -954,9 +955,7 @@ export async function executeAgentDag(
         };
         const spawnFn = deps.spawnNode ?? spawnNodeReal;
         const spawnOpts = { agentId: agent.id, agentSource: agent.source, allowUntrustedShell: deps.allowUntrustedShell, llmSettings: deps.llmSettings };
-        const spawnResult = spawnFn === spawnNodeReal
-          ? await spawnNodeReal(nodeWithDefaults, env, spawnOpts, onProgress, effectiveSignal, onSpawn)
-          : await spawnFn(nodeWithDefaults, env, spawnOpts);
+        const spawnResult = await spawnFn(nodeWithDefaults, env, spawnOpts, onProgress, effectiveSignal, onSpawn);
         result = spawnResult;
         // Try to extract framed output from stdout even for legacy nodes,
         // so users who upgrade their shell scripts to emit framed JSON get
@@ -987,6 +986,8 @@ export async function executeAgentDag(
     const outputsJson = structuredOutput ? JSON.stringify(structuredOutput) : undefined;
     const stateBytesAfter = deps.dataRoot ? stateDirSize(agent.id, deps.dataRoot) : undefined;
 
+    if (result.usedWorkflowProvider === 'temporal') ranOnTemporal = true;
+
     if (result.exitCode === 0) {
       outputs.set(node.id, {
         result: result.result,
@@ -1003,6 +1004,7 @@ export async function executeAgentDag(
         stateBytesAfter,
         usedProvider: result.usedProvider,
         attemptedProviders: result.attemptedProviders ? result.attemptedProviders.join(',') : undefined,
+        usedWorkflowProvider: result.usedWorkflowProvider,
       });
     } else {
       const category: NodeErrorCategory =
@@ -1020,6 +1022,7 @@ export async function executeAgentDag(
         outputsJson,
         usedProvider: result.usedProvider,
         attemptedProviders: result.attemptedProviders ? result.attemptedProviders.join(',') : undefined,
+        usedWorkflowProvider: result.usedWorkflowProvider,
         stateBytesAfter,
       });
       firstFailure = { nodeId: node.id, category };
@@ -1070,6 +1073,9 @@ export async function executeAgentDag(
     completedAt: new Date().toISOString(),
     result: lastCompleted?.result,
     error: finalError,
+    // Promote the run-level backend to 'temporal' if any node ran there;
+    // otherwise leave the 'local' stamped at creation (undefined = no change).
+    usedWorkflowProvider: ranOnTemporal ? 'temporal' : undefined,
   });
 
   const run = deps.runStore.getRun(runId);

--- a/packages/core/src/node-spawner.ts
+++ b/packages/core/src/node-spawner.ts
@@ -33,6 +33,13 @@ export type SpawnResult = ExecutionResult & {
    * for shell nodes.
    */
   attemptedProviders?: string[];
+  /**
+   * Execution backend that actually ran this node: `'local'` (in-process)
+   * or `'temporal'` (worker activity). A backend (the injected spawnNode)
+   * self-reports here; the executor copies it onto the node_executions row.
+   * Distinct from `usedProvider` (the LLM provider). Undefined ↔ local.
+   */
+  usedWorkflowProvider?: string;
 };
 
 /**
@@ -94,10 +101,20 @@ export type LlmFailureCategory =
   | 'auth_required'
   | 'other';
 
+/**
+ * Pluggable node-execution backend. `spawnNodeReal` is the in-process
+ * implementation; a Temporal-backed spawnNode (B1b) implements the same
+ * signature to run the node on a worker. The trailing callbacks are optional
+ * so lightweight injectors (test doubles) can ignore them — they receive the
+ * same `onProgress` / `signal` / `onSpawn` the real spawner does.
+ */
 export type SpawnNodeFn = (
   node: AgentNode,
   env: Record<string, string>,
   opts: { agentId: string; agentSource: Agent['source']; allowUntrustedShell?: ReadonlySet<string>; llmSettings?: LlmSettingsSnapshot },
+  onProgress?: (event: SpawnProgress) => void,
+  signal?: AbortSignal,
+  onSpawn?: (pid: number, startedAtMs: number) => void,
 ) => Promise<SpawnResult>;
 
 /**

--- a/packages/core/src/run-store.ts
+++ b/packages/core/src/run-store.ts
@@ -303,7 +303,7 @@ export class RunStore {
     return this.rowToRun(row);
   }
 
-  updateRun(id: string, updates: Partial<Pick<Run, 'status' | 'completedAt' | 'result' | 'exitCode' | 'error'>>): void {
+  updateRun(id: string, updates: Partial<Pick<Run, 'status' | 'completedAt' | 'result' | 'exitCode' | 'error' | 'usedWorkflowProvider'>>): void {
     const fields: string[] = [];
     const values: SqlValue[] = [];
 
@@ -312,6 +312,7 @@ export class RunStore {
     if (updates.result !== undefined) { fields.push('result = ?'); values.push(updates.result); }
     if (updates.exitCode !== undefined) { fields.push('exitCode = ?'); values.push(updates.exitCode); }
     if (updates.error !== undefined) { fields.push('error = ?'); values.push(updates.error); }
+    if (updates.usedWorkflowProvider !== undefined) { fields.push('usedWorkflowProvider = ?'); values.push(updates.usedWorkflowProvider); }
 
     if (fields.length === 0) return;
 


### PR DESCRIPTION
## What

PR1 of B1b (execute v2 DAG nodes on Temporal). A pure, behavior-preserving core refactor that makes the node-spawn seam able to host an alternate execution backend.

- `SpawnNodeFn` now receives the same `onProgress` / `signal` / `onSpawn` callbacks as `spawnNodeReal`. Previously an injected `spawnNode` got only 3 args, so the executor branched `spawnFn === spawnNodeReal ? 6args : 3args` — meaning a backend couldn't stream progress or be cancelled. The executor now calls the spawn function **uniformly**.
- `SpawnResult` gains an optional `usedWorkflowProvider` that a backend self-reports (`local` | `temporal`). The executor copies it onto the `node_executions` row and promotes the run-level `usedWorkflowProvider` to `temporal` when any node ran there. `updateRun` learns the field.

No functional change to the default in-process path — this just unblocks PR2 (the Temporal node backend).

## Test

- New tests: the widened seam passes `onProgress` (function) + `signal` (AbortSignal) to an injected backend, and a backend reporting `usedWorkflowProvider: 'temporal'` gets stamped on the node row and rolled up to the run; the default path stays `local`.
- Existing `cannedSpawner` test double is unchanged (ignores the extra args).
- Clean rebuild + full suite: **1917 passed, 3 skipped**.

Plan: `~/.claude/plans/cozy-cooking-truffle.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)