### PR TITLE
feat(core): markdownToText for clean one-line previews

### DIFF
--- a/.changeset/inbox-markdown-to-text.md
+++ b/.changeset/inbox-markdown-to-text.md
@@ -1,0 +1,14 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Add markdownToText for clean one-line previews.
+
+New `markdownToText` helper in core reduces Markdown to single-line plain text —
+unwrapping links to their label, dropping emphasis/code/heading/list/quote
+markers, and collapsing whitespace. Foundation for de-noising the `/inbox`
+list-row previews (which currently show raw Markdown syntax).

--- a/packages/core/src/markdown.test.ts
+++ b/packages/core/src/markdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { renderMarkdown, renderMarkdownSafe } from './markdown.js';
+import { renderMarkdown, renderMarkdownSafe, markdownToText } from './markdown.js';
 
 describe('renderMarkdown', () => {
   it('renders bold and italic', () => {
@@ -78,5 +78,46 @@ describe('renderMarkdownSafe (composition with sanitizer)', () => {
     const html = renderMarkdownSafe('**bold** and `code`');
     expect(html).toContain('<strong>bold</strong>');
     expect(html).toContain('<code>code</code>');
+  });
+});
+
+describe('markdownToText', () => {
+  it('strips bold/italic/underscore/code markers, keeping content', () => {
+    expect(markdownToText('**bold** and *italic* and _em_ and `code`')).toBe('bold and italic and em and code');
+  });
+
+  it('unwraps links to their label', () => {
+    expect(markdownToText('open [the agent](/agents/foo) now')).toBe('open the agent now');
+  });
+
+  it('unwraps images to their alt text', () => {
+    expect(markdownToText('![alt text](/img.png)')).toBe('alt text');
+  });
+
+  it('drops heading, list, and blockquote markers', () => {
+    expect(markdownToText('# Title')).toBe('Title');
+    expect(markdownToText('- a\n- b')).toBe('a b');
+    expect(markdownToText('1. one\n2. two')).toBe('one two');
+    expect(markdownToText('> quoted')).toBe('quoted');
+  });
+
+  it('collapses newlines and whitespace to single spaces', () => {
+    expect(markdownToText('line one\n\nline   two')).toBe('line one line two');
+  });
+
+  it('keeps fenced code contents without the fences', () => {
+    expect(markdownToText('```js\nx()\n```')).toBe('x()');
+  });
+
+  it('drops horizontal rules', () => {
+    expect(markdownToText('a\n\n---\n\nb')).toBe('a b');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(markdownToText('')).toBe('');
+  });
+
+  it('leaves plain text untouched', () => {
+    expect(markdownToText('just a normal sentence.')).toBe('just a normal sentence.');
   });
 });

--- a/packages/core/src/markdown.ts
+++ b/packages/core/src/markdown.ts
@@ -171,3 +171,34 @@ export function renderMarkdown(src: string): string {
 export function renderMarkdownSafe(src: string): string {
   return sanitizeHtml(renderMarkdown(src));
 }
+
+/**
+ * Reduce Markdown to clean, single-line plain text — for list previews and
+ * other one-line snippets where rendered markup would be noise. Unwraps links
+ * to their label, drops emphasis/code/heading/list/quote markers, and collapses
+ * all whitespace (including newlines) to single spaces. NOT for HTML output —
+ * use `renderMarkdownSafe` there. Correctness only; the caller's `html\`\``
+ * template escapes the result on interpolation.
+ */
+export function markdownToText(src: string): string {
+  if (!src) return '';
+  let s = src;
+  // Inline + fenced code: keep the contents, drop the backticks.
+  s = s.replace(/```[^\n]*\n?([\s\S]*?)```/g, '$1'); // fenced
+  s = s.replace(/`([^`]+)`/g, '$1');                  // inline
+  // Links + images: keep the visible label, drop the target.
+  s = s.replace(/!?\[([^\]]*)\]\([^)\s]*(?:\s+"[^"]*")?\)/g, '$1');
+  // Bold / italic / underscore emphasis markers (run twice for ** then *).
+  s = s.replace(/(\*\*|__)(.*?)\1/g, '$2');
+  s = s.replace(/(\*|_)(.*?)\1/g, '$2');
+  // Line-leading block markers: headings, list bullets, ordered numbers,
+  // blockquotes. Applied per line before whitespace collapse.
+  s = s.replace(/^[ \t]*#{1,6}[ \t]+/gm, '');         // headings
+  s = s.replace(/^[ \t]*>[ \t]?/gm, '');              // blockquote
+  s = s.replace(/^[ \t]*[-*+][ \t]+/gm, '');          // unordered list
+  s = s.replace(/^[ \t]*\d+[.)][ \t]+/gm, '');        // ordered list
+  s = s.replace(/^[ \t]*([-*_])(?:[ \t]*\1){2,}[ \t]*$/gm, ''); // hr lines
+  // Collapse all whitespace/newlines to single spaces.
+  s = s.replace(/\s+/g, ' ').trim();
+  return s;
+}


### PR DESCRIPTION
## What
Adds `markdownToText(src)` to core — reduces Markdown to clean single-line plain text. First of 3 PRs polishing the `/inbox` list page (phase 6).

## Why
List-row previews now show raw Markdown (`**bold**`, `[label](/agents/x)`, ISO timestamps) because bodies are stored as Markdown. This helper de-noises them. The existing `stripMarkdown` in notify-dispatcher is too crude (only strips `*_`<>`, leaves link syntax and list markers).

## Behavior
Unwraps links/images to their label, drops emphasis/code/heading/list/quote/HR markers, collapses newlines+whitespace to single spaces. Correctness only — callers escape on interpolation (not an HTML trust boundary; use `renderMarkdownSafe` for HTML).

## Tests
9 new cases in `markdown.test.ts` (markers stripped, links unwrapped, fenced code kept, multiline collapsed, plain text untouched). 25 total in the file, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)