### PR TITLE
feat(core): resume an interrupted DAG run in place (B2 PR1)

### DIFF
--- a/.changeset/dag-resume-in-place.md
+++ b/.changeset/dag-resume-in-place.md
@@ -1,0 +1,16 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Resume an interrupted DAG run in place.
+
+`executeAgentDag` accepts `options.resume`: given an existing run id, it reuses
+that run's completed node executions (reloading their outputs), clears any
+incomplete node rows, and continues from the first unfinished node instead of
+starting over. This is the foundation for durable Temporal runs (B2) — on a
+worker/activity retry the run picks up where it crashed. No behavior change for
+normal runs. New `RunStore.clearIncompleteNodeExecutions`.

--- a/packages/core/src/dag-executor.test.ts
+++ b/packages/core/src/dag-executor.test.ts
@@ -2216,3 +2216,78 @@ describe('executeAgentDag onRunFailure hook (B1c)', () => {
     expect(fired).toBe(0);
   });
 });
+
+describe('executeAgentDag resume in place (B2)', () => {
+  const chain = (): Agent => makeAgent({
+    nodes: [
+      { id: 'a', type: 'shell', command: 'echo a' },
+      { id: 'b', type: 'shell', command: 'echo b', dependsOn: ['a'] },
+      { id: 'c', type: 'shell', command: 'echo c', dependsOn: ['b'] },
+    ],
+  });
+
+  function recordingSpawner(
+    responses: Record<string, { exitCode: number; result?: string; error?: string }>,
+    calls: string[],
+  ): DagExecutorDeps['spawnNode'] {
+    return async (node) => {
+      calls.push(node.id);
+      const r = responses[node.id] ?? { exitCode: 0, result: 'ok' };
+      return { result: r.result ?? '', exitCode: r.exitCode, error: r.error };
+    };
+  }
+
+  it('resumes an interrupted run, re-running only the unfinished node', async () => {
+    // First attempt: a + b complete, c fails — the run ends 'failed'.
+    const firstCalls: string[] = [];
+    const run1 = await executeAgentDag(
+      chain(),
+      { triggeredBy: 'cli', runId: 'r-res' },
+      { runStore, spawnNode: recordingSpawner({ a: { exitCode: 0, result: 'A' }, b: { exitCode: 0, result: 'B' }, c: { exitCode: 1, error: 'boom' } }, firstCalls) },
+    );
+    expect(run1.status).toBe('failed');
+    expect(firstCalls).toEqual(['a', 'b', 'c']);
+
+    // Resume the SAME run: a + b are skipped (their stored outputs reused), only
+    // c re-runs — and this time succeeds, so the run completes.
+    const resumeCalls: string[] = [];
+    const run2 = await executeAgentDag(
+      chain(),
+      { triggeredBy: 'cli', runId: 'r-res', resume: true },
+      { runStore, spawnNode: recordingSpawner({ c: { exitCode: 0, result: 'C' } }, resumeCalls) },
+    );
+    expect(resumeCalls).toEqual(['c']);
+    expect(run2.id).toBe('r-res');
+    expect(run2.status).toBe('completed');
+
+    // a + b kept their original completed rows; c is now completed too.
+    const execs = runStore.listNodeExecutions('r-res');
+    expect(execs.filter((e) => e.status === 'completed').map((e) => e.nodeId).sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('resume of a fully completed run re-finalizes without re-running nodes', async () => {
+    await executeAgentDag(
+      makeAgent(),
+      { triggeredBy: 'cli', runId: 'r-done' },
+      { runStore, spawnNode: cannedSpawner({ main: { exitCode: 0, result: 'ok' } }) },
+    );
+    const calls: string[] = [];
+    const run2 = await executeAgentDag(
+      makeAgent(),
+      { triggeredBy: 'cli', runId: 'r-done', resume: true },
+      { runStore, spawnNode: recordingSpawner({}, calls) },
+    );
+    expect(calls).toEqual([]);
+    expect(run2.status).toBe('completed');
+  });
+
+  it('falls back to a fresh run when resume is set but the run does not exist', async () => {
+    const run = await executeAgentDag(
+      makeAgent(),
+      { triggeredBy: 'cli', runId: 'r-new', resume: true },
+      { runStore, spawnNode: cannedSpawner({ main: { exitCode: 0, result: 'ok' } }) },
+    );
+    expect(run.id).toBe('r-new');
+    expect(run.status).toBe('completed');
+  });
+});

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -20,7 +20,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import type { Agent, AgentNode, NodeErrorCategory, NodeOutput, NodeStructuredOutput } from './agent-v2-types.js';
+import type { Agent, AgentNode, NodeErrorCategory, NodeOutput, NodeStructuredOutput, NodeExecutionRecord } from './agent-v2-types.js';
 import type { Run, RunStatus } from './types.js';
 import type { RunStore } from './run-store.js';
 import type { AgentStore } from './agent-store.js';
@@ -225,8 +225,41 @@ export interface DagExecuteOptions {
    * otherwise collide on the same most-recent row).
    */
   runId?: string;
+  /**
+   * Resume an interrupted run in place. Requires `runId` to point at an
+   * existing run. The executor does NOT create a new run row; instead it skips
+   * nodes already `completed` in that run (reloading their stored outputs),
+   * clears any incomplete node rows so they re-run cleanly, and continues from
+   * the first not-completed node. Used by the durable Temporal path (B2): on a
+   * worker/activity retry the run picks up where it crashed rather than
+   * restarting. No-op-safe: a fully-completed run resumes to its terminal state.
+   */
+  resume?: boolean;
 }
 
+
+/**
+ * Seed the in-memory `outputs` map from a stored completed node execution, so
+ * downstream nodes see the same upstream snapshot the original run produced.
+ * Reused by both replay (copy prior run's nodes) and resume (this run's nodes).
+ * Prefers the structured `outputsJson` when present, falling back to `result`.
+ */
+function seedOutputFromExec(
+  outputs: Map<string, NodeOutput>,
+  exec: NodeExecutionRecord,
+  source: Agent['source'],
+): void {
+  let structured: NodeStructuredOutput | undefined;
+  if (exec.outputsJson) {
+    try { structured = JSON.parse(exec.outputsJson) as NodeStructuredOutput; } catch { /* fall back to result */ }
+  }
+  outputs.set(exec.nodeId, {
+    result: exec.result ?? '',
+    exitCode: 0,
+    source,
+    outputs: structured,
+  });
+}
 
 /**
  * Execute an agent's DAG end-to-end. Creates the parent `runs` row,
@@ -245,26 +278,38 @@ export async function executeAgentDag(
   const runId = options.runId ?? randomUUID();
   const startedAt = new Date().toISOString();
 
-  // Parent run row created up-front in 'running' state. Lets anyone polling
-  // the DB see the run exists + links to per-node rows as they land.
-  deps.runStore.createRun({
-    id: runId,
-    agentName: agent.id,
-    status: 'running',
-    startedAt,
-    triggeredBy: options.triggeredBy,
-    workflowId: agent.id,
-    workflowVersion: agent.version,
-    replayedFromRunId: options.replayFrom?.priorRunId,
-    replayedFromNodeId: options.replayFrom?.fromNodeId,
-    parentRunId: options.parentRunId,
-    parentNodeId: options.parentNodeId,
-    retryOfRunId: options.retryOf?.originalRunId,
-    attempt: options.retryOf?.attempt,
-    // v2 DAGs execute in-process today. B1b will set this to 'temporal' per
-    // node when spawns route through a Temporal activity.
-    usedWorkflowProvider: 'local',
-  });
+  // Resume mode (B2): when asked to resume an existing run, reuse its row +
+  // completed node executions instead of creating a fresh run. Falls back to a
+  // normal fresh run if the row doesn't actually exist (e.g. first attempt).
+  const resumingRun = options.resume && options.runId ? deps.runStore.getRun(options.runId) : null;
+
+  if (resumingRun) {
+    // Flip the row back to running (a crash/reaper may have marked it failed)
+    // and drop any incomplete node rows so they re-run without a PK conflict.
+    deps.runStore.updateRun(runId, { status: 'running' });
+    deps.runStore.clearIncompleteNodeExecutions(runId);
+  } else {
+    // Parent run row created up-front in 'running' state. Lets anyone polling
+    // the DB see the run exists + links to per-node rows as they land.
+    deps.runStore.createRun({
+      id: runId,
+      agentName: agent.id,
+      status: 'running',
+      startedAt,
+      triggeredBy: options.triggeredBy,
+      workflowId: agent.id,
+      workflowVersion: agent.version,
+      replayedFromRunId: options.replayFrom?.priorRunId,
+      replayedFromNodeId: options.replayFrom?.fromNodeId,
+      parentRunId: options.parentRunId,
+      parentNodeId: options.parentNodeId,
+      retryOfRunId: options.retryOf?.originalRunId,
+      attempt: options.retryOf?.attempt,
+      // v2 DAGs execute in-process today. B1b will set this to 'temporal' per
+      // node when spawns route through a Temporal activity.
+      usedWorkflowProvider: 'local',
+    });
+  }
 
   const outputs = new Map<string, NodeOutput>();
   const order = topologicalSort(agent.nodes);
@@ -363,9 +408,21 @@ export async function executeAgentDag(
         workflowVersion: agent.version,
         // Keep the original startedAt/completedAt so the audit trail is clear.
       });
-      outputs.set(id, { result: prior.result!, exitCode: 0, source: agent.source });
+      seedOutputFromExec(outputs, prior, agent.source);
     }
     replaySkipIds = new Set(priorIds);
+  }
+
+  // Resume pre-load (B2): the completed node rows already live in THIS run, so
+  // we don't copy them — just seed their outputs and skip them. Incomplete rows
+  // were cleared above, so the executor re-runs from the first unfinished node.
+  if (resumingRun) {
+    for (const exec of deps.runStore.listNodeExecutions(runId)) {
+      if (exec.status === 'completed') {
+        seedOutputFromExec(outputs, exec, agent.source);
+        replaySkipIds.add(exec.nodeId);
+      }
+    }
   }
 
   for (const node of order) {

--- a/packages/core/src/run-store.ts
+++ b/packages/core/src/run-store.ts
@@ -505,6 +505,21 @@ export class RunStore {
   }
 
   /**
+   * Delete this run's node executions that are NOT `completed` (running,
+   * failed, skipped, etc.). Used when resuming an interrupted run: completed
+   * rows are kept + skipped on replay, while incomplete rows are cleared so the
+   * executor can re-create them cleanly without a (runId, nodeId) PK conflict.
+   * Returns the number of rows removed.
+   */
+  clearIncompleteNodeExecutions(runId: string): number {
+    const stmt = this.db.prepare(
+      `DELETE FROM node_executions WHERE runId = ? AND status != 'completed'`,
+    );
+    const result = stmt.run(runId);
+    return Number(result.changes ?? 0);
+  }
+
+  /**
    * Node executions that failed with a given category. Used by
    * `sua workflow logs --category=timeout`.
    */


### PR DESCRIPTION
## What

PR1 of B2 (durable Temporal runs). A behavior-preserving core change that lets the executor **resume an interrupted run** instead of restarting it.

- `executeAgentDag` accepts `options.resume`. Given an existing `runId`, it reuses that run's `completed` node executions (reseeding their outputs), **clears incomplete node rows** so they re-run without a `(runId,nodeId)` PK conflict, and continues from the first unfinished node — rather than creating a fresh run. Falls back to a fresh run if the id doesn't exist.
- Factors the replay/resume output reseed into a shared `seedOutputFromExec` helper (also tidies the existing replay path to carry structured `outputsJson`).
- New `RunStore.clearIncompleteNodeExecutions(runId)`.

No behavior change for normal runs. This is the mechanism B2 PR2 leans on: when a Temporal activity running the executor is retried after a worker crash, it calls `executeAgentDag({ runId, resume: true })` and picks up where it left off.

## Test

- Resume an interrupted run: first attempt completes a+b, fails c → run `failed`; resume re-runs **only c** (a+b skipped, outputs reused) → run `completed`.
- Resume of a fully-completed run re-finalizes without re-running any node.
- `resume` with a non-existent id falls back to a fresh run.
- Clean rebuild + full suite: **1943 passed, 3 skipped**.

Plan: `~/.claude/plans/cozy-cooking-truffle.md`. Next: PR2 (`runDagWorkflow`/`runDagActivity`/`submitDagRun`) and PR3 (routing + per-agent `runOn`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)