### PR TITLE
feat(core): zero-dependency Markdown renderer for message bodies

### DIFF
--- a/.changeset/inbox-markdown-core.md
+++ b/.changeset/inbox-markdown-core.md
@@ -1,0 +1,16 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Add a zero-dependency Markdown renderer for chat/message bodies.
+
+New `renderMarkdown` / `renderMarkdownSafe` helpers in core render the small
+Markdown subset used in conversations (bold, italic, inline + fenced code,
+links, lists, blockquotes, headings, soft line breaks). `renderMarkdownSafe`
+composes the renderer with the existing HTML sanitizer as the trust boundary,
+so output is safe to inline. This is the foundation for rendering inbox triage
+messages as formatted text instead of plain escaped strings.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from './types.js';
 export * from './schema.js';
 export * from './sqlite-open.js';
+export * from './markdown.js';
 export * from './agent-loader.js';
 export * from './run-store.js';
 export * from './run-orphan-reaper.js';

--- a/packages/core/src/markdown.test.ts
+++ b/packages/core/src/markdown.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { renderMarkdown, renderMarkdownSafe } from './markdown.js';
+
+describe('renderMarkdown', () => {
+  it('renders bold and italic', () => {
+    expect(renderMarkdown('**bold** and *italic*')).toBe('<p><strong>bold</strong> and <em>italic</em></p>');
+    expect(renderMarkdown('_em_')).toBe('<p><em>em</em></p>');
+  });
+
+  it('renders inline code without reinterpreting markers inside', () => {
+    expect(renderMarkdown('use `**not bold**` here')).toBe('<p>use <code>**not bold**</code> here</p>');
+  });
+
+  it('renders fenced code blocks with escaped content', () => {
+    expect(renderMarkdown('```\n<a> & b\n```')).toBe('<pre><code>&lt;a&gt; &amp; b</code></pre>');
+  });
+
+  it('renders headings', () => {
+    expect(renderMarkdown('# Title')).toBe('<h1>Title</h1>');
+    expect(renderMarkdown('### Three')).toBe('<h3>Three</h3>');
+  });
+
+  it('renders unordered and ordered lists', () => {
+    expect(renderMarkdown('- a\n- b')).toBe('<ul><li>a</li><li>b</li></ul>');
+    expect(renderMarkdown('1. one\n2. two')).toBe('<ol><li>one</li><li>two</li></ol>');
+  });
+
+  it('renders blockquotes', () => {
+    expect(renderMarkdown('> quoted')).toBe('<blockquote>quoted</blockquote>');
+  });
+
+  it('renders horizontal rules', () => {
+    expect(renderMarkdown('---')).toBe('<hr>');
+  });
+
+  it('renders links', () => {
+    expect(renderMarkdown('[agent](/agents/foo)')).toBe('<p><a href="/agents/foo">agent</a></p>');
+  });
+
+  it('treats single newlines as soft breaks within a paragraph', () => {
+    expect(renderMarkdown('line one\nline two')).toBe('<p>line one<br>line two</p>');
+  });
+
+  it('separates paragraphs on blank lines', () => {
+    expect(renderMarkdown('para one\n\npara two')).toBe('<p>para one</p>\n<p>para two</p>');
+  });
+
+  it('escapes raw HTML in text', () => {
+    expect(renderMarkdown('a < b & c')).toBe('<p>a &lt; b &amp; c</p>');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(renderMarkdown('')).toBe('');
+  });
+});
+
+describe('renderMarkdownSafe (composition with sanitizer)', () => {
+  it('renders a script tag inert (escaped, never an executable tag)', () => {
+    const html = renderMarkdownSafe('hello <script>alert(1)</script> world');
+    // No live <script> element — the markup is escaped to text.
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('neutralizes javascript: links', () => {
+    const html = renderMarkdownSafe('[x](javascript:alert(1))');
+    expect(html).not.toContain('javascript:');
+  });
+
+  it('keeps relative /agents and /runs links', () => {
+    const agents = renderMarkdownSafe('[a](/agents/foo)');
+    expect(agents).toContain('href="/agents/foo"');
+    const runs = renderMarkdownSafe('[r](/runs/abc123)');
+    expect(runs).toContain('href="/runs/abc123"');
+  });
+
+  it('preserves allowlisted markdown tags through the sanitizer', () => {
+    const html = renderMarkdownSafe('**bold** and `code`');
+    expect(html).toContain('<strong>bold</strong>');
+    expect(html).toContain('<code>code</code>');
+  });
+});

--- a/packages/core/src/markdown.ts
+++ b/packages/core/src/markdown.ts
@@ -1,0 +1,173 @@
+/**
+ * Tiny zero-dependency Markdown renderer for inbox/chat message bodies.
+ *
+ * Scope is deliberately small — the subset agents and operators actually use in
+ * conversation: headings, bold/italic, inline + fenced code, links, ordered and
+ * unordered lists, blockquotes, horizontal rules, and paragraphs with soft line
+ * breaks. It is NOT a CommonMark implementation and does not try to be.
+ *
+ * SECURITY: this renderer's only job is correctness, NOT safety. The trust
+ * boundary is `sanitizeHtml()` (html-sanitizer.ts), which the safe entry point
+ * `renderMarkdownSafe()` always applies afterwards. Never feed raw
+ * `renderMarkdown()` output to the DOM — go through `renderMarkdownSafe()` (or
+ * the dashboard's `mdBody()` helper) so the sanitize step can't be forgotten.
+ */
+
+import { sanitizeHtml } from './html-sanitizer.js';
+
+/** Escape text content for HTML body context. */
+function escapeText(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/** Escape a value destined for a double-quoted attribute. */
+function escapeAttr(s: string): string {
+  return escapeText(s).replace(/"/g, '&quot;');
+}
+
+/** Apply link/bold/italic to a NON-code text segment that is already escaped. */
+function renderEmphasisAndLinks(escaped: string): string {
+  let text = escaped;
+  // Links [text](url). The url is attribute-escaped; sanitizeHtml re-validates
+  // the href (isSafeUrl) downstream, so this is correctness only.
+  text = text.replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, (_m, label: string, url: string) => {
+    return `<a href="${escapeAttr(url)}">${label}</a>`;
+  });
+  // Bold first so ** isn't half-consumed by the single-* rule.
+  text = text.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+  text = text.replace(/(^|[^*])\*([^*\s][^*]*?)\*/g, '$1<em>$2</em>');
+  text = text.replace(/(^|[^_\w])_([^_\s][^_]*?)_/g, '$1<em>$2</em>');
+  return text;
+}
+
+/**
+ * Render inline markup within a single block of text. Inline code spans are
+ * isolated first (split, not placeholder) so markers inside them are never
+ * reinterpreted and there are no sentinel collisions.
+ */
+function renderInline(input: string): string {
+  // Split keeps the delimiters: odd indices are `code` spans.
+  const parts = input.split(/(`[^`]+`)/g);
+  return parts
+    .map((seg) => {
+      if (seg.length >= 2 && seg.startsWith('`') && seg.endsWith('`')) {
+        return `<code>${escapeText(seg.slice(1, -1))}</code>`;
+      }
+      return renderEmphasisAndLinks(escapeText(seg));
+    })
+    .join('');
+}
+
+const HR_RE = /^ {0,3}([-*_])(?: *\1){2,} *$/;
+const HEADING_RE = /^ {0,3}(#{1,6})\s+(.*?)\s*#*\s*$/;
+const UL_RE = /^ {0,3}[-*+]\s+(.*)$/;
+const OL_RE = /^ {0,3}\d+[.)]\s+(.*)$/;
+const BLOCKQUOTE_RE = /^ {0,3}>\s?(.*)$/;
+
+/**
+ * Render a Markdown string to an HTML string. NOT sanitized — callers must use
+ * `renderMarkdownSafe()` instead unless they sanitize themselves.
+ */
+export function renderMarkdown(src: string): string {
+  if (!src) return '';
+  const lines = src.replace(/\r\n?/g, '\n').split('\n');
+  const out: string[] = [];
+  let i = 0;
+  let para: string[] = [];
+
+  const flushParagraph = (): void => {
+    if (!para.length) return;
+    out.push(`<p>${para.map(renderInline).join('<br>')}</p>`);
+    para = [];
+  };
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Fenced code block.
+    const fence = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
+    if (fence) {
+      flushParagraph();
+      const marker = fence[1][0];
+      const closeRe = new RegExp(`^ {0,3}${marker === '`' ? '`' : '~'}{3,}\\s*$`);
+      const body: string[] = [];
+      i++;
+      while (i < lines.length && !closeRe.test(lines[i])) {
+        body.push(lines[i]);
+        i++;
+      }
+      i++; // consume closing fence (if present)
+      out.push(`<pre><code>${escapeText(body.join('\n'))}</code></pre>`);
+      continue;
+    }
+
+    // Blank line ends a paragraph.
+    if (/^\s*$/.test(line)) {
+      flushParagraph();
+      i++;
+      continue;
+    }
+
+    // Horizontal rule.
+    if (HR_RE.test(line)) {
+      flushParagraph();
+      out.push('<hr>');
+      i++;
+      continue;
+    }
+
+    // Heading.
+    const heading = line.match(HEADING_RE);
+    if (heading) {
+      flushParagraph();
+      const level = heading[1].length;
+      out.push(`<h${level}>${renderInline(heading[2])}</h${level}>`);
+      i++;
+      continue;
+    }
+
+    // Blockquote (consecutive `>` lines).
+    if (BLOCKQUOTE_RE.test(line)) {
+      flushParagraph();
+      const quoted: string[] = [];
+      while (i < lines.length && BLOCKQUOTE_RE.test(lines[i])) {
+        quoted.push(lines[i].match(BLOCKQUOTE_RE)![1]);
+        i++;
+      }
+      out.push(`<blockquote>${quoted.map(renderInline).join('<br>')}</blockquote>`);
+      continue;
+    }
+
+    // Lists (consecutive items of the same kind).
+    const isUl = UL_RE.test(line);
+    const isOl = OL_RE.test(line);
+    if (isUl || isOl) {
+      flushParagraph();
+      const tag = isUl ? 'ul' : 'ol';
+      const re = isUl ? UL_RE : OL_RE;
+      const items: string[] = [];
+      while (i < lines.length && re.test(lines[i])) {
+        items.push(`<li>${renderInline(lines[i].match(re)![1])}</li>`);
+        i++;
+      }
+      out.push(`<${tag}>${items.join('')}</${tag}>`);
+      continue;
+    }
+
+    // Otherwise: accumulate into the current paragraph.
+    para.push(line.trim());
+    i++;
+  }
+  flushParagraph();
+
+  return out.join('\n');
+}
+
+/**
+ * Safe entry point: render Markdown, then run the result through the
+ * project-wide HTML sanitizer (the trust boundary — strips scripts/handlers,
+ * drops unsafe URLs, keeps only allowlisted tags). Use this everywhere.
+ */
+export function renderMarkdownSafe(src: string): string {
+  return sanitizeHtml(renderMarkdown(src));
+}


### PR DESCRIPTION
## What
Adds `renderMarkdown` and `renderMarkdownSafe` to core — a tiny, zero-dependency Markdown renderer for chat/message bodies. First of a small series to fix the stilted inbox triage experience (plain-text bodies, no links, raw timestamps, hedging).

## Why
Inbox message bodies are currently plain-text + HTML-escaped — no markdown, no links. This is the foundation: subsequent PRs wire it into the inbox views, add date humanization + auto-linkify, CTAs, and a smarter triage agent.

## Design
- `renderMarkdown(src)` covers the conversational subset: bold/italic, inline + fenced code, links, ordered/unordered lists, blockquotes, headings, horizontal rules, soft line breaks. **Correctness only.**
- `renderMarkdownSafe(src) = sanitizeHtml(renderMarkdown(src))` — the existing `html-sanitizer.ts` is the **trust boundary**. Callers use the safe variant so the sanitize step can't be skipped (same `unsafeHtml(sanitizeHtml(...))` pattern already used by output-widgets).
- No wiring into the UI yet — pure addition.

## Tests
`packages/core/src/markdown.test.ts` — 16 tests: the markdown subset, plus composition tests proving `<script>` renders inert, `javascript:` links are dropped, and relative `/agents` `/runs` links survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)