### PR TITLE
fix(inbox): commit thread-built agents, kill fabricated links, run inline

### DIFF
--- a/.changeset/inbox-build-commit-and-inline-run.md
+++ b/.changeset/inbox-build-commit-and-inline-run.md
@@ -1,0 +1,28 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox: agents built from a thread are now real, runnable, and honestly reported.
+
+When triage built a new agent (e.g. "make me a random XKCD viewer"), the build
+ran but nothing committed it — `agent-builder` only designs and validates YAML,
+and the inbox action path skipped the commit the dashboard wizard does. The
+agent existed only as text in the run output, so `/agents/<id>` 404'd and triage
+would still claim it was "drafted" and link a dead URL.
+
+Three fixes:
+- **Auto-commit built agents (as drafts).** When an `agent-builder` action
+  completes, the validated YAML is parsed and committed to the catalog as a
+  draft (visible + runnable on demand, not live/scheduled until reviewed). A real
+  `/agents/<id>` link is posted once it lands. An existing non-draft agent of the
+  same id is never overwritten.
+- **No more fabricated links.** Triage `/agents/<id>` links are dropped unless the
+  agent actually exists in the store, and the triage prompt no longer claims an
+  agent exists before the system confirms the commit.
+- **Run what you just built, inline.** Agents built earlier in a thread become
+  proposable, so triage can run them and stream output inline — gated on operator
+  approval (they are not auto-approved).

--- a/agents/examples/inbox-triage.yaml
+++ b/agents/examples/inbox-triage.yaml
@@ -381,6 +381,25 @@ nodes:
         operator EXPLICITLY says "build a new one" or "I want a
         fresh one" — propose builder directly.
 
+        AFTER A BUILD: do NOT claim the agent exists, say it "is
+        drafted", or write an `/agents/<id>` link yourself. The build
+        only produces a design until the system commits it. When the
+        commit succeeds the system posts its own message with the real
+        `/agents/<id>` link — let that be the source of truth. Your job
+        on the build turn is just to say you're drafting it
+        (commitmentSummary), nothing more. Never invent a link to an
+        agent you haven't seen confirmed in `ALLOWED_SUB_AGENTS` or a
+        prior system message.
+
+        RUNNING WHAT YOU BUILT: once a build commits, that agent's id
+        appears in `ALLOWED_SUB_AGENTS` on the next turn. If the
+        operator asked to run it (or to see its output), propose a
+        `run-agent` action targeting that id — its output then streams
+        inline in this thread after the operator approves. You CAN run
+        any agent listed in `ALLOWED_SUB_AGENTS` this way; never tell
+        the operator you "can't run agents from this thread" when the
+        target is in the list.
+
       If `ALLOWED_SUB_AGENTS` is empty OR no action would help, omit
       `actions` entirely (or send an empty array). Text-only
       recommendations are perfectly fine.

--- a/packages/dashboard/src/routes/inbox-build-commit.test.ts
+++ b/packages/dashboard/src/routes/inbox-build-commit.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for the inbox auto-commit of agent-builder builds. When a build
+ * action completes, the designed agent only exists as a `<yaml>` block in the
+ * run output — agent-builder never writes to the catalog. maybeCommitBuiltAgent
+ * persists it as a draft so `/agents/<id>` resolves and triage can run it;
+ * builtAgentIdsInThread surfaces those ids back into the proposable allowlist.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AgentStore, RunStore, InboxStore } from '@some-useful-agents/core';
+import { maybeCommitBuiltAgent, builtAgentIdsInThread } from './inbox.js';
+
+let dir: string;
+let agentStore: AgentStore;
+let runStore: RunStore;
+let inboxStore: InboxStore;
+
+const XKCD_YAML = `id: random-xkcd
+name: Random XKCD
+source: local
+description: Shows a random XKCD comic.
+nodes:
+  - id: fetch
+    type: shell
+    command: echo hi
+    dependsOn: []
+`;
+
+/** Minimal ctx — maybeCommitBuiltAgent only touches these three stores
+ *  plus the optional inboxEventBus (left undefined so events no-op). */
+function makeCtx(): { inboxStore: InboxStore; runStore: RunStore; agentStore: AgentStore } {
+  return { inboxStore, runStore, agentStore };
+}
+
+function seedBuildRun(runId: string, yamlBody: string, nodeStatus = 'completed'): void {
+  runStore.createRun({
+    id: runId,
+    agentName: 'agent-builder',
+    status: 'completed',
+    startedAt: new Date(0).toISOString(),
+    triggeredBy: 'dashboard',
+  });
+  runStore.createNodeExecution({
+    runId,
+    nodeId: 'design',
+    workflowVersion: 1,
+    status: nodeStatus as 'completed',
+    startedAt: new Date(0).toISOString(),
+    result: `<yaml>\n${yamlBody}</yaml>`,
+  });
+}
+
+function setup(): void {
+  dir = mkdtempSync(join(tmpdir(), 'sua-inbox-build-'));
+  const dbPath = join(dir, 'runs.db');
+  agentStore = new AgentStore(dbPath);
+  runStore = new RunStore(dbPath);
+  inboxStore = new InboxStore(dbPath);
+}
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('maybeCommitBuiltAgent', () => {
+  it('commits the built agent as a draft so /agents/<id> resolves', () => {
+    setup();
+    const msg = inboxStore.add({ priority: 'medium', source: 'manual', title: 'build xkcd', body: 'b' });
+    seedBuildRun('run-1', XKCD_YAML);
+
+    expect(agentStore.getAgent('random-xkcd')).toBeNull();
+    maybeCommitBuiltAgent(makeCtx() as never, msg.id, 'run-1');
+
+    const committed = agentStore.getAgent('random-xkcd');
+    expect(committed).not.toBeNull();
+    expect(committed?.status).toBe('draft');
+
+    // A real system message with the working link is posted.
+    const sys = inboxStore.listResponses(msg.id).find((r) => r.role === 'system');
+    expect(sys?.body).toContain('/agents/random-xkcd');
+    expect(sys?.metaJson).toContain('/agents/random-xkcd');
+  });
+
+  it('forces draft status even when the YAML declares active', () => {
+    setup();
+    const msg = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    seedBuildRun('run-1', `id: forced\nname: Forced\nsource: local\nstatus: active\nnodes:\n  - id: n\n    type: shell\n    command: echo hi\n    dependsOn: []\n`);
+    maybeCommitBuiltAgent(makeCtx() as never, msg.id, 'run-1');
+    expect(agentStore.getAgent('forced')?.status).toBe('draft');
+  });
+
+  it('refuses to overwrite an existing non-draft agent of the same id', () => {
+    setup();
+    agentStore.createAgent({
+      id: 'random-xkcd', name: 'My Real One', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'keep', type: 'shell', command: 'echo mine', dependsOn: [] }],
+    }, 'cli');
+    const msg = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    seedBuildRun('run-1', XKCD_YAML);
+
+    maybeCommitBuiltAgent(makeCtx() as never, msg.id, 'run-1');
+
+    // The real agent is untouched (name + node preserved).
+    const still = agentStore.getAgent('random-xkcd');
+    expect(still?.name).toBe('My Real One');
+    expect(still?.status).toBe('active');
+    const sys = inboxStore.listResponses(msg.id).find((r) => r.role === 'system');
+    expect(sys?.body).toContain('not overwriting');
+  });
+
+  it('no-ops when the run has no <yaml> block', () => {
+    setup();
+    const msg = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    runStore.createRun({ id: 'run-1', agentName: 'agent-builder', status: 'completed', startedAt: new Date(0).toISOString(), triggeredBy: 'dashboard' });
+    runStore.createNodeExecution({ runId: 'run-1', nodeId: 'design', workflowVersion: 1, status: 'completed', startedAt: new Date(0).toISOString(), result: 'no yaml here' });
+    maybeCommitBuiltAgent(makeCtx() as never, msg.id, 'run-1');
+    expect(inboxStore.listResponses(msg.id)).toHaveLength(0);
+  });
+});
+
+describe('builtAgentIdsInThread', () => {
+  it('returns ids of agents built (and committed) in the thread', () => {
+    setup();
+    const msg = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    // Committed agent referenced by a completed agent-builder action.
+    agentStore.createAgent({
+      id: 'random-xkcd', name: 'Random XKCD', status: 'draft', source: 'local', mcp: false,
+      nodes: [{ id: 'n', type: 'shell', command: 'echo hi', dependsOn: [] }],
+    }, 'import');
+    inboxStore.addResponse(msg.id, 'action', 'built it', JSON.stringify({
+      kind: 'action', status: 'completed', agentId: 'agent-builder',
+      resultSummary: JSON.stringify({ valid: true, agentId: 'random-xkcd' }),
+    }));
+
+    expect(builtAgentIdsInThread(makeCtx() as never, msg.id)).toEqual(['random-xkcd']);
+  });
+
+  it('excludes builds whose agent never landed in the store', () => {
+    setup();
+    const msg = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    inboxStore.addResponse(msg.id, 'action', 'built it', JSON.stringify({
+      kind: 'action', status: 'completed', agentId: 'agent-builder',
+      resultSummary: JSON.stringify({ valid: true, agentId: 'ghost-agent' }),
+    }));
+    expect(builtAgentIdsInThread(makeCtx() as never, msg.id)).toEqual([]);
+  });
+});

--- a/packages/dashboard/src/routes/inbox-links.test.ts
+++ b/packages/dashboard/src/routes/inbox-links.test.ts
@@ -34,4 +34,33 @@ describe('parseTriageLinks', () => {
     expect(parseTriageLinks(undefined)).toEqual([]);
     expect(parseTriageLinks('nope')).toEqual([]);
   });
+
+  describe('agentExists predicate (fabricated-link guard)', () => {
+    it('drops /agents/<id> links when the agent does not exist', () => {
+      expect(parseTriageLinks(
+        [{ label: 'Open Random XKCD', href: '/agents/random-xkcd' }],
+        () => false,
+      )).toEqual([]);
+    });
+
+    it('keeps /agents/<id> links when the agent exists', () => {
+      expect(parseTriageLinks(
+        [{ label: 'Open Random XKCD', href: '/agents/random-xkcd' }],
+        (id) => id === 'random-xkcd',
+      )).toEqual([{ label: 'Open Random XKCD', href: '/agents/random-xkcd' }]);
+    });
+
+    it('matches ids even with a trailing path/query/hash', () => {
+      const exists = (id: string): boolean => id === 'real';
+      expect(parseTriageLinks([{ label: 'run', href: '/agents/real/run' }], exists)).toHaveLength(1);
+      expect(parseTriageLinks([{ label: 'ghost', href: '/agents/ghost/run' }], exists)).toEqual([]);
+    });
+
+    it('leaves non-agent links untouched by the predicate', () => {
+      expect(parseTriageLinks(
+        [{ label: 'A run', href: '/runs/abc' }, { label: 'Docs', href: 'https://example.com' }],
+        () => false,
+      )).toHaveLength(2);
+    });
+  });
 });

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -910,7 +910,39 @@ function ensureSystemAgentCurrent(
   }
 }
 
-function getSubAgentAllowlist(ctx: ReturnType<typeof getContext>): string[] {
+/**
+ * Ids of user agents that were built (and committed) earlier in THIS
+ * thread by an agent-builder action. Triage may then propose running
+ * them — that's how "build me an agent, now run it" works in one thread.
+ * Derived, not stored: scan the thread's completed agent-builder actions,
+ * read the built id out of their `{agentId}` resultSummary, and keep only
+ * those that actually landed in the store (the maybeCommitBuiltAgent
+ * commit succeeded). A build that was refused/clobber-guarded never
+ * appears here because its agent isn't in the catalog.
+ */
+export function builtAgentIdsInThread(
+  ctx: ReturnType<typeof getContext>,
+  messageId: string,
+): string[] {
+  if (!ctx.inboxStore) return [];
+  const ids = new Set<string>();
+  for (const r of ctx.inboxStore.listResponses(messageId)) {
+    if (r.role !== 'action') continue;
+    const m = parseActionMeta(r);
+    if (!m || m.agentId !== 'agent-builder' || m.status !== 'completed' || !m.resultSummary) continue;
+    try {
+      const summary = JSON.parse(m.resultSummary) as { agentId?: unknown };
+      const builtId = typeof summary.agentId === 'string' ? summary.agentId : undefined;
+      if (builtId && ctx.agentStore.getAgent(builtId)) ids.add(builtId);
+    } catch { /* non-JSON summary — nothing to surface */ }
+  }
+  return [...ids];
+}
+
+function getSubAgentAllowlist(
+  ctx: ReturnType<typeof getContext>,
+  messageId?: string,
+): string[] {
   // Per-agent override on inbox-triage. When the operator has edited
   // the agent's `allowedSubAgents` list via /agents/inbox-triage/config,
   // that wins over the hardcoded fallback. Empty array = "text-only,
@@ -918,20 +950,29 @@ function getSubAgentAllowlist(ctx: ReturnType<typeof getContext>): string[] {
   // (auto-installable system agents).
   const triage = ctx.agentStore.getAgent(TRIAGE_AGENT_ID);
   const operatorOverride = triage?.allowedSubAgents;
+  const base: string[] = [];
   if (operatorOverride !== undefined) {
     // Operator-set list: only surface ids that are actually installed.
     // Unlike the system-default path we do NOT auto-import here —
     // operator-listed entries are assumed to be user agents already
     // sitting in the store.
-    return operatorOverride.filter((id) => ctx.agentStore.getAgent(id) !== undefined);
-  }
-  const available: string[] = [];
-  for (const id of TRIAGE_SUB_AGENT_ALLOWLIST) {
-    if (ensureSystemAgentCurrent(ctx, id, 'inbox triage allowlist')) {
-      available.push(id);
+    base.push(...operatorOverride.filter((id) => ctx.agentStore.getAgent(id)));
+  } else {
+    for (const id of TRIAGE_SUB_AGENT_ALLOWLIST) {
+      if (ensureSystemAgentCurrent(ctx, id, 'inbox triage allowlist')) {
+        base.push(id);
+      }
     }
   }
-  return available;
+  // Agents built earlier in this thread are proposable too, so triage can
+  // run what it just created. These are NOT in TRIAGE_AUTO_APPROVE_AGENTS,
+  // so the run is proposed and waits for operator approval before it fires.
+  if (messageId) {
+    for (const id of builtAgentIdsInThread(ctx, messageId)) {
+      if (!base.includes(id)) base.push(id);
+    }
+  }
+  return base;
 }
 
 /**
@@ -1172,8 +1213,18 @@ export interface TriageLink {
  * Validate the optional `links` array on a triage <plan>. Each entry needs a
  * short label and an href that passes the sanitizer's URL allowlist (relative
  * or http(s)/mailto). Capped at MAX_TRIAGE_LINKS; invalid entries are dropped.
+ *
+ * `agentExists`, when supplied, kills fabricated agent links: triage likes to
+ * claim it built an agent and link `/agents/<id>` before any such agent
+ * exists. A dead link reads as "it's there, go click it" when it 404s. With
+ * the predicate, an `/agents/<id>` href whose agent isn't in the store is
+ * dropped — only real agents get linked. The genuine link is emitted by the
+ * system after the build actually commits (see maybeCommitBuiltAgent).
  */
-export function parseTriageLinks(raw: unknown): TriageLink[] {
+export function parseTriageLinks(
+  raw: unknown,
+  agentExists?: (id: string) => boolean,
+): TriageLink[] {
   if (!Array.isArray(raw)) return [];
   const out: TriageLink[] = [];
   for (const entry of raw) {
@@ -1182,6 +1233,10 @@ export function parseTriageLinks(raw: unknown): TriageLink[] {
     const label = typeof e.label === 'string' ? e.label.trim().slice(0, 40) : '';
     const href = typeof e.href === 'string' ? e.href.trim() : '';
     if (!label || !href || !isSafeUrl(href)) continue;
+    if (agentExists) {
+      const m = href.match(/^\/agents\/([a-zA-Z0-9_-]+)(?:[/?#].*)?$/);
+      if (m && !agentExists(m[1])) continue; // fabricated agent link — drop it
+    }
     out.push({ label, href });
     if (out.length >= MAX_TRIAGE_LINKS) break;
   }
@@ -1435,6 +1490,16 @@ async function runProposedAction(
     maybeAutoProposeEditorAction(ctx, messageId, runId);
   }
 
+  // After agent-builder completes, the designed agent only exists as a
+  // `<yaml>` block in the run output — agent-builder validates but never
+  // commits. Persist it (as a draft) so `/agents/<id>` actually resolves
+  // and triage can propose running it. Without this the agent is a ghost:
+  // triage reports success on a build that produced text, not a catalog
+  // entry.
+  if (meta.agentId === 'agent-builder' && nextStatus === 'completed' && runId) {
+    maybeCommitBuiltAgent(ctx, messageId, runId);
+  }
+
   maybeRefireTriage(ctx, messageId);
 }
 
@@ -1471,6 +1536,78 @@ function countConsecutiveTriageTurns(
     if (r.role === 'triage') count += 1;
   }
   return count;
+}
+
+/**
+ * Commit the agent that agent-builder just designed. The build DAG
+ * (design → validate → fix) emits a validated `<yaml>` block in the
+ * `design` (or `fix`) node output but never writes to the catalog — the
+ * dashboard wizard commits separately via `/agents/build/commit`. When a
+ * build runs as an inbox action there's no such step, so the agent is a
+ * ghost: `/agents/<id>` 404s and triage can't run it.
+ *
+ * This closes that gap: parse the YAML and upsert the agent as a DRAFT
+ * (visible + runnable on demand, but not live/scheduled until the operator
+ * reviews it). Emits a system note with a REAL link so the operator — and
+ * triage's follow-up turn — see an agent that actually exists.
+ *
+ * Guards: never clobber an existing non-draft agent (a real user agent
+ * sharing the id wins); skip silently when no parseable YAML is present.
+ */
+export function maybeCommitBuiltAgent(
+  ctx: ReturnType<typeof getContext>,
+  messageId: string,
+  builderRunId: string,
+): void {
+  if (!ctx.inboxStore) return;
+  const execs = ctx.runStore.listNodeExecutions(builderRunId);
+  // Prefer `fix` (runs only when validate found issues) over `design`.
+  const fix = execs.find((e) => e.nodeId === 'fix' && e.status === 'completed');
+  const design = execs.find((e) => e.nodeId === 'design' && e.status === 'completed');
+  const source = (fix?.result ?? design?.result ?? '').toString();
+  const match = source.match(/<yaml>\s*\n?([\s\S]*?)<\/yaml>/);
+  if (!match) return;
+  const builtYaml = match[1].trim();
+  if (builtYaml.length < 10) return;
+
+  let parsed;
+  try { parsed = parseAgent(builtYaml); } catch { return; }
+
+  // Never overwrite a real (non-draft) agent that already owns this id.
+  // A draft of the same id is fair game to re-commit (iterating a build).
+  const existing = ctx.agentStore.getAgent(parsed.id);
+  if (existing && existing.status !== 'draft') {
+    const note = `Built **${parsed.name}** but an agent with id \`${parsed.id}\` already exists and is not a draft — not overwriting it. Review the build output and pick a different id if needed.`;
+    const sysReply = ctx.inboxStore.addResponse(messageId, 'system', note);
+    publishInboxEvent(ctx, messageId, 'message:created', {
+      responseId: sysReply.id, role: 'system', body: note, createdAt: sysReply.createdAt,
+    });
+    return;
+  }
+
+  // Commit as a draft regardless of what status the YAML declared — an
+  // LLM-designed agent should not go live or scheduled without review.
+  try {
+    ctx.agentStore.upsertAgent(
+      { ...parsed, status: 'draft' },
+      'import',
+      `Auto-committed (draft) from inbox build on thread ${messageId}`,
+    );
+  } catch {
+    return; // store rejected it (e.g. constraint) — leave the thread untouched
+  }
+
+  const href = `/agents/${parsed.id}`;
+  const note = `Created **${parsed.name}** as a draft at ${href}. Review it, then approve a run to see its output here.`;
+  const sysReply = ctx.inboxStore.addResponse(
+    messageId,
+    'system',
+    note,
+    JSON.stringify({ links: [{ label: `Open ${parsed.name}`, href }] }),
+  );
+  publishInboxEvent(ctx, messageId, 'message:created', {
+    responseId: sysReply.id, role: 'system', body: note, createdAt: sysReply.createdAt,
+  });
 }
 
 /** Hoisted from the end of `runProposedAction` so route-handled and
@@ -1763,7 +1900,7 @@ async function runTriageAgent(
     })
     .join('\n');
 
-  const allowlist = getSubAgentAllowlist(ctx);
+  const allowlist = getSubAgentAllowlist(ctx, messageId);
 
   // Pre-generate the runId + AbortController so the cancel route
   // (/inbox/:id/triage/cancel) can find and abort the in-flight run
@@ -1893,7 +2030,7 @@ async function runTriageAgent(
     const commitmentSummary = commitmentRaw.length >= 3 && commitmentRaw.length <= 60
       ? commitmentRaw
       : undefined;
-    const links = parseTriageLinks(parsed.links);
+    const links = parseTriageLinks(parsed.links, (id) => Boolean(ctx.agentStore.getAgent(id)));
     const triageMeta: Record<string, string> = {};
     if (verifyHint) triageMeta.verifyHint = verifyHint;
     if (commitmentSummary) triageMeta.commitmentSummary = commitmentSummary;


### PR DESCRIPTION
## Summary

Found while debugging a thread where triage said it built a **random-xkcd** agent and pointed to `/agents/random-xkcd` — but the agent didn't exist. Root cause: triage's "draft a new agent" action runs `agent-builder`, which is only `design → validate → fix`. It *produces and validates* YAML as run output but **never commits** to the catalog — the dashboard wizard commits separately via `/agents/build/commit`, and the inbox action path skipped that step. So the agent lived only as text in the run result; `/agents/<id>` 404'd, and triage still claimed success and linked a dead URL.

Three fixes, addressing both operator expectations (the agent should resolve; you should be able to run it in-thread):

**1. Auto-commit built agents (as drafts).** New `maybeCommitBuiltAgent` hooks `runProposedAction` completion: when an `agent-builder` action finishes, it parses the validated `<yaml>` from the design/fix node output and `upsertAgent(...)` as a **draft** (visible + runnable on demand, not live/scheduled until reviewed — your call). Never overwrites an existing non-draft agent of the same id; posts a real `/agents/<id>` system link once committed.

**2. Stop triage overclaiming / fabricating links.** `parseTriageLinks` gains an `agentExists` predicate — any `/agents/<id>` link whose agent isn't in the store is dropped. Even if the LLM hallucinates a link, it never renders. The triage prompt is updated to not claim an agent exists before the system confirms the commit, and to know it *can* run thread-built agents.

**3. Run what you built, inline.** `builtAgentIdsInThread` + a thread-aware `getSubAgentAllowlist` make agents built earlier in the thread proposable. Triage can now propose a `run-agent` action for them; output streams inline via the existing action machinery. **Approval-gated** — they're not in `TRIAGE_AUTO_APPROVE_AGENTS`, so the operator clicks approve before any user-built agent runs.

## Test Coverage

- `inbox-build-commit.test.ts` (new, 6 tests): commits as draft, forces draft even when YAML says active, refuses to overwrite a non-draft agent, no-ops without `<yaml>`; `builtAgentIdsInThread` returns committed ids and excludes ghosts.
- `inbox-links.test.ts` (+4): fabricated `/agents/<id>` dropped, real one kept, id-with-trailing-path matched, non-agent links untouched.
- Full inbox/dashboard sweep: **224 passing**.

## Verification

Automated: 230 tests green across the changed areas, clean `tsc --build` passes. The end-to-end happy path (triage builds → commits → operator approves → runs inline) involves an LLM build node, so it's covered by unit tests at each seam rather than one live run.

## Decisions

- Built agents land as **draft** (not active) — an LLM-designed spec shouldn't go live/scheduled without review.
- Inline runs **require approval** — consistent with the #459 trust model.

## Test plan
- [x] `vitest run` inbox-build-commit + inbox-links + dashboard + run-failure-inbox — 224 pass
- [x] Clean `npm run build`
- [x] inbox-triage.yaml still parses (validate-agents)
- [ ] Live: build random-xkcd from the inbox, confirm /agents/random-xkcd resolves and it runs inline on approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)