### PR TITLE
fix(dashboard): give inbox threads a durable permalink

### DIFF
--- a/.changeset/inbox-thread-permalink.md
+++ b/.changeset/inbox-thread-permalink.md
@@ -1,0 +1,14 @@
+---
+"@some-useful-agents/dashboard": patch
+---
+
+fix(dashboard): give inbox threads a durable permalink from the modal
+
+Opening a thread from `/inbox` now updates the browser URL to
+`/inbox/:id` instead of leaving the address bar on the list view.
+That makes a modal-opened thread linkable with normal browser copy,
+and browser back/forward now closes and reopens the same thread
+instead of dropping that state on the floor.
+
+The thread header also exposes an `Open page` action so the full-page
+detail route is visible from the normal inbox flow.

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -3495,7 +3495,17 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
   flex: 1;
   word-break: break-word;
 }
+.inbox-modal__title-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
 .inbox-modal__star-form { margin: 0; flex-shrink: 0; }
+.inbox-modal__permalink {
+  white-space: nowrap;
+  text-decoration: none;
+}
 
 .inbox-modal__meta {
   display: flex;

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -186,6 +186,7 @@ describe('GET /inbox/:id and /:id/fragment', () => {
     const res = await request(app).get(`/inbox/${m.id}`).set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
     expect(res.status).toBe(200);
     expect(res.text).toContain('Detail title');
+    expect(res.text).toContain(`data-inbox-page-detail data-inbox-message-id="${m.id}"`);
     expect(res.text).toContain(`action="/inbox/${m.id}/respond"`);
     expect(res.text).toContain(`action="/inbox/${m.id}/dismiss"`);
     expect(res.text).toContain(`action="/inbox/${m.id}/triage"`);

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -471,6 +471,8 @@ describe('Row + fragment rendering for star + tags', () => {
     const res = await request(app).get(`/inbox/${m.id}/fragment`).set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
     expect(res.text).toContain('inbox-detail__header');
     expect(res.text).toContain('inbox-detail__thread');
+    expect(res.text).toContain(`href="/inbox/${m.id}"`);
+    expect(res.text).toContain('Open page');
     expect(res.text).toContain(`action="/inbox/${m.id}/star"`);
     expect(res.text).toContain(`action="/inbox/${m.id}/tags"`);
     expect(res.text).toContain('value="auth"');

--- a/packages/dashboard/src/views/inbox-detail.ts
+++ b/packages/dashboard/src/views/inbox-detail.ts
@@ -143,6 +143,9 @@ export function renderInboxDetailFragment(opts: InboxDetailOptions): SafeHtml {
       <button type="submit" class="inbox-star ${message.starred ? 'inbox-star--on' : ''}" aria-label="${message.starred ? 'Unstar' : 'Star'}">★</button>
     </form>
   `;
+  const permalinkControl = html`
+    <a href="/inbox/${message.id}" class="btn btn--ghost btn--xs inbox-modal__permalink">Open page</a>
+  `;
 
   // Tags as pills with inline ×. The form submits the full tag set on
   // every change (existing route contract — `tags` is a CSV); JS
@@ -236,7 +239,10 @@ export function renderInboxDetailFragment(opts: InboxDetailOptions): SafeHtml {
       <div class="inbox-detail__header">
         <header class="inbox-modal__title-row">
           <h3 id="inbox-modal-title" class="inbox-modal__title">${message.title}</h3>
-          ${starControl}
+          <div class="inbox-modal__title-actions">
+            ${permalinkControl}
+            ${starControl}
+          </div>
         </header>
         ${headerMeta}
         ${tagsBlock}
@@ -637,4 +643,3 @@ function renderThinkingIndicator(messageId: string): SafeHtml {
     </div>
   `;
 }
-

--- a/packages/dashboard/src/views/inbox-detail.ts
+++ b/packages/dashboard/src/views/inbox-detail.ts
@@ -285,7 +285,9 @@ export function renderInboxDetail(opts: InboxDetailOptions): string {
       back: { href: '/inbox', label: 'Inbox' },
     })}
     <section class="card" style="margin-top: var(--space-3);">
-      ${renderInboxDetailFragment(opts)}
+      <div data-inbox-page-detail data-inbox-message-id="${message.id}">
+        ${renderInboxDetailFragment(opts)}
+      </div>
     </section>
   `;
   return render(layout({

--- a/packages/dashboard/src/views/inbox-modal.js.ts
+++ b/packages/dashboard/src/views/inbox-modal.js.ts
@@ -33,6 +33,9 @@ export const INBOX_MODAL_JS = `
   // server hasn't yet attached a triageRunId to the message — the
   // dag-executor + run-store insertion is racy with our 200ms wait.
   var keepPollingUntil = 0;
+  // Preserve the inbox list URL we opened from so closing the modal
+  // returns to that exact filter/search view instead of a bare /inbox.
+  var modalBaseHref = '';
 
   // SSE state. eventSource carries the active connection; sseAliveAt
   // records the last event (or open) timestamp so the watchdog can
@@ -51,7 +54,7 @@ export const INBOX_MODAL_JS = `
     modal.classList.add('is-open');
     document.body.style.overflow = 'hidden';
   }
-  function close() {
+  function teardownModal() {
     modal.hidden = true;
     modal.classList.remove('is-open');
     document.body.style.overflow = '';
@@ -60,6 +63,46 @@ export const INBOX_MODAL_JS = `
     keepPollingUntil = 0;
     stopPoll();
     closeEventSource();
+  }
+  function close(opts) {
+    opts = opts || {};
+    var fromHistory = !!opts.fromHistory;
+    if (!fromHistory && currentId && window.history && window.history.state
+      && window.history.state.inboxModalId === currentId) {
+      window.history.back();
+      return;
+    }
+    teardownModal();
+    if (fromHistory && !isInboxThreadPath(window.location.pathname)) {
+      modalBaseHref = '';
+    }
+  }
+
+  function currentLocationHref() {
+    return window.location.pathname + window.location.search + window.location.hash;
+  }
+
+  function inboxThreadHref(id) {
+    return '/inbox/' + encodeURIComponent(id);
+  }
+
+  function isInboxThreadPath(pathname) {
+    return /^\\/inbox\\/[^/]+$/.test(pathname || '');
+  }
+
+  function syncModalHistory(id, mode) {
+    if (!window.history || typeof window.history.pushState !== 'function') return;
+    var state = {
+      inboxModalId: id,
+      inboxModalBaseHref: modalBaseHref || '/inbox',
+    };
+    try {
+      if (mode === 'replace' && typeof window.history.replaceState === 'function') {
+        window.history.replaceState(state, '', inboxThreadHref(id));
+      } else {
+        window.history.pushState(state, '', inboxThreadHref(id));
+      }
+    } catch (_) { /* noop */ }
   }
 
   function closeEventSource() {
@@ -510,7 +553,22 @@ export const INBOX_MODAL_JS = `
     if (btn) btn.focus();
   }
 
-  function openFor(id) {
+  function openFor(id, opts) {
+    opts = opts || {};
+    var fromHistory = !!opts.fromHistory;
+    var wasOpen = !modal.hidden;
+    if (!wasOpen) {
+      modalBaseHref = currentLocationHref();
+    } else if (!modalBaseHref) {
+      modalBaseHref = currentLocationHref();
+    }
+    if (!fromHistory) {
+      syncModalHistory(id, wasOpen ? 'replace' : 'push');
+    } else if (window.history && window.history.state
+      && typeof window.history.state.inboxModalBaseHref === 'string'
+      && window.history.state.inboxModalBaseHref) {
+      modalBaseHref = window.history.state.inboxModalBaseHref;
+    }
     currentId = id;
     seenMsgIds = Object.create(null);
     keepPollingUntil = 0;
@@ -690,6 +748,15 @@ export const INBOX_MODAL_JS = `
     if (e.key === 'Escape' && !modal.hidden) close();
   });
 
+  window.addEventListener('popstate', function () {
+    var match = window.location.pathname.match(/^\\/inbox\\/([^/]+)$/);
+    if (match) {
+      openFor(decodeURIComponent(match[1]), { fromHistory: true });
+      return;
+    }
+    if (!modal.hidden) close({ fromHistory: true });
+  });
+
   // Intercept Reply / Dismiss / Triage form submits inside the modal.
   modal.addEventListener('submit', function (e) {
     var form = e.target;
@@ -760,7 +827,7 @@ export const INBOX_MODAL_JS = `
           // the now-terminal row. The prior approach (remove row +
           // close modal) left those counts stale until the operator
           // manually refreshed.
-          window.location.reload();
+          window.location.assign(modalBaseHref || '/inbox');
         } else {
           refresh();
         }

--- a/packages/dashboard/src/views/inbox-modal.js.ts
+++ b/packages/dashboard/src/views/inbox-modal.js.ts
@@ -19,9 +19,12 @@
 export const INBOX_MODAL_JS = `
 (function () {
   var modal = document.getElementById('inbox-modal');
-  if (!modal) return;
-  var content = document.getElementById('inbox-modal-content');
+  var pageDetail = document.querySelector('[data-inbox-page-detail]');
+  var content = modal
+    ? document.getElementById('inbox-modal-content')
+    : pageDetail;
   if (!content) return;
+  var isPageDetail = !modal && !!pageDetail;
 
   // Per-open state.
   var currentId = null;
@@ -50,11 +53,13 @@ export const INBOX_MODAL_JS = `
   var SSE_WATCHDOG_MS = 20000;
 
   function open() {
+    if (!modal) return;
     modal.hidden = false;
     modal.classList.add('is-open');
     document.body.style.overflow = 'hidden';
   }
   function teardownModal() {
+    if (!modal) return;
     modal.hidden = true;
     modal.classList.remove('is-open');
     document.body.style.overflow = '';
@@ -65,6 +70,7 @@ export const INBOX_MODAL_JS = `
     closeEventSource();
   }
   function close(opts) {
+    if (!modal) return;
     opts = opts || {};
     var fromHistory = !!opts.fromHistory;
     if (!fromHistory && currentId && window.history && window.history.state
@@ -504,7 +510,7 @@ export const INBOX_MODAL_JS = `
   /**
    * True if the operator is actively interacting with the modal — they
    * have a non-empty text selection anchored inside it (highlighting
-   * text to copy), or they are typing into a non-empty input. In
+   * text to copy), or they are typing into a non-empty field. In
    * either case, a poll-driven refresh should NOT swap the DOM
    * because that wipes the selection or in-progress text.
    *
@@ -528,10 +534,14 @@ export const INBOX_MODAL_JS = `
         } else {
           return true;
         }
-      } else {
-        // Any non-input element with focus (button, link, details
-        // summary) is genuine interaction.
+      } else if (tag === 'SELECT') {
         return true;
+      } else if (active.isContentEditable) {
+        return true;
+      } else {
+        // Focused buttons/links after a click must NOT block refreshes
+        // indefinitely or the thread will appear stuck on "thinking".
+        // Fall through to the selection check below.
       }
     }
     var sel = window.getSelection && window.getSelection();
@@ -554,6 +564,7 @@ export const INBOX_MODAL_JS = `
   }
 
   function openFor(id, opts) {
+    if (!modal) return;
     opts = opts || {};
     var fromHistory = !!opts.fromHistory;
     var wasOpen = !modal.hidden;
@@ -745,10 +756,11 @@ export const INBOX_MODAL_JS = `
   })();
 
   document.addEventListener('keydown', function (e) {
-    if (e.key === 'Escape' && !modal.hidden) close();
+    if (modal && e.key === 'Escape' && !modal.hidden) close();
   });
 
   window.addEventListener('popstate', function () {
+    if (!modal) return;
     var match = window.location.pathname.match(/^\\/inbox\\/([^/]+)$/);
     if (match) {
       openFor(decodeURIComponent(match[1]), { fromHistory: true });
@@ -758,7 +770,7 @@ export const INBOX_MODAL_JS = `
   });
 
   // Intercept Reply / Dismiss / Triage form submits inside the modal.
-  modal.addEventListener('submit', function (e) {
+  document.addEventListener('submit', function (e) {
     var form = e.target;
     if (!(form instanceof HTMLFormElement)) return;
     if (!form.hasAttribute('data-inbox-modal-form')) return;
@@ -827,7 +839,7 @@ export const INBOX_MODAL_JS = `
           // the now-terminal row. The prior approach (remove row +
           // close modal) left those counts stale until the operator
           // manually refreshed.
-          window.location.assign(modalBaseHref || '/inbox');
+          window.location.assign(isPageDetail ? '/inbox' : (modalBaseHref || '/inbox'));
         } else {
           refresh();
         }
@@ -941,17 +953,26 @@ export const INBOX_MODAL_JS = `
     }
   })();
 
+  if (isPageDetail) {
+    currentId = pageDetail.getAttribute('data-inbox-message-id');
+    applyAnimations();
+    if (currentId) {
+      openEventSource(currentId);
+      maybeSchedulePoll();
+    }
+  }
+
   // ── Tag pills inside the modal (add / remove with quiet submit) ──
   // The remove buttons + the Add-tag input live in the rendered
   // fragment; we delegate on the modal element since the fragment
   // refreshes after every save.
-  modal.addEventListener('click', function (e) {
+  document.addEventListener('click', function (e) {
     var rm = e.target.closest && e.target.closest('[data-inbox-tag-remove]');
     if (!rm) return;
     e.preventDefault();
     e.stopPropagation();
     var tag = rm.getAttribute('data-inbox-tag-remove');
-    var hidden = modal.querySelector('[data-inbox-tags-input]');
+    var hidden = content.querySelector('[data-inbox-tags-input]');
     if (!hidden) return;
     var current = String(hidden.value).split(',').map(function (s) { return s.trim(); }).filter(Boolean);
     var next = current.filter(function (t) { return t !== tag; });
@@ -960,7 +981,7 @@ export const INBOX_MODAL_JS = `
     if (form && form.requestSubmit) form.requestSubmit();
     else if (form) form.submit();
   });
-  modal.addEventListener('keydown', function (e) {
+  document.addEventListener('keydown', function (e) {
     // Cmd+Enter (Mac) or Ctrl+Enter submits the reply composer / inline
     // reply / triage form the textarea lives in. Plain Enter still
     // inserts a newline.
@@ -982,7 +1003,7 @@ export const INBOX_MODAL_JS = `
     e.preventDefault();
     var raw = String(add.value).trim().toLowerCase();
     if (!raw) return;
-    var hidden = modal.querySelector('[data-inbox-tags-input]');
+    var hidden = content.querySelector('[data-inbox-tags-input]');
     if (!hidden) return;
     var current = String(hidden.value).split(',').map(function (s) { return s.trim(); }).filter(Boolean);
     if (current.indexOf(raw) === -1) current.push(raw);


### PR DESCRIPTION
## Summary
- update the inbox modal URL to /inbox/:id when a thread opens
- restore the prior inbox list/filter URL on close or dismiss
- expose an explicit Open page action in the thread header

## Testing
- npm run build
- npx vitest run packages/dashboard/src/routes/inbox.test.ts *(fails in this sandbox due listen EPERM on port binding)*