### PR TITLE
fix(inbox): render RUNNABLE_CANDIDATES into the triage prompt

### DIFF
--- a/agents/examples/inbox-triage.yaml
+++ b/agents/examples/inbox-triage.yaml
@@ -148,11 +148,22 @@ nodes:
       Runnable sub-agent specs with exact input names (may be empty):
       {{inputs.RUNNABLE_AGENT_SPECS}}
 
+      Installed agents you may ALSO propose running, which haven't been
+      granted inbox-run permission yet — proposing one becomes a one-click
+      "Enable & run" (may be empty):
+      {{inputs.RUNNABLE_CANDIDATES}}
+
+      Input specs for those candidates (may be empty):
+      {{inputs.RUNNABLE_CANDIDATE_SPECS}}
+
       IMPORTANT — TOOL USE POLICY: do NOT use Bash, Read, Grep, Glob,
       or any file/search tools. Everything you need is already in the
-      message context above. The `ALLOWED_SUB_AGENTS` value is the
-      complete, authoritative list of agents you may propose — do not
-      go searching for more. Respond with the `<plan>` block directly.
+      message context above. You may propose any agent listed in
+      `ALLOWED_SUB_AGENTS` OR `RUNNABLE_CANDIDATES` — together these are
+      the complete, authoritative set you may run; do not go searching
+      for more. If the operator names an agent that appears in
+      `RUNNABLE_CANDIDATES`, propose it (it becomes "Enable & run") rather
+      than saying you can't run it. Respond with the `<plan>` block directly.
 
       ════════════════════════════════════════════════════════════════
       INSTALLED AGENT CATALOG — answer lookups DIRECTLY, do not hedge
@@ -255,10 +266,13 @@ nodes:
          turn. The proposed action is the commitment — when the
          operator approves it and it completes, you get re-invoked
          and post the result.
-      2. If no agent in ALLOWED_SUB_AGENTS can do the work, be honest
-         in `recommendation` and point the operator at the right
-         tool ("Use /build to draft a new agent — I can't author
-         one from this thread"). When you know the destination,
+      2. If no agent in ALLOWED_SUB_AGENTS OR RUNNABLE_CANDIDATES can do
+         the work, be honest in `recommendation` and point the operator
+         at the right tool ("Use /build to draft a new agent — I can't
+         author one from this thread"). But if a RUNNABLE_CANDIDATES agent
+         CAN do it (the operator named it, or its description matches),
+         propose running it — do not refuse just because it isn't in
+         ALLOWED_SUB_AGENTS. When you know the destination,
          include a one-click `links` CTA to the relevant
          `/agents/<id>` or `/runs/<id>` page rather than ending on a
          dead "pick something different" note. Honest limitations


### PR DESCRIPTION
## Summary

Follow-up to #467. The request-to-run feature that merged in #467 **doesn't actually work** — the `RUNNABLE_CANDIDATES` input was declared and passed to triage, but the prompt body never rendered `{{inputs.RUNNABLE_CANDIDATES}}`, and the prompt still told triage that `ALLOWED_SUB_AGENTS` is "the complete, authoritative list of agents you may propose." So triage never saw candidates and kept dead-ending ("I can't run X from this thread").

This renders the candidate list + specs into the prompt and reframes the proposable set as `ALLOWED_SUB_AGENTS` **OR** `RUNNABLE_CANDIDATES`.

## Why it wasn't caught in #467

#467's tests covered the code path (`parseProposedActions`, `getRunnableCandidates`) but not the prompt rendering — and #467 merged before the live dogfood ran. Passing an input to an agent ≠ the model seeing it; the template has to render it.

## Verified live

After this fix, on the running build:
- Triage proposes an **"Enable & run"** action for `xkcd-random-comic` (`grantsInboxRunnable=1`) instead of refusing.
- Approving it grants `inboxRunnable` and dispatches the run (the `#467` code path, now actually reachable).

(The agent run then failed on an unrelated `agent-builder` codegen bug in that specific agent — `UPSTREAM_PICK_RANDOM_RESULT` unbound — not this feature.)

## Notes

- Docs/examples-only change (`agents/examples/inbox-triage.yaml`), non-published path → no changeset.
- The installed `inbox-triage` agent auto-refreshes from this bundled YAML on the next triage turn, so no rebuild/redeploy needed for it to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)