### PR TITLE
feat: failed Temporal runs raise an inbox conversation (B1c)

### DIFF
--- a/.changeset/temporal-failure-inbox.md
+++ b/.changeset/temporal-failure-inbox.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Failed Temporal runs raise an inbox conversation.
+
+A run that fails on a Temporal worker — or one orphaned because the dashboard
+died mid-run — now opens a `run-failure` thread in the dashboard inbox (one per
+run, deduped) so the triage agent notices instead of the failure dying silently.
+Local in-process failures don't raise one (they're visible to whoever triggered
+them) and operator-cancelled runs never do. The executor exposes a decoupled
+`onRunFailure` hook; the dashboard wires it (and covers boot-time orphan-reaped
+runs).

--- a/docs/temporal.md
+++ b/docs/temporal.md
@@ -187,6 +187,13 @@ docker exec sua-temporal temporal task-queue describe --task-queue sua-agents
 `sua agent status [runId]`, `sua agent logs <runId>`, and the dashboard
 `/runs` page reflect Temporal runs without opening the UI.
 
+**Failed Temporal runs raise an inbox conversation.** Because a failure on a
+remote worker (or a dashboard that died mid-run) would otherwise be easy to
+miss, a failed Temporal run opens a `run-failure` thread in the dashboard inbox
+— one per run — so the triage agent picks it up like any other item. Local
+in-process failures don't (they're visible to whoever triggered them), and
+operator-cancelled runs never raise one.
+
 ### Health at a glance
 
 ```bash

--- a/packages/core/src/dag-executor.test.ts
+++ b/packages/core/src/dag-executor.test.ts
@@ -2178,3 +2178,41 @@ describe('executeAgentDag spawn backend seam (B1b)', () => {
     expect(execs.find((e) => e.nodeId === 'main')!.usedWorkflowProvider).toBeUndefined();
   });
 });
+
+describe('executeAgentDag onRunFailure hook (B1c)', () => {
+  it('fires once on a failed run with the failed node + category', async () => {
+    const calls: Array<{ runId: string; failedNodeId?: string; errorCategory?: string }> = [];
+    await executeAgentDag(
+      makeAgent(),
+      { triggeredBy: 'cli' },
+      {
+        runStore,
+        spawnNode: cannedSpawner({ main: { exitCode: 2, error: 'boom' } }),
+        onRunFailure: (info) => calls.push({ runId: info.run.id, failedNodeId: info.failedNodeId, errorCategory: info.errorCategory }),
+      },
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].failedNodeId).toBe('main');
+    expect(calls[0].errorCategory).toBe('exit_nonzero');
+  });
+
+  it('does not fire on a completed run', async () => {
+    let fired = 0;
+    await executeAgentDag(
+      makeAgent(),
+      { triggeredBy: 'cli' },
+      { runStore, spawnNode: cannedSpawner({ main: { exitCode: 0, result: 'ok' } }), onRunFailure: () => { fired++; } },
+    );
+    expect(fired).toBe(0);
+  });
+
+  it('does not fire mid-retry-chain (suppressNotify)', async () => {
+    let fired = 0;
+    await executeAgentDag(
+      makeAgent(),
+      { triggeredBy: 'cli', suppressNotify: true },
+      { runStore, spawnNode: cannedSpawner({ main: { exitCode: 2, error: 'boom' } }), onRunFailure: () => { fired++; } },
+    );
+    expect(fired).toBe(0);
+  });
+});

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -116,6 +116,14 @@ export interface DagExecutorDeps {
    */
   inboxOnProgress?: (event: { nodeId: string; progress: import('./node-spawner.js').SpawnProgress }) => void;
   /**
+   * Optional hook fired once when a run finalizes as `failed` (not on
+   * `cancelled`, and suppressed mid-retry-chain like notify). Decoupled from
+   * core: the dashboard wires this to raise an inbox conversation so a failure
+   * on a remote Temporal worker doesn't die silently. Errors are swallowed by
+   * the caller — a misbehaving hook can't break the run path.
+   */
+  onRunFailure?: (info: { run: Run; failedNodeId?: string; errorCategory?: NodeErrorCategory }) => void;
+  /**
    * Optional dashboard URL prefix used by the notify dispatcher to embed
    * a "view run in dashboard" link in Slack messages. When absent, the
    * link is omitted; the notify still fires.
@@ -1080,6 +1088,18 @@ export async function executeAgentDag(
 
   const run = deps.runStore.getRun(runId);
   if (!run) throw new Error(`Run ${runId} vanished from store after write`);
+
+  // Failure hook: fire once when the run ends `failed` (not cancelled), on the
+  // final attempt only (suppressNotify mirrors the retry wrapper's once-on-last
+  // semantics). The dashboard raises an inbox conversation from here. Wrapped so
+  // a misbehaving hook can't bubble into the run path.
+  if (deps.onRunFailure && finalStatus === 'failed' && !options.suppressNotify) {
+    try {
+      deps.onRunFailure({ run, failedNodeId: firstFailure?.nodeId, errorCategory: firstFailure?.category });
+    } catch {
+      // Hook errors are non-fatal — the run result is already committed.
+    }
+  }
 
   // Notify dispatch fires AFTER the run row is committed. Wrapped so any
   // dispatcher exception can never bubble into the run path — the run

--- a/packages/dashboard/src/context.ts
+++ b/packages/dashboard/src/context.ts
@@ -34,6 +34,12 @@ export interface DashboardContext {
    * the CLI from sua.config.json; the worker uses these same values.
    */
   temporal?: { address: string; namespace: string; taskQueue: string };
+  /**
+   * Run-failure hook passed into every executeAgentDag call. Raises an inbox
+   * conversation when a Temporal run fails so the triage agent sees it (B1c).
+   * Undefined when there's no inbox store.
+   */
+  onRunFailure?: (info: { run: import('@some-useful-agents/core').Run; failedNodeId?: string; errorCategory?: string }) => void;
   /** Run store reader for /runs and /runs/:id. */
   runStore: RunStore;
   /**

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -63,6 +63,7 @@ import { inboxRouter } from './routes/inbox.js';
 import { inboxEventsRouter } from './routes/inbox-events.js';
 import { InboxEventBus } from './lib/inbox-event-bus.js';
 import { seedInboxDemoIfRequested } from './inbox-demo-seed.js';
+import { raiseRunFailureInbox } from './lib/run-failure-inbox.js';
 import { pulseRouter } from './routes/pulse.js';
 import { pulseLayoutPlanRouter } from './routes/pulse-layout-plan.js';
 import { dashboardLayoutPlanRouter } from './routes/dashboard-layout-plan.js';
@@ -453,6 +454,23 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
   // before real producers ship in PR 3. No-op without the env flag.
   seedInboxDemoIfRequested(inboxStore, agentStore);
 
+  // B1c: surface failed Temporal runs in the inbox so the triage agent notices.
+  // The reusable hook is passed into every executeAgentDag call (in-band
+  // failures); the loop below covers the silent case — runs orphaned because a
+  // prior dashboard process died mid-run, just finalized as failed by the
+  // reaper above. Both no-op for local runs and dedupe by runId.
+  const dashboardBaseUrl = (opts.dashboardBaseUrl ?? `http://${host}:${opts.port}`).replace(/\/$/, '');
+  const onRunFailure = inboxStore
+    ? (info: { run: import('@some-useful-agents/core').Run; failedNodeId?: string; errorCategory?: string }) =>
+        raiseRunFailureInbox(inboxStore, info, dashboardBaseUrl)
+    : undefined;
+  if (inboxStore) {
+    for (const rid of reapResult.reapedRunIds) {
+      const orphan = runStore.getRun(rid);
+      if (orphan) raiseRunFailureInbox(inboxStore, { run: orphan, errorCategory: 'abandoned' }, dashboardBaseUrl);
+    }
+  }
+
   // Integrations store. Same DB file. Independently optional from packs/
   // dashboards so a schema issue in either doesn't keep the other offline.
   let integrationsStore: IntegrationsStore | undefined;
@@ -511,6 +529,7 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     provider,
     workflowSpawnNode,
     temporal: opts.temporal,
+    onRunFailure,
     runStore,
     agentStore,
     loadAgents: () => loadAgents({ directories: opts.agentDirs }),
@@ -545,7 +564,7 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     inboxTriageAbortControllers: new Map(),
     inboxTriagePendingRefires: new Set(),
     dataDir: dirname(opts.dbPath),
-    dashboardBaseUrl: (opts.dashboardBaseUrl ?? `http://${host}:${opts.port}`).replace(/\/$/, ''),
+    dashboardBaseUrl,
   };
 
   const app = buildDashboardApp(ctx);

--- a/packages/dashboard/src/lib/run-failure-inbox.test.ts
+++ b/packages/dashboard/src/lib/run-failure-inbox.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import type { InboxStore, Run, AddMessageInput } from '@some-useful-agents/core';
+import { buildRunFailureMessage, raiseRunFailureInbox } from './run-failure-inbox.js';
+
+const run = (overrides: Partial<Run> = {}): Run => ({
+  id: 'run-abc12345-xyz',
+  agentName: 'news-digest',
+  status: 'failed',
+  startedAt: '2026-01-01T00:00:00Z',
+  triggeredBy: 'dashboard',
+  ...overrides,
+});
+
+/** Minimal InboxStore stand-in that records add() calls. */
+function fakeStore(): { store: InboxStore; added: AddMessageInput[] } {
+  const added: AddMessageInput[] = [];
+  const store = { add: (input: AddMessageInput) => { added.push(input); return {} as unknown; } } as unknown as InboxStore;
+  return { store, added };
+}
+
+describe('buildRunFailureMessage', () => {
+  it('produces a high-priority run-failure message with the documented dedupeKey', () => {
+    const msg = buildRunFailureMessage(
+      { run: run({ error: 'boom' }), failedNodeId: 'fetch', errorCategory: 'exit_nonzero' },
+      'http://127.0.0.1:3000/',
+    );
+    expect(msg.priority).toBe('high');
+    expect(msg.source).toBe('run-failure');
+    expect(msg.title).toContain('news-digest');
+    expect(msg.dedupeKey).toBe('run-failure:run-abc12345-xyz');
+    expect(msg.runId).toBe('run-abc12345-xyz');
+    expect(msg.body).toContain('fetch');
+    expect(msg.body).toContain('boom');
+    expect(msg.body).toContain('/runs/run-abc12345-xyz'); // trailing slash on base url normalized
+  });
+});
+
+describe('raiseRunFailureInbox', () => {
+  it('creates a message for a Temporal run', () => {
+    const { store, added } = fakeStore();
+    raiseRunFailureInbox(store, { run: run({ usedWorkflowProvider: 'temporal' }) });
+    expect(added).toHaveLength(1);
+    expect(added[0].dedupeKey).toBe('run-failure:run-abc12345-xyz');
+  });
+
+  it('no-ops for a local run (local failures are already visible)', () => {
+    const { store, added } = fakeStore();
+    raiseRunFailureInbox(store, { run: run({ usedWorkflowProvider: 'local' }) });
+    raiseRunFailureInbox(store, { run: run({ usedWorkflowProvider: undefined }) });
+    expect(added).toHaveLength(0);
+  });
+
+  it('no-ops when there is no inbox store', () => {
+    expect(() => raiseRunFailureInbox(undefined, { run: run({ usedWorkflowProvider: 'temporal' }) })).not.toThrow();
+  });
+});

--- a/packages/dashboard/src/lib/run-failure-inbox.ts
+++ b/packages/dashboard/src/lib/run-failure-inbox.ts
@@ -1,0 +1,57 @@
+import type { AddMessageInput, InboxStore, Run } from '@some-useful-agents/core';
+
+export interface RunFailureInfo {
+  run: Run;
+  failedNodeId?: string;
+  errorCategory?: string;
+}
+
+/**
+ * Build the inbox message for a failed run. Pure + exported so it can be
+ * unit-tested without a store. `dedupeKey` follows the documented
+ * `run-failure:<runId>` convention so a run only ever opens one conversation,
+ * even if the failure path fires more than once.
+ */
+export function buildRunFailureMessage(info: RunFailureInfo, dashboardBaseUrl?: string): AddMessageInput {
+  const { run } = info;
+  const runLink = dashboardBaseUrl ? `${dashboardBaseUrl.replace(/\/$/, '')}/runs/${run.id}` : `/runs/${run.id}`;
+  const lines = [
+    `Agent **${run.agentName}** failed a run on the Temporal worker.`,
+    '',
+    `- Run: [${run.id.slice(0, 8)}](${runLink})`,
+    ...(info.failedNodeId ? [`- Failed node: \`${info.failedNodeId}\`${info.errorCategory ? ` (${info.errorCategory})` : ''}`] : []),
+    ...(run.error ? [`- Error: ${run.error}`] : []),
+    '',
+    'This ran on a Temporal worker — open the run for details, or check the Temporal UI (the per-node workflow is named `sua-node-…`).',
+  ];
+  return {
+    priority: 'high',
+    source: 'run-failure',
+    title: `Temporal run failed: ${run.agentName}`,
+    body: lines.join('\n'),
+    agentId: run.agentName,
+    runId: run.id,
+    dedupeKey: `run-failure:${run.id}`,
+  };
+}
+
+/**
+ * Raise (or no-op) an inbox conversation for a failed run. Scoped to runs that
+ * executed on Temporal — local in-process failures are visible to whoever
+ * triggered them, whereas a remote-worker failure would otherwise be silent.
+ * Operator-cancelled runs never reach here (the executor only fires its failure
+ * hook on `failed`, not `cancelled`).
+ */
+export function raiseRunFailureInbox(
+  inboxStore: InboxStore | undefined,
+  info: RunFailureInfo,
+  dashboardBaseUrl?: string,
+): void {
+  if (!inboxStore) return;
+  if (info.run.usedWorkflowProvider !== 'temporal') return;
+  try {
+    inboxStore.add(buildRunFailureMessage(info, dashboardBaseUrl));
+  } catch {
+    // Inbox creation is best-effort; never let it bubble into the run path.
+  }
+}

--- a/packages/dashboard/src/routes/build-orchestrator.ts
+++ b/packages/dashboard/src/routes/build-orchestrator.ts
@@ -171,6 +171,7 @@ async function kickoffAgentRun(args: {
       dataRoot: ctx.agentStore.dataRoot,
       llmSettings: buildLlmSettingsSnapshot(ctx),
       spawnNode: ctx.workflowSpawnNode,
+      onRunFailure: ctx.onRunFailure,
     },
   ).catch(() => { /* failure surfaces via runStore.getRun(runId).status */ });
   return runId;

--- a/packages/dashboard/src/routes/dashboard-layout-plan.ts
+++ b/packages/dashboard/src/routes/dashboard-layout-plan.ts
@@ -191,6 +191,7 @@ async function kickoffDashboardPlannerRun(args: {
       dataRoot: ctx.agentStore.dataRoot,
       llmSettings: buildLlmSettingsSnapshot(ctx),
       spawnNode: ctx.workflowSpawnNode,
+      onRunFailure: ctx.onRunFailure,
     },
   );
 

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -1261,6 +1261,7 @@ async function runProposedAction(
         dataRoot: ctx.agentStore.dataRoot,
         llmSettings: buildLlmSettingsSnapshot(ctx),
         spawnNode: ctx.workflowSpawnNode,
+        onRunFailure: ctx.onRunFailure,
       },
     );
     runId = run.id;
@@ -1686,6 +1687,7 @@ async function runTriageAgent(
         dataRoot: ctx.agentStore.dataRoot,
         llmSettings: buildLlmSettingsSnapshot(ctx),
         spawnNode: ctx.workflowSpawnNode,
+        onRunFailure: ctx.onRunFailure,
         // Forward token-level progress from the triage LLM node to
         // the SSE bus. Filtered to output_chunk so we don't spam
         // clients with turn_start / tool_use markers (those still

--- a/packages/dashboard/src/routes/pulse-layout-plan.ts
+++ b/packages/dashboard/src/routes/pulse-layout-plan.ts
@@ -184,6 +184,7 @@ async function kickoffLayoutPlannerRun(args: {
       dataRoot: ctx.agentStore.dataRoot,
       llmSettings: buildLlmSettingsSnapshot(ctx),
       spawnNode: ctx.workflowSpawnNode,
+      onRunFailure: ctx.onRunFailure,
     },
   );
 

--- a/packages/dashboard/src/routes/run-mutations.ts
+++ b/packages/dashboard/src/routes/run-mutations.ts
@@ -167,6 +167,7 @@ runMutationsRouter.post('/runs/:id/replay', async (req: Request, res: Response) 
       dataRoot: ctx.agentStore.dataRoot,
       llmSettings: buildLlmSettingsSnapshot(ctx),
       spawnNode: ctx.workflowSpawnNode,
+      onRunFailure: ctx.onRunFailure,
     },
   );
 
@@ -288,6 +289,7 @@ runMutationsRouter.post('/runs/:id/retry', async (req: Request, res: Response) =
       dataRoot: ctx.agentStore.dataRoot,
       llmSettings: buildLlmSettingsSnapshot(ctx),
       spawnNode: ctx.workflowSpawnNode,
+      onRunFailure: ctx.onRunFailure,
     },
     { memoryStore: ctx.agentMemoryStore },
   );

--- a/packages/dashboard/src/routes/run-now-build.ts
+++ b/packages/dashboard/src/routes/run-now-build.ts
@@ -377,6 +377,7 @@ async function kickoffPlannerRun(args: PlannerKickoffArgs): Promise<string | nul
       dataRoot: ctx.agentStore.dataRoot,
       llmSettings: buildLlmSettingsSnapshot(ctx),
       spawnNode: ctx.workflowSpawnNode,
+      onRunFailure: ctx.onRunFailure,
     },
   );
 
@@ -523,6 +524,7 @@ buildRouter.post('/agents/:name/analyze', async (req: Request, res: Response) =>
       dataRoot: ctx.agentStore.dataRoot,
       llmSettings: buildLlmSettingsSnapshot(ctx),
       spawnNode: ctx.workflowSpawnNode,
+      onRunFailure: ctx.onRunFailure,
     },
   );
 
@@ -725,6 +727,7 @@ Output ONLY the complete fixed YAML. Nothing else.`,
         dataRoot: ctx.agentStore.dataRoot,
         llmSettings: buildLlmSettingsSnapshot(ctx),
         spawnNode: ctx.workflowSpawnNode,
+        onRunFailure: ctx.onRunFailure,
       },
     );
 
@@ -1134,6 +1137,7 @@ buildRouter.post('/agents/build/commit', (req: Request, res: Response) => {
               dataRoot: ctx.agentStore.dataRoot,
               llmSettings: buildLlmSettingsSnapshot(ctx),
               spawnNode: ctx.workflowSpawnNode,
+              onRunFailure: ctx.onRunFailure,
             },
           ).catch(() => { /* surfaced as a failed run row */ });
         }

--- a/packages/dashboard/src/routes/run-now.ts
+++ b/packages/dashboard/src/routes/run-now.ts
@@ -72,6 +72,7 @@ runNowRouter.post('/agents/:name/run', async (req: Request, res: Response) => {
         dataRoot: ctx.agentStore.dataRoot,
         llmSettings: buildLlmSettingsSnapshot(ctx),
         spawnNode: ctx.workflowSpawnNode,
+        onRunFailure: ctx.onRunFailure,
       },
     );
 

--- a/packages/dashboard/src/routes/widget-run.ts
+++ b/packages/dashboard/src/routes/widget-run.ts
@@ -48,6 +48,7 @@ widgetRunRouter.post('/agents/:name/widget-run', (req: Request, res: Response) =
       dataRoot: ctx.agentStore.dataRoot,
       llmSettings: buildLlmSettingsSnapshot(ctx),
       spawnNode: ctx.workflowSpawnNode,
+      onRunFailure: ctx.onRunFailure,
     },
   );
 


### PR DESCRIPTION
## What

When a v2 DAG run fails on a Temporal worker — or is orphaned because the dashboard died mid-run — it now opens a `run-failure` thread in the dashboard inbox, so the triage agent notices instead of the failure dying silently. This is the payoff of B1b's worker-reports-back machinery.

- **core:** a decoupled `deps.onRunFailure` hook, fired once when a run finalizes `failed` (not `cancelled`; suppressed mid-retry-chain like notify), carrying the run + first failed node + category. Core stays inbox-agnostic.
- **dashboard:** wires the hook to `raiseRunFailureInbox` — opens a `run-failure` message (priority high, deduped `run-failure:<runId>`, with agent / runId / failed node / error / run link). **Scoped to Temporal runs** (local failures are visible to whoever triggered them); **skips operator-cancels**. Also raises for Temporal runs **orphaned by a prior dashboard exit**, caught by the boot-time orphan reaper.
- Reuses the existing inbox `run-failure` source + `run-failure:<runId>` dedup convention — no new inbox infra.

## Why scoped to Temporal

A local in-process failure surfaces to whoever triggered it. A remote-worker failure (or a crashed dashboard) is exactly the silent case worth surfacing. The hook is general; the dashboard handler scopes it — easy to widen behind a setting later.

## Test

- core: `onRunFailure` fires once on failure with the failed node + category; not on completion; not mid-retry (`suppressNotify`).
- dashboard: `buildRunFailureMessage` (pure) — title/body/dedupeKey/links; `raiseRunFailureInbox` — creates for temporal, no-ops for local/undefined, tolerates no store.
- **Live-verified:** drove a failing node (`exit 3`) through the real worker — run finalized `failed` (`backend=temporal`) and a `[high] Temporal run failed` inbox thread was raised, deduped by runId.
- Clean rebuild + full suite: **1940 passed, 3 skipped**.

This completes the B1 line (B1a/B1b/B1c). Next: **B2** — durable whole-DAG-as-workflow (survives a crash, resumes), which also brings the per-agent `runOn` control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)