### PR TITLE
fix(temporal): keepalive heartbeat for per-node activity

### DIFF
--- a/.changeset/temporal-node-heartbeat-keepalive.md
+++ b/.changeset/temporal-node-heartbeat-keepalive.md
@@ -1,0 +1,22 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Fix Temporal node runs dying on a false heartbeat timeout.
+
+`runNodeActivity` only heartbeated when a node emitted a progress event, with a
+30s heartbeat timeout and no keepalive. An LLM node that thinks for longer than
+30s before its first streamed token (e.g. agent-builder's `design` step,
+inbox-triage's `triage` step) went silent, so Temporal killed the activity with
+"activity Heartbeat timeout" even though the child process was working fine — the
+run was recorded as a generic "Temporal node workflow failed: Workflow execution
+failed". A keepalive heartbeat now fires every 10s while the node runs, matching
+the whole-DAG activity.
+
+Also unwrap the underlying cause when a node workflow fails: the dashboard now
+surfaces the real reason (the activity error or heartbeat timeout) instead of
+Temporal's boilerplate "Workflow execution failed".

--- a/packages/temporal-provider/src/activities.ts
+++ b/packages/temporal-provider/src/activities.ts
@@ -192,22 +192,40 @@ export async function runNodeActivity(input: RunNodeActivityInput): Promise<Spaw
     try { ctx?.heartbeat({ progress: progressTrail }); } catch { /* outside activity ctx — ignore */ }
   };
 
-  const result = await spawnNodeReal(
-    input.node,
-    env,
-    {
-      agentId: input.agentId,
-      agentSource: input.agentSource,
-      // Community-shell trust is enforced by executeAgentDag before the node
-      // ever reaches a backend, so the worker needs no allowlist here.
-      allowUntrustedShell: new Set<string>(),
-      llmSettings: input.llmProviders ? { providers: input.llmProviders } : undefined,
-    },
-    onProgress,
-    ctx?.cancellationSignal,
-  );
+  // Keepalive heartbeat: a node that produces no progress event for longer than
+  // the workflow's heartbeatTimeout (30s) — e.g. an LLM that thinks before its
+  // first streamed token — would otherwise look dead to Temporal and get killed
+  // with "activity Heartbeat timeout" even though the child is working fine. Beat
+  // on an interval regardless of progress, re-sending the current trail so the
+  // dashboard's describe-poll still sees every event. Mirrors runDagActivity.
+  const keepalive = ctx
+    ? setInterval(() => {
+        try {
+          ctx?.heartbeat(progressTrail.length ? { progress: progressTrail } : undefined);
+        } catch { /* ignore */ }
+      }, 10_000)
+    : undefined;
 
-  return { ...result, usedWorkflowProvider: 'temporal' };
+  try {
+    const result = await spawnNodeReal(
+      input.node,
+      env,
+      {
+        agentId: input.agentId,
+        agentSource: input.agentSource,
+        // Community-shell trust is enforced by executeAgentDag before the node
+        // ever reaches a backend, so the worker needs no allowlist here.
+        allowUntrustedShell: new Set<string>(),
+        llmSettings: input.llmProviders ? { providers: input.llmProviders } : undefined,
+      },
+      onProgress,
+      ctx?.cancellationSignal,
+    );
+
+    return { ...result, usedWorkflowProvider: 'temporal' };
+  } finally {
+    if (keepalive) clearInterval(keepalive);
+  }
 }
 
 /**

--- a/packages/temporal-provider/src/node-spawn.test.ts
+++ b/packages/temporal-provider/src/node-spawn.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { Client } from '@temporalio/client';
 import type { AgentNode, SpawnResult, SpawnProgress } from '@some-useful-agents/core';
-import { createTemporalSpawnNode, extractHeartbeatProgress } from './node-spawn.js';
+import { createTemporalSpawnNode, extractHeartbeatProgress, describeWorkflowError } from './node-spawn.js';
 
 const node = (overrides: Partial<AgentNode> = {}): AgentNode => ({
   id: 'fetch',
@@ -111,6 +111,20 @@ describe('createTemporalSpawnNode', () => {
     expect(res.category).toBe('exit_nonzero');
   });
 
+  it('surfaces the underlying cause, not the generic WorkflowFailedError message', async () => {
+    // Temporal's WorkflowFailedError.message is always "Workflow execution
+    // failed"; the real reason (here, a heartbeat timeout) lives in .cause.
+    const generic = new Error('Workflow execution failed');
+    generic.cause = new Error('activity Heartbeat timeout');
+    const client = fakeClient({ reject: generic });
+    const spawn = createTemporalSpawnNode({ client, secretsPath: '/tmp/secrets.enc' });
+
+    const res = await spawn(node(), { PATH: '/usr/bin' }, spawnOpts);
+
+    expect(res.error).toContain('activity Heartbeat timeout');
+    expect(res.error).not.toBe('Temporal node workflow failed: Workflow execution failed');
+  });
+
   it('re-emits heartbeated progress through onProgress, each event once', async () => {
     const trail: SpawnProgress[] = [
       { timestamp: 't1', type: 'turn_start', turn: 1 },
@@ -146,5 +160,30 @@ describe('extractHeartbeatProgress', () => {
     expect(extractHeartbeatProgress({ pendingActivities: [] })).toEqual([]);
     expect(extractHeartbeatProgress({})).toEqual([]);
     expect(extractHeartbeatProgress({ pendingActivities: [{}] })).toEqual([]);
+  });
+});
+
+describe('describeWorkflowError', () => {
+  it('unwraps to the deepest cause message', () => {
+    const top = new Error('Workflow execution failed');
+    top.cause = new Error('Activity task timed out');
+    (top.cause as Error).cause = new Error('activity Heartbeat timeout');
+    expect(describeWorkflowError(top)).toBe('activity Heartbeat timeout');
+  });
+
+  it('falls back to the top message when there is no cause', () => {
+    expect(describeWorkflowError(new Error('plain boom'))).toBe('plain boom');
+  });
+
+  it('stringifies non-Error values', () => {
+    expect(describeWorkflowError('weird')).toBe('weird');
+  });
+
+  it('does not loop on a cyclic cause chain', () => {
+    const a = new Error('a');
+    const b = new Error('b');
+    a.cause = b;
+    b.cause = a;
+    expect(typeof describeWorkflowError(a)).toBe('string');
   });
 });

--- a/packages/temporal-provider/src/node-spawn.ts
+++ b/packages/temporal-provider/src/node-spawn.ts
@@ -46,6 +46,26 @@ export function extractHeartbeatProgress(description: DescribeLike): SpawnProgre
 }
 
 /**
+ * A Temporal `WorkflowFailedError`'s own `.message` is always the generic
+ * "Workflow execution failed" — the real reason (activity error, heartbeat
+ * timeout, etc.) lives in its `.cause` chain. Walk to the deepest cause with a
+ * message so the run record shows something actionable instead of boilerplate.
+ */
+export function describeWorkflowError(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+  let cur: Error = err;
+  const seen = new Set<Error>();
+  // Descend while a cause carries a usable message. Stop at the deepest one.
+  while (cur.cause instanceof Error && !seen.has(cur.cause)) {
+    seen.add(cur);
+    const next = cur.cause;
+    if (!next.message) break;
+    cur = next;
+  }
+  return cur.message || err.message || String(err);
+}
+
+/**
  * Build a {@link SpawnNodeFn} that runs each DAG node on a Temporal worker
  * (B1b). The dashboard injects this as `deps.spawnNode` when the provider is
  * Temporal; `executeAgentDag` keeps orchestrating in-process and calls this per
@@ -135,7 +155,7 @@ export function createTemporalSpawnNode(opts: CreateTemporalSpawnNodeOptions): S
         exitCode: cancelled ? 143 : 1,
         error: cancelled
           ? `Node "${node.id}" cancelled`
-          : `Temporal node workflow failed: ${err instanceof Error ? err.message : String(err)}`,
+          : `Temporal node workflow failed: ${describeWorkflowError(err)}`,
         category: cancelled ? 'cancelled' : 'exit_nonzero',
         usedWorkflowProvider: 'temporal',
       };


### PR DESCRIPTION
## Summary

Temporal-routed node runs were dying on a **false heartbeat timeout**. `runNodeActivity` (the per-node path behind `runNodeWorkflow`) only heartbeated when a node emitted a progress event, with a 30s `heartbeatTimeout` and no keepalive. An LLM node that thinks for >30s before its first streamed token went silent, so Temporal killed the activity with "activity Heartbeat timeout" even though the child process was working fine. The run was then recorded as the generic, useless `Temporal node workflow failed: Workflow execution failed`.

Found while troubleshooting a failed `agent-builder` run — **9 runs** had died this way (`agent-builder/design`, `inbox-triage/triage`), all LLM-heavy first nodes. `runDagActivity` is immune because it already has a 10s keepalive; the in-process executor has no heartbeat at all, so these agents work fine without Temporal.

**Changes:**
- **`activities.ts`** — `runNodeActivity` now fires a 10s keepalive heartbeat while the node runs, re-sending the current progress trail so the dashboard's describe-poll still sees every event. Mirrors `runDagActivity`. This is the actual fix.
- **`node-spawn.ts`** — new `describeWorkflowError` walks the `WorkflowFailedError.cause` chain (with a cycle guard) so the run record surfaces the real reason (e.g. "activity Heartbeat timeout") instead of Temporal's boilerplate.

## Test Coverage

5 new tests in `node-spawn.test.ts` (13 total, all passing):
- cause-unwrap surfaces the underlying failure, not the generic message
- `describeWorkflowError`: deepest-cause, no-cause fallback, non-Error stringify, cyclic-chain guard

`runNodeActivity`'s direct-invocation tests still pass (keepalive is a no-op without an activity Context).

## Verification

Automated: temporal-provider suite 24/24 green, clean `tsc --build` passes.

Not covered by an automated test: the keepalive *timing* itself (would need `@temporalio/testing` MockActivityEnvironment + fake timers — `runDagActivity`'s existing keepalive isn't unit-tested either). Real confirmation is re-running agent-builder through Temporal and watching the design node survive past 30s.

## Test plan
- [x] `vitest run packages/temporal-provider` — 24/24 pass
- [x] Clean `npm run build` passes
- [ ] Re-run agent-builder through Temporal, confirm design node no longer heartbeat-times-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)