### PR TITLE
fix(dashboard): correct the 'View in Temporal' deep link (no more 404)

### DIFF
--- a/.changeset/temporal-deep-link.md
+++ b/.changeset/temporal-deep-link.md
@@ -1,0 +1,16 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Fix the "View in Temporal" deep link (no more 404).
+
+Durable per-run executions now persist their Temporal execution runId
+(`temporal_run_id`), so the run-detail "View in Temporal" link points at the
+real history page (`/workflows/sua-run-<id>/<runId>/history`) instead of a bare
+workflow id that 404s. Per-node Temporal runs (e.g. inbox-dispatched agents,
+which have no single run-level workflow) now land on the namespace's workflows
+list rather than a guessed `sua-run-<id>` that doesn't exist.

--- a/packages/core/src/run-store.ts
+++ b/packages/core/src/run-store.ts
@@ -189,6 +189,12 @@ export class RunStore {
     if (!runCols.has('usedworkflowprovider')) {
       this.db.exec(`ALTER TABLE runs ADD COLUMN usedWorkflowProvider TEXT`);
     }
+    // Temporal workflow execution runId for durable per-run executions
+    // (`sua-run-<id>`). Drives the precise "View in Temporal" deep link.
+    // Nullable; NULL ↔ per-node or local runs.
+    if (!runCols.has('temporal_run_id')) {
+      this.db.exec(`ALTER TABLE runs ADD COLUMN temporal_run_id TEXT`);
+    }
     this.db.exec(`
       CREATE INDEX IF NOT EXISTS idx_runs_retry_of
         ON runs(retry_of_run_id) WHERE retry_of_run_id IS NOT NULL;
@@ -305,7 +311,7 @@ export class RunStore {
     return this.rowToRun(row);
   }
 
-  updateRun(id: string, updates: Partial<Pick<Run, 'status' | 'completedAt' | 'result' | 'exitCode' | 'error' | 'usedWorkflowProvider'>>): void {
+  updateRun(id: string, updates: Partial<Pick<Run, 'status' | 'completedAt' | 'result' | 'exitCode' | 'error' | 'usedWorkflowProvider' | 'temporalRunId'>>): void {
     const fields: string[] = [];
     const values: SqlValue[] = [];
 
@@ -315,6 +321,7 @@ export class RunStore {
     if (updates.exitCode !== undefined) { fields.push('exitCode = ?'); values.push(updates.exitCode); }
     if (updates.error !== undefined) { fields.push('error = ?'); values.push(updates.error); }
     if (updates.usedWorkflowProvider !== undefined) { fields.push('usedWorkflowProvider = ?'); values.push(updates.usedWorkflowProvider); }
+    if (updates.temporalRunId !== undefined) { fields.push('temporal_run_id = ?'); values.push(updates.temporalRunId); }
 
     if (fields.length === 0) return;
 
@@ -564,6 +571,7 @@ export class RunStore {
       retryOfRunId: (row.retry_of_run_id as string | null) ?? undefined,
       attempt: typeof row.attempt === 'number' ? row.attempt : 1,
       usedWorkflowProvider: (row.usedWorkflowProvider as string | null) ?? undefined,
+      temporalRunId: (row.temporal_run_id as string | null) ?? undefined,
     };
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -125,6 +125,14 @@ export interface Run {
    * treat as `local`.
    */
   usedWorkflowProvider?: string;
+  /**
+   * Temporal workflow execution runId, set only for DURABLE per-run executions
+   * (the `sua-run-<id>` workflow started by `submitDagRun`). Lets the dashboard
+   * build a precise Temporal Web UI deep link
+   * (`/workflows/sua-run-<id>/<temporalRunId>/history`). Absent for per-node
+   * Temporal runs (which have no single run-level workflow) and local runs.
+   */
+  temporalRunId?: string;
 }
 
 export interface RunRequest {

--- a/packages/dashboard/src/lib/temporal-link.test.ts
+++ b/packages/dashboard/src/lib/temporal-link.test.ts
@@ -2,14 +2,19 @@ import { describe, it, expect } from 'vitest';
 import { temporalWorkflowLink, TEMPORAL_UI_URL } from './temporal-link.js';
 
 describe('temporalWorkflowLink', () => {
-  it('builds a Web UI deep link for a temporal run', () => {
-    const link = temporalWorkflowLink({ id: 'abc-123', usedWorkflowProvider: 'temporal' });
-    expect(link).toBe(`${TEMPORAL_UI_URL}/namespaces/default/workflows/sua-run-abc-123`);
+  it('deep-links a durable per-run workflow to its history page', () => {
+    const link = temporalWorkflowLink({ id: 'abc-123', usedWorkflowProvider: 'temporal', temporalRunId: 'run-xyz' });
+    expect(link).toBe(`${TEMPORAL_UI_URL}/namespaces/default/workflows/sua-run-abc-123/run-xyz/history`);
   });
 
   it('honors a custom namespace', () => {
-    const link = temporalWorkflowLink({ id: 'r1', usedWorkflowProvider: 'temporal' }, 'prod');
-    expect(link).toContain('/namespaces/prod/workflows/sua-run-r1');
+    const link = temporalWorkflowLink({ id: 'r1', usedWorkflowProvider: 'temporal', temporalRunId: 'x' }, 'prod');
+    expect(link).toContain('/namespaces/prod/workflows/sua-run-r1/x/history');
+  });
+
+  it('lands on the workflows list for a per-node temporal run (no stored runId)', () => {
+    const link = temporalWorkflowLink({ id: 'r1', usedWorkflowProvider: 'temporal' });
+    expect(link).toBe(`${TEMPORAL_UI_URL}/namespaces/default/workflows`);
   });
 
   it('returns undefined for local runs', () => {

--- a/packages/dashboard/src/lib/temporal-link.ts
+++ b/packages/dashboard/src/lib/temporal-link.ts
@@ -4,16 +4,29 @@ import type { Run } from '@some-useful-agents/core';
 export const TEMPORAL_UI_URL = 'http://localhost:8233';
 
 /**
- * Deep link to a run's workflow in the Temporal Web UI, or undefined when the
- * run didn't execute on Temporal. The workflow id is `sua-run-<runId>` (durable
- * v2 runs + v1 single-node runs). B1b per-node runs (`sua-node-…`) have no single
- * run-level workflow; those are superseded by the durable per-run path.
+ * Deep link to a run in the Temporal Web UI, or undefined when the run didn't
+ * execute on Temporal.
+ *
+ * Two execution shapes:
+ *  - DURABLE per-run (`submitDagRun`): one `sua-run-<runId>` workflow. We stored
+ *    its execution runId (`run.temporalRunId`), so we link straight to that
+ *    workflow's history page.
+ *  - Per-node (`sua-node-…` workflows, one per node, random-suffixed ids that
+ *    aren't persisted): there's no single run-level workflow to point at, so we
+ *    land on the namespace's workflow LIST (a valid page where the operator can
+ *    find the `sua-node-*` executions) rather than a 404ing `sua-run-<id>` guess.
  */
 export function temporalWorkflowLink(
-  run: Pick<Run, 'id' | 'usedWorkflowProvider'>,
+  run: Pick<Run, 'id' | 'usedWorkflowProvider' | 'temporalRunId'>,
   namespace = 'default',
 ): string | undefined {
   if (run.usedWorkflowProvider !== 'temporal') return undefined;
-  const wf = encodeURIComponent(`sua-run-${run.id}`);
-  return `${TEMPORAL_UI_URL}/namespaces/${encodeURIComponent(namespace)}/workflows/${wf}`;
+  const ns = encodeURIComponent(namespace);
+  if (run.temporalRunId) {
+    const wf = encodeURIComponent(`sua-run-${run.id}`);
+    const rid = encodeURIComponent(run.temporalRunId);
+    return `${TEMPORAL_UI_URL}/namespaces/${ns}/workflows/${wf}/${rid}/history`;
+  }
+  // Per-node temporal run: no single workflow id to target. Land on the list.
+  return `${TEMPORAL_UI_URL}/namespaces/${ns}/workflows`;
 }

--- a/packages/temporal-provider/src/provider.ts
+++ b/packages/temporal-provider/src/provider.ts
@@ -143,7 +143,9 @@ export class TemporalProvider implements Provider {
       args: [input],
     });
 
-    this.store.updateRun(runId, { status: 'running' });
+    // Persist the Temporal execution runId so the dashboard can deep-link to
+    // this durable workflow's history (`/workflows/sua-run-<id>/<runId>/history`).
+    this.store.updateRun(runId, { status: 'running', temporalRunId: handle.firstExecutionRunId });
     void this.trackDagCompletion(runId, handle.workflowId);
 
     return { ...run, status: 'running' };


### PR DESCRIPTION
## Problem
The run-detail "View in Temporal" link always pointed at `/workflows/sua-run-<runId>`. For inbox-dispatched agent runs (which execute via the **per-node** path — `sua-node-<agent>-<node>-<rand>` workflows, no single run-level workflow), that `sua-run-<id>` workflow doesn't exist → **404**. The correct UI URL is also `/workflows/<wfid>/<temporalRunId>/history`, but the execution runId was never stored.

## Fix
- **Durable per-run** runs (`submitDagRun`) now persist their Temporal execution runId in a new `runs.temporal_run_id` column (migration + `Run.temporalRunId`). `temporalWorkflowLink` builds the precise `…/workflows/sua-run-<id>/<runId>/history`.
- **Per-node** temporal runs (no stored runId — their `sua-node-*` ids are random and unpersisted) land on the namespace **workflows list** (a valid page) instead of a 404ing guess.
- **Local** runs: no link (unchanged).

## Files
- `core`: `types.ts` (`Run.temporalRunId`), `run-store.ts` (column migration, `updateRun`, `rowToRun`)
- `temporal-provider`: `provider.ts` (store `handle.firstExecutionRunId` in `submitDagRun`)
- `dashboard`: `lib/temporal-link.ts` + tests

## Verify
- `temporal-link.test.ts`: durable → history deep link; per-node → workflows list; local → none.
- Full core+dashboard+temporal suite green (one unrelated scrypt-timeout flake, passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)