### PR TITLE
fix(dashboard): inbox thread not updating when triage finishes with an error

### DIFF
--- a/.changeset/inbox-triage-live-update.md
+++ b/.changeset/inbox-triage-live-update.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Fix inbox thread not updating when triage finishes with an error.
+
+Several triage completion branches ("did not complete", "no <plan>", "malformed
+JSON") added a system message to the conversation without emitting the
+`message:created` SSE event, so an open thread didn't refresh and the operator
+had to reload the page to see it. All triage system messages now route through a
+helper that always publishes the event, so the thread updates live.

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -196,6 +196,24 @@ function publishInboxEvent(
   catch { /* telemetry path — never break a route */ }
 }
 
+/**
+ * Add a `system`-role message AND publish the `message:created` SSE event so an
+ * open modal refreshes live. Every triage system note must go through this — a
+ * bare `addResponse` leaves the message invisible until a manual page refresh
+ * (the bug where triage "finished" but the thread didn't update).
+ */
+function addSystemMessage(
+  ctx: ReturnType<typeof getContext>,
+  messageId: string,
+  body: string,
+): InboxResponse {
+  const reply = ctx.inboxStore!.addResponse(messageId, 'system', body);
+  publishInboxEvent(ctx, messageId, 'message:created', {
+    responseId: reply.id, role: 'system', body: reply.body, createdAt: reply.createdAt,
+  });
+  return reply;
+}
+
 function parseSort(req: Request): { sort: InboxSortKey; dir: InboxSortDir } {
   const sortRaw = typeof req.query.sort === 'string' ? req.query.sort : '';
   const dirRaw = typeof req.query.dir === 'string' ? req.query.dir : '';
@@ -1802,18 +1820,18 @@ async function runTriageAgent(
     // waiting) — same friendly silence.
     if (run?.status === 'cancelled') return;
     if (!run || run.status !== 'completed' || !run.result) {
-      ctx.inboxStore.addResponse(
+      addSystemMessage(
+        ctx,
         messageId,
-        'system',
         `Triage agent did not complete (${run?.status ?? 'unknown'}). ${run?.error ?? ''}`.trim(),
       );
       return;
     }
     const planJson = extractPlanJson(run.result);
     if (!planJson) {
-      ctx.inboxStore.addResponse(
+      addSystemMessage(
+        ctx,
         messageId,
-        'system',
         'Triage agent returned no <plan>…</plan> block; raw response was discarded.',
       );
       return;
@@ -1822,7 +1840,7 @@ async function runTriageAgent(
     try {
       parsed = JSON.parse(planJson);
     } catch {
-      ctx.inboxStore.addResponse(messageId, 'system', 'Triage agent returned malformed JSON.');
+      addSystemMessage(ctx, messageId, 'Triage agent returned malformed JSON.');
       return;
     }
     const rec = typeof parsed.recommendation === 'string' ? parsed.recommendation.trim() : '';


### PR DESCRIPTION
## Problem
"The triage agent finished thinking but the thread didn't update — I had to refresh to see the message."

The happy path publishes `triage:complete` (which refreshes the open modal), but three **error-completion** branches added a `system` message via a bare `addResponse` with **no `message:created` event**:
- "Triage agent did not complete (…)"
- "Triage agent returned no `<plan>` block"
- "Triage agent returned malformed JSON"

If triage landed in one of these after the poll keep-alive window closed, the message was written silently and only appeared on a manual reload.

## Fix
Add `addSystemMessage(ctx, messageId, body)` that adds the row **and** publishes `message:created`, and route the three silent branches through it. Now every triage system note refreshes the thread live.

## Verify
- Build + inbox route/SSE tests green (65).
- Repro: a triage turn that returns a non-plan result now surfaces immediately in the open modal instead of requiring a refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)