### PR TITLE
feat: agent createdAt in the catalog — answer 'what's the newest agent?'

### DIFF
--- a/.changeset/agent-created-at-catalog.md
+++ b/.changeset/agent-created-at-catalog.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Agents expose a created-at timestamp; the catalog can answer "what's the newest agent?".
+
+`Agent.createdAt` is now populated from the `agents` table on read. The inbox
+agent-catalog snapshot includes `createdAt`, sorted newest-first, so
+`agent-catalog-search` can answer recency questions ("newest / most recently
+added agent") definitively instead of guessing at list order. Inbox triage now
+routes those questions to the catalog search.

--- a/agents/examples/agent-catalog-search.yaml
+++ b/agents/examples/agent-catalog-search.yaml
@@ -30,8 +30,9 @@ inputs:
     required: false
     default: ""
     description: >
-      JSON snapshot of installed agents. Each entry has
-      `{id, name, description, tags, source, status}`. Auto-injected by
+      JSON snapshot of installed agents, sorted newest-first. Each entry has
+      `{id, name, description, tags, source, status, createdAt}` where
+      `createdAt` is the ISO time the agent was installed. Auto-injected by
       the inbox route at action-run time.
 
 nodes:
@@ -79,6 +80,13 @@ nodes:
       - Rank by relevance. Score 1.0 = perfect match, 0.0 = no signal.
       - Cap at 5 matches. If nothing scores above 0.3, return zero
         matches and put a short explanation in `recommendation`.
+      - RECENCY queries ("what's the newest agent?", "most recently added",
+        "latest agent", "what did I install last?"): the catalog is sorted
+        newest-first by `createdAt`, so the FIRST eligible entry is the
+        answer. Return it as the single match (score 1.0) and state its
+        `createdAt` in `recommendation` (e.g. "node-discovery, added
+        2026-05-31"). Do NOT hedge about list order — `createdAt` is
+        authoritative.
 
       ════════════════════════════════════════════════════════════════
       OUTPUT FORMAT — exact shape, single <matches>...</matches> block

--- a/agents/examples/inbox-triage.yaml
+++ b/agents/examples/inbox-triage.yaml
@@ -262,7 +262,12 @@ nodes:
         "got a cocktail recipe agent?"). Pass `QUERY` = the user's
         request in their own words. The dashboard auto-injects the
         installed-agent catalog as `AGENT_CATALOG`, so you don't
-        thread that yourself.
+        thread that yourself. ALSO use this for RECENCY / metadata
+        questions about the catalog — "what's the newest agent?",
+        "most recently added", "what did I install last?" — the
+        injected catalog carries each agent's `createdAt`, so
+        catalog-search can answer definitively. Do not answer these
+        from memory or hedge about list order; dispatch the search.
 
         Propose `agent-catalog-search` DIRECTLY when the operator
         names a concrete topic or capability. Do NOT ask "which

--- a/packages/core/src/agent-store.ts
+++ b/packages/core/src/agent-store.ts
@@ -447,6 +447,7 @@ export class AgentStore {
       pulseVisible: row.pulse_visible == null ? undefined : (row.pulse_visible as number) === 1,
       dashboardVisible: row.dashboard_visible == null ? undefined : (row.dashboard_visible as number) === 1,
       stateMaxBytes: row.state_max_bytes == null ? undefined : (row.state_max_bytes as number),
+      createdAt: (row.created_at as string | null) ?? undefined,
       version: row.current_version as number,
       provider: dag.provider,
       model: dag.model,

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -348,6 +348,14 @@ export interface Agent {
    */
   version: number;
 
+  /**
+   * ISO timestamp the agent was first created/installed (the `agents` row's
+   * `created_at`). Populated on read from the store; absent on YAML-parsed
+   * agents that haven't been persisted yet. Lets the catalog answer
+   * "what's the newest agent?".
+   */
+  createdAt?: string;
+
   /** Default LLM provider for all claude-code nodes. Nodes can override. */
   provider?: LlmProvider;
   /** Default model for all claude-code nodes. Nodes can override. */

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -815,6 +815,8 @@ describe('POST /inbox/:id/actions/:rid/run — agent-catalog-search enrichment',
     expect(meta.resultSummary).toContain('weather-forecast-marker');
     // System agent must NOT appear in the injected catalog.
     expect(meta.resultSummary).not.toContain('agent-analyzer');
+    // The catalog carries createdAt so recency ("newest agent?") is answerable.
+    expect(meta.resultSummary).toContain('createdAt');
   });
 });
 

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -954,6 +954,9 @@ function enrichAgentCatalogSearchInputs(
     const agents = ctx.agentStore.listAgents();
     const catalog = agents
       .filter((a) => !SYSTEM_AGENT_IDS.has(a.id))
+      // Newest first, so "what's the newest agent?" is the first entry and
+      // recency questions are answerable without guessing at list order.
+      .sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? ''))
       .map((a) => ({
         id: a.id,
         name: a.name,
@@ -961,6 +964,9 @@ function enrichAgentCatalogSearchInputs(
         tags: a.tags ?? [],
         source: a.source,
         status: a.status,
+        // ISO timestamp the agent was first installed/created. Lets the
+        // catalog-search agent answer "newest / most recently added".
+        createdAt: a.createdAt,
       }));
     out.AGENT_CATALOG = JSON.stringify(catalog);
   } catch { /* swallow — empty catalog still lets the agent respond "no matches" */ }


### PR DESCRIPTION
## What

Closes the gap where the inbox/triage agent couldn't say which agent is newest ("I can't tell definitively from the catalog… it doesn't include added-at timestamps").

It turned out the `agents` table already had `created_at` — nothing read it onto the `Agent` record or into the catalog the agent sees. So:

- **core:** `Agent.createdAt` is now populated from the `agents` row on read (added the field + the row mapping).
- **dashboard:** the injected `AGENT_CATALOG` includes `createdAt` and is **sorted newest-first**, so recency is the first entry — no guessing at list order.
- **agents:** `agent-catalog-search` documents `createdAt` + gains a recency ranking rule (newest queries → first eligible entry, state its date, don't hedge). Inbox triage routes "newest / most recently added / what did I install last?" to the catalog search.

## Test

- The catalog enrichment test now asserts `createdAt` is present in the injected `AGENT_CATALOG`.
- Both edited system-agent YAMLs parse; full suite: **1949 passed, 3 skipped**.

This is also the first item appended to a new self-learning capabilities log I'm keeping in memory (the "known gaps" entry that prompted it is now resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)