### PR TITLE
feat(temporal): durable v2 DAG runs — submitDagRun + runDagWorkflow (B2 PR2)

### DIFF
--- a/.changeset/temporal-durable-dag.md
+++ b/.changeset/temporal-durable-dag.md
@@ -1,0 +1,16 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Durable v2 DAG runs on Temporal (provider layer).
+
+The Temporal provider gains `submitDagRun`, which runs a whole v2 DAG as one
+durable `sua-run-<id>` workflow: a long worker activity (`runDagActivity`) runs
+the existing executor against the shared store. If the worker crashes, Temporal
+re-dispatches the activity and it resumes the run from the last completed node
+(via `resume`). A failed agent returns normally and does NOT retry — only an
+infra crash re-dispatches. Not yet wired into the dashboard run paths (next PR).

--- a/packages/temporal-provider/src/activities.test.ts
+++ b/packages/temporal-provider/src/activities.test.ts
@@ -1,16 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { rmSync } from 'node:fs';
+import { mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
-import { EncryptedFileStore } from '@some-useful-agents/core';
-import type { AgentDefinition } from '@some-useful-agents/core';
+import { EncryptedFileStore, RunStore } from '@some-useful-agents/core';
+import type { AgentDefinition, Agent } from '@some-useful-agents/core';
 import type { AgentNode } from '@some-useful-agents/core';
-import { runAgentActivity, runNodeActivity } from './activities.js';
+import { runAgentActivity, runNodeActivity, runDagActivity } from './activities.js';
 
 const TEST_DIR = join(import.meta.dirname, '__test-activities__');
 const SECRETS_PATH = join(TEST_DIR, 'secrets.enc');
 
 beforeEach(() => {
   rmSync(TEST_DIR, { recursive: true, force: true });
+  mkdirSync(TEST_DIR, { recursive: true });
 });
 
 afterEach(() => {
@@ -173,5 +174,35 @@ describe('runNodeActivity', () => {
     expect(result.error).toContain('Missing secrets on worker');
     expect(result.error).toContain('ABSENT');
     expect(result.usedWorkflowProvider).toBe('temporal');
+  });
+});
+
+const dagAgent = (nodes: AgentNode[]): Agent => ({
+  id: 'dag-act', name: 'Dag', status: 'active', source: 'local', mcp: false, version: 1, nodes,
+});
+
+describe('runDagActivity', () => {
+  const DB = join(TEST_DIR, 'runs.db');
+
+  const twoNode = (): Agent => dagAgent([
+    { id: 'a', type: 'shell', command: 'echo a > /dev/null' },
+    { id: 'b', type: 'shell', command: 'echo b > /dev/null', dependsOn: ['a'] },
+  ]);
+
+  // Note: these assert on the activity's RETURN value. The full resume-on-crash
+  // behavior is covered cross-process by the core resume tests (dag-executor)
+  // and the live durability e2e — a second RunStore handle in THIS process won't
+  // reliably see another handle's writes (node:sqlite WAL), which is a test-only
+  // artifact, not how the worker (a separate process) reads the shared DB.
+
+  it('runs a whole DAG on the worker and returns completed', async () => {
+    const res = await runDagActivity({ agent: twoNode(), runId: 'r1', triggeredBy: 'dashboard', dbPath: DB, secretsPath: SECRETS_PATH });
+    expect(res.status).toBe('completed');
+  });
+
+  it('returns failed (does NOT throw) when a node fails — a failed agent must not retry', async () => {
+    const agent = dagAgent([{ id: 'boom', type: 'shell', command: 'exit 7' }]);
+    const res = await runDagActivity({ agent, runId: 'r2', triggeredBy: 'dashboard', dbPath: DB, secretsPath: SECRETS_PATH });
+    expect(res.status).toBe('failed');
   });
 });

--- a/packages/temporal-provider/src/activities.ts
+++ b/packages/temporal-provider/src/activities.ts
@@ -1,4 +1,4 @@
-import type { AgentDefinition, AgentNode, Agent, SpawnResult, SpawnProgress } from '@some-useful-agents/core';
+import type { AgentDefinition, AgentNode, Agent, SpawnResult, SpawnProgress, Run, DagExecutorDeps } from '@some-useful-agents/core';
 import {
   buildAgentEnv,
   getTrustLevel,
@@ -7,8 +7,18 @@ import {
   redactKnownSecrets,
   resolveInputs,
   spawnNodeReal,
+  executeAgentDag,
+  RunStore,
+  AgentStore,
+  ToolStore,
+  IntegrationsStore,
+  VariablesStore,
 } from '@some-useful-agents/core';
 import { Context } from '@temporalio/activity';
+
+function quiet<T>(make: () => T): T | undefined {
+  try { return make(); } catch { return undefined; }
+}
 
 export interface RunAgentActivityInput {
   agent: AgentDefinition;
@@ -198,4 +208,87 @@ export async function runNodeActivity(input: RunNodeActivityInput): Promise<Spaw
   );
 
   return { ...result, usedWorkflowProvider: 'temporal' };
+}
+
+/**
+ * Input for {@link runDagActivity}: a whole v2 DAG run, executed on the worker.
+ * All fields are serializable. Secrets/variables/tools are reconstructed on the
+ * worker from the shared paths — nothing sensitive travels in the payload.
+ */
+export interface RunDagActivityInput {
+  agent: Agent;
+  runId: string;
+  inputs?: Record<string, string>;
+  triggeredBy: Run['triggeredBy'];
+  /** Shared SQLite path (run/agent/tool/integration stores). */
+  dbPath: string;
+  /** Encrypted secrets file path. */
+  secretsPath: string;
+  /** Global variables JSON path (optional). */
+  variablesPath?: string;
+  /** Agent-state base dir (optional). */
+  dataRoot?: string;
+  /** LLM provider waterfall (names only). */
+  llmProviders?: string[];
+  /** Community shell agents pre-allowed by the operator. */
+  allowUntrustedShell?: string[];
+}
+
+export interface RunDagActivityResult {
+  status: string;
+  error?: string;
+}
+
+/**
+ * Activity: run an ENTIRE v2 DAG on the worker via the existing in-process
+ * executor (B2 durable path). The run row is pre-created by the provider, so we
+ * always pass `resume: true` — on the first attempt that's a no-op (no completed
+ * nodes), and on a Temporal retry after a worker crash it skips finished nodes
+ * and picks up where it stopped.
+ *
+ * Returns normally for BOTH completed and failed runs — a failed agent is a
+ * legitimate terminal outcome and must NOT be retried. Only a real crash (the
+ * activity never returns → heartbeat timeout) triggers Temporal's retry, which
+ * is the resume path. Nodes run with the local spawner (we're already on the
+ * worker; no per-node round-trip).
+ */
+export async function runDagActivity(input: RunDagActivityInput): Promise<RunDagActivityResult> {
+  let ctx: ReturnType<typeof Context.current> | undefined;
+  try { ctx = Context.current(); } catch { ctx = undefined; }
+
+  const runStore = new RunStore(input.dbPath);
+  const deps: DagExecutorDeps = {
+    runStore,
+    secretsStore: new EncryptedFileStore(input.secretsPath),
+    agentStore: quiet(() => new AgentStore(input.dbPath)),
+    toolStore: quiet(() => new ToolStore(input.dbPath)),
+    integrationsStore: quiet(() => new IntegrationsStore(input.dbPath)),
+    variablesStore: input.variablesPath ? quiet(() => new VariablesStore(input.variablesPath as string)) : undefined,
+    allowUntrustedShell: new Set(input.allowUntrustedShell ?? []),
+    llmSettings: input.llmProviders ? { providers: input.llmProviders } : undefined,
+    dataRoot: input.dataRoot,
+    // spawnNode omitted → spawnNodeReal (local execution on this worker).
+  };
+
+  // Keep the long activity alive + cancellable: heartbeat on an interval while
+  // the DAG runs. The executor also heartbeats via node progress, but a DAG can
+  // sit between nodes; this is the floor.
+  const hb = ctx ? setInterval(() => { try { ctx?.heartbeat(); } catch { /* ignore */ } }, 10_000) : undefined;
+  try {
+    const run = await executeAgentDag(
+      input.agent,
+      {
+        runId: input.runId,
+        inputs: input.inputs,
+        triggeredBy: input.triggeredBy,
+        resume: true,
+        signal: ctx?.cancellationSignal,
+      },
+      deps,
+    );
+    return { status: run.status, error: run.error };
+  } finally {
+    if (hb) clearInterval(hb);
+    runStore.close();
+  }
 }

--- a/packages/temporal-provider/src/index.ts
+++ b/packages/temporal-provider/src/index.ts
@@ -1,5 +1,6 @@
 export * from './provider.js';
 export * from './worker.js';
 export { createTemporalSpawnNode, type CreateTemporalSpawnNodeOptions } from './node-spawn.js';
-export type { RunNodeActivityInput } from './activities.js';
+export type { RunNodeActivityInput, RunDagActivityInput, RunDagActivityResult } from './activities.js';
+export type { SubmitDagRunOptions } from './provider.js';
 export type { RunAgentWorkflowInput, RunAgentWorkflowResult } from './workflows.js';

--- a/packages/temporal-provider/src/provider.ts
+++ b/packages/temporal-provider/src/provider.ts
@@ -1,10 +1,28 @@
 import { Connection, Client, WorkflowNotFoundError } from '@temporalio/client';
 import { randomUUID } from 'node:crypto';
-import type { Provider, RunRequest, Run, RunStatus, SpawnNodeFn } from '@some-useful-agents/core';
+import { dirname } from 'node:path';
+import type { Provider, RunRequest, Run, RunStatus, SpawnNodeFn, Agent } from '@some-useful-agents/core';
 import { RunStore } from '@some-useful-agents/core';
 import { DEFAULT_TASK_QUEUE } from './worker.js';
 import { createTemporalSpawnNode } from './node-spawn.js';
 import type { RunAgentWorkflowInput, RunAgentWorkflowResult } from './workflows.js';
+import type { RunDagActivityInput, RunDagActivityResult } from './activities.js';
+
+/** Options for submitting a durable v2 DAG run (B2). */
+export interface SubmitDagRunOptions {
+  inputs?: Record<string, string>;
+  triggeredBy: Run['triggeredBy'];
+  /** Pre-generated run id (the caller may want it before the promise resolves). */
+  runId?: string;
+  /** Global variables JSON path, passed to the worker. */
+  variablesPath?: string;
+  /** Agent-state base dir, passed to the worker. Defaults to dirname(dbPath). */
+  dataRoot?: string;
+  /** LLM provider waterfall (names only). */
+  llmProviders?: string[];
+  /** Community shell agents pre-allowed by the operator. */
+  allowUntrustedShell?: string[];
+}
 
 export interface TemporalProviderOptions {
   dbPath: string;           // local SQLite run-store for fast CLI queries
@@ -98,6 +116,75 @@ export class TemporalProvider implements Provider {
     void this.trackCompletion(run.id, handle.workflowId);
 
     return { ...run, status: 'running' };
+  }
+
+  /**
+   * Submit a v2 DAG agent as a DURABLE Temporal run (B2). Pre-creates the run
+   * row, starts one `sua-run-<runId>` workflow that runs the whole executor on
+   * the worker, and returns immediately. The activity owns the run-status
+   * lifecycle in the shared store; if the worker crashes, Temporal re-dispatches
+   * the activity and it resumes from the last completed node. The state root
+   * defaults to the db path's directory.
+   */
+  async submitDagRun(agent: Agent, opts: SubmitDagRunOptions): Promise<Run> {
+    const runId = opts.runId ?? randomUUID();
+    const run: Run = {
+      id: runId,
+      agentName: agent.id,
+      status: 'pending',
+      startedAt: new Date().toISOString(),
+      triggeredBy: opts.triggeredBy,
+      usedWorkflowProvider: 'temporal',
+      workflowId: agent.id,
+      workflowVersion: agent.version,
+    };
+    this.store.createRun(run);
+
+    const input: RunDagActivityInput = {
+      agent,
+      runId,
+      inputs: opts.inputs,
+      triggeredBy: opts.triggeredBy,
+      dbPath: this.options.dbPath,
+      secretsPath: this.options.secretsPath,
+      variablesPath: opts.variablesPath,
+      dataRoot: opts.dataRoot ?? dirname(this.options.dbPath),
+      llmProviders: opts.llmProviders,
+      allowUntrustedShell: opts.allowUntrustedShell ?? [...this.allowUntrustedShell],
+    };
+
+    const handle = await this.client.workflow.start('runDagWorkflow', {
+      taskQueue: this.options.taskQueue,
+      workflowId: `sua-run-${runId}`,
+      args: [input],
+    });
+
+    this.store.updateRun(runId, { status: 'running' });
+    void this.trackDagCompletion(runId, handle.workflowId);
+
+    return { ...run, status: 'running' };
+  }
+
+  /**
+   * Safety net for durable runs: the activity writes the final run status into
+   * the shared store itself, so on success we leave it alone. We only act on the
+   * reject path — workflow terminated or all crash-retries exhausted — to mark a
+   * still-running run failed so the dashboard stops polling.
+   */
+  private async trackDagCompletion(runId: string, workflowId: string): Promise<void> {
+    try {
+      await (this.client.workflow.getHandle(workflowId).result() as Promise<RunDagActivityResult>);
+      // Activity already finalized the run row; nothing to do on success.
+    } catch (err) {
+      const current = this.store.getRun(runId);
+      if (current && (current.status === 'running' || current.status === 'pending')) {
+        this.store.updateRun(runId, {
+          status: 'failed',
+          completedAt: new Date().toISOString(),
+          error: `Durable run workflow ended without finalizing: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+    }
   }
 
   private async trackCompletion(runId: string, workflowId: string): Promise<void> {

--- a/packages/temporal-provider/src/workflows.ts
+++ b/packages/temporal-provider/src/workflows.ts
@@ -1,6 +1,6 @@
 import { proxyActivities, ActivityCancellationType } from '@temporalio/workflow';
 import type * as activities from './activities.js';
-import type { RunNodeActivityInput } from './activities.js';
+import type { RunNodeActivityInput, RunDagActivityInput, RunDagActivityResult } from './activities.js';
 import type { SpawnResult } from '@some-useful-agents/core';
 
 const { runAgentActivity } = proxyActivities<typeof activities>({
@@ -70,4 +70,28 @@ export async function runAgentWorkflow(input: RunAgentWorkflowInput): Promise<Ru
  */
 export async function runNodeWorkflow(input: RunNodeActivityInput): Promise<SpawnResult> {
   return runNodeActivity(input);
+}
+
+// Durable whole-DAG run (B2). One long activity runs the entire executor on the
+// worker. `maximumAttempts: 3` is the crash-resume engine: if the worker dies,
+// the activity stops heartbeating, Temporal reschedules it, and it resumes the
+// run from the last completed node. A failed AGENT does not retry — the activity
+// returns normally for failed runs, so only an infra crash re-dispatches.
+const { runDagActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '1 hour',
+  heartbeatTimeout: '60 seconds',
+  cancellationType: ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
+  retry: {
+    maximumAttempts: 3,
+    initialInterval: '5 seconds',
+  },
+});
+
+/**
+ * One durable workflow per v2 DAG run (`sua-run-<runId>`). Thin wrapper: the
+ * activity holds all the logic + state (in the shared RunStore). The workflow
+ * exists so the run is durable + re-dispatchable across worker restarts.
+ */
+export async function runDagWorkflow(input: RunDagActivityInput): Promise<RunDagActivityResult> {
+  return runDagActivity(input);
 }


### PR DESCRIPTION
## What

PR2 of B2 — the durable Temporal layer. A v2 DAG run can now execute as **one durable workflow per run** that survives a worker crash and resumes.

- **`runDagActivity`** runs the *whole existing executor* on the worker (local `spawnNodeReal`; RunStore/AgentStore/ToolStore/secrets reconstructed from the shared paths). It always calls `executeAgentDag({ resume: true })`: the provider pre-creates the run row, so attempt 1 is a no-op skip-set and a crash-retry resumes from the last completed node. **Returns normally for completed AND failed runs** — a failed agent must not retry; only an infra crash (no return → heartbeat timeout) re-dispatches. Heartbeats to stay alive + cancellable.
- **`runDagWorkflow`** wraps it: long `startToCloseTimeout`, 60s `heartbeatTimeout`, `maximumAttempts: 3` — that retry policy is the crash-resume engine.
- **`provider.submitDagRun(agent, opts)`** pre-creates the run row (`pending` → `running`, `usedWorkflowProvider: temporal`), starts `sua-run-<id>`, and `trackDagCompletion` only marks failure if the workflow gives up (the activity owns success). Secrets never enter the workflow payload (read on the worker).

The workflow bundle stays deterministic — only `@temporalio/workflow` imports survive compilation (all core/activity imports are type-only).

## Verified live (the headline)

Submitted a multi-node run, **SIGKILL'd the worker mid-run**, restarted it: Temporal re-dispatched the activity after the heartbeat timeout, the run **resumed** and completed — the completed node was **not** re-run (proven by a once-only side effect), the interrupted node re-ran (at-least-once). One `sua-run-<id>` workflow, `ActivityTaskStarted` (re-dispatch) → `WorkflowExecutionCompleted`.

## Test

- `runDagActivity`: runs a whole DAG → `completed`; a failing node → `failed` **without throwing** (the no-retry contract). Resume-on-crash itself is covered by PR1's core resume tests + the live e2e (a second SQLite handle in-process is a test-only visibility artifact, noted in the test).
- Clean rebuild + full suite: **1945 passed, 3 skipped**.

Not yet wired into the dashboard — PR3 adds routing + the per-agent `runOn` control. Plan: `~/.claude/plans/cozy-cooking-truffle.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)