### PR TITLE
feat(dashboard): CTA affordances for inbox triage (ctaLabel + link buttons)

### DIFF
--- a/.changeset/inbox-ctas.md
+++ b/.changeset/inbox-ctas.md
@@ -1,0 +1,16 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Add CTA affordances to inbox triage replies.
+
+Triage can now attach an optional `ctaLabel` to a proposed action (so the
+dispatch button reads "Describe this agent" instead of the generic "Run") and
+an optional `links` array to its plan, rendered as link-CTA buttons under the
+reply. Link hrefs are validated against the sanitizer's URL allowlist (relative
+or http(s)/mailto only). Dispatch CTAs reuse the existing action pipeline, so
+they still run and update the conversation inline without a refresh.

--- a/packages/core/src/html-sanitizer.ts
+++ b/packages/core/src/html-sanitizer.ts
@@ -147,7 +147,7 @@ function isAttrAllowed(tag: string, attr: string): boolean {
  * data:image/* are allowed; everything else (javascript:, vbscript:, data:
  * with non-image MIME, file:) is dropped.
  */
-function isSafeUrl(value: string): boolean {
+export function isSafeUrl(value: string): boolean {
   const v = value.trim();
   if (!v) return false;
   // Anchor / relative paths are safe.

--- a/packages/core/src/inbox-store.ts
+++ b/packages/core/src/inbox-store.ts
@@ -71,6 +71,12 @@ export interface InboxActionMeta {
   agentId: string;
   inputs: Record<string, string>;
   rationale?: string;
+  /**
+   * Optional verb-led label for the action's Run button (e.g. "Describe this
+   * agent" instead of the generic "Run"). Triage may set it so the dispatch
+   * CTA reads naturally; falls back to "Run" when absent.
+   */
+  ctaLabel?: string;
   /** Sub-agent run id once execution starts. */
   runId?: string;
   startedAt?: number;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -309,7 +309,7 @@ export {
   type TemplateGenerator,
   type TemplateGenerationRequest,
 } from './template-generator.js';
-export { sanitizeHtml, substitutePlaceholders } from './html-sanitizer.js';
+export { sanitizeHtml, substitutePlaceholders, isSafeUrl } from './html-sanitizer.js';
 export {
   mcpServerConfigSchema,
   mcpServerIdFromKey,

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -2189,6 +2189,14 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
   border-top: 1px solid var(--color-border);
   margin: var(--space-3) 0;
 }
+
+/* Structured link-CTA buttons under a triage reply (metaJson.links). */
+.inbox-msg__ctas {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
 /* Optimistic "Sending..." placeholder rendered by the modal JS the
  * moment Post reply submits. Dimmed so the operator can tell it's
  * not yet confirmed, but visible enough that they know their text

--- a/packages/dashboard/src/routes/inbox-links.test.ts
+++ b/packages/dashboard/src/routes/inbox-links.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Unit tests for the triage <plan> `links` validator. Kept in a standalone
+ * file (no app/DB fixture) so the pure-function assertions don't interleave
+ * with inbox.test.ts's stateful afterEach teardown.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseTriageLinks } from './inbox.js';
+
+describe('parseTriageLinks', () => {
+  it('keeps valid label + relative href entries', () => {
+    expect(parseTriageLinks([{ label: 'Open agent', href: '/agents/foo' }])).toEqual([
+      { label: 'Open agent', href: '/agents/foo' },
+    ]);
+  });
+
+  it('keeps http(s) links', () => {
+    expect(parseTriageLinks([{ label: 'Docs', href: 'https://example.com' }])).toHaveLength(1);
+  });
+
+  it('drops entries with unsafe hrefs', () => {
+    expect(parseTriageLinks([{ label: 'x', href: 'javascript:alert(1)' }])).toEqual([]);
+  });
+
+  it('drops entries missing a label or href', () => {
+    expect(parseTriageLinks([{ href: '/agents/foo' }, { label: 'no href' }])).toEqual([]);
+  });
+
+  it('caps at four links', () => {
+    const many = Array.from({ length: 8 }, (_, i) => ({ label: `L${i}`, href: `/agents/a${i}` }));
+    expect(parseTriageLinks(many)).toHaveLength(4);
+  });
+
+  it('returns empty for non-array input', () => {
+    expect(parseTriageLinks(undefined)).toEqual([]);
+    expect(parseTriageLinks('nope')).toEqual([]);
+  });
+});

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -176,6 +176,28 @@ describe('GET /inbox/:id and /:id/fragment', () => {
     expect(res.text).toContain('first reply');
   });
 
+  it('renders structured link-CTA buttons from a triage reply metaJson.links', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    inboxStore.addResponse(m.id, 'triage', 'Here is the agent.', JSON.stringify({
+      links: [{ label: 'Open agent', href: '/agents/foo' }],
+    }));
+    const res = await request(app).get(`/inbox/${m.id}/fragment`).set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.text).toContain('inbox-msg__ctas');
+    expect(res.text).toContain('href="/agents/foo"');
+    expect(res.text).toContain('Open agent');
+  });
+
+  it('renders the action ctaLabel on the Run button when present', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    inboxStore.addResponse(m.id, 'action', 'describe it', JSON.stringify({
+      kind: 'action', status: 'proposed', agentId: 'agent-catalog-search', inputs: {}, ctaLabel: 'Describe this agent',
+    }));
+    const res = await request(app).get(`/inbox/${m.id}/fragment`).set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.text).toContain('Describe this agent');
+  });
+
   it('renders the thinking indicator when the most recent response is a recent user reply', async () => {
     const app = await makeApp();
     const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -31,6 +31,7 @@ import {
   exportAgent,
   executeAgentDag,
   extractPlanJson,
+  isSafeUrl,
   listBuiltinTools,
   parseAgent,
   LLM_PROVIDERS,
@@ -1073,6 +1074,34 @@ function collectRunSummary(
  * so the route can surface refusals as `system` responses in the
  * conversation. Unknown agent ids fall into rejected.
  */
+/** Max structured link-CTA buttons a single triage reply may carry. */
+const MAX_TRIAGE_LINKS = 4;
+
+export interface TriageLink {
+  label: string;
+  href: string;
+}
+
+/**
+ * Validate the optional `links` array on a triage <plan>. Each entry needs a
+ * short label and an href that passes the sanitizer's URL allowlist (relative
+ * or http(s)/mailto). Capped at MAX_TRIAGE_LINKS; invalid entries are dropped.
+ */
+export function parseTriageLinks(raw: unknown): TriageLink[] {
+  if (!Array.isArray(raw)) return [];
+  const out: TriageLink[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue;
+    const e = entry as Record<string, unknown>;
+    const label = typeof e.label === 'string' ? e.label.trim().slice(0, 40) : '';
+    const href = typeof e.href === 'string' ? e.href.trim() : '';
+    if (!label || !href || !isSafeUrl(href)) continue;
+    out.push({ label, href });
+    if (out.length >= MAX_TRIAGE_LINKS) break;
+  }
+  return out;
+}
+
 function parseProposedActions(
   rawActions: unknown,
   allowlist: readonly string[],
@@ -1101,12 +1130,14 @@ function parseProposedActions(
       }
     }
     const rationale = typeof e.rationale === 'string' ? e.rationale.trim() : undefined;
+    const ctaLabel = typeof e.ctaLabel === 'string' ? e.ctaLabel.trim().slice(0, 40) : undefined;
     accepted.push({
       kind: 'action',
       status: 'proposed',
       agentId,
       inputs,
       rationale: rationale || undefined,
+      ctaLabel: ctaLabel || undefined,
     });
   }
   return { accepted, rejected };
@@ -1744,7 +1775,7 @@ async function runTriageAgent(
       );
       return;
     }
-    let parsed: { recommendation?: unknown; verifyHint?: unknown; actions?: unknown; commitmentSummary?: unknown };
+    let parsed: { recommendation?: unknown; verifyHint?: unknown; actions?: unknown; commitmentSummary?: unknown; links?: unknown };
     try {
       parsed = JSON.parse(planJson);
     } catch {
@@ -1772,9 +1803,11 @@ async function runTriageAgent(
     const commitmentSummary = commitmentRaw.length >= 3 && commitmentRaw.length <= 60
       ? commitmentRaw
       : undefined;
+    const links = parseTriageLinks(parsed.links);
     const triageMeta: Record<string, string> = {};
     if (verifyHint) triageMeta.verifyHint = verifyHint;
     if (commitmentSummary) triageMeta.commitmentSummary = commitmentSummary;
+    if (links.length > 0) triageMeta.links = JSON.stringify(links);
     const triageReply = ctx.inboxStore.addResponse(
       messageId,
       'triage',

--- a/packages/dashboard/src/views/inbox-detail.ts
+++ b/packages/dashboard/src/views/inbox-detail.ts
@@ -320,6 +320,30 @@ function mdBody(text: string): SafeHtml {
   return unsafeHtml(`<div class="inbox-md">${renderMarkdownSafe(pre)}</div>`);
 }
 
+/**
+ * Render the optional structured link-CTA buttons a triage reply may carry in
+ * its `metaJson.links`. Hrefs were already URL-validated server-side
+ * (parseTriageLinks); we re-escape on render. External links open in a new tab.
+ */
+function renderTriageLinks(metaJson?: string): SafeHtml {
+  if (!metaJson) return html``;
+  let links: Array<{ label?: unknown; href?: unknown }> = [];
+  try {
+    const parsed = JSON.parse(metaJson) as { links?: unknown };
+    if (Array.isArray(parsed.links)) links = parsed.links as typeof links;
+  } catch { return html``; }
+  const buttons = links
+    .filter((l) => typeof l.label === 'string' && typeof l.href === 'string')
+    .map((l) => {
+      const href = l.href as string;
+      const external = /^https?:\/\//i.test(href);
+      const target = external ? html` target="_blank" rel="noreferrer"` : html``;
+      return html`<a class="btn btn--xs btn--ghost" href="${href}"${target}>${l.label as string}</a>`;
+    });
+  if (buttons.length === 0) return html``;
+  return html`<div class="inbox-msg__ctas">${buttons as unknown as SafeHtml[]}</div>`;
+}
+
 function renderConversationEntry(r: InboxResponse, currentTargetYaml?: string): SafeHtml {
   if (r.role === 'action') return renderActionEntry(r, currentTargetYaml);
   const role = (ROLE_LABEL[r.role] ?? r.role);
@@ -338,6 +362,7 @@ function renderConversationEntry(r: InboxResponse, currentTargetYaml?: string): 
           </button>
         </div>
         <div class="inbox-msg__text" data-inbox-copy-source>${mdBody(r.body)}</div>
+        ${r.role === 'triage' ? renderTriageLinks(r.metaJson) : html``}
       </div>
     </div>
   `;
@@ -429,7 +454,7 @@ function renderActionEntry(r: InboxResponse, currentTargetYaml?: string): SafeHt
       <div class="inbox-action__controls">
         <form method="POST" action="/inbox/${r.messageId}/actions/${r.id}/run"
           data-inbox-modal-form data-inbox-modal-keeps-triage="1" style="margin:0;">
-          <button type="submit" class="btn btn--xs btn--primary">Run</button>
+          <button type="submit" class="btn btn--xs btn--primary">${meta.ctaLabel || 'Run'}</button>
         </form>
         <form method="POST" action="/inbox/${r.messageId}/actions/${r.id}/skip"
           data-inbox-modal-form style="margin:0;">


### PR DESCRIPTION
## What
Triage can now present clearer calls to action (part 4 of the series):
- **`ctaLabel`** on a proposed action → the dispatch button reads e.g. "Describe this agent" instead of the generic "Run".
- **`links[]`** on the triage `<plan>` → rendered as link-CTA buttons under the reply (navigate to an agent, a run, docs, etc.).

Dispatch CTAs reuse the existing action pipeline, so they still run and update the conversation **inline without a refresh** (SSE). Plain inline markdown links also work from PR #446.

## Stacked on #446 → #445 → #444
Base is `main`; rebase after parents merge.

## Design / safety
- New optional `InboxActionMeta.ctaLabel` (core); parsed in `parseProposedActions` (capped 40 chars).
- New `parseTriageLinks` validates each `{label, href}` — href must pass the sanitizer's `isSafeUrl` (now exported from core: relative or http(s)/mailto only; `javascript:` dropped). Capped at 4 links.
- Triage links persisted on the triage response `metaJson`; rendered as `.btn` anchors (external → `target=_blank rel=noreferrer`).
- The agent prompt that emits these lands in the next PR; this PR is the parse + render plumbing.

## Tests
- `inbox-links.test.ts` — 6 tests for `parseTriageLinks` (valid/relative/http, unsafe dropped, missing fields, cap, non-array). Standalone file to avoid the integration suite's stateful teardown.
- `inbox.test.ts` — 2 fragment render tests (link buttons render; `ctaLabel` shows on the Run button).
- Full core+dashboard suite: 1863 pass / 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)