### PR TITLE
feat: manage the Temporal worker (daemon service + scripts + Settings page)

### DIFF
--- a/.changeset/temporal-worker-controls.md
+++ b/.changeset/temporal-worker-controls.md
@@ -1,0 +1,21 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Manage the Temporal worker as a first-class service.
+
+The Temporal worker is now a managed `sua daemon` service: add `worker` to
+`daemon.services` or run `sua daemon start --service worker`. When
+`provider: temporal` is configured, `sua daemon start` also passes
+`--provider temporal` to the dashboard + MCP server so the whole stack agrees.
+New `scripts/temporal-up.sh` / `temporal-down.sh` bring the entire stack
+(Temporal server + dashboard + MCP + worker) up and down in one command.
+
+A new **Settings → Temporal** page shows the active run provider, the Temporal
+connection (address / namespace / task queue), and the worker's status with
+Start / Stop controls (managing the same daemon-tracked worker — the worker
+still runs on the host, never inside the web process).

--- a/docs/temporal.md
+++ b/docs/temporal.md
@@ -115,9 +115,21 @@ sua worker start
 # ✓ Worker connected. Listening for agent runs...
 ```
 
-Leave it running (Ctrl-C stops it). For a long-lived setup, wrap it in
-`launchd` / `systemd`, or run it under `sua daemon` if you manage services that
-way.
+Leave it running (Ctrl-C stops it). Three ways to keep it up long-lived:
+
+- **Daemon service.** The worker is a managed `sua daemon` service. Add it to
+  `daemon.services` in `sua.config.json` (alongside `dashboard` / `mcp`), or
+  start it directly: `sua daemon start --service worker`. `sua daemon status`
+  shows it; `sua daemon stop --service worker` stops it. When
+  `provider: temporal` is set in config, `sua daemon start` also passes
+  `--provider temporal` to the dashboard + MCP server so the whole stack agrees.
+- **One command for the whole stack.** `./scripts/temporal-up.sh` brings up the
+  Temporal server (Docker), waits for health, then starts the dashboard, MCP,
+  and worker on the temporal provider — and prints the sign-in URL.
+  `./scripts/temporal-down.sh` tears it back down.
+- **From the dashboard.** `Settings → Temporal` shows the worker's status with
+  Start / Stop buttons (it manages the same daemon-tracked worker), plus the
+  active provider and the Temporal connection. `launchd` / `systemd` also work.
 
 > If you submit a Temporal run with **no worker** polling, the run sits
 > `pending` — the Temporal server has accepted the workflow but nothing is

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -247,9 +247,13 @@ daemonCommand
  * configured ports instead of their CLI defaults.
  */
 function portArgsForServices(config: SuaConfig): Partial<Record<ServiceName, string[]>> {
+  // When the configured provider is Temporal, the daemon-managed dashboard and
+  // MCP server must also run on it — otherwise `sua daemon start` would bring up
+  // a worker next to a `local` dashboard and v2 nodes would never reach it.
+  const providerArgs = config.provider === 'temporal' ? ['--provider', 'temporal'] : [];
   return {
-    dashboard: ['--port', String(getDashboardPort(config))],
-    mcp: ['--port', String(config.mcpPort)],
+    dashboard: ['--port', String(getDashboardPort(config)), ...providerArgs],
+    mcp: ['--port', String(config.mcpPort), ...providerArgs],
   };
 }
 

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -113,6 +113,11 @@ of scope for this release — wrap in launchd / systemd if you need it.
         allowUntrustedShell,
         dashboardBaseUrl: getDashboardBaseUrl(config),
         provider,
+        temporal: {
+          address: config.temporalAddress ?? 'localhost:7233',
+          namespace: config.temporalNamespace ?? 'default',
+          taskQueue: config.temporalTaskQueue ?? 'sua-agents',
+        },
       });
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === 'EADDRINUSE') {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -32,7 +32,7 @@ export interface SuaConfig {
    */
   daemon?: {
     /** Services started by `sua daemon start` (with no --service flag). */
-    services?: ('schedule' | 'dashboard' | 'mcp')[];
+    services?: ('schedule' | 'dashboard' | 'mcp' | 'worker')[];
     /** Rotate log when it exceeds this many bytes (rotate-on-start). */
     logRotateBytes?: number;
   };
@@ -124,7 +124,7 @@ export function getRetentionDays(config: SuaConfig): number {
   return config.runRetentionDays ?? 30;
 }
 
-export function getDaemonServices(config: SuaConfig): ('schedule' | 'dashboard' | 'mcp')[] {
+export function getDaemonServices(config: SuaConfig): ('schedule' | 'dashboard' | 'mcp' | 'worker')[] {
   return config.daemon?.services ?? ['schedule', 'dashboard'];
 }
 

--- a/packages/core/src/daemon-supervisor.test.ts
+++ b/packages/core/src/daemon-supervisor.test.ts
@@ -36,7 +36,7 @@ describe('daemonPaths', () => {
   });
 
   it('exposes the canonical service list', () => {
-    expect(ALL_SERVICES).toEqual(['schedule', 'dashboard', 'mcp']);
+    expect(ALL_SERVICES).toEqual(['schedule', 'dashboard', 'mcp', 'worker']);
   });
 });
 

--- a/packages/core/src/daemon-supervisor.ts
+++ b/packages/core/src/daemon-supervisor.ts
@@ -19,9 +19,9 @@ import {
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
 
-export type ServiceName = 'schedule' | 'dashboard' | 'mcp';
+export type ServiceName = 'schedule' | 'dashboard' | 'mcp' | 'worker';
 
-export const ALL_SERVICES: readonly ServiceName[] = ['schedule', 'dashboard', 'mcp'] as const;
+export const ALL_SERVICES: readonly ServiceName[] = ['schedule', 'dashboard', 'mcp', 'worker'] as const;
 
 export interface SpawnedService {
   name: ServiceName;
@@ -131,6 +131,10 @@ const SERVICE_ARGV: Record<ServiceName, string[]> = {
   schedule: ['schedule', 'start'],
   dashboard: ['dashboard', 'start'],
   mcp: ['mcp', 'start'],
+  // The Temporal worker. Only useful when the provider is `temporal`; it polls
+  // the task queue and executes agent/node work on the host (ADR-0004). Opt-in
+  // via `daemon.services` or `sua daemon start --service worker`.
+  worker: ['worker', 'start'],
 };
 
 /**

--- a/packages/dashboard/src/context.ts
+++ b/packages/dashboard/src/context.ts
@@ -29,6 +29,11 @@ export interface DashboardContext {
    * while orchestration stays in the dashboard (B1b).
    */
   workflowSpawnNode?: SpawnNodeFn;
+  /**
+   * Temporal connection config (shown read-only on /settings/temporal). Set by
+   * the CLI from sua.config.json; the worker uses these same values.
+   */
+  temporal?: { address: string; namespace: string; taskQueue: string };
   /** Run store reader for /runs and /runs/:id. */
   runStore: RunStore;
   /**

--- a/packages/dashboard/src/dashboard.test.ts
+++ b/packages/dashboard/src/dashboard.test.ts
@@ -3924,3 +3924,32 @@ describe('POST /agents/:id/allowed-sub-agents', () => {
     expect(agentStore.getAgent('warn-host')?.allowedSubAgents).toEqual(['ghost-tool']);
   });
 });
+
+describe('Settings → Temporal (/settings/temporal)', () => {
+  const authed = (app: Parameters<typeof request>[0], path: string) =>
+    request(app).get(path)
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+
+  it('renders the provider, worker, and connection cards', async () => {
+    const app = await makeApp();
+    const res = await authed(app, '/settings/temporal');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Run provider');
+    expect(res.text).toContain('Worker');
+    expect(res.text).toContain('Task queue');
+    // Default harness provider is local — worker is stopped, Start button shows.
+    expect(res.text).toContain('Start worker');
+  });
+
+  it('worker start fails cleanly and redirects when sua bin path is unavailable', async () => {
+    // argv[1] is the vitest runner here, so spawnService will attempt a child;
+    // we only assert the route is wired and redirects (303), not the spawn.
+    const app = await makeApp();
+    const res = await request(app).post('/settings/temporal/worker/stop')
+      .set('Host', `127.0.0.1:${PORT}`)
+      .set('Cookie', `${SESSION_COOKIE}=${TOKEN}`);
+    expect(res.status).toBe(303);
+    expect(res.headers.location).toMatch(/^\/settings\/temporal/);
+  });
+});

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -55,6 +55,7 @@ import { assetsRouter } from './routes/assets.js';
 import { outputFilesRouter } from './routes/output-files.js';
 import { settingsRouter } from './routes/settings.js';
 import { settingsMcpRouter } from './routes/settings-mcp.js';
+import { settingsTemporalRouter } from './routes/settings-temporal.js';
 import { helpRouter } from './routes/help.js';
 import { versionsRouter } from './routes/versions.js';
 import { imgBlockReportRouter } from './routes/img-block-report.js';
@@ -94,6 +95,8 @@ export interface StartDashboardOptions {
   allowUntrustedShell?: Set<string>;
   /** Run-history retention in days (shown on /settings/general). Defaults to 30. */
   retentionDays?: number;
+  /** Temporal connection config, shown read-only on /settings/temporal. */
+  temporal?: { address: string; namespace: string; taskQueue: string };
   /**
    * Public base URL the dashboard is reachable at. Used to build clickable
    * run links inside notify handler payloads (Slack, etc). Falls back to
@@ -267,6 +270,7 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   app.use(runMutationsRouter);
   app.use(widgetRunRouter);
   app.use(settingsMcpRouter);
+  app.use(settingsTemporalRouter);
   app.use(settingsRouter);
   app.use(helpRouter);
   app.use(versionsRouter);
@@ -506,6 +510,7 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     port: opts.port,
     provider,
     workflowSpawnNode,
+    temporal: opts.temporal,
     runStore,
     agentStore,
     loadAgents: () => loadAgents({ directories: opts.agentDirs }),

--- a/packages/dashboard/src/routes/settings-temporal.ts
+++ b/packages/dashboard/src/routes/settings-temporal.ts
@@ -1,0 +1,72 @@
+import { Router, type Request, type Response } from 'express';
+import { spawnService, stopService, getServiceStatus } from '@some-useful-agents/core';
+import { getContext } from '../context.js';
+import { renderSettingsShell } from '../views/settings-shell.js';
+import { renderSettingsTemporal } from '../views/settings-temporal.js';
+
+/**
+ * Routes for /settings/temporal: the run provider, Temporal connection, and the
+ * worker (a daemon-managed host service that executes v2 DAG nodes). Worker
+ * start/stop mirrors /settings/mcp — the dashboard is a local host process, so
+ * it manages sibling daemon services the same way the CLI does.
+ */
+export const settingsTemporalRouter: Router = Router();
+
+const DEFAULT_TEMPORAL = { address: 'localhost:7233', namespace: 'default', taskQueue: 'sua-agents' };
+const TEMPORAL_UI_URL = 'http://localhost:8233';
+
+settingsTemporalRouter.get('/settings/temporal', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const workerStatus = getServiceStatus(ctx.dataDir, 'worker');
+
+  const errorParam = typeof req.query.error === 'string' ? req.query.error : undefined;
+  const flashParam = typeof req.query.flash === 'string' ? req.query.flash : undefined;
+  const flash = errorParam
+    ? { kind: 'error' as const, message: errorParam }
+    : flashParam
+    ? { kind: 'ok' as const, message: flashParam }
+    : undefined;
+
+  const body = renderSettingsTemporal({
+    providerName: ctx.provider.name,
+    workerStatus,
+    temporal: ctx.temporal ?? DEFAULT_TEMPORAL,
+    temporalUiUrl: TEMPORAL_UI_URL,
+  });
+  res.type('html').send(renderSettingsShell({ active: 'temporal', body, flash }));
+});
+
+settingsTemporalRouter.post('/settings/temporal/worker/start', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const suaBin = process.argv[1];
+  if (!suaBin) {
+    res.redirect(303, `/settings/temporal?error=${encodeURIComponent('Cannot determine the sua binary path. Run `sua worker start` from the CLI.')}`);
+    return;
+  }
+  try {
+    const result = spawnService(ctx.dataDir, 'worker', {
+      suaBin,
+      cwd: process.cwd(),
+      env: process.env,
+    });
+    res.redirect(303, `/settings/temporal?flash=${encodeURIComponent(`Worker started (PID ${result.pid}).`)}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/settings/temporal?error=${encodeURIComponent(`Start failed: ${msg}`)}`);
+  }
+});
+
+settingsTemporalRouter.post('/settings/temporal/worker/stop', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  try {
+    const result = stopService(ctx.dataDir, 'worker');
+    if (!result.signalled && result.pid === undefined) {
+      res.redirect(303, `/settings/temporal?flash=${encodeURIComponent('Worker was not running.')}`);
+      return;
+    }
+    res.redirect(303, `/settings/temporal?flash=${encodeURIComponent(`Stopped worker (PID ${result.pid}).`)}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.redirect(303, `/settings/temporal?error=${encodeURIComponent(`Stop failed: ${msg}`)}`);
+  }
+});

--- a/packages/dashboard/src/views/settings-shell.ts
+++ b/packages/dashboard/src/views/settings-shell.ts
@@ -2,7 +2,7 @@ import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { pageHeader } from './page-header.js';
 
-export type SettingsTab = 'secrets' | 'variables' | 'mcp' | 'mcp-servers' | 'integrations' | 'llm' | 'appearance' | 'general';
+export type SettingsTab = 'secrets' | 'variables' | 'mcp' | 'mcp-servers' | 'integrations' | 'llm' | 'temporal' | 'appearance' | 'general';
 
 export interface SettingsShellArgs {
   active: SettingsTab;
@@ -29,6 +29,7 @@ export function renderSettingsShell(args: SettingsShellArgs): string {
       ${tab('mcp-servers', 'MCP Servers')}
       ${tab('integrations', 'Integrations')}
       ${tab('llm', 'LLM')}
+      ${tab('temporal', 'Temporal')}
       ${tab('appearance', 'Appearance')}
       ${tab('general', 'General')}
     </nav>

--- a/packages/dashboard/src/views/settings-temporal.ts
+++ b/packages/dashboard/src/views/settings-temporal.ts
@@ -1,0 +1,106 @@
+import type { ServiceStatus } from '@some-useful-agents/core';
+import { html, unsafeHtml, type SafeHtml } from './html.js';
+
+export interface SettingsTemporalArgs {
+  /** Active run provider for this dashboard process ('local' | 'temporal'). */
+  providerName: string;
+  /** Live status of the daemon-managed Temporal worker (PID file + liveness). */
+  workerStatus: ServiceStatus;
+  /** Temporal connection config (read-only; the worker uses the same values). */
+  temporal: { address: string; namespace: string; taskQueue: string };
+  /** Temporal Web UI URL (the bundled docker-compose maps it here). */
+  temporalUiUrl: string;
+  /** Inline error from a failed worker start/stop. */
+  actionError?: string;
+}
+
+/**
+ * Render the `/settings/temporal` body. Surfaces the run provider, the Temporal
+ * connection, and the worker — which executes v2 DAG nodes on the host. The
+ * worker can be started/stopped here (it is a daemon-managed service, same as
+ * the MCP server on /settings/mcp); it is NOT spawned inside the web process.
+ */
+export function renderSettingsTemporal(args: SettingsTemporalArgs): SafeHtml {
+  const onTemporal = args.providerName === 'temporal';
+  return html`
+    ${args.actionError ? html`<div class="flash flash--error">${args.actionError}</div>` : unsafeHtml('')}
+
+    <div class="card">
+      <p class="card__title">Run provider</p>
+      <dl class="kv">
+        <dt>Active</dt>
+        <dd>${onTemporal
+          ? html`<span class="badge badge--info">temporal</span>`
+          : html`<span class="badge badge--muted">local</span>`}</dd>
+      </dl>
+      ${onTemporal
+        ? html`<p class="dim" style="margin-top: var(--space-2);">
+            v2 DAG nodes run on the Temporal worker. A worker must be running
+            below or runs will sit pending.
+          </p>`
+        : html`<p class="dim" style="margin-top: var(--space-2);">
+            This dashboard runs work in-process. To use Temporal, restart it with
+            <code>sua dashboard start --provider temporal</code> (or set
+            <code>"provider": "temporal"</code> in <code>sua.config.json</code>),
+            then start a worker. The worker below only matters under the temporal
+            provider.
+          </p>`}
+    </div>
+
+    <div class="card">
+      <p class="card__title">Worker</p>
+      ${renderStatusBlock(args.workerStatus)}
+      <div style="display: flex; gap: var(--space-2); margin-top: var(--space-3);">
+        ${args.workerStatus.state === 'running'
+          ? html`<form action="/settings/temporal/worker/stop" method="post" style="margin: 0;"
+              data-confirm="Stop the Temporal worker? In-flight Temporal runs will stop progressing until a worker is running again.">
+              <button type="submit" class="btn btn--warn">Stop worker</button>
+            </form>`
+          : html`<form action="/settings/temporal/worker/start" method="post" style="margin: 0;">
+              <button type="submit" class="btn btn--primary">Start worker</button>
+            </form>`}
+        <a class="btn btn--ghost" href="/settings/temporal">Refresh</a>
+      </div>
+      <p class="dim" style="margin-top: var(--space-2);">
+        The worker runs on the host (it executes your shell + <code>claude</code>),
+        not inside Docker — see ADR-0004. This control manages the daemon-tracked
+        worker; you can also run <code>sua worker start</code> in a terminal, or
+        bring up the whole stack with <code>./scripts/temporal-up.sh</code>.
+        Runtime output is appended to <code>${args.workerStatus.logPath}</code>.
+      </p>
+    </div>
+
+    <div class="card">
+      <p class="card__title">Connection</p>
+      <dl class="kv">
+        <dt>Address</dt><dd class="mono">${args.temporal.address}</dd>
+        <dt>Namespace</dt><dd class="mono">${args.temporal.namespace}</dd>
+        <dt>Task queue</dt><dd class="mono">${args.temporal.taskQueue}</dd>
+        <dt>Web UI</dt><dd><a href="${args.temporalUiUrl}" target="_blank" rel="noreferrer">${args.temporalUiUrl}</a></dd>
+      </dl>
+      <p class="dim" style="margin-top: var(--space-2);">
+        Configure these in <code>sua.config.json</code>
+        (<code>temporalAddress</code> / <code>temporalNamespace</code> /
+        <code>temporalTaskQueue</code>). The Temporal server itself runs in Docker
+        (<code>docker compose up -d</code>).
+      </p>
+    </div>
+  `;
+}
+
+function renderStatusBlock(status: ServiceStatus): SafeHtml {
+  const badge = status.state === 'running'
+    ? html`<span class="badge badge--ok">running</span>`
+    : status.state === 'stale'
+    ? html`<span class="badge badge--warn">stale (PID ${String(status.pid ?? '?')} dead)</span>`
+    : html`<span class="badge badge--muted">stopped</span>`;
+  const pidLine = status.pid !== undefined && status.state === 'running'
+    ? html`<dd class="mono">PID ${String(status.pid)}</dd>`
+    : html`<dd class="dim">—</dd>`;
+  return html`
+    <dl class="kv">
+      <dt>State</dt><dd>${badge}</dd>
+      <dt>Process</dt>${pidLine}
+    </dl>
+  `;
+}

--- a/scripts/temporal-down.sh
+++ b/scripts/temporal-down.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# temporal-down.sh — tear down what temporal-up.sh started.
+#
+# Stops the daemon-managed services (dashboard, mcp, worker), then stops the
+# Temporal Docker containers. Postgres data is preserved (use `docker compose
+# down -v` by hand to wipe workflow history).
+#
+# Usage:
+#   ./scripts/temporal-down.sh           # stop daemon services + Temporal containers
+#   KEEP_DOCKER=1 ./scripts/temporal-down.sh   # stop daemon services only
+#
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+if command -v sua >/dev/null 2>&1; then
+  SUA="sua"
+else
+  SUA="node packages/cli/dist/index.js"
+fi
+
+echo "==> Stopping daemon services (dashboard, mcp, worker)…"
+$SUA daemon stop --service dashboard --service mcp --service worker || true
+
+if [ "${KEEP_DOCKER:-}" != "1" ]; then
+  echo "==> Stopping Temporal containers (data preserved)…"
+  docker compose stop
+fi
+
+echo "==> Down."

--- a/scripts/temporal-up.sh
+++ b/scripts/temporal-up.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# temporal-up.sh — bring up the full Temporal stack in the order the worker
+# model expects: the Temporal server (Docker), then the daemon-managed dashboard
+# + MCP server + worker, all on the `temporal` provider.
+#
+# The Temporal SERVER runs in Docker; the WORKER runs on the host (it executes
+# your shell + `claude`, see docs/adr/0004-temporal-worker-on-host.md). This
+# script wires both up so v2 DAG agents run on Temporal end-to-end.
+#
+# Usage:
+#   ./scripts/temporal-up.sh            # build if needed, start everything
+#   SKIP_BUILD=1 ./scripts/temporal-up.sh
+#
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Prefer a `sua` on PATH; fall back to the freshly built local CLI.
+if command -v sua >/dev/null 2>&1; then
+  SUA="sua"
+else
+  SUA="node packages/cli/dist/index.js"
+fi
+
+echo "==> Starting Temporal server (Docker)…"
+docker compose up -d
+
+echo "==> Waiting for Temporal to be healthy…"
+for i in $(seq 1 30); do
+  if docker exec sua-temporal temporal operator cluster health --address sua-temporal:7233 >/dev/null 2>&1; then
+    echo "    Temporal is SERVING."
+    break
+  fi
+  if [ "$i" = "30" ]; then
+    echo "    Temporal did not become healthy in time. Check: docker compose logs temporal" >&2
+    exit 1
+  fi
+  sleep 2
+done
+
+if [ "${SKIP_BUILD:-}" != "1" ]; then
+  echo "==> Building the CLI…"
+  npm run build >/dev/null
+fi
+
+echo "==> Starting daemon services (dashboard, mcp, worker) on the temporal provider…"
+# SUA_PROVIDER makes the dashboard + mcp children resolve the temporal provider;
+# the worker reads its Temporal connection from config/env regardless.
+export SUA_PROVIDER=temporal
+$SUA daemon start --service dashboard --service mcp --service worker
+
+DASH_PORT="${SUA_DASHBOARD_PORT:-3000}"
+TOKEN_FILE="${HOME}/.sua/mcp-token"
+echo
+echo "==> Up."
+if [ -f "$TOKEN_FILE" ]; then
+  echo "    Dashboard sign-in: http://127.0.0.1:${DASH_PORT}/auth#token=$(cat "$TOKEN_FILE")"
+else
+  echo "    Dashboard: http://127.0.0.1:${DASH_PORT}/  (run '$SUA daemon status' for the sign-in URL)"
+fi
+echo "    Temporal UI:       http://localhost:8233"
+echo
+echo "Status: $SUA daemon status        Stop: ./scripts/temporal-down.sh"


### PR DESCRIPTION
## What

Make the Temporal worker easy to define and start "as expected" — it's no longer a thing you have to remember to run by hand in a spare terminal.

- **Daemon service.** `worker` is now a first-class `sua daemon` service (`ServiceName`/`ALL_SERVICES`/`SERVICE_ARGV`). Add it to `daemon.services` or `sua daemon start --service worker`; `sua daemon status`/`stop` manage it. When `provider: temporal` is configured, `sua daemon start` also passes `--provider temporal` to the dashboard + MCP children, so the whole stack agrees instead of a worker sitting next to a `local` dashboard.
- **One-command stack.** `scripts/temporal-up.sh` starts the Temporal server (Docker), waits for health, then brings up dashboard + MCP + worker on the temporal provider and prints the sign-in URL. `scripts/temporal-down.sh` tears it down.
- **Settings → Temporal page.** Shows the active run provider, the Temporal connection (address / namespace / task queue), and the worker's status with **Start / Stop** buttons. The worker is the daemon-tracked **host** service (same mechanism `/settings/mcp` already uses to start/stop the MCP server) — it never runs inside the web process (ADR-0004).

## Design note

A web server shouldn't fork host processes in general, but the sua dashboard is a **local-first host process** and already manages sibling daemon services this way (`/settings/mcp` start/stop). The worker control reuses that exact precedent; the worker still executes on the host where your shell + `claude` live.

## Test

- Daemon supervisor test updated for the new service; `/settings/temporal` route tests (renders provider/worker/connection; worker stop route redirects 303).
- **Live-verified:** started the worker from the Settings page (POST → 303), `sua daemon status` shows it `running` (daemon-tracked PID), and the page then renders `running` + PID + a Stop button.
- Clean rebuild + full suite: **1929 passed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)