### PR TITLE
feat: run v2 DAG nodes on Temporal workers (B1b PR2)

### DIFF
--- a/.changeset/temporal-node-backend.md
+++ b/.changeset/temporal-node-backend.md
@@ -1,0 +1,21 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Run v2 DAG nodes on Temporal workers.
+
+When the dashboard is started with `--provider temporal`, multi-node (v2 DAG)
+agents now execute each node as a Temporal worker activity (one
+`sua-node-<runId>-<nodeId>` workflow per node) instead of in-process. The
+dashboard still orchestrates the DAG; node shell/LLM work is offloaded to the
+worker, made cancellable (the activity heartbeats), and shown in the Temporal
+UI. Runs and node executions are stamped `usedWorkflowProvider`.
+
+Declared secrets are read on the worker from the secrets file and never travel
+in the Temporal activity payload; non-declared sensitive env values are dropped
+before crossing to the worker (a payload-encryption codec to lift that is a
+planned follow-up). Durable whole-DAG-as-workflow orchestration is the next step.

--- a/docs/temporal.md
+++ b/docs/temporal.md
@@ -11,14 +11,22 @@
 This page is the operator guide: start Temporal in Docker, point `sua` at it,
 run a worker, and monitor it.
 
-> **Scope note (current release).** Only **v1 single-node agents** route through
-> Temporal today — the path behind "Run now" and `sua agent run`. **v2 DAG
-> agents** (anything multi-node: triage, build-from-goal, layout-planner, and
-> most agents built in the dashboard) run **in-process via `executeAgentDag`
-> regardless of the provider.** So with Temporal enabled, the Temporal Web UI
-> shows your v1 runs only; multi-node agents won't appear there yet. Making v2
-> DAGs execute as Temporal workflows is planned (Phase B) — see
-> `ROADMAP.md` / the Temporal wiring plan.
+> **Scope note (current release).** Both **v1 single-node agents** (behind "Run
+> now" and `sua agent run`) and **v2 DAG agents** (triage, build-from-goal,
+> layout-planner, dashboard-built agents) run on Temporal when the dashboard is
+> started with `--provider temporal`. v2 DAGs execute **one workflow per node**
+> (`sua-node-<runId>-<nodeId>`): the dashboard still orchestrates the DAG
+> in-process and offloads each node's shell/LLM work to a worker activity. So
+> node execution is durable + cancellable + visible in the UI, but the
+> *orchestration* still lives in the dashboard — a daemon crash mid-run loses the
+> in-flight run. Collapsing a whole DAG into a single durable workflow (so runs
+> survive a crash and resume) is the next step — see the Temporal wiring plan.
+>
+> Secrets a node declares are read on the worker from the secrets file and never
+> travel in the Temporal activity payload (which Temporal persists in history). A
+> few non-declared sensitive env values are dropped before crossing to the worker
+> rather than risk landing in workflow history; a payload-encryption codec to
+> lift that limitation is a planned follow-up.
 
 ## Architecture: server in Docker, worker on the host
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -348,6 +348,8 @@ export {
 export {
   type LlmSpawner,
   type SpawnProgress,
+  type SpawnResult,
+  type SpawnNodeFn,
   type LlmSpawnOptions,
   type LlmSettingsSnapshot,
   type LlmFailureCategory,
@@ -356,7 +358,9 @@ export {
   claudeTextSpawner,
   codexSpawner,
   getSpawner,
+  spawnNodeReal,
 } from './node-spawner.js';
+export { stripSensitiveEnv } from './node-env.js';
 export {
   LlmSettingsStore,
   LLM_PROVIDERS,

--- a/packages/core/src/node-env.test.ts
+++ b/packages/core/src/node-env.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { stripSensitiveEnv } from './node-env.js';
+import type { AgentNode } from './agent-v2-types.js';
+
+const node = (secrets?: string[]): AgentNode => ({
+  id: 'n1',
+  type: 'shell',
+  command: 'echo hi',
+  ...(secrets ? { secrets } : {}),
+});
+
+describe('stripSensitiveEnv', () => {
+  it('keeps benign keys and strips declared secrets', () => {
+    const { safe, strippedKeys } = stripSensitiveEnv(
+      { PATH: '/usr/bin', GREETING: 'hi', MY_SECRET: 'shh' },
+      node(['MY_SECRET']),
+    );
+    expect(safe).toEqual({ PATH: '/usr/bin', GREETING: 'hi' });
+    expect(strippedKeys).toContain('MY_SECRET');
+    expect(safe.MY_SECRET).toBeUndefined();
+  });
+
+  it('strips sensitive-looking key names even when not declared', () => {
+    const { safe, strippedKeys } = stripSensitiveEnv(
+      { API_TOKEN: 'abc', NORMAL: 'ok' },
+      node(),
+    );
+    expect(safe.NORMAL).toBe('ok');
+    expect(safe.API_TOKEN).toBeUndefined();
+    expect(strippedKeys).toContain('API_TOKEN');
+  });
+
+  it('strips values matching sensitive patterns (e.g. an sk- key)', () => {
+    const { safe, strippedKeys } = stripSensitiveEnv(
+      { SOMEVAR: 'sk-abcdefghijklmnopqrstuvwx', PLAIN: 'fine' },
+      node(),
+    );
+    expect(safe.PLAIN).toBe('fine');
+    expect(safe.SOMEVAR).toBeUndefined();
+    expect(strippedKeys).toContain('SOMEVAR');
+  });
+});

--- a/packages/core/src/node-env.ts
+++ b/packages/core/src/node-env.ts
@@ -221,3 +221,35 @@ export function filterEnvForLog(env: Record<string, string>, node: AgentNode): R
   }
   return out;
 }
+
+/**
+ * Split an env map into the keys that are safe to ship off-process and the
+ * sensitive keys that must not be. Used by the Temporal node backend: secret
+ * values get resolved into env before a node spawns, so before handing env to
+ * an activity (whose input Temporal persists in workflow history) we drop
+ * anything sensitive. The worker re-injects the node's *declared* secrets from
+ * `secretsPath`; non-declared sensitive keys (rare — only `LC_*` passes through
+ * from process.env) are simply dropped. Same sensitivity rules as
+ * `filterEnvForLog` (declared secrets, sensitive names, sensitive value
+ * patterns).
+ */
+export function stripSensitiveEnv(
+  env: Record<string, string>,
+  node: AgentNode,
+): { safe: Record<string, string>; strippedKeys: string[] } {
+  const safe: Record<string, string> = {};
+  const strippedKeys: string[] = [];
+  const secrets = new Set(node.secrets ?? []);
+  for (const [k, v] of Object.entries(env)) {
+    if (
+      secrets.has(k) ||
+      looksLikeSensitive(k) ||
+      SENSITIVE_VALUE_PATTERNS.some((re) => re.test(v))
+    ) {
+      strippedKeys.push(k);
+    } else {
+      safe[k] = v;
+    }
+  }
+  return { safe, strippedKeys };
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,3 +1,5 @@
+import type { SpawnNodeFn } from './node-spawner.js';
+
 export interface AgentInputSpec {
   type: 'string' | 'number' | 'boolean' | 'enum';
   values?: string[];
@@ -144,4 +146,11 @@ export interface Provider {
   listRuns(filter?: { agentName?: string; status?: RunStatus; limit?: number }): Promise<Run[]>;
   cancelRun(runId: string): Promise<void>;
   getRunLogs(runId: string): Promise<string>;
+  /**
+   * Optional: build a node-execution backend (SpawnNodeFn) for v2 DAG runs.
+   * The Temporal provider returns one that runs each node on a worker; the
+   * dashboard injects it as `deps.spawnNode`. Providers that execute in-process
+   * (local) leave this undefined and the executor uses its built-in spawner.
+   */
+  createSpawnNode?(): SpawnNodeFn;
 }

--- a/packages/dashboard/src/context.ts
+++ b/packages/dashboard/src/context.ts
@@ -1,4 +1,4 @@
-import type { Provider, RunStore, SecretsStore, AgentDefinition, AgentStore, ToolStore, VariablesStore, LlmSettingsStore, PacksStore, DashboardsStore, LayoutHintsStore, BlockedImgHostsStore, InboxStore, IntegrationsStore, PlannerTelemetryStore, PlannerLoopStepLogStore, PlannerMemoryStore, AgentMemoryStore } from '@some-useful-agents/core';
+import type { Provider, SpawnNodeFn, RunStore, SecretsStore, AgentDefinition, AgentStore, ToolStore, VariablesStore, LlmSettingsStore, PacksStore, DashboardsStore, LayoutHintsStore, BlockedImgHostsStore, InboxStore, IntegrationsStore, PlannerTelemetryStore, PlannerLoopStepLogStore, PlannerMemoryStore, AgentMemoryStore } from '@some-useful-agents/core';
 import type { SecretsSession } from './secrets-session.js';
 import type { InboxEventBus } from './lib/inbox-event-bus.js';
 
@@ -21,6 +21,14 @@ export interface DashboardContext {
    * in-process via executeAgentDag regardless of provider (see ADR-0013).
    */
   provider: Provider;
+  /**
+   * v2 DAG node-execution backend. Set when the provider is Temporal (built via
+   * `provider.createSpawnNode()` at startup); undefined for local. Every
+   * `executeAgentDag` call passes it as `deps.spawnNode` — undefined ⇒ the
+   * executor's in-process spawner. This is how v2 DAGs run on Temporal workers
+   * while orchestration stays in the dashboard (B1b).
+   */
+  workflowSpawnNode?: SpawnNodeFn;
   /** Run store reader for /runs and /runs/:id. */
   runStore: RunStore;
   /**

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -495,11 +495,17 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     // Non-fatal: agent loop still runs, just doesn't persist iterations.
   }
 
+  // v2 DAG node backend. When the provider is Temporal it builds a SpawnNodeFn
+  // that runs each node on the worker; every executeAgentDag call passes it as
+  // deps.spawnNode. Undefined for local ⇒ in-process execution (unchanged).
+  const workflowSpawnNode = provider.createSpawnNode?.();
+
   const ctx: DashboardContext = {
     token,
     allowlist: buildLoopbackAllowlist(opts.port),
     port: opts.port,
     provider,
+    workflowSpawnNode,
     runStore,
     agentStore,
     loadAgents: () => loadAgents({ directories: opts.agentDirs }),

--- a/packages/dashboard/src/routes/build-orchestrator.ts
+++ b/packages/dashboard/src/routes/build-orchestrator.ts
@@ -170,6 +170,7 @@ async function kickoffAgentRun(args: {
       variablesStore: ctx.variablesStore,
       dataRoot: ctx.agentStore.dataRoot,
       llmSettings: buildLlmSettingsSnapshot(ctx),
+      spawnNode: ctx.workflowSpawnNode,
     },
   ).catch(() => { /* failure surfaces via runStore.getRun(runId).status */ });
   return runId;

--- a/packages/dashboard/src/routes/dashboard-layout-plan.ts
+++ b/packages/dashboard/src/routes/dashboard-layout-plan.ts
@@ -190,6 +190,7 @@ async function kickoffDashboardPlannerRun(args: {
       variablesStore: ctx.variablesStore,
       dataRoot: ctx.agentStore.dataRoot,
       llmSettings: buildLlmSettingsSnapshot(ctx),
+      spawnNode: ctx.workflowSpawnNode,
     },
   );
 

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -1260,6 +1260,7 @@ async function runProposedAction(
         variablesStore: ctx.variablesStore,
         dataRoot: ctx.agentStore.dataRoot,
         llmSettings: buildLlmSettingsSnapshot(ctx),
+        spawnNode: ctx.workflowSpawnNode,
       },
     );
     runId = run.id;
@@ -1684,6 +1685,7 @@ async function runTriageAgent(
         variablesStore: ctx.variablesStore,
         dataRoot: ctx.agentStore.dataRoot,
         llmSettings: buildLlmSettingsSnapshot(ctx),
+        spawnNode: ctx.workflowSpawnNode,
         // Forward token-level progress from the triage LLM node to
         // the SSE bus. Filtered to output_chunk so we don't spam
         // clients with turn_start / tool_use markers (those still

--- a/packages/dashboard/src/routes/pulse-layout-plan.ts
+++ b/packages/dashboard/src/routes/pulse-layout-plan.ts
@@ -183,6 +183,7 @@ async function kickoffLayoutPlannerRun(args: {
       variablesStore: ctx.variablesStore,
       dataRoot: ctx.agentStore.dataRoot,
       llmSettings: buildLlmSettingsSnapshot(ctx),
+      spawnNode: ctx.workflowSpawnNode,
     },
   );
 

--- a/packages/dashboard/src/routes/run-mutations.ts
+++ b/packages/dashboard/src/routes/run-mutations.ts
@@ -166,6 +166,7 @@ runMutationsRouter.post('/runs/:id/replay', async (req: Request, res: Response) 
       dashboardBaseUrl: ctx.dashboardBaseUrl,
       dataRoot: ctx.agentStore.dataRoot,
       llmSettings: buildLlmSettingsSnapshot(ctx),
+      spawnNode: ctx.workflowSpawnNode,
     },
   );
 
@@ -286,6 +287,7 @@ runMutationsRouter.post('/runs/:id/retry', async (req: Request, res: Response) =
       dashboardBaseUrl: ctx.dashboardBaseUrl,
       dataRoot: ctx.agentStore.dataRoot,
       llmSettings: buildLlmSettingsSnapshot(ctx),
+      spawnNode: ctx.workflowSpawnNode,
     },
     { memoryStore: ctx.agentMemoryStore },
   );

--- a/packages/dashboard/src/routes/run-now-build.ts
+++ b/packages/dashboard/src/routes/run-now-build.ts
@@ -376,6 +376,7 @@ async function kickoffPlannerRun(args: PlannerKickoffArgs): Promise<string | nul
       variablesStore: ctx.variablesStore,
       dataRoot: ctx.agentStore.dataRoot,
       llmSettings: buildLlmSettingsSnapshot(ctx),
+      spawnNode: ctx.workflowSpawnNode,
     },
   );
 
@@ -521,6 +522,7 @@ buildRouter.post('/agents/:name/analyze', async (req: Request, res: Response) =>
       variablesStore: ctx.variablesStore,
       dataRoot: ctx.agentStore.dataRoot,
       llmSettings: buildLlmSettingsSnapshot(ctx),
+      spawnNode: ctx.workflowSpawnNode,
     },
   );
 
@@ -722,6 +724,7 @@ Output ONLY the complete fixed YAML. Nothing else.`,
         variablesStore: ctx.variablesStore,
         dataRoot: ctx.agentStore.dataRoot,
         llmSettings: buildLlmSettingsSnapshot(ctx),
+        spawnNode: ctx.workflowSpawnNode,
       },
     );
 
@@ -1130,6 +1133,7 @@ buildRouter.post('/agents/build/commit', (req: Request, res: Response) => {
               variablesStore: ctx.variablesStore,
               dataRoot: ctx.agentStore.dataRoot,
               llmSettings: buildLlmSettingsSnapshot(ctx),
+              spawnNode: ctx.workflowSpawnNode,
             },
           ).catch(() => { /* surfaced as a failed run row */ });
         }

--- a/packages/dashboard/src/routes/run-now.ts
+++ b/packages/dashboard/src/routes/run-now.ts
@@ -71,6 +71,7 @@ runNowRouter.post('/agents/:name/run', async (req: Request, res: Response) => {
         dashboardBaseUrl: ctx.dashboardBaseUrl,
         dataRoot: ctx.agentStore.dataRoot,
         llmSettings: buildLlmSettingsSnapshot(ctx),
+        spawnNode: ctx.workflowSpawnNode,
       },
     );
 

--- a/packages/dashboard/src/routes/widget-run.ts
+++ b/packages/dashboard/src/routes/widget-run.ts
@@ -47,6 +47,7 @@ widgetRunRouter.post('/agents/:name/widget-run', (req: Request, res: Response) =
       dashboardBaseUrl: ctx.dashboardBaseUrl,
       dataRoot: ctx.agentStore.dataRoot,
       llmSettings: buildLlmSettingsSnapshot(ctx),
+      spawnNode: ctx.workflowSpawnNode,
     },
   );
 

--- a/packages/temporal-provider/src/activities.test.ts
+++ b/packages/temporal-provider/src/activities.test.ts
@@ -3,7 +3,8 @@ import { rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { EncryptedFileStore } from '@some-useful-agents/core';
 import type { AgentDefinition } from '@some-useful-agents/core';
-import { runAgentActivity } from './activities.js';
+import type { AgentNode } from '@some-useful-agents/core';
+import { runAgentActivity, runNodeActivity } from './activities.js';
 
 const TEST_DIR = join(import.meta.dirname, '__test-activities__');
 const SECRETS_PATH = join(TEST_DIR, 'secrets.enc');
@@ -114,5 +115,63 @@ describe('runAgentActivity', () => {
     expect(result.exitCode).toBe(1);
     expect(result.error).toMatch(/community shell agent/);
     expect(result.error).toMatch(/--allow-untrusted-shell/);
+  });
+});
+
+const shellNode = (overrides: Partial<AgentNode> = {}): AgentNode => ({
+  id: 'main',
+  type: 'shell',
+  command: 'echo node-from-activity',
+  ...overrides,
+});
+
+describe('runNodeActivity', () => {
+  it('runs a shell node and stamps usedWorkflowProvider=temporal', async () => {
+    const result = await runNodeActivity({
+      node: shellNode(),
+      env: { PATH: process.env.PATH ?? '/usr/bin:/bin' },
+      agentId: 'demo',
+      agentSource: 'local',
+      secretsPath: SECRETS_PATH,
+      declaredSecrets: [],
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.result).toContain('node-from-activity');
+    expect(result.usedWorkflowProvider).toBe('temporal');
+  });
+
+  it('re-injects declared secrets from the worker-local store', async () => {
+    const store = new EncryptedFileStore(SECRETS_PATH, { allowLegacyFallback: true });
+    await store.set('NODE_SECRET', 'node-injected');
+
+    const result = await runNodeActivity({
+      node: shellNode({ command: 'echo "got=$NODE_SECRET"', secrets: ['NODE_SECRET'] }),
+      // The secret is NOT in env (the dashboard stripped it); the worker re-reads it.
+      env: { PATH: process.env.PATH ?? '/usr/bin:/bin' },
+      agentId: 'demo',
+      agentSource: 'local',
+      secretsPath: SECRETS_PATH,
+      declaredSecrets: ['NODE_SECRET'],
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.result).toContain('got=node-injected');
+  });
+
+  it('fails clearly when a declared secret is missing on the worker', async () => {
+    const result = await runNodeActivity({
+      node: shellNode({ secrets: ['ABSENT'] }),
+      env: { PATH: process.env.PATH ?? '/usr/bin:/bin' },
+      agentId: 'demo',
+      agentSource: 'local',
+      secretsPath: SECRETS_PATH,
+      declaredSecrets: ['ABSENT'],
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.error).toContain('Missing secrets on worker');
+    expect(result.error).toContain('ABSENT');
+    expect(result.usedWorkflowProvider).toBe('temporal');
   });
 });

--- a/packages/temporal-provider/src/activities.ts
+++ b/packages/temporal-provider/src/activities.ts
@@ -1,4 +1,4 @@
-import type { AgentDefinition } from '@some-useful-agents/core';
+import type { AgentDefinition, AgentNode, Agent, SpawnResult, SpawnProgress } from '@some-useful-agents/core';
 import {
   buildAgentEnv,
   getTrustLevel,
@@ -6,7 +6,9 @@ import {
   EncryptedFileStore,
   redactKnownSecrets,
   resolveInputs,
+  spawnNodeReal,
 } from '@some-useful-agents/core';
+import { Context } from '@temporalio/activity';
 
 export interface RunAgentActivityInput {
   agent: AgentDefinition;
@@ -110,4 +112,85 @@ export async function runAgentActivity(input: RunAgentActivityInput): Promise<Ru
       : undefined,
     warnings,
   };
+}
+
+/**
+ * Input for {@link runNodeActivity}: one v2 DAG node, executed on the worker.
+ *
+ * `env` is the SAFE env — the dashboard-side spawnNode already stripped
+ * sensitive keys (`stripSensitiveEnv`) before this crossed the activity
+ * boundary, since Temporal persists activity inputs in workflow history. The
+ * node's DECLARED secrets are named in `declaredSecrets` and re-read here from
+ * `secretsPath` on the worker, never travelling in the payload.
+ */
+export interface RunNodeActivityInput {
+  node: AgentNode;
+  /** Sensitive keys already removed; declared secrets re-injected on the worker. */
+  env: Record<string, string>;
+  agentId: string;
+  agentSource: Agent['source'];
+  /** LLM provider waterfall (names only; onFallback telemetry is not propagated). */
+  llmProviders?: string[];
+  /** Path to the encrypted secrets file, read on the worker. */
+  secretsPath: string;
+  /** Names of the node's declared secrets to re-inject from `secretsPath`. */
+  declaredSecrets: string[];
+}
+
+/**
+ * Activity: run ONE DAG node on the worker via the same `spawnNodeReal` the
+ * in-process executor uses. Heartbeats each progress event so (a) the run is
+ * cancellable — Temporal only delivers cancellation to activities that
+ * heartbeat — and (b) the Temporal UI shows liveness. The dashboard keeps
+ * owning DAG orchestration; this just offloads the node's shell/LLM spawn.
+ */
+export async function runNodeActivity(input: RunNodeActivityInput): Promise<SpawnResult> {
+  // Resolve the activity context defensively: present on a real worker (where
+  // heartbeat + cancellation matter), absent when invoked directly (unit tests).
+  let ctx: ReturnType<typeof Context.current> | undefined;
+  try { ctx = Context.current(); } catch { ctx = undefined; }
+
+  // Re-inject declared secrets from the worker-local secrets store. Only opened
+  // when the node actually declares secrets.
+  const env = { ...input.env };
+  if (input.declaredSecrets.length > 0) {
+    const all = await new EncryptedFileStore(input.secretsPath).getAll();
+    const missing: string[] = [];
+    for (const name of input.declaredSecrets) {
+      if (name in all) env[name] = all[name];
+      else missing.push(name);
+    }
+    if (missing.length > 0) {
+      return {
+        result: '',
+        exitCode: 1,
+        error: `Missing secrets on worker for node "${input.node.id}": ${missing.join(', ')}. Run 'sua secrets set <name>'.`,
+        category: 'setup',
+        usedWorkflowProvider: 'temporal',
+      };
+    }
+  }
+
+  const onProgress = (event: SpawnProgress): void => {
+    // Heartbeat the latest event. Carrying progress is refined in PR3; here it
+    // is primarily what makes the activity cancellable.
+    try { ctx?.heartbeat(event); } catch { /* heartbeat outside activity ctx — ignore */ }
+  };
+
+  const result = await spawnNodeReal(
+    input.node,
+    env,
+    {
+      agentId: input.agentId,
+      agentSource: input.agentSource,
+      // Community-shell trust is enforced by executeAgentDag before the node
+      // ever reaches a backend, so the worker needs no allowlist here.
+      allowUntrustedShell: new Set<string>(),
+      llmSettings: input.llmProviders ? { providers: input.llmProviders } : undefined,
+    },
+    onProgress,
+    ctx?.cancellationSignal,
+  );
+
+  return { ...result, usedWorkflowProvider: 'temporal' };
 }

--- a/packages/temporal-provider/src/index.ts
+++ b/packages/temporal-provider/src/index.ts
@@ -1,3 +1,5 @@
 export * from './provider.js';
 export * from './worker.js';
+export { createTemporalSpawnNode, type CreateTemporalSpawnNodeOptions } from './node-spawn.js';
+export type { RunNodeActivityInput } from './activities.js';
 export type { RunAgentWorkflowInput, RunAgentWorkflowResult } from './workflows.js';

--- a/packages/temporal-provider/src/node-spawn.test.ts
+++ b/packages/temporal-provider/src/node-spawn.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import type { Client } from '@temporalio/client';
+import type { AgentNode, SpawnResult } from '@some-useful-agents/core';
+import { createTemporalSpawnNode } from './node-spawn.js';
+
+const node = (overrides: Partial<AgentNode> = {}): AgentNode => ({
+  id: 'fetch',
+  type: 'shell',
+  command: 'echo hi',
+  ...overrides,
+});
+
+const spawnOpts = { agentId: 'demo', agentSource: 'local' as const };
+
+/**
+ * Minimal fake Temporal client capturing the workflow.start call and letting
+ * the test resolve / reject the handle's result(), plus observe cancel().
+ */
+function fakeClient(behavior: {
+  result?: SpawnResult;
+  reject?: Error;
+  onStart?: (args: { workflowType: string; options: { workflowId: string; taskQueue: string; args: unknown[] } }) => void;
+  onCancel?: () => void;
+}): Client {
+  return {
+    workflow: {
+      async start(workflowType: string, options: { workflowId: string; taskQueue: string; args: unknown[] }) {
+        behavior.onStart?.({ workflowType, options });
+        return {
+          workflowId: options.workflowId,
+          async result(): Promise<SpawnResult> {
+            if (behavior.reject) throw behavior.reject;
+            return behavior.result ?? { result: 'ok', exitCode: 0 };
+          },
+          async cancel() { behavior.onCancel?.(); },
+        };
+      },
+    },
+  } as unknown as Client;
+}
+
+describe('createTemporalSpawnNode', () => {
+  it('starts runNodeWorkflow on the task queue and returns the result stamped temporal', async () => {
+    let started: { workflowType: string; options: { workflowId: string; taskQueue: string; args: unknown[] } } | undefined;
+    const client = fakeClient({
+      result: { result: 'done', exitCode: 0 },
+      onStart: (s) => { started = s; },
+    });
+    const spawn = createTemporalSpawnNode({ client, secretsPath: '/tmp/secrets.enc', taskQueue: 'sua-agents' });
+
+    const res = await spawn(node(), { PATH: '/usr/bin' }, spawnOpts);
+
+    expect(started?.workflowType).toBe('runNodeWorkflow');
+    expect(started?.options.taskQueue).toBe('sua-agents');
+    expect(started?.options.workflowId).toMatch(/^sua-node-demo-fetch-/);
+    expect(res.exitCode).toBe(0);
+    expect(res.result).toBe('done');
+    expect(res.usedWorkflowProvider).toBe('temporal');
+  });
+
+  it('strips declared secrets from the activity input env', async () => {
+    let started: { options: { args: unknown[] } } | undefined;
+    const client = fakeClient({ result: { result: 'ok', exitCode: 0 }, onStart: (s) => { started = s; } });
+    const spawn = createTemporalSpawnNode({ client, secretsPath: '/tmp/secrets.enc' });
+
+    await spawn(
+      node({ secrets: ['MY_SECRET'] }),
+      { PATH: '/usr/bin', MY_SECRET: 'shh', API_TOKEN: 'abc' },
+      spawnOpts,
+    );
+
+    const input = started!.options.args[0] as { env: Record<string, string>; declaredSecrets: string[] };
+    expect(input.env.PATH).toBe('/usr/bin');
+    expect(input.env.MY_SECRET).toBeUndefined();   // declared secret stripped
+    expect(input.env.API_TOKEN).toBeUndefined();   // sensitive name stripped
+    expect(input.declaredSecrets).toEqual(['MY_SECRET']);
+  });
+
+  it('cancels the workflow when the abort signal fires and returns a cancelled result', async () => {
+    let cancelled = false;
+    const controller = new AbortController();
+    const client = fakeClient({
+      onCancel: () => { cancelled = true; },
+      // result() rejects (as a real cancelled workflow does) after cancel.
+      reject: new Error('workflow cancelled'),
+    });
+    const spawn = createTemporalSpawnNode({ client, secretsPath: '/tmp/secrets.enc' });
+
+    controller.abort();
+    const res = await spawn(node(), { PATH: '/usr/bin' }, spawnOpts, undefined, controller.signal);
+
+    expect(cancelled).toBe(true);
+    expect(res.category).toBe('cancelled');
+    expect(res.usedWorkflowProvider).toBe('temporal');
+  });
+
+  it('returns a failed result (not a throw) when the workflow errors', async () => {
+    const client = fakeClient({ reject: new Error('boom') });
+    const spawn = createTemporalSpawnNode({ client, secretsPath: '/tmp/secrets.enc' });
+
+    const res = await spawn(node(), { PATH: '/usr/bin' }, spawnOpts);
+
+    expect(res.exitCode).toBe(1);
+    expect(res.error).toContain('boom');
+    expect(res.category).toBe('exit_nonzero');
+  });
+});

--- a/packages/temporal-provider/src/node-spawn.ts
+++ b/packages/temporal-provider/src/node-spawn.ts
@@ -1,0 +1,90 @@
+import { randomUUID } from 'node:crypto';
+import type { Client } from '@temporalio/client';
+import type { SpawnNodeFn, SpawnResult } from '@some-useful-agents/core';
+import { stripSensitiveEnv } from '@some-useful-agents/core';
+import { DEFAULT_TASK_QUEUE } from './worker.js';
+import type { RunNodeActivityInput } from './activities.js';
+
+export interface CreateTemporalSpawnNodeOptions {
+  /** A connected Temporal client (reuse the provider's). */
+  client: Client;
+  /** Path to the encrypted secrets file, read on the worker. */
+  secretsPath: string;
+  /** Task queue the worker polls. Defaults to the provider's queue. */
+  taskQueue?: string;
+}
+
+/**
+ * Build a {@link SpawnNodeFn} that runs each DAG node on a Temporal worker
+ * (B1b). The dashboard injects this as `deps.spawnNode` when the provider is
+ * Temporal; `executeAgentDag` keeps orchestrating in-process and calls this per
+ * node.
+ *
+ * Each node becomes its own one-shot `runNodeWorkflow` (clients can't invoke
+ * activities directly). Secrets are stripped from `env` before they cross the
+ * activity boundary — Temporal persists inputs in workflow history — and
+ * re-injected on the worker from `secretsPath`. Abort → workflow cancel. Like
+ * `spawnNodeReal`, this resolves to a SpawnResult for normal failures rather
+ * than throwing, so the executor records the node outcome uniformly.
+ */
+export function createTemporalSpawnNode(opts: CreateTemporalSpawnNodeOptions): SpawnNodeFn {
+  const taskQueue = opts.taskQueue ?? DEFAULT_TASK_QUEUE;
+
+  return async (node, env, spawnOpts, _onProgress, signal): Promise<SpawnResult> => {
+    const { safe } = stripSensitiveEnv(env, node);
+    const input: RunNodeActivityInput = {
+      node,
+      env: safe,
+      agentId: spawnOpts.agentId,
+      agentSource: spawnOpts.agentSource,
+      llmProviders: spawnOpts.llmSettings?.providers,
+      secretsPath: opts.secretsPath,
+      declaredSecrets: node.secrets ?? [],
+    };
+
+    const workflowId = `sua-node-${spawnOpts.agentId}-${node.id}-${randomUUID().slice(0, 8)}`;
+
+    let handle;
+    try {
+      handle = await opts.client.workflow.start('runNodeWorkflow', {
+        taskQueue,
+        workflowId,
+        args: [input],
+      });
+    } catch (err) {
+      return {
+        result: '',
+        exitCode: 1,
+        error: `Failed to start Temporal node workflow: ${err instanceof Error ? err.message : String(err)}`,
+        category: 'spawn_failure',
+        usedWorkflowProvider: 'temporal',
+      };
+    }
+
+    // Map the executor's abort signal onto workflow cancellation. The activity
+    // heartbeats, so the worker receives the cancel and SIGTERMs the child.
+    const onAbort = (): void => { void handle.cancel().catch(() => { /* already gone */ }); };
+    if (signal?.aborted) onAbort();
+    else signal?.addEventListener('abort', onAbort, { once: true });
+
+    try {
+      const result = await handle.result();
+      // The activity stamps this too, but guarantee it from the factory so the
+      // backend identity never depends on the activity remembering.
+      return { ...result, usedWorkflowProvider: 'temporal' };
+    } catch (err) {
+      const cancelled = signal?.aborted === true;
+      return {
+        result: '',
+        exitCode: cancelled ? 143 : 1,
+        error: cancelled
+          ? `Node "${node.id}" cancelled`
+          : `Temporal node workflow failed: ${err instanceof Error ? err.message : String(err)}`,
+        category: cancelled ? 'cancelled' : 'exit_nonzero',
+        usedWorkflowProvider: 'temporal',
+      };
+    } finally {
+      if (signal && !signal.aborted) signal.removeEventListener('abort', onAbort);
+    }
+  };
+}

--- a/packages/temporal-provider/src/provider.ts
+++ b/packages/temporal-provider/src/provider.ts
@@ -1,8 +1,9 @@
 import { Connection, Client, WorkflowNotFoundError } from '@temporalio/client';
 import { randomUUID } from 'node:crypto';
-import type { Provider, RunRequest, Run, RunStatus } from '@some-useful-agents/core';
+import type { Provider, RunRequest, Run, RunStatus, SpawnNodeFn } from '@some-useful-agents/core';
 import { RunStore } from '@some-useful-agents/core';
 import { DEFAULT_TASK_QUEUE } from './worker.js';
+import { createTemporalSpawnNode } from './node-spawn.js';
 import type { RunAgentWorkflowInput, RunAgentWorkflowResult } from './workflows.js';
 
 export interface TemporalProviderOptions {
@@ -49,6 +50,21 @@ export class TemporalProvider implements Provider {
   async shutdown(): Promise<void> {
     await this.connection?.close();
     this.store.close();
+  }
+
+  /**
+   * Build a node-execution backend (SpawnNodeFn) bound to this provider's
+   * client + task queue (B1b). The dashboard injects the result as
+   * `deps.spawnNode` so v2 DAG nodes run on the Temporal worker while the
+   * dashboard keeps orchestrating the DAG. Must be called after
+   * `initialize()` (the client must exist).
+   */
+  createSpawnNode(): SpawnNodeFn {
+    return createTemporalSpawnNode({
+      client: this.client,
+      secretsPath: this.options.secretsPath,
+      taskQueue: this.options.taskQueue,
+    });
   }
 
   async submitRun(request: RunRequest): Promise<Run> {

--- a/packages/temporal-provider/src/workflows.ts
+++ b/packages/temporal-provider/src/workflows.ts
@@ -1,10 +1,25 @@
-import { proxyActivities } from '@temporalio/workflow';
+import { proxyActivities, ActivityCancellationType } from '@temporalio/workflow';
 import type * as activities from './activities.js';
+import type { RunNodeActivityInput } from './activities.js';
+import type { SpawnResult } from '@some-useful-agents/core';
 
 const { runAgentActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: '10 minutes',
   retry: {
     maximumAttempts: 1, // Agent runs are not idempotent; don't auto-retry
+  },
+});
+
+// Node activities heartbeat (for cancellation + liveness), so they get a
+// heartbeatTimeout and wait for cancellation to complete (the worker SIGTERMs
+// the child and unwinds) before the workflow resolves cancelled. No auto-retry:
+// a node spawn is not idempotent.
+const { runNodeActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '1 hour',
+  heartbeatTimeout: '30 seconds',
+  cancellationType: ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
+  retry: {
+    maximumAttempts: 1,
   },
 });
 
@@ -44,4 +59,15 @@ export async function runAgentWorkflow(input: RunAgentWorkflowInput): Promise<Ru
     allowUntrustedShell: input.allowUntrustedShell,
     inputs: input.inputs,
   });
+}
+
+/**
+ * One-shot workflow wrapping a single v2 DAG node (B1b). Temporal clients can
+ * only start workflows, not activities, so each offloaded node runs as its own
+ * `sua-node-…` workflow. The dashboard still orchestrates the DAG; this just
+ * hosts one node's activity so it executes on the worker, is cancellable, and
+ * shows up in the Temporal UI. B2 collapses these into one workflow per run.
+ */
+export async function runNodeWorkflow(input: RunNodeActivityInput): Promise<SpawnResult> {
+  return runNodeActivity(input);
 }


### PR DESCRIPTION
## What

PR2 of B1b. With `--provider temporal`, **v2 DAG agents now execute each node on a Temporal worker** (previously only v1 single-node agents touched Temporal). The dashboard still orchestrates the DAG in-process and offloads each node's shell/LLM spawn.

- **core:** `stripSensitiveEnv(env, node)` splits env into safe vs sensitive keys; export `spawnNodeReal` + `SpawnResult`/`SpawnNodeFn`; optional `Provider.createSpawnNode()`.
- **temporal-provider:** `runNodeActivity` (runs one node via `spawnNodeReal` on the worker, **heartbeats** so the run is cancellable + visible, re-injects declared secrets from `secretsPath`, stamps `usedWorkflowProvider=temporal`) + `runNodeWorkflow` wrapper. `createTemporalSpawnNode` returns a `SpawnNodeFn` that starts one `sua-node-<runId>-<nodeId>` workflow per node, strips sensitive env before it crosses the activity boundary, maps abort → workflow cancel, and resolves to a `SpawnResult` on failure (never throws). `TemporalProvider.createSpawnNode()` binds it to the provider's client.
- **dashboard:** build `ctx.workflowSpawnNode` once at startup; inject `spawnNode` at all ~8 `executeAgentDag` sites alongside `llmSettings`. Undefined for local ⇒ in-process, unchanged.

## Security

Declared secrets are resolved into `env` before a node spawns; since Temporal persists activity inputs in history, the spawnNode **strips sensitive keys** before dispatch and the worker **re-reads declared secrets from `secretsPath`** — secrets never enter Temporal history. Non-declared sensitive env values are dropped on the worker (documented). A payload-encryption codec to lift that limitation is a planned follow-up.

## Scope

This keeps **orchestration in the dashboard** (one workflow per node). Durable whole-DAG-as-workflow (survives a crash and resumes) is the next step (B2). PR3 adds full live progress (heartbeat poll-rebroadcast → inbox token stream).

## Test

- Unit: `stripSensitiveEnv` (3), `createTemporalSpawnNode` with a fake client — workflow start, secret stripping, abort→cancel, failure→SpawnResult (4), `runNodeActivity` real shell + secret re-injection + missing-secret (3).
- **Live e2e:** against the running Temporal + worker, drove a shell node through `createTemporalSpawnNode` — ran on the worker (separate pid), returned `usedWorkflowProvider: 'temporal'`, and `sua-node-…` `runNodeWorkflow` showed Completed in the Temporal UI.
- Clean rebuild + full suite: **1927 passed, 3 skipped**.

Plan: `~/.claude/plans/cozy-cooking-truffle.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)