### PR TITLE
feat: live progress for v2 DAG nodes on Temporal (B1b PR3)

### DIFF
--- a/.changeset/temporal-live-progress.md
+++ b/.changeset/temporal-live-progress.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Live progress for v2 DAG nodes running on Temporal.
+
+The node activity now heartbeats its full progress trail, and the dashboard-side
+spawnNode polls the workflow and re-broadcasts new progress events through the
+normal `onProgress` path — so `node_executions.progressJson` and the inbox
+"thinking…" token stream update for Temporal runs, at ~1s granularity. Final
+sub-second progress may be dropped; the run result is always captured.

--- a/docs/temporal.md
+++ b/docs/temporal.md
@@ -22,6 +22,12 @@ run a worker, and monitor it.
 > in-flight run. Collapsing a whole DAG into a single durable workflow (so runs
 > survive a crash and resume) is the next step — see the Temporal wiring plan.
 >
+> Live progress (turn / tool-use events, the inbox "thinking…" stream) is
+> surfaced for Temporal runs too: the worker heartbeats its progress trail and
+> the dashboard re-broadcasts it at ~1s granularity (not token-by-token, and the
+> final fraction-of-a-second batch may be dropped — the run result is always
+> captured).
+>
 > Secrets a node declares are read on the worker from the secrets file and never
 > travel in the Temporal activity payload (which Temporal persists in history). A
 > few non-declared sensitive env values are dropped before crossing to the worker

--- a/packages/temporal-provider/src/activities.ts
+++ b/packages/temporal-provider/src/activities.ts
@@ -171,10 +171,15 @@ export async function runNodeActivity(input: RunNodeActivityInput): Promise<Spaw
     }
   }
 
+  // Heartbeat the FULL accumulated progress trail (not just the latest event)
+  // as a single { progress } detail. A single `describe()` read on the
+  // dashboard side then sees every event so far, so the poll-rebroadcast can
+  // diff by index and re-emit any it hasn't surfaced yet — even if it missed
+  // intermediate heartbeats. The heartbeat also keeps the activity cancellable.
+  const progressTrail: SpawnProgress[] = [];
   const onProgress = (event: SpawnProgress): void => {
-    // Heartbeat the latest event. Carrying progress is refined in PR3; here it
-    // is primarily what makes the activity cancellable.
-    try { ctx?.heartbeat(event); } catch { /* heartbeat outside activity ctx — ignore */ }
+    progressTrail.push(event);
+    try { ctx?.heartbeat({ progress: progressTrail }); } catch { /* outside activity ctx — ignore */ }
   };
 
   const result = await spawnNodeReal(

--- a/packages/temporal-provider/src/node-spawn.test.ts
+++ b/packages/temporal-provider/src/node-spawn.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { Client } from '@temporalio/client';
-import type { AgentNode, SpawnResult } from '@some-useful-agents/core';
-import { createTemporalSpawnNode } from './node-spawn.js';
+import type { AgentNode, SpawnResult, SpawnProgress } from '@some-useful-agents/core';
+import { createTemporalSpawnNode, extractHeartbeatProgress } from './node-spawn.js';
 
 const node = (overrides: Partial<AgentNode> = {}): AgentNode => ({
   id: 'fetch',
@@ -21,6 +21,10 @@ function fakeClient(behavior: {
   reject?: Error;
   onStart?: (args: { workflowType: string; options: { workflowId: string; taskQueue: string; args: unknown[] } }) => void;
   onCancel?: () => void;
+  /** When set, result() resolves only after this many ms (lets polls run first). */
+  resultAfterMs?: number;
+  /** Returns the describe() payload (e.g. pendingActivities with heartbeatDetails). */
+  describe?: () => unknown;
 }): Client {
   return {
     workflow: {
@@ -29,9 +33,11 @@ function fakeClient(behavior: {
         return {
           workflowId: options.workflowId,
           async result(): Promise<SpawnResult> {
+            if (behavior.resultAfterMs) await new Promise((r) => setTimeout(r, behavior.resultAfterMs));
             if (behavior.reject) throw behavior.reject;
             return behavior.result ?? { result: 'ok', exitCode: 0 };
           },
+          async describe() { return behavior.describe ? behavior.describe() : { pendingActivities: [] }; },
           async cancel() { behavior.onCancel?.(); },
         };
       },
@@ -103,5 +109,42 @@ describe('createTemporalSpawnNode', () => {
     expect(res.exitCode).toBe(1);
     expect(res.error).toContain('boom');
     expect(res.category).toBe('exit_nonzero');
+  });
+
+  it('re-emits heartbeated progress through onProgress, each event once', async () => {
+    const trail: SpawnProgress[] = [
+      { timestamp: 't1', type: 'turn_start', turn: 1 },
+      { timestamp: 't2', type: 'tool_use', message: 'bash' },
+    ];
+    const client = fakeClient({
+      result: { result: 'ok', exitCode: 0 },
+      resultAfterMs: 60,                       // let the poll fire before completion
+      describe: () => ({ pendingActivities: [{ heartbeatDetails: { progress: trail } }] }),
+    });
+    const spawn = createTemporalSpawnNode({ client, secretsPath: '/tmp/secrets.enc', progressPollMs: 10 });
+
+    const seen: SpawnProgress[] = [];
+    await spawn(node(), { PATH: '/usr/bin' }, spawnOpts, (e) => seen.push(e));
+
+    // Both events surfaced exactly once, in order — despite many polls.
+    expect(seen).toEqual(trail);
+  });
+});
+
+describe('extractHeartbeatProgress', () => {
+  const trail: SpawnProgress[] = [{ timestamp: 't1', type: 'turn_start', turn: 1 }];
+
+  it('reads progress from a single heartbeatDetails object', () => {
+    expect(extractHeartbeatProgress({ pendingActivities: [{ heartbeatDetails: { progress: trail } }] })).toEqual(trail);
+  });
+
+  it('reads progress when details are wrapped in an array', () => {
+    expect(extractHeartbeatProgress({ pendingActivities: [{ heartbeatDetails: [{ progress: trail }] }] })).toEqual(trail);
+  });
+
+  it('returns [] when there is no pending activity or no heartbeat yet', () => {
+    expect(extractHeartbeatProgress({ pendingActivities: [] })).toEqual([]);
+    expect(extractHeartbeatProgress({})).toEqual([]);
+    expect(extractHeartbeatProgress({ pendingActivities: [{}] })).toEqual([]);
   });
 });

--- a/packages/temporal-provider/src/node-spawn.ts
+++ b/packages/temporal-provider/src/node-spawn.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import type { Client } from '@temporalio/client';
-import type { SpawnNodeFn, SpawnResult } from '@some-useful-agents/core';
+import type { SpawnNodeFn, SpawnResult, SpawnProgress } from '@some-useful-agents/core';
 import { stripSensitiveEnv } from '@some-useful-agents/core';
 import { DEFAULT_TASK_QUEUE } from './worker.js';
 import type { RunNodeActivityInput } from './activities.js';
@@ -12,6 +12,37 @@ export interface CreateTemporalSpawnNodeOptions {
   secretsPath: string;
   /** Task queue the worker polls. Defaults to the provider's queue. */
   taskQueue?: string;
+  /**
+   * How often to poll the workflow for heartbeated progress, in ms. Defaults to
+   * 1000. The worker heartbeats the full progress trail; the poll diffs by index
+   * and re-emits new events through `onProgress`. Set 0 to disable polling.
+   */
+  progressPollMs?: number;
+}
+
+/**
+ * Minimal shape of a Temporal workflow description we read for progress. The
+ * worker heartbeats `{ progress: SpawnProgress[] }`; depending on SDK surfacing
+ * `heartbeatDetails` may arrive as that object or wrapped in a details array.
+ */
+interface DescribeLike {
+  pendingActivities?: Array<{ heartbeatDetails?: unknown }>;
+}
+
+/**
+ * Pull the accumulated progress trail out of a workflow `describe()` result.
+ * Defensive about how the data converter surfaces heartbeat details (single
+ * object vs. array-of-details). Returns [] when there's no pending activity or
+ * no heartbeat yet.
+ */
+export function extractHeartbeatProgress(description: DescribeLike): SpawnProgress[] {
+  for (const act of description.pendingActivities ?? []) {
+    const d = act.heartbeatDetails;
+    const obj = Array.isArray(d) ? d[0] : d;
+    const progress = (obj as { progress?: unknown } | undefined)?.progress;
+    if (Array.isArray(progress)) return progress as SpawnProgress[];
+  }
+  return [];
 }
 
 /**
@@ -30,7 +61,9 @@ export interface CreateTemporalSpawnNodeOptions {
 export function createTemporalSpawnNode(opts: CreateTemporalSpawnNodeOptions): SpawnNodeFn {
   const taskQueue = opts.taskQueue ?? DEFAULT_TASK_QUEUE;
 
-  return async (node, env, spawnOpts, _onProgress, signal): Promise<SpawnResult> => {
+  const pollMs = opts.progressPollMs ?? 1000;
+
+  return async (node, env, spawnOpts, onProgress, signal): Promise<SpawnResult> => {
     const { safe } = stripSensitiveEnv(env, node);
     const input: RunNodeActivityInput = {
       node,
@@ -67,6 +100,29 @@ export function createTemporalSpawnNode(opts: CreateTemporalSpawnNodeOptions): S
     if (signal?.aborted) onAbort();
     else signal?.addEventListener('abort', onAbort, { once: true });
 
+    // Live progress: poll the workflow's heartbeated progress trail and re-emit
+    // any events not yet surfaced through the real onProgress. Because the
+    // executor still orchestrates in-process, this drives the normal path —
+    // node_executions.progressJson writes AND the inbox token stream — for
+    // Temporal runs, at ~poll-interval granularity (not token-by-token).
+    let progressTimer: ReturnType<typeof setTimeout> | undefined;
+    let emitted = 0;
+    let polling = false;
+    const poll = async (): Promise<void> => {
+      if (polling) return;
+      polling = true;
+      try {
+        const desc = await handle.describe();
+        const trail = extractHeartbeatProgress(desc as DescribeLike);
+        for (let i = emitted; i < trail.length; i++) onProgress?.(trail[i]);
+        emitted = Math.max(emitted, trail.length);
+      } catch { /* describe races completion — ignore, the result settles below */ }
+      finally { polling = false; }
+    };
+    if (onProgress && pollMs > 0) {
+      progressTimer = setInterval(() => { void poll(); }, pollMs);
+    }
+
     try {
       const result = await handle.result();
       // The activity stamps this too, but guarantee it from the factory so the
@@ -84,6 +140,7 @@ export function createTemporalSpawnNode(opts: CreateTemporalSpawnNodeOptions): S
         usedWorkflowProvider: 'temporal',
       };
     } finally {
+      if (progressTimer) clearInterval(progressTimer);
       if (signal && !signal.aborted) signal.removeEventListener('abort', onAbort);
     }
   };


### PR DESCRIPTION
## What

Final B1b piece. Surfaces **live progress** for v2 DAG nodes executing on a Temporal worker — the inbox "thinking…" stream and run-detail turn indicators now update for Temporal runs, not just in-process ones.

- The node activity accumulates its `SpawnProgress` trail and **heartbeats the full array** as `{ progress }` (rather than the latest event only).
- The dashboard-side spawnNode **polls the workflow** (`describe()`, ~1s), reads the heartbeated trail, **diffs by index**, and re-emits new events through the real `onProgress`. Because the executor still orchestrates in-process, this drives the normal path: `node_executions.progressJson` writes **and** the inbox `inboxOnProgress` token stream.
- `extractHeartbeatProgress` defensively decodes `heartbeatDetails` (single object vs. details-array surfacing).

## Granularity / limits

~1s cadence, not token-by-token. The final sub-second batch between the last poll and completion may be dropped (the pending activity vanishes from `describe()` once done) — the **run result is always captured**. Token-level streaming for cross-host workers stays out of scope.

## Test

- `createTemporalSpawnNode` poll-rebroadcast: each heartbeated event re-emitted through `onProgress` exactly once, in order, across many polls.
- `extractHeartbeatProgress`: single-object form, array-wrapped form, and empty/no-heartbeat cases.
- Full suite: **1932 passed**, 3 skipped (one unrelated pre-existing network-timeout flake in `img-block-report`, passes in isolation).

Note: progress events come from llm-prompt nodes (shell nodes emit none), so the live "thinking…" stream is best seen by running an LLM agent on Temporal in the dashboard. The rebroadcast logic is unit-tested; the worker execution path was e2e-verified in #432.

This completes B1b. Next: **B1c** (failure/stuck runs → inbox conversation), which builds on this heartbeat signal; then **B2** (durable whole-DAG-as-workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)