### PR TITLE
feat: record + surface per-provider LLM fallback failure reasons

### DIFF
--- a/.changeset/llm-provider-failure-reasons.md
+++ b/.changeset/llm-provider-failure-reasons.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Record and surface WHY each LLM provider was skipped in the fallback waterfall.
+
+When the LLM provider waterfall falls back (e.g. codex → apple-foundation-models),
+the per-attempt failure reason used to be discarded once a later provider
+succeeded. Each failed attempt is now captured (`{provider, category, error}`),
+persisted on the node execution (`provider_failures_json`), and logged to stderr
+(`[llm-fallback] agent/node: codex failed (timeout): …`). The run-detail node
+card now reads "ran on apple-foundation-models · codex (timeout) failed" with the
+full error in the hover, instead of a bare "codex failed".

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -663,6 +663,14 @@ export interface NodeExecutionRecord {
    */
   attemptedProviders?: string;
   /**
+   * JSON array of per-attempt failure reasons for providers the waterfall
+   * tried and abandoned (the winner is excluded): `[{provider, category,
+   * error?}]`. Lets the dashboard show WHY each skipped provider was skipped
+   * (e.g. "codex: timeout"). Stored as JSON (structured); undefined when no
+   * provider failed.
+   */
+  providerFailures?: string;
+  /**
    * Execution backend that ran this node: `'local'` (in-process) or
    * `'temporal'` (worker activity). Different axis from `usedLLMProvider`
    * above, which is the LLM provider. Undefined on legacy rows ↔ `local`.

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -1069,6 +1069,7 @@ export async function executeAgentDag(
         stateBytesAfter,
         usedLLMProvider: result.usedLLMProvider,
         attemptedProviders: result.attemptedProviders ? result.attemptedProviders.join(',') : undefined,
+        providerFailures: result.providerFailures ? JSON.stringify(result.providerFailures) : undefined,
         usedWorkflowProvider: result.usedWorkflowProvider,
       });
     } else {
@@ -1087,6 +1088,7 @@ export async function executeAgentDag(
         outputsJson,
         usedLLMProvider: result.usedLLMProvider,
         attemptedProviders: result.attemptedProviders ? result.attemptedProviders.join(',') : undefined,
+        providerFailures: result.providerFailures ? JSON.stringify(result.providerFailures) : undefined,
         usedWorkflowProvider: result.usedWorkflowProvider,
         stateBytesAfter,
       });

--- a/packages/core/src/node-spawner.ts
+++ b/packages/core/src/node-spawner.ts
@@ -17,6 +17,17 @@ import { ensureAppleRunner } from './apple-foundationmodels-runner.js';
 
 // ── Types ──────────────────────────────────────────────────────────────
 
+/**
+ * One failed provider attempt in the LLM waterfall: which provider, the
+ * classified failure category (timeout / credit_exhausted / binary_missing /
+ * …), and a short error snippet for diagnosis.
+ */
+export interface ProviderFailure {
+  provider: string;
+  category: string;
+  error?: string;
+}
+
 export type SpawnResult = ExecutionResult & {
   category?: NodeErrorCategory;
   /**
@@ -33,6 +44,13 @@ export type SpawnResult = ExecutionResult & {
    * for shell nodes.
    */
   attemptedProviders?: string[];
+  /**
+   * Per-attempt failure reasons for every provider the waterfall tried and
+   * abandoned (the winner is not listed). Lets the dashboard show WHY each
+   * skipped provider was skipped (e.g. "codex: timeout") instead of a bare
+   * "codex failed". Undefined when no provider failed.
+   */
+  providerFailures?: ProviderFailure[];
   /**
    * Execution backend that actually ran this node: `'local'` (in-process)
    * or `'temporal'` (worker activity). A backend (the injected spawnNode)
@@ -617,6 +635,10 @@ export async function spawnNodeReal(
   const chain = buildProviderChain(node.provider, _opts.llmSettings?.providers);
 
   const attemptedProviders: string[] = [];
+  // Per-attempt failure trail: why each non-winning provider was skipped.
+  // Surfaced on the node card and logged below so a successful fallback run
+  // still records WHY the earlier providers failed.
+  const providerFailures: ProviderFailure[] = [];
   let lastResult: SpawnResult | undefined;
   let lastCategory: LlmFailureCategory = 'other';
 
@@ -633,6 +655,7 @@ export async function spawnNodeReal(
         ...result,
         usedLLMProvider: provider,
         attemptedProviders,
+        providerFailures: providerFailures.length > 0 ? providerFailures : undefined,
         error: attemptedProviders.length > 1
           ? `Fallback ${provider} succeeded after ${attemptedProviders.slice(0, -1).join(', ')} failed (${lastCategory}).`
           : result.error,
@@ -641,6 +664,16 @@ export async function spawnNodeReal(
 
     lastResult = result;
     lastCategory = classifyLlmFailure(result);
+
+    // Record + log WHY this provider failed, so a successful fallback run
+    // still leaves a diagnosable trail (the per-attempt error is otherwise
+    // discarded once a later provider wins).
+    const errSnippet = (result.error ?? '').replace(/\s+/g, ' ').trim().slice(0, 300);
+    providerFailures.push({ provider, category: lastCategory, error: errSnippet || undefined });
+    process.stderr.write(
+      `[llm-fallback] ${_opts.agentId ?? '?'}/${node.id}: ${provider} failed (${lastCategory})` +
+      `${errSnippet ? `: ${errSnippet}` : ''}\n`,
+    );
 
     // Decide whether to continue the waterfall.
     if (!shouldFallback(lastCategory)) break;
@@ -665,6 +698,7 @@ export async function spawnNodeReal(
     ...(lastResult ?? { result: '', exitCode: 1 }),
     usedLLMProvider: attemptedProviders[attemptedProviders.length - 1],
     attemptedProviders,
+    providerFailures: providerFailures.length > 0 ? providerFailures : undefined,
   };
 }
 

--- a/packages/core/src/run-store.test.ts
+++ b/packages/core/src/run-store.test.ts
@@ -317,6 +317,23 @@ describe('RunStore node_executions', () => {
     expect(got.error).toBe('Timed out after 30s');
   });
 
+  it('round-trips providerFailures (per-attempt LLM failure reasons)', () => {
+    store.createNodeExecution({
+      runId: 'r-x', nodeId: 'triage', workflowVersion: 1,
+      status: 'running', startedAt: new Date().toISOString(),
+    });
+    const failures = JSON.stringify([{ provider: 'codex', category: 'timeout', error: 'hard wall-clock cap' }]);
+    store.updateNodeExecution('r-x', 'triage', {
+      status: 'completed', completedAt: new Date().toISOString(), exitCode: 0,
+      usedLLMProvider: 'apple-foundation-models',
+      attemptedProviders: 'codex,apple-foundation-models',
+      providerFailures: failures,
+    });
+    const got = store.getNodeExecution('r-x', 'triage')!;
+    expect(got.providerFailures).toBe(failures);
+    expect(JSON.parse(got.providerFailures!)[0]).toMatchObject({ provider: 'codex', category: 'timeout' });
+  });
+
   it('updateNodeExecution applies a partial patch', () => {
     store.createNodeExecution({
       runId: 'r-x', nodeId: 'fetch', workflowVersion: 1,

--- a/packages/core/src/run-store.ts
+++ b/packages/core/src/run-store.ts
@@ -244,6 +244,12 @@ export class RunStore {
     if (!execCols.has('attemptedproviders')) {
       this.db.exec(`ALTER TABLE node_executions ADD COLUMN attemptedProviders TEXT`);
     }
+    // Per-attempt failure reasons (JSON `[{provider,category,error?}]`) for the
+    // providers the waterfall tried and abandoned. Surfaces WHY each skipped
+    // provider was skipped. Nullable; NULL ↔ no provider failed.
+    if (!execCols.has('provider_failures_json')) {
+      this.db.exec(`ALTER TABLE node_executions ADD COLUMN provider_failures_json TEXT`);
+    }
 
     // Workflow (execution backend) provider per node: 'local' | 'temporal'.
     // Different axis from `usedLLMProvider` (the `usedProvider` column), which is
@@ -462,7 +468,7 @@ export class RunStore {
     runId: string,
     nodeId: string,
     updates: Partial<Pick<NodeExecutionRecord,
-      'status' | 'errorCategory' | 'completedAt' | 'result' | 'exitCode' | 'error' | 'inputsJson' | 'upstreamInputsJson' | 'outputsJson' | 'progressJson' | 'stateBytesBefore' | 'stateBytesAfter' | 'childPid' | 'childStartedAtMs' | 'usedLLMProvider' | 'attemptedProviders' | 'usedWorkflowProvider'
+      'status' | 'errorCategory' | 'completedAt' | 'result' | 'exitCode' | 'error' | 'inputsJson' | 'upstreamInputsJson' | 'outputsJson' | 'progressJson' | 'stateBytesBefore' | 'stateBytesAfter' | 'childPid' | 'childStartedAtMs' | 'usedLLMProvider' | 'attemptedProviders' | 'providerFailures' | 'usedWorkflowProvider'
     >>,
   ): void {
     const fields: string[] = [];
@@ -483,6 +489,7 @@ export class RunStore {
     if (updates.childStartedAtMs !== undefined) { fields.push('childStartedAtMs = ?'); values.push(updates.childStartedAtMs); }
     if (updates.usedLLMProvider !== undefined) { fields.push('usedProvider = ?'); values.push(updates.usedLLMProvider); }
     if (updates.attemptedProviders !== undefined) { fields.push('attemptedProviders = ?'); values.push(updates.attemptedProviders); }
+    if (updates.providerFailures !== undefined) { fields.push('provider_failures_json = ?'); values.push(updates.providerFailures); }
     if (updates.usedWorkflowProvider !== undefined) { fields.push('usedWorkflowProvider = ?'); values.push(updates.usedWorkflowProvider); }
     if (fields.length === 0) return;
 
@@ -597,6 +604,7 @@ export class RunStore {
       childStartedAtMs: (row.childStartedAtMs as number | null) ?? undefined,
       usedLLMProvider: (row.usedProvider as string | null) ?? undefined,
       attemptedProviders: (row.attemptedProviders as string | null) ?? undefined,
+      providerFailures: (row.provider_failures_json as string | null) ?? undefined,
       usedWorkflowProvider: (row.usedWorkflowProvider as string | null) ?? undefined,
     };
   }

--- a/packages/dashboard/src/views/run-detail.test.ts
+++ b/packages/dashboard/src/views/run-detail.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import type { Agent, NodeExecutionRecord, Run } from '@some-useful-agents/core';
+import { renderRunDetail } from './run-detail.js';
+
+// Minimal v2 agent so renderRunDetail treats the run as a DAG and renders the
+// per-node cards (gated on run.workflowId && nodeExecutions && agent).
+const agent = {
+  id: 'inbox-triage', name: 'Inbox Triage', status: 'active', source: 'examples',
+  version: 1,
+  nodes: [{ id: 'triage', type: 'llm-prompt', prompt: 'x' }],
+} as unknown as Agent;
+
+const baseRun: Run = {
+  id: 'run-1',
+  agentName: 'inbox-triage',
+  status: 'completed',
+  startedAt: new Date().toISOString(),
+  triggeredBy: 'dashboard',
+  workflowId: 'inbox-triage',
+  workflowVersion: 1,
+};
+
+function nodeExec(extra: Partial<NodeExecutionRecord>): NodeExecutionRecord {
+  return {
+    runId: 'run-1', nodeId: 'triage', workflowVersion: 1,
+    status: 'completed', startedAt: new Date().toISOString(), exitCode: 0,
+    ...extra,
+  };
+}
+
+describe('renderRunDetail — LLM waterfall chip', () => {
+  it('shows the failed provider WITH its reason when providerFailures is present', () => {
+    const html = renderRunDetail({
+      run: baseRun,
+      agent,
+      nodeExecutions: [nodeExec({
+        usedLLMProvider: 'apple-foundation-models',
+        attemptedProviders: 'codex,apple-foundation-models',
+        providerFailures: JSON.stringify([{ provider: 'codex', category: 'timeout', error: 'hard cap' }]),
+      })],
+    });
+    expect(html).toContain('ran on');
+    expect(html).toContain('apple-foundation-models');
+    // The reason is shown inline next to the failed provider.
+    expect(html).toContain('codex (timeout)');
+    // The error snippet rides along in the hover title.
+    expect(html).toContain('codex: timeout — hard cap');
+  });
+
+  it('falls back to the bare provider name when no providerFailures stored', () => {
+    const html = renderRunDetail({
+      run: baseRun,
+      agent,
+      nodeExecutions: [nodeExec({
+        usedLLMProvider: 'apple-foundation-models',
+        attemptedProviders: 'codex,apple-foundation-models',
+      })],
+    });
+    expect(html).toContain('ran on');
+    expect(html).toContain('codex');
+    expect(html).not.toContain('codex (');
+  });
+
+  it('renders no waterfall chip when only one provider was tried', () => {
+    const html = renderRunDetail({
+      run: baseRun,
+      agent,
+      nodeExecutions: [nodeExec({ usedLLMProvider: 'codex', attemptedProviders: 'codex' })],
+    });
+    expect(html).not.toContain('failed</span>');
+  });
+});

--- a/packages/dashboard/src/views/run-detail.ts
+++ b/packages/dashboard/src/views/run-detail.ts
@@ -459,9 +459,23 @@ function renderNodeCards(execs: NodeExecutionRecord[], runId?: string, canReplay
     if (e.attemptedProviders) {
       const trail = e.attemptedProviders.split(',').filter(Boolean);
       if (trail.length > 1 && e.usedLLMProvider) {
-        const failedFrom = trail.slice(0, -1).join(', ');
+        // Per-attempt failure reasons (why each skipped provider was skipped),
+        // so the chip reads "codex (timeout) failed" instead of "codex failed".
+        let failures: Array<{ provider: string; category: string; error?: string }> = [];
+        if (e.providerFailures) {
+          try { failures = JSON.parse(e.providerFailures); } catch { /* leave empty */ }
+        }
+        const reasonOf = new Map(failures.map((f) => [f.provider, f.category]));
+        const failedFrom = trail
+          .slice(0, -1)
+          .map((p) => (reasonOf.has(p) ? `${p} (${reasonOf.get(p)})` : p))
+          .join(', ');
+        // Hover detail: full per-provider category + error snippet when present.
+        const titleDetail = failures.length > 0
+          ? failures.map((f) => `${f.provider}: ${f.category}${f.error ? ` — ${f.error}` : ''}`).join('\n')
+          : `LLM waterfall: ${trail.join(' → ')}`;
         const verdict = e.status === 'completed' ? 'ran on' : 'ended on';
-        waterfallChip = html`<span class="badge badge--muted" title="LLM waterfall: ${trail.join(' → ')}">${verdict} <span class="mono">${e.usedLLMProvider}</span> · <span class="mono">${failedFrom}</span> failed</span>`;
+        waterfallChip = html`<span class="badge badge--muted" title="${titleDetail}">${verdict} <span class="mono">${e.usedLLMProvider}</span> · <span class="mono">${failedFrom}</span> failed</span>`;
       }
     }
 


### PR DESCRIPTION
## What
When the LLM provider waterfall falls back (e.g. **codex → apple-foundation-models**), it now records and surfaces **why** each skipped provider failed, instead of discarding the reason once a later provider succeeds.

Closes the gap from a dogfooding question: a run showed "ran on apple-foundation-models · codex failed" with no way to tell *why* codex failed.

## Changes
- **Capture** (`node-spawner.ts`): each failed attempt is collected as `{provider, category, error}` (`SpawnResult.providerFailures`).
- **Log** (`node-spawner.ts`): every failure writes a stderr line — `[llm-fallback] <agent>/<node>: codex failed (timeout): <error snippet>` — so a successful fallback run still leaves a diagnosable trail in the worker/dashboard logs.
- **Persist**: new `node_executions.provider_failures_json` column (migration) + `NodeExecutionRecord.providerFailures`; the executor serializes it on both the success and failure write paths.
- **Surface** (`run-detail.ts`): the node card chip now reads **"ran on apple-foundation-models · codex (timeout) failed"**, with the full per-provider category + error in the hover title.

## Why no claude in a chain, etc.
Unchanged behavior — the waterfall still stops at the first success; this only makes the *skipped* providers' reasons visible.

## Tests
- `run-store.test.ts` — `providerFailures` round-trips through the store.
- `run-detail.test.ts` (new) — chip shows `codex (timeout)` + the error in the title; falls back to the bare name without the data; no chip for a single provider.
- Full core+dashboard suite: 1882 pass / 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)