### PR TITLE
fix(dashboard): force-close connections on shutdown so SIGTERM doesn't hang

### DIFF
--- a/.changeset/dashboard-sigterm-hang.md
+++ b/.changeset/dashboard-sigterm-hang.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Fix dashboard hanging on SIGTERM/SIGINT.
+
+The dashboard's graceful shutdown called `server.close()`, which only stops
+accepting new connections and waits for existing ones to drain. The inbox SSE
+stream and the 2s poll keep-alives never close on their own, so shutdown hung
+forever and the process became a zombie squatting on the port — surfacing as
+recurring "dashboard crashed on startup" (EADDRINUSE) errors. Shutdown now
+pairs `server.close()` with `server.closeAllConnections()` (Node 18.2+) to
+force-terminate the lingering sockets, so the dashboard stops promptly.

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -585,7 +585,18 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     server,
     authUrl,
     async close() {
-      await new Promise<void>((resolve) => server.close(() => resolve()));
+      // `server.close()` only stops accepting NEW connections; it resolves its
+      // callback once EXISTING ones drain. The inbox SSE stream and the 2s poll
+      // keep-alives never close on their own, so a naive close() hangs forever —
+      // SIGTERM appears to do nothing and the process becomes a zombie squatting
+      // on the port (the EADDRINUSE-on-restart symptom). Force-terminate the
+      // lingering sockets after asking the server to stop. `closeAllConnections`
+      // exists on Node 18.2+; optional-chain it so older runtimes degrade to the
+      // old (hanging) behavior rather than throwing.
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+        server.closeAllConnections?.();
+      });
       await provider.shutdown();
       runStore.close();
       agentStore.close();

--- a/packages/dashboard/src/listen.test.ts
+++ b/packages/dashboard/src/listen.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import express from 'express';
+import http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { listenWithErrors } from './index.js';
 
@@ -25,5 +26,45 @@ describe('listenWithErrors', () => {
     } finally {
       await new Promise<void>((r) => first.close(() => r()));
     }
+  });
+});
+
+describe('graceful shutdown with an open SSE/keep-alive connection', () => {
+  // Regression: the dashboard close() used to be `server.close(cb)` alone, which
+  // only resolves once existing connections drain. The inbox SSE stream never
+  // closes on its own, so SIGTERM hung forever and left a zombie on the port.
+  // The fix pairs server.close() with server.closeAllConnections(); this test
+  // proves that pattern resolves even while a never-ending response is open.
+  it('resolves close() even with a never-ending SSE response open', async () => {
+    const app = express();
+    // An SSE-style handler that writes headers and then never ends — exactly the
+    // shape of the inbox stream / poll keep-alive that wedged the old shutdown.
+    app.get('/stream', (_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/event-stream', Connection: 'keep-alive' });
+      res.write(': open\n\n');
+      // intentionally never res.end()
+    });
+
+    const server = await listenWithErrors(app, 0, '127.0.0.1');
+    const port = (server.address() as AddressInfo).port;
+
+    // Open the long-lived connection and wait until the server has actually
+    // accepted it, so close() has a live socket to force-terminate.
+    await new Promise<void>((resolve, reject) => {
+      const req = http.get({ host: '127.0.0.1', port, path: '/stream' }, (res) => {
+        res.on('data', () => resolve());
+        res.on('error', () => {});
+      });
+      req.on('error', reject);
+    });
+
+    // The close() pattern under test. Without closeAllConnections() this never
+    // resolves; the test's own timeout would then fail it.
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+      server.closeAllConnections?.();
+    });
+
+    expect(server.listening).toBe(false);
   });
 });

--- a/scripts/dev-restart.sh
+++ b/scripts/dev-restart.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# dev-restart.sh — rebuild the workspace and restart the daemon so the running
+# services serve the code you just checked out / edited.
+#
+# This exists because `sua daemon start` does NOT do what people expect:
+#   - it never rebuilds (start/restart just spawn whatever is in dist/), and
+#   - `start` is a no-op when a service is already running (duplicate-safe),
+#     so it silently leaves you on the OLD code.
+# The fix-current-code sequence is always: build, THEN restart.
+#
+# Confirm you're current by checking the footer SHA (sua v.. · <sha>) matches
+# `git rev-parse --short HEAD`. A "-dirty" suffix just means uncommitted changes.
+#
+# Usage:
+#   ./scripts/dev-restart.sh              # build, then restart the daemon
+#   SKIP_BUILD=1 ./scripts/dev-restart.sh # restart only (already built)
+#   CLEAN=1 ./scripts/dev-restart.sh      # nuke dist + tsbuildinfo first
+#
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Prefer a `sua` on PATH; fall back to the freshly built local CLI.
+if command -v sua >/dev/null 2>&1; then
+  SUA="sua"
+else
+  SUA="node packages/cli/dist/index.js"
+fi
+
+if [ "${CLEAN:-}" = "1" ]; then
+  echo "==> Clean (rm dist + tsbuildinfo)…"
+  rm -rf packages/*/dist packages/*/*.tsbuildinfo
+fi
+
+if [ "${SKIP_BUILD:-}" != "1" ]; then
+  echo "==> Building…"
+  npm run build >/dev/null
+fi
+
+# Restart services one at a time. A single `daemon restart` brings them all up
+# concurrently, and the schedule/worker/dashboard race to open the SQLite store
+# ("Could not start the temporal provider: database is locked"). Staggering with
+# a brief pause sidesteps the WAL open race; dashboard goes last so the port is
+# free by the time it binds.
+echo "==> Restarting daemon services (staggered to avoid the SQLite open race)…"
+for svc in schedule worker dashboard; do
+  $SUA daemon restart --service "$svc" 2>&1 | sed 's/^/    /'
+  sleep 1
+done
+
+echo
+$SUA daemon status
+
+DASH_PORT="${SUA_DASHBOARD_PORT:-3000}"
+TOKEN_FILE="${HOME}/.sua/mcp-token"
+echo
+echo "==> Running commit: $(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+echo "    Verify the footer SHA on any page matches the above."
+if [ -f "$TOKEN_FILE" ]; then
+  echo "    Sign-in: http://127.0.0.1:${DASH_PORT}/auth#token=$(cat "$TOKEN_FILE")"
+fi


### PR DESCRIPTION
## Problem
The dashboard's graceful shutdown called `server.close()`, which only stops accepting new connections and then waits for existing ones to drain. The inbox SSE stream and the 2s poll keep-alives never close on their own, so SIGTERM hung forever and the process became a zombie squatting on the port — surfacing as recurring `EADDRINUSE` "dashboard crashed on startup" errors.

## Fix
Pair `server.close()` with `server.closeAllConnections()` (Node 18.2+, optional-chained so older runtimes degrade gracefully) to force-terminate lingering sockets. Shutdown now completes promptly.

## Extras
- `scripts/dev-restart.sh` — build + (staggered) `daemon restart` helper. Exists because `sua daemon start` neither rebuilds nor restarts an already-running service; the "run current code" sequence is `npm run build && sua daemon restart`.
- Regression test in `listen.test.ts`: opens a never-ending SSE response and asserts the close pattern resolves (without the fix it hangs → test times out).

## Verification
- `npx vitest run` (dashboard) → all pass
- Observed clean SIGTERM shutdown in the daemon log after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)