### PR TITLE
feat(dashboard): link a run to its Temporal workflow

### DIFF
--- a/.changeset/run-temporal-link.md
+++ b/.changeset/run-temporal-link.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Link a run to its Temporal workflow.
+
+The run detail page's Backend row now shows a "View in Temporal ↗" deep link for
+runs that executed on Temporal, opening the run's `sua-run-<id>` workflow in the
+Temporal Web UI (honoring the configured namespace). Local runs are unaffected.

--- a/packages/dashboard/src/lib/temporal-link.test.ts
+++ b/packages/dashboard/src/lib/temporal-link.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { temporalWorkflowLink, TEMPORAL_UI_URL } from './temporal-link.js';
+
+describe('temporalWorkflowLink', () => {
+  it('builds a Web UI deep link for a temporal run', () => {
+    const link = temporalWorkflowLink({ id: 'abc-123', usedWorkflowProvider: 'temporal' });
+    expect(link).toBe(`${TEMPORAL_UI_URL}/namespaces/default/workflows/sua-run-abc-123`);
+  });
+
+  it('honors a custom namespace', () => {
+    const link = temporalWorkflowLink({ id: 'r1', usedWorkflowProvider: 'temporal' }, 'prod');
+    expect(link).toContain('/namespaces/prod/workflows/sua-run-r1');
+  });
+
+  it('returns undefined for local runs', () => {
+    expect(temporalWorkflowLink({ id: 'r1', usedWorkflowProvider: 'local' })).toBeUndefined();
+    expect(temporalWorkflowLink({ id: 'r1', usedWorkflowProvider: undefined })).toBeUndefined();
+  });
+});

--- a/packages/dashboard/src/lib/temporal-link.ts
+++ b/packages/dashboard/src/lib/temporal-link.ts
@@ -1,0 +1,19 @@
+import type { Run } from '@some-useful-agents/core';
+
+/** Temporal Web UI base (the bundled docker-compose maps the UI here). */
+export const TEMPORAL_UI_URL = 'http://localhost:8233';
+
+/**
+ * Deep link to a run's workflow in the Temporal Web UI, or undefined when the
+ * run didn't execute on Temporal. The workflow id is `sua-run-<runId>` (durable
+ * v2 runs + v1 single-node runs). B1b per-node runs (`sua-node-…`) have no single
+ * run-level workflow; those are superseded by the durable per-run path.
+ */
+export function temporalWorkflowLink(
+  run: Pick<Run, 'id' | 'usedWorkflowProvider'>,
+  namespace = 'default',
+): string | undefined {
+  if (run.usedWorkflowProvider !== 'temporal') return undefined;
+  const wf = encodeURIComponent(`sua-run-${run.id}`);
+  return `${TEMPORAL_UI_URL}/namespaces/${encodeURIComponent(namespace)}/workflows/${wf}`;
+}

--- a/packages/dashboard/src/routes/runs.ts
+++ b/packages/dashboard/src/routes/runs.ts
@@ -3,6 +3,7 @@ import type { RunStatus } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 import { renderRunsList } from '../views/runs-list.js';
 import { renderRunDetail } from '../views/run-detail.js';
+import { temporalWorkflowLink } from '../lib/temporal-link.js';
 import {
   parseHiddenFieldsParam,
   parseSortParamsFromQuery,
@@ -123,7 +124,9 @@ runsRouter.get('/runs/:id', (req: Request, res: Response) => {
     page: parsePageParamsFromQuery(req.query as Record<string, unknown>),
   };
 
-  res.type('html').send(renderRunDetail({ run, partial, nodeExecutions, agent, back, flash, widgetControls }));
+  const temporalLink = temporalWorkflowLink(run, ctx.temporal?.namespace);
+
+  res.type('html').send(renderRunDetail({ run, partial, nodeExecutions, agent, back, flash, widgetControls, temporalLink }));
 });
 
 function parseIntOr(v: unknown, fallback: number): number {

--- a/packages/dashboard/src/routes/settings-temporal.ts
+++ b/packages/dashboard/src/routes/settings-temporal.ts
@@ -3,6 +3,7 @@ import { spawnService, stopService, getServiceStatus } from '@some-useful-agents
 import { getContext } from '../context.js';
 import { renderSettingsShell } from '../views/settings-shell.js';
 import { renderSettingsTemporal } from '../views/settings-temporal.js';
+import { TEMPORAL_UI_URL } from '../lib/temporal-link.js';
 
 /**
  * Routes for /settings/temporal: the run provider, Temporal connection, and the
@@ -13,7 +14,6 @@ import { renderSettingsTemporal } from '../views/settings-temporal.js';
 export const settingsTemporalRouter: Router = Router();
 
 const DEFAULT_TEMPORAL = { address: 'localhost:7233', namespace: 'default', taskQueue: 'sua-agents' };
-const TEMPORAL_UI_URL = 'http://localhost:8233';
 
 settingsTemporalRouter.get('/settings/temporal', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -21,6 +21,11 @@ export interface RunDetailOptions {
   flash?: { kind: 'error' | 'info' | 'ok'; message: string };
   /** URL-driven state for the output widget's interactive controls. */
   widgetControls?: WidgetControlState;
+  /**
+   * Deep link to this run's workflow in the Temporal Web UI. Set by the route
+   * only for runs that executed on Temporal (workflow id `sua-run-<runId>`).
+   */
+  temporalLink?: string;
 }
 
 export function renderRunDetail(opts: RunDetailOptions): string {
@@ -175,7 +180,7 @@ export function renderRunDetail(opts: RunDetailOptions): string {
           <dt>Duration</dt><dd>${formatDuration(run.startedAt, run.completedAt)}</dd>
           <dt>Exit code</dt><dd class="mono">${formatExitCode(run.exitCode) || html`<span class="dim">—</span>`}</dd>
           <dt>Triggered by</dt><dd>${run.triggeredBy}</dd>
-          <dt>Backend</dt><dd class="mono">${run.usedWorkflowProvider ?? 'local'}</dd>
+          <dt>Backend</dt><dd class="mono">${run.usedWorkflowProvider ?? 'local'}${opts.temporalLink ? html` · <a href="${opts.temporalLink}" target="_blank" rel="noreferrer">View in Temporal ↗</a>` : html``}</dd>
           ${replayedFrom}
           ${retryOf}
         </dl>


### PR DESCRIPTION
## What

For a run that executed on Temporal, the run detail page's **Backend** row now shows a **"View in Temporal ↗"** deep link — one click from the dashboard run to its `sua-run-<id>` workflow in the Temporal Web UI (honoring the configured namespace). Local runs are unaffected.

- New `temporalWorkflowLink(run, namespace)` helper (returns undefined for non-temporal runs) + centralizes the `TEMPORAL_UI_URL` constant that `/settings/temporal` also uses.
- The route passes the link to the run-detail view when `run.usedWorkflowProvider === 'temporal'`.

## Test

- Helper unit test: builds the deep link, honors a custom namespace, returns undefined for local runs.
- **Verified live:** the Backend row on a real durable run renders `temporal · View in Temporal ↗` → `…/namespaces/default/workflows/sua-run-<id>`.
- Dashboard suite: 504 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)