### PR TITLE
fix(dashboard): clearer 'already running' message + reclaim stale instance

### DIFF
--- a/.changeset/dashboard-port-reclaim.md
+++ b/.changeset/dashboard-port-reclaim.md
@@ -1,0 +1,19 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Dashboard start: clearer "already running" message + reclaim a stale instance.
+
+When a dashboard is already bound to the port, `sua dashboard start` now probes
+its `/health` build stamp and tells you the pid, commit, and build time — and
+flags when the running instance is an OLDER build than the one you're starting
+(the "I deployed but still see old code" trap). On a TTY it offers to stop that
+process and take over; a new `--replace` flag does the same non-interactively.
+A foreign (non-dashboard) process on the port is never killed.
+
+The daemon now starts the dashboard with `--replace`, so a leftover hand-started
+dashboard is reclaimed on restart instead of silently leaving stale code serving.

--- a/packages/cli/src/commands/dashboard.test.ts
+++ b/packages/cli/src/commands/dashboard.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { createServer, type Server } from 'node:http';
-import { dialableHost, isDashboardServing } from './dashboard.js';
+import { dialableHost, isDashboardServing, probeServingDashboard, findListenerPids, reclaimPort } from './dashboard.js';
 
 /** Spin up a throwaway HTTP server returning `body` (JSON) for any request. */
 async function serveJson(body: unknown, status = 200): Promise<{ port: number; close: () => Promise<void> }> {
@@ -60,5 +60,68 @@ describe('isDashboardServing', () => {
     const deadPort = s.port;
     await s.close();
     expect(await isDashboardServing('127.0.0.1', deadPort)).toBe(false);
+  });
+});
+
+describe('probeServingDashboard', () => {
+  let close: (() => Promise<void>) | undefined;
+  afterEach(async () => {
+    await close?.();
+    close = undefined;
+  });
+
+  it('returns the serving build identity (commit + builtAt)', async () => {
+    const s = await serveJson({
+      status: 'ok',
+      scheduler: { status: 'running' },
+      commit: 'deadbee',
+      builtAt: '2026-06-07T18:00:00.000Z',
+    });
+    close = s.close;
+    expect(await probeServingDashboard('127.0.0.1', s.port)).toEqual({
+      commit: 'deadbee',
+      builtAt: '2026-06-07T18:00:00.000Z',
+    });
+  });
+
+  it('returns null commit/builtAt when the dashboard predates the stamp', async () => {
+    const s = await serveJson({ status: 'ok', scheduler: {} });
+    close = s.close;
+    expect(await probeServingDashboard('127.0.0.1', s.port)).toEqual({ commit: null, builtAt: null });
+  });
+
+  it('returns null for a foreign process on the port', async () => {
+    const s = await serveJson({ hello: 'world' });
+    close = s.close;
+    expect(await probeServingDashboard('127.0.0.1', s.port)).toBeNull();
+  });
+});
+
+describe('findListenerPids', () => {
+  it('finds the pid of a process listening on a port', async () => {
+    const s = await serveJson({});
+    try {
+      const pids = await findListenerPids(s.port);
+      // lsof may be unavailable in some CI images; only assert when it returns.
+      if (pids.length > 0) expect(pids).toContain(process.pid);
+    } finally {
+      await s.close();
+    }
+  });
+
+  it('returns [] for a free port', async () => {
+    const s = await serveJson({});
+    const deadPort = s.port;
+    await s.close();
+    expect(await findListenerPids(deadPort)).toEqual([]);
+  });
+});
+
+describe('reclaimPort', () => {
+  it('reports success immediately when nothing holds the port', async () => {
+    const s = await serveJson({});
+    const deadPort = s.port;
+    await s.close();
+    expect(await reclaimPort(deadPort, [], 1000)).toBe(true);
   });
 });

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -1,6 +1,10 @@
 import { Command } from 'commander';
-import { startDashboardServer } from '@some-useful-agents/dashboard';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { startDashboardServer, getBuildInfo } from '@some-useful-agents/dashboard';
 import { getMcpTokenPath, readMcpToken } from '@some-useful-agents/core';
+
+const execFileAsync = promisify(execFile);
 import { loadConfig, getAgentDirs, getDbPath, getSecretsPath, getVariablesPath, getLlmSettingsPath, getRetentionDays, getDashboardBaseUrl, resolveProvider } from '../config.js';
 import { createProvider } from '../provider-factory.js';
 import * as ui from '../ui.js';
@@ -14,21 +18,95 @@ export function dialableHost(host: string): string {
   return host === '0.0.0.0' || host === '::' ? '127.0.0.1' : host;
 }
 
+/** Build identity of a dashboard answering /health (see build-info.ts). */
+export interface DashboardProbe {
+  /** Git short SHA the running dashboard reports, or null if it predates the stamp. */
+  commit: string | null;
+  /** ISO build timestamp, or null. */
+  builtAt: string | null;
+}
+
 /**
  * Probe a port that refused to bind, to tell "our dashboard is already running"
- * apart from "the port is taken by something else". Returns true only when
- * /health answers with the sua-dashboard signature.
+ * apart from "the port is taken by something else". Returns the serving
+ * dashboard's build identity when /health answers with the sua-dashboard
+ * signature, or null otherwise (foreign process / nothing listening).
  */
-export async function isDashboardServing(host: string, port: number): Promise<boolean> {
+export async function probeServingDashboard(host: string, port: number): Promise<DashboardProbe | null> {
   try {
     const res = await fetch(`http://${dialableHost(host)}:${port}/health`, {
       signal: AbortSignal.timeout(1500),
     });
-    if (!res.ok) return false;
-    const body = (await res.json()) as { status?: string; scheduler?: unknown };
-    return body.status === 'ok' && 'scheduler' in body;
+    if (!res.ok) return null;
+    const body = (await res.json()) as { status?: string; scheduler?: unknown; commit?: string; builtAt?: string };
+    if (body.status === 'ok' && 'scheduler' in body) {
+      return { commit: body.commit ?? null, builtAt: body.builtAt ?? null };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Back-compat boolean wrapper around {@link probeServingDashboard}. */
+export async function isDashboardServing(host: string, port: number): Promise<boolean> {
+  return (await probeServingDashboard(host, port)) !== null;
+}
+
+/**
+ * Best-effort: PIDs LISTENing on a TCP port, via `lsof` (darwin/linux).
+ * Returns [] when lsof is missing or nothing is listening — callers must
+ * tolerate an empty result rather than assume the port is free.
+ */
+export async function findListenerPids(port: number): Promise<number[]> {
+  try {
+    const { stdout } = await execFileAsync('lsof', ['-nP', `-iTCP:${port}`, '-sTCP:LISTEN', '-t']);
+    return [...new Set(
+      stdout.split('\n').map((s) => Number.parseInt(s.trim(), 10)).filter((n) => Number.isInteger(n) && n > 0),
+    )];
+  } catch {
+    return [];
+  }
+}
+
+const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * SIGTERM the given pids, wait for the port to clear (up to timeoutMs), then
+ * SIGKILL any stragglers. Returns true once the port has no LISTEN-ers.
+ */
+export async function reclaimPort(port: number, pids: number[], timeoutMs = 6000): Promise<boolean> {
+  for (const pid of pids) {
+    try { process.kill(pid, 'SIGTERM'); } catch { /* already gone */ }
+  }
+  const deadline = Date.now() + timeoutMs;
+  let escalated = false;
+  while (Date.now() < deadline) {
+    const still = await findListenerPids(port);
+    if (still.length === 0) return true;
+    // Halfway through, escalate to SIGKILL for anything that ignored SIGTERM.
+    if (!escalated && Date.now() > deadline - timeoutMs / 2) {
+      escalated = true;
+      for (const pid of still) {
+        try { process.kill(pid, 'SIGKILL'); } catch { /* gone */ }
+      }
+    }
+    await delay(200);
+  }
+  return (await findListenerPids(port)).length === 0;
+}
+
+/** Yes/no prompt on a TTY. Defaults to no on empty/EOF. */
+async function confirmTty(question: string): Promise<boolean> {
+  const { createInterface } = await import('node:readline/promises');
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const ans = (await rl.question(`${question} [y/N] `)).trim().toLowerCase();
+    return ans === 'y' || ans === 'yes';
   } catch {
     return false;
+  } finally {
+    rl.close();
   }
 }
 
@@ -51,6 +129,11 @@ dashboardCommand
     collectName,
     [] as string[],
   )
+  .option(
+    '--replace',
+    'If a dashboard is already serving this port, stop it and take over (no prompt). ' +
+      'Without this, an interactive shell is asked; non-interactive starts refuse to clobber.',
+  )
   .addHelpText(
     'after',
     `
@@ -67,7 +150,7 @@ The dashboard runs foreground; Ctrl-C stops it. Daemonization is out
 of scope for this release — wrap in launchd / systemd if you need it.
 `,
   )
-  .action(async (options: { port: string; host: string; provider?: string; allowUntrustedShell: string[] }) => {
+  .action(async (options: { port: string; host: string; provider?: string; allowUntrustedShell: string[]; replace?: boolean }) => {
     const port = Number.parseInt(options.port, 10);
     if (!Number.isFinite(port) || port < 1 || port > 65535) {
       ui.fail(`Invalid port "${options.port}".`);
@@ -99,52 +182,103 @@ of scope for this release — wrap in launchd / systemd if you need it.
       process.exit(1);
     }
 
+    const startOptions = {
+      port,
+      host: options.host,
+      agentDirs: dirs.all,
+      dbPath: getDbPath(config),
+      secretsPath: getSecretsPath(config),
+      variablesPath: getVariablesPath(config),
+      llmSettingsPath: getLlmSettingsPath(config),
+      retentionDays: getRetentionDays(config),
+      allowUntrustedShell,
+      dashboardBaseUrl: getDashboardBaseUrl(config),
+      provider,
+      temporal: {
+        address: config.temporalAddress ?? 'localhost:7233',
+        namespace: config.temporalNamespace ?? 'default',
+        taskQueue: config.temporalTaskQueue ?? 'sua-agents',
+      },
+    };
+
+    const urlHost = dialableHost(options.host);
     let handle;
     try {
-      handle = await startDashboardServer({
-        port,
-        host: options.host,
-        agentDirs: dirs.all,
-        dbPath: getDbPath(config),
-        secretsPath: getSecretsPath(config),
-        variablesPath: getVariablesPath(config),
-        llmSettingsPath: getLlmSettingsPath(config),
-        retentionDays: getRetentionDays(config),
-        allowUntrustedShell,
-        dashboardBaseUrl: getDashboardBaseUrl(config),
-        provider,
-        temporal: {
-          address: config.temporalAddress ?? 'localhost:7233',
-          namespace: config.temporalNamespace ?? 'default',
-          taskQueue: config.temporalTaskQueue ?? 'sua-agents',
-        },
-      });
+      handle = await startDashboardServer(startOptions);
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === 'EADDRINUSE') {
-        const urlHost = dialableHost(options.host);
-        if (await isDashboardServing(options.host, port)) {
-          const token = readMcpToken(getMcpTokenPath());
-          ui.banner(
-            `Dashboard already running on ${urlHost}:${port}`,
-            [
-              `Another dashboard is already serving this port — no need to start a second one.`,
-              ``,
-              ...(token
-                ? [`Sign-in URL:`, `http://${urlHost}:${port}/auth#token=${token}`, ``]
-                : []),
-              `Open http://${urlHost}:${port}/`,
-            ],
-          );
-          process.exit(0);
-        }
+      if ((err as NodeJS.ErrnoException).code !== 'EADDRINUSE') {
+        ui.fail((err as Error).message);
+        process.exit(1);
+      }
+
+      const probe = await probeServingDashboard(options.host, port);
+      const pids = await findListenerPids(port);
+      const pidLabel = pids.length ? `pid ${pids.join(', ')}` : 'unknown pid';
+
+      // A foreign process (not a sua dashboard) holds the port — never kill it.
+      if (!probe) {
         ui.fail(
-          `Port ${port} is already in use by another process. Stop it, or start on a ` +
-            `different port: sua dashboard start --port <port>.`,
+          `Port ${port} is already in use by ${pidLabel} (not a sua dashboard). ` +
+            `Stop it, or start on a different port: ${ui.cmd('sua dashboard start --port <port>')}.`,
         );
         process.exit(1);
       }
-      ui.fail((err as Error).message);
-      process.exit(1);
+
+      // A sua dashboard is already here. Compare builds so a STALE instance
+      // (the classic "I deployed but still see old code" trap) is obvious.
+      const ours = getBuildInfo().commit;
+      const theirs = probe.commit ?? 'unknown';
+      const builtAt = probe.builtAt ? ` · built ${probe.builtAt}` : '';
+      // 'dev' means we have no stamp of our own to compare against.
+      const stale = ours !== 'dev' && theirs !== ours;
+
+      let replace = options.replace === true;
+      if (!replace && process.stdin.isTTY) {
+        const detail = stale
+          ? `It is serving an OLDER build (commit ${theirs}) than this one (commit ${ours}).`
+          : `It is serving the same build (commit ${theirs}).`;
+        ui.info(`A dashboard is already running on ${urlHost}:${port} (${pidLabel}${builtAt}).`);
+        console.log(ui.dim(`  ${detail}`));
+        replace = await confirmTty(`Stop ${pidLabel} and start this one here?`);
+      }
+
+      if (!replace) {
+        const token = readMcpToken(getMcpTokenPath());
+        ui.banner(
+          `Dashboard already running on ${urlHost}:${port}`,
+          [
+            `${pidLabel} · commit ${theirs}${builtAt}`,
+            stale
+              ? `This is an OLDER build than the one you started (commit ${ours}).`
+              : `Same build as this one (commit ${ours}) — no need to start a second.`,
+            ``,
+            `To take over the port with this build: ${ui.cmd('sua dashboard start --replace')}`,
+            ...(token ? [``, `Sign-in: http://${urlHost}:${port}/auth#token=${token}`] : []),
+            `Open http://${urlHost}:${port}/`,
+          ],
+        );
+        // Exit non-zero when stale so a supervisor knows it did NOT take over.
+        process.exit(stale ? 1 : 0);
+      }
+
+      if (!pids.length) {
+        ui.fail(
+          `Couldn't identify the process on ${urlHost}:${port} to stop ` +
+            `(lsof unavailable?). Stop it manually, then retry.`,
+        );
+        process.exit(1);
+      }
+      ui.info(`Stopping existing dashboard (${pidLabel})…`);
+      if (!(await reclaimPort(port, pids))) {
+        ui.fail(`Port ${port} is still busy after stopping ${pidLabel}. Stop it manually, then retry.`);
+        process.exit(1);
+      }
+      try {
+        handle = await startDashboardServer(startOptions);
+      } catch (err2) {
+        ui.fail(`Failed to start after reclaiming port ${port}: ${(err2 as Error).message}`);
+        process.exit(1);
+      }
     }
 
     ui.banner(

--- a/packages/core/src/daemon-supervisor.ts
+++ b/packages/core/src/daemon-supervisor.ts
@@ -129,7 +129,12 @@ export interface SpawnOptions {
 
 const SERVICE_ARGV: Record<ServiceName, string[]> = {
   schedule: ['schedule', 'start'],
-  dashboard: ['dashboard', 'start'],
+  // --replace: the daemon owns this port, so a leftover/orphaned dashboard
+  // (e.g. one started by hand with `sua dashboard start` and never stopped)
+  // should be reclaimed rather than silently leaving stale code serving.
+  // The supervisor spawn is non-interactive, so without --replace it would
+  // refuse to clobber and exit; with it, a stale instance is taken over.
+  dashboard: ['dashboard', 'start', '--replace'],
   mcp: ['mcp', 'start'],
   // The Temporal worker. Only useful when the provider is `temporal`; it polls
   // the task queue and executes agent/node work on the host (ADR-0004). Opt-in

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -606,3 +606,5 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
 
 export { buildDashboardApp as _buildDashboardApp };
 export type { DashboardContext } from './context.js';
+export { getBuildInfo } from './build-info.js';
+export type { BuildInfo } from './build-info.js';


### PR DESCRIPTION
## Problem
A daemon dashboard restart appeared to succeed but kept serving **old code**. Root cause: the `EADDRINUSE` path in `sua dashboard start` saw *any* sua dashboard answering `/health`, printed "already serving — no need to start a second one", and exited 0 — even when the process holding the port was a stale, hand-started orphan. The new (correct) code never took over. This is the "I deployed but still see `6145ffe-dirty`" trap.

## Fix
`sua dashboard start` now, on `EADDRINUSE`:
- probes `/health` for the running build's `commit`/`builtAt`, shows the **pid + build**, and **flags when it's an OLDER build** than the one being started (exits 1 in that case so a supervisor knows it did *not* take over);
- on a **TTY**, offers to stop that process and take over;
- honors a new **`--replace`** flag to do the same non-interactively;
- **never kills a foreign** (non-dashboard) process on the port — that still errors out with the pid.

The **daemon supervisor** now starts the dashboard with `--replace`, so a leftover hand-started dashboard is reclaimed on restart instead of silently shadowing the managed one — preventing recurrence.

## New helpers (unit-tested)
`probeServingDashboard` (build identity), `findListenerPids` (lsof), `reclaimPort` (SIGTERM → wait → SIGKILL). `isDashboardServing` kept as a boolean wrapper.

## Verified live
- Stale-build message shows pid/commit/builtAt + `--replace` hint ✅
- `--replace` reclaims an orphan end-to-end on an isolated port ✅
- `sua daemon restart --service dashboard` serves the new build ✅
- 90 cli+daemon tests pass; clean rebuild ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)