### PR TITLE
feat(dashboard): pin a 'Needs you' section atop the inbox

### DIFF
--- a/.changeset/inbox-needs-you.md
+++ b/.changeset/inbox-needs-you.md
@@ -1,0 +1,16 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Pin a "Needs you" section at the top of the inbox.
+
+Threads awaiting your reply (status "Your turn") now float into a dedicated
+"Needs you" section at the top of `/inbox`, ordered longest-waiting-first, so
+what needs an operator reply is always first. They're removed from the main
+list (no double-listing), and the now-redundant "Reply to triage" banner
+suggestion is dropped; the suggested-actions banner points at the section
+instead of showing misleading "all resolved" copy.

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -2972,6 +2972,38 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
   border-radius: var(--radius-md);
   overflow: hidden;
 }
+
+/* "Needs you" pinned section — awaiting_user threads floated to the top. The
+ * amber left-edge accent (reused from the per-row awaiting cue) marks the whole
+ * block as the operator's action queue. */
+.inbox-needs-you {
+  margin-bottom: var(--space-4);
+}
+.inbox-needs-you__head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-xs);
+  font-weight: var(--weight-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-2);
+}
+.inbox-needs-you__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.25rem;
+  padding: 0 0.35rem;
+  border-radius: var(--radius-sm);
+  background: var(--color-warn, #f59e0b);
+  color: #1a1206;
+  font-size: var(--font-size-xs);
+}
+.inbox-list--needs-you {
+  border-left: 3px solid var(--color-warn, #f59e0b);
+}
 .inbox-list__header {
   display: grid;
   grid-template-columns: 12px 1fr auto auto auto 24px 24px;

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -157,6 +157,23 @@ describe('GET /inbox', () => {
     const res = await request(app).get('/inbox').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
     expect(res.text).toContain('No replies yet');
   });
+
+  it('pins awaiting_user threads in a "Needs you" section above the main list, not duplicated', async () => {
+    const app = await makeApp();
+    const waiting = inboxStore.add({ priority: 'low', source: 'manual', title: 'awaiting-thread', body: 'b' });
+    inboxStore.updateStatus(waiting.id, 'awaiting_user');
+    inboxStore.add({ priority: 'high', source: 'run-failure', title: 'open-thread', body: 'b' });
+    const res = await request(app).get('/inbox').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    // Section header present, and the awaiting row sits above the main list.
+    expect(res.text).toContain('inbox-needs-you');
+    expect(res.text).toContain('Needs you');
+    expect(res.text.indexOf('inbox-needs-you')).toBeLessThan(res.text.indexOf('inbox-list__header'));
+    // The awaiting row appears exactly once (in the section, not the main list).
+    const occurrences = res.text.split(`data-inbox-row-id="${waiting.id}"`).length - 1;
+    expect(occurrences).toBe(1);
+    // The redundant "Reply to triage" suggestion is gone.
+    expect(res.text).not.toContain('Reply to triage');
+  });
 });
 
 describe('GET /inbox/:id and /:id/fragment', () => {

--- a/packages/dashboard/src/views/inbox-list.ts
+++ b/packages/dashboard/src/views/inbox-list.ts
@@ -175,7 +175,6 @@ function buildSuggestions(rows: InboxMessage[]): Array<{ label: string; count: n
   const open = rows.filter((r) => r.status === 'open' || r.status === 'triaged');
   const highOpen = open.filter((r) => r.priority === 'high');
   const untriaged = open.filter((r) => r.status === 'open');
-  const awaiting = rows.filter((r) => r.status === 'awaiting_user');
 
   if (highOpen.length > 0) {
     out.push({
@@ -193,14 +192,9 @@ function buildSuggestions(rows: InboxMessage[]): Array<{ label: string; count: n
       href: untriaged[0] ? `#row-${untriaged[0].id}` : undefined,
     });
   }
-  if (awaiting.length > 0) {
-    out.push({
-      label: `Reply to triage`,
-      count: awaiting.length,
-      tag: 'awaiting',
-      href: awaiting[0] ? `#row-${awaiting[0].id}` : undefined,
-    });
-  }
+  // `awaiting_user` ("Your turn") threads are surfaced by the dedicated
+  // "Needs you" section pinned at the top of the list, so they no longer need a
+  // banner suggestion.
   return out;
 }
 
@@ -213,12 +207,13 @@ export function renderInboxList(opts: InboxListOptions): string {
 
   const starredAll = rows.filter((r) => r.starred);
   const suggestions = archiveView ? [] : buildSuggestions(rows);
+  const awaitingCount = rows.filter((r) => r.status === 'awaiting_user').length;
   const previewPayloads = opts.previewPayloads ?? new Map<string, InboxRowPreviewPayload>();
 
   const filterBar = renderFilterBar(filter, allTags);
   const suggestBanner = archiveView
     ? renderArchiveHeader(archiveView, rows.length)
-    : renderSuggestBanner(suggestions, rows.length, terminalCount);
+    : renderSuggestBanner(suggestions, rows.length, terminalCount, awaitingCount);
   const rail = renderRail(starredAll);
   const main = renderMain(rows, opts.sort, opts.dir, filter, previewPayloads);
   const archiveLink = !archiveView && terminalCount > 0
@@ -319,7 +314,7 @@ function renderFilterBar(filter: { q: string; starred: boolean; tag: string }, a
   `;
 }
 
-function renderSuggestBanner(suggestions: Array<{ label: string; count: number; href?: string; tag: string }>, totalRows: number, terminalCount: number): SafeHtml {
+function renderSuggestBanner(suggestions: Array<{ label: string; count: number; href?: string; tag: string }>, totalRows: number, terminalCount: number, awaitingCount = 0): SafeHtml {
   if (totalRows === 0) {
     // When the active inbox is empty AND there's a terminal-state
     // history, acknowledge the cleanup so the operator can see "yes,
@@ -356,16 +351,25 @@ function renderSuggestBanner(suggestions: Array<{ label: string; count: number; 
     `;
   }
   if (suggestions.length === 0) {
+    // When the only outstanding work is "Your turn" threads, the pinned
+    // "Needs you" section is the signal — point at it instead of the
+    // (misleading) "all resolved" copy.
+    const body = awaitingCount > 0
+      ? html`<span style="font-size: var(--font-size-sm); color: var(--color-text-muted);">
+            ${awaitingCount} thread${awaitingCount === 1 ? '' : 's'} need${awaitingCount === 1 ? 's' : ''} your reply — see <strong>Needs you</strong> above.
+          </span>`
+      : html`<span style="font-size: var(--font-size-sm); color: var(--color-text-muted);">
+            All ${totalRows} items are resolved or dismissed. Browse below if you want to revisit.
+          </span>`;
+    const title = awaitingCount > 0 ? 'Over to you' : 'Nothing pressing';
     return html`
       <div class="inbox-suggest inbox-suggest--clean" id="inbox-suggest">
         <div class="inbox-suggest__head">
-          <span class="inbox-suggest__title">Nothing pressing</span>
+          <span class="inbox-suggest__title">${title}</span>
           <button type="button" class="inbox-suggest__toggle" data-inbox-suggest-toggle aria-expanded="true">Hide</button>
         </div>
         <div class="inbox-suggest__items">
-          <span style="font-size: var(--font-size-sm); color: var(--color-text-muted);">
-            All ${totalRows} items are resolved or dismissed. Browse below if you want to revisit.
-          </span>
+          ${body}
         </div>
       </div>
     `;
@@ -428,15 +432,38 @@ function renderMain(rows: InboxMessage[], sort: InboxSortKey, dir: InboxSortDir,
       </div>
     `;
   }
-  // Flat sortable list. The priority-group cards are gone — the
-  // priority dot on each row + the (sorted) order carry the
-  // urgency cue without the structural overhead.
-  return html`
-    <div class="inbox-list" role="table">
-      ${renderListHeader(sort, dir, filter)}
-      ${rows.map((m) => renderRow(m, previewPayloads.get(m.id))) as unknown as SafeHtml[]}
-    </div>
-  `;
+  // "Needs you" pinned section: awaiting_user ("Your turn") threads float to a
+  // dedicated block at the top, longest-waiting-first (oldest last activity), so
+  // what needs an operator reply is always first and ordered by neglect. They
+  // are removed from the main list below to avoid double-listing.
+  const needsYou = rows
+    .filter((m) => m.status === 'awaiting_user')
+    .sort((a, b) => (a.lastActivityAt ?? a.createdAt) - (b.lastActivityAt ?? b.createdAt));
+  const rest = rows.filter((m) => m.status !== 'awaiting_user');
+
+  const needsYouBlock = needsYou.length > 0
+    ? html`
+      <section class="inbox-needs-you" aria-label="Needs you">
+        <div class="inbox-needs-you__head">Needs you <span class="inbox-needs-you__count">${needsYou.length}</span></div>
+        <div class="inbox-list inbox-list--needs-you" role="table">
+          ${needsYou.map((m) => renderRow(m, previewPayloads.get(m.id))) as unknown as SafeHtml[]}
+        </div>
+      </section>
+    `
+    : html``;
+
+  // Flat sortable list (everything not awaiting a reply). The priority-group
+  // cards are gone — the priority dot + sorted order carry the urgency cue.
+  const mainBlock = rest.length > 0
+    ? html`
+      <div class="inbox-list" role="table">
+        ${renderListHeader(sort, dir, filter)}
+        ${rest.map((m) => renderRow(m, previewPayloads.get(m.id))) as unknown as SafeHtml[]}
+      </div>
+    `
+    : html``;
+
+  return html`${needsYouBlock}${mainBlock}`;
 }
 
 /**


### PR DESCRIPTION
## What
Threads awaiting your reply ("Your turn" / `awaiting_user`) now float into a dedicated **"Needs you"** section pinned at the top of `/inbox`, ordered longest-waiting-first. Final PR (3 of 3) of phase 6.

## Stacked on #450 → #449
Base is `main`; rebase after parents merge.

## Changes
- `renderMain` partitions `awaiting_user` rows into a top `.inbox-needs-you` section (amber left-edge accent, count chip), removed from the main sortable list (no double-listing). Ordered by oldest `lastActivityAt` — surfaces what's been left hanging.
- `buildSuggestions` drops the now-redundant "Reply to triage" entry.
- The suggested-actions banner no longer shows misleading "all resolved / Nothing pressing" when the only outstanding work is awaiting replies — it points at the "Needs you" section ("Over to you").

## Tests
`inbox.test.ts`: section renders above the main list, awaiting rows appear exactly once (not duplicated), "Reply to triage" gone. Full core+dashboard suite: 1877 pass / 3 skipped. Verified live on :3000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)