### PR TITLE
fix(core): guard SQLite stores against startup lock contention

### DIFF
--- a/.changeset/store-busy-timeout.md
+++ b/.changeset/store-busy-timeout.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Guard SQLite stores against startup lock contention.
+
+Stores set `PRAGMA journal_mode = WAL` but never a busy timeout, so `node:sqlite`
+raised `database is locked` the instant it couldn't grab a lock. When the daemon
+restarts the schedule, worker, and dashboard services at once they race to open
+the same DB file, and one would crash on startup ("Could not start the temporal
+provider: database is locked"). Stores now open through a shared `openStoreDb`
+helper that applies `PRAGMA busy_timeout` (5s), so SQLite waits and retries
+instead of failing. Behavior-preserving in the uncontended case.

--- a/packages/cli/src/commands/schedule.ts
+++ b/packages/cli/src/commands/schedule.ts
@@ -1,6 +1,5 @@
 import { resolve, join, dirname } from 'node:path';
 import { existsSync, mkdirSync } from 'node:fs';
-import { DatabaseSync } from 'node:sqlite';
 import { Command } from 'commander';
 import chalk from 'chalk';
 import Table from 'cli-table3';
@@ -17,6 +16,7 @@ import {
   cronToHuman,
   getSchedulerStatus,
   nextFireTime,
+  openStoreDb,
 } from '@some-useful-agents/core';
 import { loadConfig, getAgentDirs, getSecretsPath, getDbPath, getDashboardBaseUrl } from '../config.js';
 import { createProvider } from '../provider-factory.js';
@@ -197,7 +197,7 @@ scheduleCommand
     const dbPath = getDbPath(config);
     const dbDir = dirname(dbPath);
     if (!existsSync(dbDir)) mkdirSync(dbDir, { recursive: true });
-    const sharedDb = new DatabaseSync(dbPath);
+    const sharedDb = openStoreDb(dbPath);
     const agentStore = AgentStore.fromHandle(sharedDb);
     const v2Agents = agentStore.listAgents().filter(
       (a) => a.schedule && a.status === 'active',

--- a/packages/core/src/agent-store.ts
+++ b/packages/core/src/agent-store.ts
@@ -1,4 +1,5 @@
 import { DatabaseSync } from 'node:sqlite';
+import { openStoreDb } from './sqlite-open.js';
 import { mkdirSync, existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { chmod600Safe } from './fs-utils.js';
@@ -46,7 +47,7 @@ export class AgentStore {
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
     }
-    this.db = new DatabaseSync(dbPath);
+    this.db = openStoreDb(dbPath);
     this.ownsConnection = true;
     chmod600Safe(dbPath);
     this.dataRoot = dir;

--- a/packages/core/src/blocked-img-hosts-store.ts
+++ b/packages/core/src/blocked-img-hosts-store.ts
@@ -1,4 +1,5 @@
 import { DatabaseSync } from 'node:sqlite';
+import { openStoreDb } from './sqlite-open.js';
 import { mkdirSync, existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { chmod600Safe } from './fs-utils.js';
@@ -51,7 +52,7 @@ export class BlockedImgHostsStore {
   constructor(dbPath: string) {
     const dir = dirname(dbPath);
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-    this.db = new DatabaseSync(dbPath);
+    this.db = openStoreDb(dbPath);
     this.ownsConnection = true;
     chmod600Safe(dbPath);
     this.dataRoot = dir;

--- a/packages/core/src/dashboards-store.ts
+++ b/packages/core/src/dashboards-store.ts
@@ -1,4 +1,5 @@
 import { DatabaseSync } from 'node:sqlite';
+import { openStoreDb } from './sqlite-open.js';
 import { mkdirSync, existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { chmod600Safe } from './fs-utils.js';
@@ -43,7 +44,7 @@ export class DashboardsStore {
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
     }
-    this.db = new DatabaseSync(dbPath);
+    this.db = openStoreDb(dbPath);
     this.ownsConnection = true;
     chmod600Safe(dbPath);
     this.dataRoot = dir;

--- a/packages/core/src/inbox-store.ts
+++ b/packages/core/src/inbox-store.ts
@@ -1,4 +1,5 @@
 import { DatabaseSync } from 'node:sqlite';
+import { openStoreDb } from './sqlite-open.js';
 import { mkdirSync, existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { randomUUID } from 'node:crypto';
@@ -286,7 +287,7 @@ export class InboxStore {
   constructor(dbPath: string) {
     const dir = dirname(dbPath);
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-    this.db = new DatabaseSync(dbPath);
+    this.db = openStoreDb(dbPath);
     this.ownsConnection = true;
     chmod600Safe(dbPath);
     this.dataRoot = dir;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from './types.js';
 export * from './schema.js';
+export * from './sqlite-open.js';
 export * from './agent-loader.js';
 export * from './run-store.js';
 export * from './run-orphan-reaper.js';

--- a/packages/core/src/integrations-store.ts
+++ b/packages/core/src/integrations-store.ts
@@ -1,4 +1,5 @@
 import { DatabaseSync } from 'node:sqlite';
+import { openStoreDb } from './sqlite-open.js';
 import { mkdirSync, existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { chmod600Safe } from './fs-utils.js';
@@ -50,7 +51,7 @@ export class IntegrationsStore {
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
     }
-    this.db = new DatabaseSync(dbPath);
+    this.db = openStoreDb(dbPath);
     this.ownsConnection = true;
     chmod600Safe(dbPath);
     this.dataRoot = dir;

--- a/packages/core/src/layout-hints-store.ts
+++ b/packages/core/src/layout-hints-store.ts
@@ -1,4 +1,5 @@
 import { DatabaseSync } from 'node:sqlite';
+import { openStoreDb } from './sqlite-open.js';
 import { mkdirSync, existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { chmod600Safe } from './fs-utils.js';
@@ -60,7 +61,7 @@ export class LayoutHintsStore {
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
     }
-    this.db = new DatabaseSync(dbPath);
+    this.db = openStoreDb(dbPath);
     this.ownsConnection = true;
     chmod600Safe(dbPath);
     this.dataRoot = dir;

--- a/packages/core/src/packs-store.ts
+++ b/packages/core/src/packs-store.ts
@@ -1,4 +1,5 @@
 import { DatabaseSync } from 'node:sqlite';
+import { openStoreDb } from './sqlite-open.js';
 import { mkdirSync, existsSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { chmod600Safe } from './fs-utils.js';
@@ -97,7 +98,7 @@ export class PacksStore {
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true });
     }
-    this.db = new DatabaseSync(dbPath);
+    this.db = openStoreDb(dbPath);
     this.ownsConnection = true;
     chmod600Safe(dbPath);
     this.dataRoot = dir;

--- a/packages/core/src/run-store.ts
+++ b/packages/core/src/run-store.ts
@@ -1,4 +1,5 @@
 import { DatabaseSync } from 'node:sqlite';
+import { openStoreDb } from './sqlite-open.js';
 
 type SqlValue = string | number | null | bigint | Uint8Array;
 import { mkdirSync, existsSync } from 'node:fs';
@@ -54,7 +55,7 @@ export class RunStore {
       mkdirSync(dir, { recursive: true });
     }
 
-    this.db = new DatabaseSync(dbPath);
+    this.db = openStoreDb(dbPath);
     this.ownsConnection = true;
     // Lock the DB file down to user-only. Agent stdout can contain secrets
     // and the DB is unencrypted plaintext; the only at-rest protection is

--- a/packages/core/src/sqlite-open.test.ts
+++ b/packages/core/src/sqlite-open.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { openStoreDb, DEFAULT_BUSY_TIMEOUT_MS } from './sqlite-open.js';
+
+const dirs: string[] = [];
+function tmpDb(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'sua-sqlite-open-'));
+  dirs.push(dir);
+  return join(dir, 'test.db');
+}
+
+afterEach(() => {
+  while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true });
+});
+
+describe('openStoreDb', () => {
+  it('applies the default busy_timeout to the connection', () => {
+    const db = openStoreDb(tmpDb());
+    try {
+      const row = db.prepare('PRAGMA busy_timeout').get() as { timeout: number };
+      expect(row.timeout).toBe(DEFAULT_BUSY_TIMEOUT_MS);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('honors a custom busy_timeout', () => {
+    const db = openStoreDb(tmpDb(), { busyTimeoutMs: 1234 });
+    try {
+      const row = db.prepare('PRAGMA busy_timeout').get() as { timeout: number };
+      expect(row.timeout).toBe(1234);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('leaves the timeout at the SQLite default when set to 0 (opt out)', () => {
+    const db = openStoreDb(tmpDb(), { busyTimeoutMs: 0 });
+    try {
+      const row = db.prepare('PRAGMA busy_timeout').get() as { timeout: number };
+      // SQLite's own default is 0 (no wait) — we didn't touch it.
+      expect(row.timeout).toBe(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('returns a usable connection (can create + query a table)', () => {
+    const db = openStoreDb(tmpDb());
+    try {
+      db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)');
+      db.prepare('INSERT INTO t (v) VALUES (?)').run('hi');
+      const row = db.prepare('SELECT v FROM t WHERE id = 1').get() as { v: string };
+      expect(row.v).toBe('hi');
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/packages/core/src/sqlite-open.ts
+++ b/packages/core/src/sqlite-open.ts
@@ -1,0 +1,44 @@
+import { DatabaseSync } from 'node:sqlite';
+
+/**
+ * Default busy timeout, in milliseconds, applied to every store connection.
+ *
+ * Without it, `node:sqlite` raises `SQLITE_BUSY` ("database is locked") the
+ * instant it can't grab a lock — even though the holder usually releases within
+ * milliseconds. That bit us when the daemon restarts schedule + worker +
+ * dashboard at once and they race to open the same DB file (the WAL switch and
+ * the orphan-reap write both need a brief exclusive lock). A busy timeout makes
+ * SQLite block-and-retry for up to this long before giving up, which absorbs the
+ * startup contention without any caller-side retry loop.
+ */
+export const DEFAULT_BUSY_TIMEOUT_MS = 5000;
+
+export interface OpenStoreDbOptions {
+  /** Open the database read-only. */
+  readOnly?: boolean;
+  /** Override the busy timeout (ms). 0 disables it (immediate SQLITE_BUSY). */
+  busyTimeoutMs?: number;
+}
+
+/**
+ * Open a SQLite store connection with the project-wide contention guard applied.
+ *
+ * Every store should open through this rather than calling `new DatabaseSync`
+ * directly, so the `busy_timeout` is set uniformly and can't drift. The timeout
+ * is applied immediately after open and BEFORE callers run `PRAGMA journal_mode
+ * = WAL` — the WAL switch itself needs the write lock, so it must already be
+ * covered by the busy timeout.
+ */
+export function openStoreDb(dbPath: string, opts: OpenStoreDbOptions = {}): DatabaseSync {
+  // node:sqlite rejects an explicit `undefined` second arg ("options must be an
+  // object"), so only pass the options object when we actually have one.
+  const db = opts.readOnly
+    ? new DatabaseSync(dbPath, { readOnly: true })
+    : new DatabaseSync(dbPath);
+  const timeout = opts.busyTimeoutMs ?? DEFAULT_BUSY_TIMEOUT_MS;
+  if (timeout > 0) {
+    // PRAGMA busy_timeout is per-connection state and must be set on each handle.
+    db.exec(`PRAGMA busy_timeout = ${timeout}`);
+  }
+  return db;
+}

--- a/packages/core/src/tool-store.ts
+++ b/packages/core/src/tool-store.ts
@@ -1,4 +1,5 @@
 import { DatabaseSync } from 'node:sqlite';
+import { openStoreDb } from './sqlite-open.js';
 import type { ToolDefinition, ToolSource } from './tool-types.js';
 import type { McpServerConfig, McpTransport } from './mcp-server-types.js';
 
@@ -14,7 +15,7 @@ export class ToolStore {
   private readonly db: DatabaseSync;
 
   constructor(dbPath: string) {
-    this.db = new DatabaseSync(dbPath);
+    this.db = openStoreDb(dbPath);
     this.db.exec('PRAGMA journal_mode = WAL');
     this.ensureSchema();
   }


### PR DESCRIPTION
## Problem
When the daemon restarts the schedule, worker, and dashboard services at once (`sua daemon restart`), they race to open the same SQLite DB file. Stores set `PRAGMA journal_mode = WAL` but never a busy timeout, so `node:sqlite` raised `database is locked` the instant it couldn't grab a lock — and a service would crash on startup:

```
❌  dashboard: crashed on startup
Could not start the temporal provider: database is locked
```

This was the recurring "dashboard crashed on startup" symptom.

## Fix
Add a shared `openStoreDb()` helper in core that opens the connection and applies `PRAGMA busy_timeout` (5s) **before** the WAL switch (the WAL switch itself needs the write lock). Route all 9 WAL stores plus the CLI schedule service through it. SQLite now waits-and-retries instead of failing immediately.

Behavior-preserving in the uncontended case.

## Files
- `packages/core/src/sqlite-open.ts` — new `openStoreDb()` helper (+ unit tests)
- 9 stores: `run-store`, `agent-store`, `inbox-store`, `tool-store`, `packs-store`, `dashboards-store`, `layout-hints-store`, `integrations-store`, `blocked-img-hosts-store`
- `packages/cli/src/commands/schedule.ts` — shared-DB open routed through the helper

## Verification
- `npx vitest run` → **1956 pass / 3 skipped**
- 3× consecutive concurrent `daemon restart` → zero crashes (was crashing reliably before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)