### PR TITLE
fix(inbox): run autoFixYaml when committing a thread-built agent (fixes { {outputs.X}})

### DIFF
--- a/.changeset/inbox-commit-autofix-yaml.md
+++ b/.changeset/inbox-commit-autofix-yaml.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Fix inbox-built agents rendering literal `{ {outputs.X}}` in their widget.
+
+The template pipeline escapes `{{` → `{ {` to prevent re-expansion. The dashboard
+build wizard repairs this before committing (via `autoFixYaml`), but the inbox
+auto-commit path (agent built from a thread) skipped that repair, so the escaped
+form was persisted and the output widget rendered a literal `{ {outputs.X}}`. The
+inbox commit path now runs the same `autoFixYaml` repair the wizard does.

--- a/packages/dashboard/src/routes/inbox-build-commit.test.ts
+++ b/packages/dashboard/src/routes/inbox-build-commit.test.ts
@@ -85,6 +85,30 @@ describe('maybeCommitBuiltAgent', () => {
     expect(sys?.metaJson).toContain('/agents/random-xkcd');
   });
 
+  it('un-escapes "{ {outputs.X}}" in the widget template via autoFixYaml', () => {
+    setup();
+    const msg = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    // The build pipeline escapes {{ -> { { to stop re-expansion; the inbox
+    // path must repair it (as the wizard does) or the widget renders the
+    // literal "{ {outputs.X}}".
+    seedBuildRun('run-1', `id: tmpl-agent
+name: Tmpl Agent
+source: local
+nodes:
+  - id: n
+    type: shell
+    command: echo hi
+    dependsOn: []
+outputWidget:
+  type: ai-template
+  template: "XKCD #{ {outputs.comic_num}} - { {outputs.title}}"
+`);
+    maybeCommitBuiltAgent(makeCtx() as never, msg.id, 'run-1');
+    const committed = agentStore.getAgent('tmpl-agent');
+    expect(committed?.outputWidget?.template).toContain('{{outputs.comic_num}}');
+    expect(committed?.outputWidget?.template).not.toContain('{ {');
+  });
+
   it('forces draft status even when the YAML declares active', () => {
     setup();
     const msg = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -46,7 +46,7 @@ import {
 } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 import { buildLlmSettingsSnapshot } from '../lib/llm-settings-snapshot.js';
-import { formatToolCatalog } from './run-now-build.js';
+import { formatToolCatalog, autoFixYaml } from './run-now-build.js';
 import { applyProviderPin } from './build-orchestrator.js';
 import { TEMPLATE_REGISTRY } from '../views/pulse-templates.js';
 import {
@@ -1829,7 +1829,12 @@ export function maybeCommitBuiltAgent(
   const source = (fix?.result ?? design?.result ?? '').toString();
   const match = source.match(/<yaml>\s*\n?([\s\S]*?)<\/yaml>/);
   if (!match) return;
-  const builtYaml = match[1].trim();
+  // Run the same repair the dashboard wizard applies before committing an
+  // LLM-built agent. Most important here: autoFixYaml un-escapes `{ {` back to
+  // `{{` in outputWidget.template / prompts — the template pipeline escapes
+  // `{{` → `{ {` to prevent re-expansion, and without this repair the inbox path
+  // persists the escaped form, so the widget renders a literal `{ {outputs.X}}`.
+  const builtYaml = autoFixYaml(match[1].trim());
   if (builtYaml.length < 10) return;
 
   let parsed;


### PR DESCRIPTION
## Summary

You hit `{ {outputs.comic_num}}` (spaced braces) rendering literally in `xkcd-random-comic`'s widget. Root cause and answer to "inbox-caused or different bug": **it's a general bug, but the inbox path is why you saw it.**

- The template pipeline escapes `{{` → `{ {` (in `resolveUpstreamTemplate`, to stop re-expansion). That escaped form can get persisted into a built agent's `outputWidget.template`.
- The **dashboard wizard** build path repairs it before commit via `autoFixYaml` ("Fix 6b" un-escapes `outputWidget.template`).
- The **inbox auto-commit path** (`maybeCommitBuiltAgent`, added with the build-from-inbox feature) never called `autoFixYaml`, so the corruption survived → the renderer printed `{ {outputs.X}}`.

Verified the stored `xkcd-random-comic` v1–v7 (all built via the inbox) have `{ {` baked into the template; running the un-escape turns the 6 occurrences back into `{{`.

## Fix

`maybeCommitBuiltAgent` now runs the same `autoFixYaml` the wizard does before `parseAgent`. One-line wrap + the existing import.

## Test

`inbox-build-commit.test.ts` (+1): a build whose YAML has `XKCD #{ {outputs.comic_num}}` commits with the template repaired to `{{outputs.comic_num}}`. 6 pass.

## Not in this PR

- Your current `xkcd-random-comic` is now a `key-value` widget (you switched it), so it's unaffected. Future inbox builds with an ai-template widget will be clean.
- Separately: the output-widget editor's ai-template **prompt + Generate** controls live on the **Fields** tab, not the **type** tab — switching type on `?tab=type` doesn't reveal them. That's a UX gap (feature exists, discoverability doesn't); not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)