### PR TITLE
fix(dashboard): polish inbox links + modal scrollbar

### DIFF
--- a/.changeset/inbox-link-polish.md
+++ b/.changeset/inbox-link-polish.md
@@ -1,0 +1,14 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Polish inbox links and modal scrollbar.
+
+Auto-linked `/agents/<id>` and `/runs/<id>` references now show the id as the
+link label (not the raw path), and all links in inbox messages and triage CTAs
+open in a new tab so following one keeps the inbox open. The modal's scroll
+container gets a thin, muted scrollbar instead of the heavy default slab.

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -3442,6 +3442,21 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
 
 /* ---------- Modal close × in top-right ---------- */
 .inbox-modal { position: relative; }
+
+/* Subtle scrollbar for the modal's scroll container. The default opaque OS
+ * scrollbar reads as a heavy gray slab against the dark surface; a thin,
+ * muted, transparent-track bar keeps the focus on the conversation. */
+#inbox-modal-content {
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border) transparent;
+}
+#inbox-modal-content::-webkit-scrollbar { width: 8px; }
+#inbox-modal-content::-webkit-scrollbar-track { background: transparent; }
+#inbox-modal-content::-webkit-scrollbar-thumb {
+  background: var(--color-border);
+  border-radius: 4px;
+}
+#inbox-modal-content::-webkit-scrollbar-thumb:hover { background: var(--color-text-muted); }
 .inbox-modal__close {
   position: absolute;
   top: var(--space-2);

--- a/packages/dashboard/src/views/components.test.ts
+++ b/packages/dashboard/src/views/components.test.ts
@@ -98,12 +98,12 @@ describe('humanizeTimestamps', () => {
 });
 
 describe('linkifyRefs', () => {
-  it('linkifies a bare /agents ref', () => {
-    expect(linkifyRefs('see /agents/foo for details')).toBe('see [/agents/foo](/agents/foo) for details');
+  it('linkifies a bare /agents ref with the id as the label', () => {
+    expect(linkifyRefs('see /agents/foo for details')).toBe('see [foo](/agents/foo) for details');
   });
 
-  it('linkifies a bare /runs ref', () => {
-    expect(linkifyRefs('run /runs/abc-123 failed')).toBe('run [/runs/abc-123](/runs/abc-123) failed');
+  it('linkifies a bare /runs ref with the id as the label', () => {
+    expect(linkifyRefs('run /runs/abc-123 failed')).toBe('run [abc-123](/runs/abc-123) failed');
   });
 
   it('leaves an existing Markdown link untouched (no double-linking)', () => {

--- a/packages/dashboard/src/views/components.ts
+++ b/packages/dashboard/src/views/components.ts
@@ -103,15 +103,19 @@ const PROTECT_RE = /(\[[^\]]+\]\([^)]+\)|`[^`]+`)/g;
 
 /**
  * Turn bare `/runs/<id>` and `/agents/<id>` references in free text into
- * Markdown links so they become clickable after Markdown rendering. Existing
- * Markdown links and inline-code spans are left untouched. Runs on plain text
- * BEFORE Markdown rendering.
+ * Markdown links so they become clickable after Markdown rendering. The visible
+ * label is the trailing id (e.g. `apple-fm`), not the raw path, so prose stays
+ * readable; the href keeps the full path. Existing Markdown links and
+ * inline-code spans are left untouched. Runs on plain text BEFORE rendering.
  */
 export function linkifyRefs(text: string): string {
   if (!text) return text;
   return text
     .split(PROTECT_RE)
-    .map((seg, i) => (i % 2 === 1 ? seg : seg.replace(REF_RE, (m) => `[${m}](${m})`)))
+    .map((seg, i) => (i % 2 === 1 ? seg : seg.replace(REF_RE, (m) => {
+      const label = m.slice(m.lastIndexOf('/') + 1);
+      return `[${label}](${m})`;
+    })))
     .join('');
 }
 

--- a/packages/dashboard/src/views/inbox-detail.ts
+++ b/packages/dashboard/src/views/inbox-detail.ts
@@ -317,13 +317,18 @@ function mdBody(text: string): SafeHtml {
   // disturbing the plain-text `pre-wrap` path used by the optimistic
   // "Sending…" placeholder, which writes textContent into the same container.
   const pre = humanizeTimestamps(linkifyRefs(text));
-  return unsafeHtml(`<div class="inbox-md">${renderMarkdownSafe(pre)}</div>`);
+  // Open links in a new tab so following an agent/run link keeps the inbox
+  // modal open. Applied after sanitize (target/rel are allowlisted); safe
+  // because we control the injected attributes.
+  const rendered = renderMarkdownSafe(pre).replace(/<a /g, '<a target="_blank" rel="noreferrer" ');
+  return unsafeHtml(`<div class="inbox-md">${rendered}</div>`);
 }
 
 /**
  * Render the optional structured link-CTA buttons a triage reply may carry in
  * its `metaJson.links`. Hrefs were already URL-validated server-side
- * (parseTriageLinks); we re-escape on render. External links open in a new tab.
+ * (parseTriageLinks); we re-escape on render. Links open in a new tab so
+ * following a CTA keeps the inbox open.
  */
 function renderTriageLinks(metaJson?: string): SafeHtml {
   if (!metaJson) return html``;
@@ -336,9 +341,7 @@ function renderTriageLinks(metaJson?: string): SafeHtml {
     .filter((l) => typeof l.label === 'string' && typeof l.href === 'string')
     .map((l) => {
       const href = l.href as string;
-      const external = /^https?:\/\//i.test(href);
-      const target = external ? html` target="_blank" rel="noreferrer"` : html``;
-      return html`<a class="btn btn--xs btn--ghost" href="${href}"${target}>${l.label as string}</a>`;
+      return html`<a class="btn btn--xs btn--ghost" href="${href}" target="_blank" rel="noreferrer">${l.label as string}</a>`;
     });
   if (buttons.length === 0) return html``;
   return html`<div class="inbox-msg__ctas">${buttons as unknown as SafeHtml[]}</div>`;


### PR DESCRIPTION
## What
Two dogfooding polish fixes (independent, off `main`):
1. **Shorter link labels** — auto-linked `/agents/<id>` and `/runs/<id>` references now show the **id** as the link text (e.g. `apple-fm`) instead of the raw path, so triage prose stays readable. The href keeps the full path.
2. **New-tab links** — links in inbox messages and triage CTA buttons open in a new tab (`target=_blank rel=noreferrer`), so following an agent/run link keeps the inbox open.
3. **Subtle scrollbar** — the modal's scroll container (`#inbox-modal-content`) gets a thin, muted scrollbar instead of the heavy default OS slab.

## Files
`components.ts` (`linkifyRefs` label), `inbox-detail.ts` (`mdBody` + `renderTriageLinks` new-tab), `screens.css` (scrollbar), `components.test.ts`.

## Verify
`components.test.ts` updated for the id-label format; build green. Dogfoodable at /inbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)