### PR TITLE
refactor: rename usedProvider field → usedLLMProvider (keep DB column)

### DIFF
--- a/.changeset/used-llm-provider-rename.md
+++ b/.changeset/used-llm-provider-rename.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Rename the LLM-provider field to usedLLMProvider for clarity.
+
+`SpawnResult.usedProvider` and `NodeExecutionRecord.usedProvider` are renamed to
+`usedLLMProvider`, so the LLM-provider axis (claude/codex/apple) reads clearly
+next to the execution-backend axis (`usedWorkflowProvider`, local/temporal). The
+SQLite column stays named `usedProvider` (mapped in the run store), so there's no
+migration and existing data is untouched.

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -646,12 +646,15 @@ export interface NodeExecutionRecord {
    */
   childStartedAtMs?: number;
   /**
-   * LLM provider that actually produced the result for this node. Set
-   * for llm-prompt nodes only; undefined for shell. When the provider
-   * waterfall fell back through multiple CLIs (e.g. claude failed →
-   * tried codex), this is the LAST one tried.
+   * LLM provider that actually produced the result for this node (claude /
+   * codex / apple). Set for llm-prompt nodes only; undefined for shell. When
+   * the provider waterfall fell back through multiple CLIs (e.g. claude failed →
+   * tried codex), this is the LAST one tried. Distinct from
+   * `usedWorkflowProvider` (the execution backend: local / temporal). Persisted
+   * in the `node_executions.usedProvider` column (the column name is kept for
+   * back-compat).
    */
-  usedProvider?: string;
+  usedLLMProvider?: string;
   /**
    * Comma-separated trail of every provider attempted in waterfall
    * order. Length 1 means no fallback fired. Stored as CSV (not JSON)
@@ -661,7 +664,7 @@ export interface NodeExecutionRecord {
   attemptedProviders?: string;
   /**
    * Execution backend that ran this node: `'local'` (in-process) or
-   * `'temporal'` (worker activity). Different axis from `usedProvider`
+   * `'temporal'` (worker activity). Different axis from `usedLLMProvider`
    * above, which is the LLM provider. Undefined on legacy rows ↔ `local`.
    */
   usedWorkflowProvider?: string;

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -1067,7 +1067,7 @@ export async function executeAgentDag(
         exitCode: 0,
         outputsJson,
         stateBytesAfter,
-        usedProvider: result.usedProvider,
+        usedLLMProvider: result.usedLLMProvider,
         attemptedProviders: result.attemptedProviders ? result.attemptedProviders.join(',') : undefined,
         usedWorkflowProvider: result.usedWorkflowProvider,
       });
@@ -1085,7 +1085,7 @@ export async function executeAgentDag(
         exitCode: result.exitCode,
         error: result.error ?? `Process exited with code ${result.exitCode}`,
         outputsJson,
-        usedProvider: result.usedProvider,
+        usedLLMProvider: result.usedLLMProvider,
         attemptedProviders: result.attemptedProviders ? result.attemptedProviders.join(',') : undefined,
         usedWorkflowProvider: result.usedWorkflowProvider,
         stateBytesAfter,

--- a/packages/core/src/node-spawner.ts
+++ b/packages/core/src/node-spawner.ts
@@ -20,16 +20,16 @@ import { ensureAppleRunner } from './apple-foundationmodels-runner.js';
 export type SpawnResult = ExecutionResult & {
   category?: NodeErrorCategory;
   /**
-   * Provider that ultimately produced this result. Set by spawnNodeReal
+   * LLM provider that ultimately produced this result. Set by spawnNodeReal
    * for llm-prompt nodes only. When the waterfall ran multiple providers
    * before one succeeded (or all failed), this is the LAST provider
    * attempted — paired with `attemptedProviders` for the full trail.
    * Undefined for shell nodes.
    */
-  usedProvider?: string;
+  usedLLMProvider?: string;
   /**
    * Ordered trail of every provider the waterfall tried, including the
-   * one in `usedProvider`. Length 1 means no fallback fired. Undefined
+   * one in `usedLLMProvider`. Length 1 means no fallback fired. Undefined
    * for shell nodes.
    */
   attemptedProviders?: string[];
@@ -37,7 +37,7 @@ export type SpawnResult = ExecutionResult & {
    * Execution backend that actually ran this node: `'local'` (in-process)
    * or `'temporal'` (worker activity). A backend (the injected spawnNode)
    * self-reports here; the executor copies it onto the node_executions row.
-   * Distinct from `usedProvider` (the LLM provider). Undefined ↔ local.
+   * Distinct from `usedLLMProvider` (the LLM provider). Undefined ↔ local.
    */
   usedWorkflowProvider?: string;
 };
@@ -631,7 +631,7 @@ export async function spawnNodeReal(
       // breadcrumb.
       return {
         ...result,
-        usedProvider: provider,
+        usedLLMProvider: provider,
         attemptedProviders,
         error: attemptedProviders.length > 1
           ? `Fallback ${provider} succeeded after ${attemptedProviders.slice(0, -1).join(', ')} failed (${lastCategory}).`
@@ -663,7 +663,7 @@ export async function spawnNodeReal(
   // operator can see what was tried.
   return {
     ...(lastResult ?? { result: '', exitCode: 1 }),
-    usedProvider: attemptedProviders[attemptedProviders.length - 1],
+    usedLLMProvider: attemptedProviders[attemptedProviders.length - 1],
     attemptedProviders,
   };
 }

--- a/packages/core/src/run-store.ts
+++ b/packages/core/src/run-store.ts
@@ -183,8 +183,8 @@ export class RunStore {
 
     // Workflow (execution backend) provider: which provider executed this run
     // — 'local' (in-process) or 'temporal' (worker). Distinct from the LLM
-    // provider axis (node_executions.usedProvider). Nullable; NULL ↔ legacy/
-    // local. See ~/.claude/plans/temporal-wiring.md (B1a).
+    // provider axis (node_executions.usedProvider column ↔ usedLLMProvider
+    // field). Nullable; NULL ↔ legacy/local. See ~/.claude/plans/temporal-wiring.md (B1a).
     if (!runCols.has('usedworkflowprovider')) {
       this.db.exec(`ALTER TABLE runs ADD COLUMN usedWorkflowProvider TEXT`);
     }
@@ -229,7 +229,8 @@ export class RunStore {
     // LLM provider waterfall: which provider ultimately produced the
     // result + the trail of providers attempted. Both nullable so
     // shell nodes + pre-waterfall rows stay clean. CSV is enough —
-    // the trail rarely exceeds 3 entries.
+    // the trail rarely exceeds 3 entries. The `usedProvider` COLUMN backs the
+    // `usedLLMProvider` field (column name kept for back-compat).
     if (!execCols.has('usedprovider')) {
       this.db.exec(`ALTER TABLE node_executions ADD COLUMN usedProvider TEXT`);
     }
@@ -238,9 +239,9 @@ export class RunStore {
     }
 
     // Workflow (execution backend) provider per node: 'local' | 'temporal'.
-    // Different axis from `usedProvider` above, which is the LLM provider
-    // (claude/codex/apple) — read that as the "LLM provider". This one records
-    // where the node's work actually ran. Nullable; NULL ↔ legacy/local.
+    // Different axis from `usedLLMProvider` (the `usedProvider` column), which is
+    // the LLM provider (claude/codex/apple). This one records where the node's
+    // work actually ran. Nullable; NULL ↔ legacy/local.
     if (!execCols.has('usedworkflowprovider')) {
       this.db.exec(`ALTER TABLE node_executions ADD COLUMN usedWorkflowProvider TEXT`);
     }
@@ -442,7 +443,9 @@ export class RunStore {
       record.outputsJson ?? null, record.progressJson ?? null,
       record.stateBytesBefore ?? null, record.stateBytesAfter ?? null,
       record.childPid ?? null, record.childStartedAtMs ?? null,
-      record.usedProvider ?? null, record.attemptedProviders ?? null,
+      // The `usedProvider` column holds the LLM provider (field renamed to
+      // usedLLMProvider; column name kept for back-compat).
+      record.usedLLMProvider ?? null, record.attemptedProviders ?? null,
       record.usedWorkflowProvider ?? null,
     );
   }
@@ -451,7 +454,7 @@ export class RunStore {
     runId: string,
     nodeId: string,
     updates: Partial<Pick<NodeExecutionRecord,
-      'status' | 'errorCategory' | 'completedAt' | 'result' | 'exitCode' | 'error' | 'inputsJson' | 'upstreamInputsJson' | 'outputsJson' | 'progressJson' | 'stateBytesBefore' | 'stateBytesAfter' | 'childPid' | 'childStartedAtMs' | 'usedProvider' | 'attemptedProviders' | 'usedWorkflowProvider'
+      'status' | 'errorCategory' | 'completedAt' | 'result' | 'exitCode' | 'error' | 'inputsJson' | 'upstreamInputsJson' | 'outputsJson' | 'progressJson' | 'stateBytesBefore' | 'stateBytesAfter' | 'childPid' | 'childStartedAtMs' | 'usedLLMProvider' | 'attemptedProviders' | 'usedWorkflowProvider'
     >>,
   ): void {
     const fields: string[] = [];
@@ -470,7 +473,7 @@ export class RunStore {
     if (updates.stateBytesAfter !== undefined) { fields.push('stateBytesAfter = ?'); values.push(updates.stateBytesAfter); }
     if (updates.childPid !== undefined) { fields.push('childPid = ?'); values.push(updates.childPid); }
     if (updates.childStartedAtMs !== undefined) { fields.push('childStartedAtMs = ?'); values.push(updates.childStartedAtMs); }
-    if (updates.usedProvider !== undefined) { fields.push('usedProvider = ?'); values.push(updates.usedProvider); }
+    if (updates.usedLLMProvider !== undefined) { fields.push('usedProvider = ?'); values.push(updates.usedLLMProvider); }
     if (updates.attemptedProviders !== undefined) { fields.push('attemptedProviders = ?'); values.push(updates.attemptedProviders); }
     if (updates.usedWorkflowProvider !== undefined) { fields.push('usedWorkflowProvider = ?'); values.push(updates.usedWorkflowProvider); }
     if (fields.length === 0) return;
@@ -583,7 +586,7 @@ export class RunStore {
       stateBytesAfter: (row.stateBytesAfter as number | null) ?? undefined,
       childPid: (row.childPid as number | null) ?? undefined,
       childStartedAtMs: (row.childStartedAtMs as number | null) ?? undefined,
-      usedProvider: (row.usedProvider as string | null) ?? undefined,
+      usedLLMProvider: (row.usedProvider as string | null) ?? undefined,
       attemptedProviders: (row.attemptedProviders as string | null) ?? undefined,
       usedWorkflowProvider: (row.usedWorkflowProvider as string | null) ?? undefined,
     };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -121,7 +121,7 @@ export interface Run {
   /**
    * Which execution backend ran this: `'local'` (in-process) or `'temporal'`
    * (durable worker). Distinct from the LLM provider axis
-   * (`NodeExecutionRecord.usedProvider`). NULL/undefined on legacy rows ↔
+   * (`NodeExecutionRecord.usedLLMProvider`). NULL/undefined on legacy rows ↔
    * treat as `local`.
    */
   usedWorkflowProvider?: string;

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -453,10 +453,10 @@ function renderNodeCards(execs: NodeExecutionRecord[], runId?: string, canReplay
     let waterfallChip: SafeHtml = html``;
     if (e.attemptedProviders) {
       const trail = e.attemptedProviders.split(',').filter(Boolean);
-      if (trail.length > 1 && e.usedProvider) {
+      if (trail.length > 1 && e.usedLLMProvider) {
         const failedFrom = trail.slice(0, -1).join(', ');
         const verdict = e.status === 'completed' ? 'ran on' : 'ended on';
-        waterfallChip = html`<span class="badge badge--muted" title="LLM waterfall: ${trail.join(' → ')}">${verdict} <span class="mono">${e.usedProvider}</span> · <span class="mono">${failedFrom}</span> failed</span>`;
+        waterfallChip = html`<span class="badge badge--muted" title="LLM waterfall: ${trail.join(' → ')}">${verdict} <span class="mono">${e.usedLLMProvider}</span> · <span class="mono">${failedFrom}</span> failed</span>`;
       }
     }
 


### PR DESCRIPTION
## What

The last tracked cleanup gap. Now that two provider axes coexist, the bare `usedProvider` was ambiguous. Rename the **field** so it reads clearly:

- `SpawnResult.usedProvider` → `usedLLMProvider`
- `NodeExecutionRecord.usedProvider` → `usedLLMProvider`

…sitting next to `usedWorkflowProvider` (the execution backend, local/temporal, from B1a). Updated everywhere: the spawner waterfall, the executor writes, the run-store create/update/row mapping, the dashboard waterfall chip, and comments.

The **SQLite column stays named `usedProvider`** (mapped in the run store) — **no migration, no data change**. Behavior-preserving.

## Test

- Full suite: **1949 passed, 3 skipped** (no test referenced the field; the rename is internal). Clean rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)