### PR TITLE
feat(core): output contract → fallback-worthy LLM failure

### DIFF
--- a/.changeset/llm-output-contract.md
+++ b/.changeset/llm-output-contract.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Treat contract-violating LLM output as a fallback-worthy failure.
+
+A node can now declare an `outputContract` (`mustMatch` regex / `minChars`). When
+a 0-exit LLM result fails it — e.g. a weak fallback model returns no `<plan>`
+block — the provider waterfall now classifies it as a new fallback-worthy
+category `invalid_output` and escalates to the next (stronger) provider instead
+of accepting useless output. If every provider fails the contract, the run fails
+honestly instead of being a silent success. Opt-in: nodes without a contract are
+unaffected.

--- a/.playwright-mcp/page-2026-06-03T19-21-40-121Z.yml
+++ b/.playwright-mcp/page-2026-06-03T19-21-40-121Z.yml
@@ -1,0 +1,41 @@
+- generic [active] [ref=e1]:
+  - banner [ref=e2]:
+    - link "sua" [ref=e3] [cursor=pointer]:
+      - /url: /
+    - navigation [ref=e4]:
+      - link "Inbox" [ref=e5] [cursor=pointer]:
+        - /url: /inbox
+      - link "Pulse" [ref=e6] [cursor=pointer]:
+        - /url: /pulse
+      - link "Agents" [ref=e7] [cursor=pointer]:
+        - /url: /agents
+      - link "Settings" [ref=e8] [cursor=pointer]:
+        - /url: /settings
+      - link "Help" [ref=e9] [cursor=pointer]:
+        - /url: /help
+    - button "Toggle theme" [ref=e10] [cursor=pointer]:
+      - generic [ref=e11]: light
+  - main [ref=e12]:
+    - generic [ref=e13]:
+      - heading "Sign in required" [level=1] [ref=e14]
+      - paragraph [ref=e15]:
+        - text: The dashboard is locked until you visit the one-time URL that
+        - code [ref=e16]: sua dashboard start
+        - text: printed to your terminal.
+      - paragraph [ref=e17]: "Look for a line starting with:"
+      - generic [ref=e18]: Dashboard ready at http://127.0.0.1:3000/auth#token=<...>
+      - paragraph [ref=e19]:
+        - text: Click it once to set a session cookie; after that, bookmark
+        - link "http://127.0.0.1:3000/" [ref=e20] [cursor=pointer]:
+          - /url: /
+        - text: .
+  - contentinfo [ref=e21]:
+    - generic [ref=e22]:
+      - generic [ref=e23]: sua v0.22.0 · bbc7964
+      - navigation [ref=e24]:
+        - link "Help & tutorial" [ref=e25] [cursor=pointer]:
+          - /url: /help
+        - link "GitHub" [ref=e26] [cursor=pointer]:
+          - /url: https://github.com/gregmeyer/some-useful-agents
+        - link "Docs" [ref=e27] [cursor=pointer]:
+          - /url: https://github.com/gregmeyer/some-useful-agents/tree/main/docs

--- a/.playwright-mcp/page-2026-06-03T19-21-46-380Z.yml
+++ b/.playwright-mcp/page-2026-06-03T19-21-46-380Z.yml
@@ -1,0 +1,41 @@
+- generic [active] [ref=e1]:
+  - banner [ref=e2]:
+    - link "sua" [ref=e3] [cursor=pointer]:
+      - /url: /
+    - navigation [ref=e4]:
+      - link "Inbox" [ref=e5] [cursor=pointer]:
+        - /url: /inbox
+      - link "Pulse" [ref=e6] [cursor=pointer]:
+        - /url: /pulse
+      - link "Agents" [ref=e7] [cursor=pointer]:
+        - /url: /agents
+      - link "Settings" [ref=e8] [cursor=pointer]:
+        - /url: /settings
+      - link "Help" [ref=e9] [cursor=pointer]:
+        - /url: /help
+    - button "Toggle theme" [ref=e10] [cursor=pointer]:
+      - generic [ref=e11]: light
+  - main [ref=e12]:
+    - generic [ref=e13]:
+      - heading "Sign in required" [level=1] [ref=e14]
+      - paragraph [ref=e15]:
+        - text: The dashboard is locked until you visit the one-time URL that
+        - code [ref=e16]: sua dashboard start
+        - text: printed to your terminal.
+      - paragraph [ref=e17]: "Look for a line starting with:"
+      - generic [ref=e18]: Dashboard ready at http://127.0.0.1:3000/auth#token=<...>
+      - paragraph [ref=e19]:
+        - text: Click it once to set a session cookie; after that, bookmark
+        - link "http://127.0.0.1:3000/" [ref=e20] [cursor=pointer]:
+          - /url: /
+        - text: .
+  - contentinfo [ref=e21]:
+    - generic [ref=e22]:
+      - generic [ref=e23]: sua v0.22.0 · bbc7964
+      - navigation [ref=e24]:
+        - link "Help & tutorial" [ref=e25] [cursor=pointer]:
+          - /url: /help
+        - link "GitHub" [ref=e26] [cursor=pointer]:
+          - /url: https://github.com/gregmeyer/some-useful-agents
+        - link "Docs" [ref=e27] [cursor=pointer]:
+          - /url: https://github.com/gregmeyer/some-useful-agents/tree/main/docs

--- a/.playwright-mcp/page-2026-06-03T19-21-54-402Z.yml
+++ b/.playwright-mcp/page-2026-06-03T19-21-54-402Z.yml
@@ -1,0 +1,41 @@
+- generic [active] [ref=e1]:
+  - banner [ref=e2]:
+    - link "sua" [ref=e3] [cursor=pointer]:
+      - /url: /
+    - navigation [ref=e4]:
+      - link "Inbox" [ref=e5] [cursor=pointer]:
+        - /url: /inbox
+      - link "Pulse" [ref=e6] [cursor=pointer]:
+        - /url: /pulse
+      - link "Agents" [ref=e7] [cursor=pointer]:
+        - /url: /agents
+      - link "Settings" [ref=e8] [cursor=pointer]:
+        - /url: /settings
+      - link "Help" [ref=e9] [cursor=pointer]:
+        - /url: /help
+    - button "Toggle theme" [ref=e10] [cursor=pointer]:
+      - generic [ref=e11]: light
+  - main [ref=e12]:
+    - generic [ref=e13]:
+      - heading "Sign in required" [level=1] [ref=e14]
+      - paragraph [ref=e15]:
+        - text: The dashboard is locked until you visit the one-time URL that
+        - code [ref=e16]: sua dashboard start
+        - text: printed to your terminal.
+      - paragraph [ref=e17]: "Look for a line starting with:"
+      - generic [ref=e18]: Dashboard ready at http://127.0.0.1:3000/auth#token=<...>
+      - paragraph [ref=e19]:
+        - text: Click it once to set a session cookie; after that, bookmark
+        - link "http://127.0.0.1:3000/" [ref=e20] [cursor=pointer]:
+          - /url: /
+        - text: .
+  - contentinfo [ref=e21]:
+    - generic [ref=e22]:
+      - generic [ref=e23]: sua v0.22.0 · bbc7964
+      - navigation [ref=e24]:
+        - link "Help & tutorial" [ref=e25] [cursor=pointer]:
+          - /url: /help
+        - link "GitHub" [ref=e26] [cursor=pointer]:
+          - /url: https://github.com/gregmeyer/some-useful-agents
+        - link "Docs" [ref=e27] [cursor=pointer]:
+          - /url: https://github.com/gregmeyer/some-useful-agents/tree/main/docs

--- a/.playwright-mcp/page-2026-06-03T19-24-09-506Z.yml
+++ b/.playwright-mcp/page-2026-06-03T19-24-09-506Z.yml
@@ -1,0 +1,41 @@
+- generic [active] [ref=e1]:
+  - banner [ref=e2]:
+    - link "sua" [ref=e3] [cursor=pointer]:
+      - /url: /
+    - navigation [ref=e4]:
+      - link "Inbox" [ref=e5] [cursor=pointer]:
+        - /url: /inbox
+      - link "Pulse" [ref=e6] [cursor=pointer]:
+        - /url: /pulse
+      - link "Agents" [ref=e7] [cursor=pointer]:
+        - /url: /agents
+      - link "Settings" [ref=e8] [cursor=pointer]:
+        - /url: /settings
+      - link "Help" [ref=e9] [cursor=pointer]:
+        - /url: /help
+    - button "Toggle theme" [ref=e10] [cursor=pointer]:
+      - generic [ref=e11]: light
+  - main [ref=e12]:
+    - generic [ref=e13]:
+      - heading "Sign in required" [level=1] [ref=e14]
+      - paragraph [ref=e15]:
+        - text: The dashboard is locked until you visit the one-time URL that
+        - code [ref=e16]: sua dashboard start
+        - text: printed to your terminal.
+      - paragraph [ref=e17]: "Look for a line starting with:"
+      - generic [ref=e18]: Dashboard ready at http://127.0.0.1:3000/auth#token=<...>
+      - paragraph [ref=e19]:
+        - text: Click it once to set a session cookie; after that, bookmark
+        - link "http://127.0.0.1:3000/" [ref=e20] [cursor=pointer]:
+          - /url: /
+        - text: .
+  - contentinfo [ref=e21]:
+    - generic [ref=e22]:
+      - generic [ref=e23]: sua v0.22.0 · bbc7964
+      - navigation [ref=e24]:
+        - link "Help & tutorial" [ref=e25] [cursor=pointer]:
+          - /url: /help
+        - link "GitHub" [ref=e26] [cursor=pointer]:
+          - /url: https://github.com/gregmeyer/some-useful-agents
+        - link "Docs" [ref=e27] [cursor=pointer]:
+          - /url: https://github.com/gregmeyer/some-useful-agents/tree/main/docs

--- a/packages/core/src/agent-v2-schema.test.ts
+++ b/packages/core/src/agent-v2-schema.test.ts
@@ -422,3 +422,22 @@ describe('extractUpstreamReferences', () => {
     expect([...extractUpstreamReferences('{{upstream.a.data.nested.field}}')]).toEqual(['a']);
   });
 });
+
+describe('agentV2Schema — outputContract', () => {
+  it('accepts a node with an outputContract', () => {
+    const r = agentV2Schema.safeParse(validSingleNode({
+      nodes: [{
+        id: 'main', type: 'llm-prompt', prompt: 'do it',
+        outputContract: { mustMatch: '<plan>[\\s\\S]*?</plan>', minChars: 10, description: 'a <plan> block' },
+      }],
+    }));
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects a non-string mustMatch', () => {
+    const r = agentV2Schema.safeParse(validSingleNode({
+      nodes: [{ id: 'main', type: 'llm-prompt', prompt: 'x', outputContract: { mustMatch: 123 } }],
+    }));
+    expect(r.success).toBe(false);
+  });
+});

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -127,6 +127,15 @@ export const agentNodeSchema = z.object({
 
   dependsOn: z.array(z.string()).optional(),
 
+  // Output contract for llm-prompt nodes — a 0-exit result that fails this is
+  // a fallback-worthy failure (category invalid_output) so the waterfall
+  // escalates to a stronger provider. Opt-in.
+  outputContract: z.object({
+    mustMatch: z.string().optional(),
+    minChars: z.number().int().nonnegative().optional(),
+    description: z.string().optional(),
+  }).optional(),
+
   // Flow control
   onlyIf: onlyIfSchema.optional(),
   conditionalConfig: conditionalConfigSchema.optional(),

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -86,6 +86,13 @@ export type NodeErrorCategory =
   | 'condition_not_met'
   | 'flow_ended'
   /**
+   * An llm-prompt node exited 0 but its output failed the node's declared
+   * `outputContract` (e.g. a weak fallback model returned no `<plan>` block).
+   * Treated as a fallback-worthy failure so the provider waterfall escalates;
+   * terminal only when every provider's output failed the contract.
+   */
+  | 'invalid_output'
+  /**
    * Tool-policy denied this node. Set when a future enforcement engine
    * (PR C of the tool-policies feature) refuses a tool call against a
    * resource the project policy blocks. Lives in the enum from PR B
@@ -279,10 +286,32 @@ export interface AgentNode {
   endMessage?: string;
 
   /**
+   * Optional output contract for llm-prompt nodes. A 0-exit result that fails
+   * the contract is treated as a fallback-worthy failure (category
+   * `invalid_output`) so the provider waterfall escalates to a stronger model
+   * instead of accepting useless output from a weak one. Opt-in: free-form
+   * nodes that omit this are never judged. Enforced in `node-spawner.ts`.
+   */
+  outputContract?: OutputContract;
+
+  /**
    * Optional layout hint for the v0.14 drag/drop editor. Ignored by the
    * executor. Stored in the DAG JSON so layouts survive export/import.
    */
   position?: { x: number; y: number };
+}
+
+/**
+ * What a node's output must satisfy to count as a real success. Checked against
+ * the node's text result after a 0-exit spawn.
+ */
+export interface OutputContract {
+  /** Regex (tested with the dotAll flag) the result must match — e.g. `<plan>[\s\S]*?</plan>`. */
+  mustMatch?: string;
+  /** Minimum non-whitespace character count — catches empty / near-empty output. */
+  minChars?: number;
+  /** Human label for the contract, used in failure messages + the node card hover. */
+  description?: string;
 }
 
 /**

--- a/packages/core/src/agent-yaml.test.ts
+++ b/packages/core/src/agent-yaml.test.ts
@@ -114,6 +114,31 @@ describe('exportAgent + round-trip', () => {
     expect(a2).toEqual(a1);
   });
 
+  it('preserves a node outputContract through parse + export round-trip', () => {
+    const yaml = `
+id: contract-agent
+name: Contract Agent
+description: has a node output contract
+status: active
+source: examples
+nodes:
+  - id: main
+    type: llm-prompt
+    prompt: do it
+    outputContract:
+      mustMatch: '<plan>[\\s\\S]*?</plan>'
+      minChars: 10
+      description: a <plan> block
+`;
+    const a1 = parseAgent(yaml);
+    expect(a1.nodes[0].outputContract).toEqual({
+      mustMatch: '<plan>[\\s\\S]*?</plan>', minChars: 10, description: 'a <plan> block',
+    });
+    // And survives export → re-parse.
+    const a2 = parseAgent(exportAgent(a1));
+    expect(a2.nodes[0].outputContract).toEqual(a1.nodes[0].outputContract);
+  });
+
   it('emits fields in stable order (id, name, description, ... nodes, ...)', () => {
     const a = parseAgent(THREE_NODE_YAML);
     const yaml = exportAgent(a);

--- a/packages/core/src/agent-yaml.ts
+++ b/packages/core/src/agent-yaml.ts
@@ -92,6 +92,7 @@ function parsedToAgent(p: AgentV2Parsed): Agent {
     ...(n.loopConfig && { loopConfig: n.loopConfig }),
     ...(n.agentInvokeConfig && { agentInvokeConfig: n.agentInvokeConfig }),
     ...(n.endMessage !== undefined && { endMessage: n.endMessage }),
+    ...(n.outputContract && { outputContract: n.outputContract }),
     ...(n.position && { position: n.position }),
   }));
 
@@ -160,6 +161,7 @@ const NODE_KEY_ORDER = [
   // control flow
   'onlyIf', 'conditionalConfig', 'switchConfig', 'loopConfig', 'agentInvokeConfig',
   'endMessage',
+  'outputContract',
   'position',
 ] as const;
 

--- a/packages/core/src/node-spawner.test.ts
+++ b/packages/core/src/node-spawner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { appleFoundationModelsSpawner, buildProviderChain, claudeSpawner, codexSpawner, classifyLlmFailure, shouldFallback, type SpawnResult } from './node-spawner.js';
+import { appleFoundationModelsSpawner, buildProviderChain, claudeSpawner, codexSpawner, classifyLlmFailure, shouldFallback, validateOutputContract, type SpawnResult } from './node-spawner.js';
 
 function r(partial: Partial<SpawnResult>): SpawnResult {
   return {
@@ -89,8 +89,53 @@ describe('shouldFallback (waterfall trigger)', () => {
     expect(shouldFallback('rate_limited')).toBe(true);
   });
 
+  it('falls back on invalid_output (a weak model that whiffed the format — escalate)', () => {
+    expect(shouldFallback('invalid_output')).toBe(true);
+  });
+
   it('does NOT fall back on other — silent switching would mask real bugs', () => {
     expect(shouldFallback('other')).toBe(false);
+  });
+});
+
+describe('classifyLlmFailure — invalid_output passthrough', () => {
+  it('maps a contract-failed result (category invalid_output) to invalid_output', () => {
+    expect(classifyLlmFailure(r({ exitCode: 1, category: 'invalid_output', error: 'Output failed contract: missing <plan>' }))).toBe('invalid_output');
+  });
+  it('still returns other for a zero-exit result regardless of category', () => {
+    expect(classifyLlmFailure(r({ exitCode: 0, category: 'invalid_output' }))).toBe('other');
+  });
+});
+
+describe('validateOutputContract', () => {
+  it('passes when no contract is set', () => {
+    expect(validateOutputContract(undefined, 'anything')).toEqual({ ok: true });
+  });
+
+  it('passes when the output matches mustMatch (dotAll across newlines)', () => {
+    const c = { mustMatch: '<plan>[\\s\\S]*?</plan>', description: 'a <plan> block' };
+    expect(validateOutputContract(c, 'sure:\n<plan>\n{"x":1}\n</plan>\nok')).toEqual({ ok: true });
+  });
+
+  it('fails (with reason) when mustMatch is absent from the output', () => {
+    const c = { mustMatch: '<plan>[\\s\\S]*?</plan>', description: 'a <plan> block' };
+    const res = validateOutputContract(c, 'here is a plain prose answer, no block');
+    expect(res.ok).toBe(false);
+    expect((res as { reason: string }).reason).toContain('a <plan> block');
+  });
+
+  it('fails when output is shorter than minChars (non-whitespace)', () => {
+    expect(validateOutputContract({ minChars: 10 }, '  hi  ').ok).toBe(false);
+    expect(validateOutputContract({ minChars: 10 }, 'plenty of content here').ok).toBe(true);
+  });
+
+  it('treats empty output as failing a non-zero minChars', () => {
+    expect(validateOutputContract({ minChars: 1 }, '').ok).toBe(false);
+    expect(validateOutputContract({ minChars: 1 }, undefined).ok).toBe(false);
+  });
+
+  it('treats a malformed mustMatch regex as no constraint (never blocks on operator typo)', () => {
+    expect(validateOutputContract({ mustMatch: '([unclosed' }, 'whatever')).toEqual({ ok: true });
   });
 });
 

--- a/packages/core/src/node-spawner.ts
+++ b/packages/core/src/node-spawner.ts
@@ -9,7 +9,7 @@
 
 import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
-import type { Agent, AgentNode, NodeErrorCategory } from './agent-v2-types.js';
+import type { Agent, AgentNode, NodeErrorCategory, OutputContract } from './agent-v2-types.js';
 import type { ExecutionResult } from './agent-executor.js';
 import { substituteInputs } from './input-resolver.js';
 import { resolveUpstreamTemplate, resolveVarsTemplate, resolveStateTemplate } from './node-templates.js';
@@ -117,6 +117,7 @@ export type LlmFailureCategory =
   | 'timeout'
   | 'rate_limited'
   | 'auth_required'
+  | 'invalid_output'
   | 'other';
 
 /**
@@ -645,20 +646,35 @@ export async function spawnNodeReal(
   for (let i = 0; i < chain.length; i++) {
     const provider = chain[i];
     attemptedProviders.push(provider);
-    const result = await runLlmAttempt(provider, node, resolvedPrompt, childEnv, onProgress, signal, onSpawn);
+    let result = await runLlmAttempt(provider, node, resolvedPrompt, childEnv, onProgress, signal, onSpawn);
 
+    // A 0-exit result still has to satisfy the node's output contract. A weak
+    // fallback model that ignores the required format (e.g. no <plan> block)
+    // "succeeds" at the CLI level but produced nothing useful — treat that as a
+    // fallback-worthy failure so the waterfall escalates to a stronger model.
     if (result.exitCode === 0) {
-      // Success — annotate with the trail so the dashboard can show
-      // "ran on codex after claude failed" without parsing the error
-      // breadcrumb.
-      return {
+      const check = validateOutputContract(node.outputContract, result.result);
+      if (check.ok) {
+        // Success — annotate with the trail so the dashboard can show
+        // "ran on codex after claude failed" without parsing the error
+        // breadcrumb.
+        return {
+          ...result,
+          usedLLMProvider: provider,
+          attemptedProviders,
+          providerFailures: providerFailures.length > 0 ? providerFailures : undefined,
+          error: attemptedProviders.length > 1
+            ? `Fallback ${provider} succeeded after ${attemptedProviders.slice(0, -1).join(', ')} failed (${lastCategory}).`
+            : result.error,
+        };
+      }
+      // Contract failed: rewrite the 0-exit result into a failure so the
+      // shared failure path below records it + decides whether to fall back.
+      result = {
         ...result,
-        usedLLMProvider: provider,
-        attemptedProviders,
-        providerFailures: providerFailures.length > 0 ? providerFailures : undefined,
-        error: attemptedProviders.length > 1
-          ? `Fallback ${provider} succeeded after ${attemptedProviders.slice(0, -1).join(', ')} failed (${lastCategory}).`
-          : result.error,
+        exitCode: 1,
+        category: 'invalid_output',
+        error: `Output failed contract: ${check.reason}`,
       };
     }
 
@@ -870,6 +886,8 @@ export function buildProviderChain(
  */
 export function classifyLlmFailure(result: SpawnResult): LlmFailureCategory {
   if (result.exitCode === 0) return 'other';
+  // Output-contract violations are pre-classified by the waterfall.
+  if (result.category === 'invalid_output') return 'invalid_output';
   const haystack = `${result.error ?? ''}\n${result.result ?? ''}`.toLowerCase();
   if (result.category === 'spawn_failure'
     || haystack.includes('command not found')
@@ -932,7 +950,37 @@ export function shouldFallback(category: LlmFailureCategory): boolean {
     || category === 'binary_missing'
     || category === 'timeout'
     || category === 'auth_required'
-    || category === 'rate_limited';
+    || category === 'rate_limited'
+    || category === 'invalid_output';
+}
+
+/**
+ * Validate a node's text output against its declared {@link OutputContract}. A
+ * 0-exit result that fails this is treated as a fallback-worthy failure so the
+ * provider waterfall escalates to a stronger model instead of accepting useless
+ * output. Opt-in: a missing/empty contract always passes. A malformed
+ * `mustMatch` regex is treated as no constraint (never blocks on operator typo).
+ */
+export function validateOutputContract(
+  contract: OutputContract | undefined,
+  output: string | undefined,
+): { ok: true } | { ok: false; reason: string } {
+  if (!contract) return { ok: true };
+  const text = output ?? '';
+  if (typeof contract.minChars === 'number' && contract.minChars > 0) {
+    const nonWs = text.replace(/\s+/g, '').length;
+    if (nonWs < contract.minChars) {
+      return { ok: false, reason: `output too short (${nonWs} < ${contract.minChars} chars)` };
+    }
+  }
+  if (contract.mustMatch) {
+    let re: RegExp | undefined;
+    try { re = new RegExp(contract.mustMatch, 's'); } catch { re = undefined; }
+    if (re && !re.test(text)) {
+      return { ok: false, reason: `missing ${contract.description ?? `/${contract.mustMatch}/`}` };
+    }
+  }
+  return { ok: true };
 }
 
 // ── Process spawner ────────────────────────────────────────────────────

--- a/packages/dashboard/src/views/components.ts
+++ b/packages/dashboard/src/views/components.ts
@@ -159,6 +159,7 @@ const ERROR_CATEGORY_LABELS: Record<string, string> = {
   upstream_failed: 'Skipped (upstream failed)',
   condition_not_met: 'Skipped (condition not met)',
   flow_ended: 'Flow ended',
+  invalid_output: 'Output failed the task contract',
 };
 
 export function formatErrorCategory(category: string): string {


### PR DESCRIPTION
## What
Closes the "a fallback LLM succeeds but does nothing" gap. Exit 0 means the CLI ran, not that the output is useful — a weak fallback model (apple-foundation-models) can return prose that ignores the required format, and the waterfall accepts it as success without ever trying the strong model.

A node can now declare an **`outputContract`**; a 0-exit result that fails it becomes a **fallback-worthy** failure (new category `invalid_output`) so the waterfall escalates. If every provider fails the contract, the run fails honestly.

PR 1 of 2 — **the engine** (opt-in; behavior-preserving until a node declares a contract). PR 2 adds contracts to inbox-triage + the structured system agents.

## Changes (`core`)
- `AgentNode.outputContract` + zod schema: `{ mustMatch?: string (regex), minChars?: number, description?: string }`.
- `validateOutputContract(contract, output)` — dotAll regex; `minChars` on non-whitespace length; malformed regex → treated as no constraint (never blocks on an operator typo).
- New `invalid_output` in `LlmFailureCategory` (→ `shouldFallback` true) and `NodeErrorCategory` (+ dashboard label "Output failed the task contract").
- Waterfall (`spawnNodeReal`): on a 0-exit attempt, validate before declaring success; on failure synthesize an `invalid_output` failure and continue the chain. `classifyLlmFailure` passes the category through.

## Free synergy
`invalid_output` attempts ride the per-provider failure trail (#460) — the node card shows "ran on claude · apple-foundation-models (invalid_output) failed" — and an exhausted-chain failure surfaces live in the inbox via #456.

## Tests
- `validateOutputContract` (match / no-match / minChars / empty / bad-regex guard / no-contract).
- `shouldFallback('invalid_output')` true; `classifyLlmFailure` passes the category through and still returns 'other' on exit 0.
- schema accepts `outputContract`, rejects non-string `mustMatch`.
- Full core+dashboard suite: 1893 pass / 3 skipped.

## Note
The live spawn isn't unit-mockable, so the fall-through *decision* is covered by the validator + `shouldFallback` units; the end-to-end escalation is verified live once PR 2 lands a contract on triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)