### PR TITLE
fix(inbox): grant note no longer reads as if the run is still pending

### DIFF
--- a/.changeset/inbox-grant-note-ordering.md
+++ b/.changeset/inbox-grant-note-ordering.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Inbox: fix the "Enable & run" grant note reading as if the run is still pending.
+
+The approve-to-run grant note said "Granted X… Running it now…", but it's posted
+after the action card (proposed earlier), so it renders below the already-finished
+run result. "Running it now…" then misled both the operator and the follow-up
+triage turn ("the run was just started, wait for the result") even when the run
+had already completed or failed. The note now states only the durable fact —
+"Enabled X to run from inbox threads — revoke in its Config tab" — and the action
+card remains the source of truth for the run's outcome.

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -1603,7 +1603,13 @@ async function runProposedAction(
         'dashboard',
         'Granted inboxRunnable via inbox approve-to-run',
       );
-      const note = `Granted **${subAgent.name}** permission to run from inbox threads (revoke in its Config). Running it now…`;
+      // Past-tense + no "running it now…": the grant note's created_at is
+      // later than the action card (proposed earlier), so it renders BELOW
+      // the run result. "Running it now…" then reads as if the run hasn't
+      // happened — confusing the operator AND the follow-up triage turn into
+      // "wait for the result" when it already finished. State only the durable
+      // fact; the action card itself shows the run's outcome.
+      const note = `Enabled **${subAgent.name}** to run from inbox threads — revoke any time in its Config tab.`;
       const sysReply = ctx.inboxStore.addResponse(messageId, 'system', note);
       publishInboxEvent(ctx, messageId, 'message:created', {
         responseId: sysReply.id, role: 'system', body: note, createdAt: sysReply.createdAt,


### PR DESCRIPTION
## Summary

You spotted this dogfooding request-to-run: the "Enable & run" grant note said *"Granted X… **Running it now…**"*, but it's posted inside `runProposedAction` — after the action card was proposed — so by `created_at` it renders **below** the already-finished run result. "Running it now…" then misled both the operator and the **follow-up triage turn**, which said *"the run was just started, wait for the result"* even when the run had already completed (or failed).

Fix: state only the durable fact — *"Enabled X to run from inbox threads — revoke any time in its Config tab."* The action card stays the source of truth for the run's outcome.

## Verified live (before opening this PR)

Ran `magic-8-ball` via Enable & run on the running build:
- Grant note: "Enabled **Magic 8 Ball** to run from inbox threads — revoke any time in its Config tab." ✓
- Follow-up triage turn now reads the result correctly: *"The Magic 8 Ball already answered: **Without a doubt.**"* — instead of the old "wait for the result." ✓

The thread you shared (`fc774ca6`) showed the old behavior: completed/failed action, then a "…Running it now…" note below it, then triage telling you to wait.

## Notes

- The grant note still renders after the action card (its `created_at` is necessarily later than the proposal). The reword makes that ordering non-misleading rather than fighting `created_at`.
- 76 inbox tests pass; this is a string-only behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)