### PR TITLE
fix(dashboard): block repeated failed triage actions

### DIFF
--- a/.changeset/inbox-triage-repeat-guard.md
+++ b/.changeset/inbox-triage-repeat-guard.md
@@ -1,0 +1,13 @@
+---
+"@some-useful-agents/dashboard": patch
+---
+
+fix(dashboard): stop inbox triage from repeating identical failed actions
+
+When inbox triage proposes a sub-agent action that already failed on
+the same thread with the same inputs, the dashboard now refuses the
+repeat instead of auto-running the same broken step again.
+
+This prevents loops where triage keeps retrying an unchanged action
+until the per-thread auto-follow-up cap is hit, and forces the next
+turn to revise the inputs or choose a different next step.

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -837,6 +837,35 @@ function parseActionMeta(r: InboxResponse): InboxActionMeta | null {
   return null;
 }
 
+function stableStringifyInputs(inputs: Record<string, string>): string {
+  return JSON.stringify(
+    Object.keys(inputs)
+      .sort()
+      .reduce<Record<string, string>>((acc, key) => {
+        acc[key] = inputs[key];
+        return acc;
+      }, {}),
+  );
+}
+
+function hasMatchingFailedAction(
+  ctx: ReturnType<typeof getContext>,
+  messageId: string,
+  candidate: InboxActionMeta,
+): boolean {
+  if (!ctx.inboxStore) return false;
+  const candidateInputs = stableStringifyInputs(candidate.inputs);
+  for (const response of ctx.inboxStore.listResponses(messageId)) {
+    const existing = parseActionMeta(response);
+    if (!existing) continue;
+    if (existing.agentId !== candidate.agentId) continue;
+    if (existing.status !== 'failed' && existing.status !== 'refused') continue;
+    if (stableStringifyInputs(existing.inputs) !== candidateInputs) continue;
+    return true;
+  }
+  return false;
+}
+
 /**
  * Build the effective allowlist of sub-agent ids triage may propose
  * running. For entries not yet installed, attempt a one-shot import
@@ -1893,10 +1922,21 @@ async function runTriageAgent(
     // declined and why.
     if (allowlist.length > 0) {
       const { accepted, rejected } = parseProposedActions(parsed.actions, allowlist);
+      const dedupedAccepted: InboxActionMeta[] = [];
+      for (const action of accepted) {
+        if (hasMatchingFailedAction(ctx, messageId, action)) {
+          rejected.push({
+            agentId: action.agentId,
+            reason: 'same action already failed on this thread; revise the inputs or choose a different next step',
+          });
+          continue;
+        }
+        dedupedAccepted.push(action);
+      }
       const existing = countActionsOnMessage(ctx, messageId);
       const budget = Math.max(0, MAX_ACTIONS_PER_MESSAGE - existing);
-      const toInsert = accepted.slice(0, budget);
-      const overflow = accepted.length - toInsert.length;
+      const toInsert = dedupedAccepted.slice(0, budget);
+      const overflow = dedupedAccepted.length - toInsert.length;
       for (const action of toInsert) {
         const body = action.rationale
           ?? `Run agent \`${action.agentId}\`.`;


### PR DESCRIPTION
## Summary
- reject inbox triage action proposals that exactly match a previously failed action on the same thread
- surface a refusal reason telling triage to revise inputs or choose a different next step
- stop auto-follow-up loops that keep re-running the same broken sub-agent action until the thread cap is hit

## Testing
- npm run build