### PR TITLE
feat(integrations): owner-authorized Apple Reminders & Notes (experimental, macOS-only)

### DIFF
--- a/.changeset/apple-reminders-notes.md
+++ b/.changeset/apple-reminders-notes.md
@@ -1,0 +1,23 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Add an owner-authorized Apple Reminders & Notes integration (experimental, macOS-only, default off).
+
+A new `apple` integration kind lets agents create/read reminders and create/read
+notes on the owner's Mac. It compiles a tiny Swift runner on demand (EventKit for
+Reminders, AppleScript for Notes) — the same compile-on-demand pattern as the
+Apple Foundation Models provider. Saving the integration in the dashboard
+generates `apple.<slug>.reminder-create` / `reminder-read` / `reminder-update` /
+`note-create` / `note-read` tools.
+
+The engine ships dormant: the `apple` kind, its tools, and the dashboard tab stay
+hidden until the owner enables `experimental.apple` in `sua.config.json` (or sets
+`SUA_EXPERIMENTAL_APPLE=1`). A new `sua apple authorize` command triggers the macOS
+permission prompts from a foreground Terminal so the first grant isn't swallowed by
+a headless daemon. Notes is best-effort (no first-party API). Off macOS the tools
+fail with a clear macOS-only error.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -38,6 +38,7 @@ Config never stores raw credentials — sensitive values are kept in the encrypt
 | `csv` | Query a CSV file | `path`, `has_header`, `delimiter` | yes |
 | `postgres` | Query a Postgres database | `url_secret` (DSN secret, default `DATABASE_URL`), `schemas` | yes |
 | `sqlite` | Query a SQLite database file | `path` | yes |
+| `apple` | macOS Reminders & Notes (experimental) | none (discovered at add-time) | yes |
 
 For the data-source kinds, sua introspects the schema when you save the
 integration and stores a snapshot, so the generated tools know the available
@@ -54,6 +55,49 @@ prefix stripped — `user:customers` → `customers`):
 | `csv` | `csv.<slug>.read`, `csv.<slug>.count` |
 | `postgres` | `postgres.<slug>.<table>.find`, `…find-one`, `…count` (a `<schema>.` segment is inserted for non-`public` schemas) |
 | `sqlite` | `sqlite.<slug>.<table>.find`, `…find-one`, `…count` |
+| `apple` | `apple.<slug>.reminder-create`, `…reminder-read`, `…reminder-update`, `…note-create`, `…note-read` |
+
+## Apple (Reminders & Notes) — experimental, macOS-only
+
+Lets agents create/read reminders and create/read notes on the owner's Mac. It
+compiles a tiny Swift runner on demand (cached at `~/.sua/runners/apple_reminders`)
+that talks to **EventKit** for Reminders and drives **Notes.app via AppleScript**
+for Notes. Unlike the read-only data-source kinds, this kind exposes
+**side-effecting write tools** — `reminder-create`, `reminder-update`, and
+`note-create` change your real data.
+
+**Enable it** (off by default — the engine ships dormant):
+
+```jsonc
+// sua.config.json
+{ "experimental": { "apple": true } }
+```
+
+or `export SUA_EXPERIMENTAL_APPLE=1`. The dashboard **Apple** tab and the
+`apple.*` tools stay hidden/unresolved until this is on.
+
+**Authorize macOS access** once, from a Terminal (not the daemon — a headless
+prompt is silently denied):
+
+```bash
+sua apple authorize
+```
+
+This triggers the **Reminders** permission prompt (EventKit) and the
+**Automation → Notes** prompt (AppleScript) so you can click Allow. The prompts
+attribute to whatever launched the process, not to "sua".
+
+**Add the integration** in Settings → Integrations → Apple. sua introspects your
+authorized reminder lists and note folders and stores them as the snapshot.
+**Adding the integration is the authorization gesture** — it's what grants agents
+the ability to create/read your reminders and notes. No secret to manage; nothing
+personal is stored outside your local `data/runs.db`.
+
+**Caveats.** Reminders is solid (EventKit). **Notes is best-effort**: there is no
+first-party Notes API, so it goes through AppleScript — `note-create` works but
+returns no reliable id, and `note-read` is slow and capped (default 20). Off
+macOS, or without Xcode Command Line Tools (`xcrun`), the tools fail with a clear
+"macOS-only" error.
 
 Common shapes:
 

--- a/packages/cli/src/commands/apple.ts
+++ b/packages/cli/src/commands/apple.ts
@@ -1,0 +1,68 @@
+import { Command } from 'commander';
+import { ensureAppleRunner, runAppleSubcommand, isAppleIntegrationEnabled } from '@some-useful-agents/core';
+import * as ui from '../ui.js';
+
+/**
+ * `sua apple` — manage the macOS Apple Reminders/Notes integration.
+ *
+ * The `authorize` subcommand is the deliberate foreground moment for granting
+ * macOS privacy access. TCC prompts attribute to the spawning process and a
+ * headless daemon's prompt is silently denied, so the owner runs this once
+ * from a Terminal: it compiles the runner, then makes a real Reminders call
+ * (triggering the Reminders prompt) and a Notes call (triggering the
+ * Automation prompt) so the dialogs actually appear.
+ */
+export const appleCommand = new Command('apple').description(
+  'macOS Apple Reminders/Notes integration (experimental, macOS-only)',
+);
+
+appleCommand
+  .command('authorize')
+  .description('Grant macOS Reminders + Notes access by triggering the permission prompts (run from a Terminal)')
+  .action(async () => {
+    if (!isAppleIntegrationEnabled()) {
+      ui.warn('The Apple integration is experimental and currently disabled.');
+      console.log(
+        ui.dim(
+          '  Enable it with `experimental.apple: true` in sua.config.json or `export SUA_EXPERIMENTAL_APPLE=1`.\n' +
+            '  You can still grant permissions now — they take effect once enabled.\n',
+        ),
+      );
+    }
+
+    const handle = ensureAppleRunner();
+    if (handle.status !== 'ready') {
+      ui.fail(`Cannot build the Apple runner: ${handle.message ?? handle.status}`);
+      process.exit(1);
+    }
+
+    ui.info('Requesting Reminders access — approve the macOS dialog if it appears…');
+    try {
+      const rem = await runAppleSubcommand(handle.binaryPath, 'reminder-read', { limit: 1 }, { timeoutSec: 120 });
+      if (rem.status === 'ok') ui.ok('Reminders: access granted.');
+      else ui.fail(`Reminders: ${rem.errorMessage ?? rem.status}`);
+    } catch (err) {
+      ui.fail(`Reminders: ${(err as Error).message}`);
+    }
+
+    ui.info('Requesting Notes (Automation) access — approve the macOS dialog if it appears…');
+    try {
+      const notes = await runAppleSubcommand(handle.binaryPath, 'lists', {}, { timeoutSec: 120 });
+      if (notes.status === 'ok') {
+        const data = (notes.data ?? {}) as { note_folders?: unknown[] };
+        const folderCount = Array.isArray(data.note_folders) ? data.note_folders.length : 0;
+        ui.ok(`Notes: access granted (${folderCount} folder${folderCount === 1 ? '' : 's'} visible).`);
+      } else {
+        ui.fail(`Notes: ${notes.errorMessage ?? notes.status}`);
+      }
+    } catch (err) {
+      ui.fail(`Notes: ${(err as Error).message}`);
+    }
+
+    console.log(
+      ui.dim(
+        '\nIf a bucket shows denied, grant it in System Settings → Privacy & Security ' +
+          '(Reminders, and Automation → Notes), then re-run `sua apple authorize`.',
+      ),
+    );
+  });

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -36,6 +36,19 @@ export interface SuaConfig {
     /** Rotate log when it exceeds this many bytes (rotate-on-start). */
     logRotateBytes?: number;
   };
+  /**
+   * Opt-ins for capabilities that ship dormant in the package. Each flag is
+   * bridged onto its `SUA_EXPERIMENTAL_*` env var by `loadConfig()` so core
+   * can gate on a single runtime source of truth.
+   */
+  experimental?: {
+    /**
+     * Enable the macOS-only Apple Reminders/Notes integration (the `apple`
+     * integration kind + its generated tools + the dashboard tab). Default
+     * off. Equivalent to `SUA_EXPERIMENTAL_APPLE=1`.
+     */
+    apple?: boolean;
+  };
 }
 
 const DEFAULT_CONFIG: SuaConfig = {
@@ -57,16 +70,29 @@ const DEFAULT_CONFIG: SuaConfig = {
 export function loadConfig(): SuaConfig {
   const configPath = join(process.cwd(), 'sua.config.json');
   if (!existsSync(configPath)) {
-    return DEFAULT_CONFIG;
+    return applyExperimentalFlags(DEFAULT_CONFIG);
   }
 
   try {
     const raw = readFileSync(configPath, 'utf-8');
     const parsed = JSON.parse(raw);
-    return { ...DEFAULT_CONFIG, ...parsed };
+    return applyExperimentalFlags({ ...DEFAULT_CONFIG, ...parsed });
   } catch {
-    return DEFAULT_CONFIG;
+    return applyExperimentalFlags(DEFAULT_CONFIG);
   }
+}
+
+/**
+ * Bridge persistent `experimental.*` config flags onto their
+ * `SUA_EXPERIMENTAL_*` env vars so core can gate on a single runtime source
+ * of truth (see core's `isAppleIntegrationEnabled`). Never unsets an env var
+ * the operator set explicitly — env wins over config.
+ */
+function applyExperimentalFlags(config: SuaConfig): SuaConfig {
+  if (config.experimental?.apple && process.env.SUA_EXPERIMENTAL_APPLE === undefined) {
+    process.env.SUA_EXPERIMENTAL_APPLE = '1';
+  }
+  return config;
 }
 
 /**

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,6 +33,7 @@ import { toolCommand } from './commands/tool.js';
 import { examplesCommand } from './commands/examples.js';
 import { varsCommand } from './commands/vars.js';
 import { plannerCommand } from './commands/planner.js';
+import { appleCommand } from './commands/apple.js';
 
 // Read version from our own package.json so `sua --version` always matches
 // the installed package version (no hardcoded drift).
@@ -102,5 +103,6 @@ program.addCommand(toolCommand);
 program.addCommand(examplesCommand);
 program.addCommand(varsCommand);
 program.addCommand(plannerCommand);
+program.addCommand(appleCommand);
 
 program.parse();

--- a/packages/core/src/experimental.ts
+++ b/packages/core/src/experimental.ts
@@ -1,0 +1,28 @@
+/**
+ * Experimental-feature gates.
+ *
+ * Some capabilities ship in the published package but stay dormant until
+ * the owner opts in — so the code rides along through CI on `main` without
+ * being live by default. The Apple Reminders/Notes integration is the first
+ * of these: macOS-only, side-effecting on the owner's personal data, and
+ * gated until they explicitly enable it.
+ *
+ * The canonical runtime switch is the `SUA_EXPERIMENTAL_APPLE` env var. The
+ * CLI's `loadConfig()` bridges the persistent `experimental.apple` config
+ * field onto that env var at process start, so core can gate on a single
+ * source of truth without threading config through every call site.
+ */
+
+function envTrue(name: string): boolean {
+  const v = process.env[name];
+  return v === '1' || v === 'true' || v === 'yes';
+}
+
+/**
+ * True when the owner has enabled the experimental Apple (Reminders/Notes)
+ * integration — via `experimental.apple: true` in `sua.config.json` (bridged
+ * to the env var on load) or `SUA_EXPERIMENTAL_APPLE=1` directly. Default off.
+ */
+export function isAppleIntegrationEnabled(): boolean {
+  return envTrue('SUA_EXPERIMENTAL_APPLE');
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -158,8 +158,20 @@ export {
   sqliteFindToolId,
   sqliteFindOneToolId,
   sqliteCountToolId,
+  appleToolId,
   integrationSlug,
 } from './integrations/generated-tools.js';
+export {
+  ensureAppleRunner,
+  runAppleSubcommand,
+  appleReminderBinaryPath,
+  appleRunnerVersionString,
+  APPLE_SWIFT_SOURCE,
+  type AppleSnapshot,
+  type AppleRunnerHandle,
+  type AppleRunResult,
+} from './integrations/apple-runner.js';
+export { isAppleIntegrationEnabled } from './experimental.js';
 export {
   PlannerTelemetryStore,
   type PlannerTelemetryRow,

--- a/packages/core/src/integrations/apple-runner.test.ts
+++ b/packages/core/src/integrations/apple-runner.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runAppleSubcommand, ensureAppleRunner } from './apple-runner.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+/** Write an executable fake runner so tests exercise the spawn/parse path. */
+function fakeBinary(body: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'apple-fake-'));
+  dirs.push(dir);
+  const path = join(dir, 'fake');
+  writeFileSync(path, body, 'utf-8');
+  chmodSync(path, 0o755);
+  return path;
+}
+
+describe('runAppleSubcommand', () => {
+  it('parses an ok JSON line', async () => {
+    const bin = fakeBinary(`#!/usr/bin/env bash
+cat >/dev/null
+echo '{"status":"ok","data":{"id":"r1","title":"Buy milk"},"error_message":null}'
+`);
+    const res = await runAppleSubcommand(bin, 'reminder-create', { title: 'Buy milk' });
+    expect(res.status).toBe('ok');
+    expect(res.data).toEqual({ id: 'r1', title: 'Buy milk' });
+    expect(res.errorMessage).toBeNull();
+  });
+
+  it('surfaces a denied status + message (nonzero exit)', async () => {
+    const bin = fakeBinary(`#!/usr/bin/env bash
+cat >/dev/null
+echo '{"status":"denied","data":null,"error_message":"Reminders access denied"}'
+exit 1
+`);
+    const res = await runAppleSubcommand(bin, 'reminder-read', {});
+    expect(res.status).toBe('denied');
+    expect(res.errorMessage).toContain('denied');
+  });
+
+  it('takes the last JSON line past stray framework logging', async () => {
+    const bin = fakeBinary(`#!/usr/bin/env bash
+cat >/dev/null
+echo 'some framework warning on stdout'
+echo '{"status":"ok","data":{"count":0,"reminders":[]},"error_message":null}'
+`);
+    const res = await runAppleSubcommand(bin, 'reminder-read', {});
+    expect(res.status).toBe('ok');
+    expect((res.data as { count: number }).count).toBe(0);
+  });
+
+  it('throws on non-JSON output', async () => {
+    const bin = fakeBinary(`#!/usr/bin/env bash
+cat >/dev/null
+echo 'totally not json'
+`);
+    await expect(runAppleSubcommand(bin, 'lists', {})).rejects.toThrow(/non-JSON/);
+  });
+
+  it('throws when the binary produces no output', async () => {
+    const bin = fakeBinary(`#!/usr/bin/env bash
+cat >/dev/null
+`);
+    await expect(runAppleSubcommand(bin, 'lists', {})).rejects.toThrow(/no output/);
+  });
+
+  it('pipes the JSON payload to the binary on stdin', async () => {
+    const bin = fakeBinary(`#!/usr/bin/env bash
+payload=$(cat)
+printf '{"status":"ok","data":{"received":%s},"error_message":null}\\n' "$payload"
+`);
+    const res = await runAppleSubcommand(bin, 'reminder-create', { title: 'X', list: 'Home' });
+    expect((res.data as { received: unknown }).received).toEqual({ title: 'X', list: 'Home' });
+  });
+
+  it('passes --dry-run before the subcommand when requested', async () => {
+    // Fake echoes its argv so we can assert the flag ordering.
+    const bin = fakeBinary(`#!/usr/bin/env bash
+cat >/dev/null
+echo "{\\"status\\":\\"ok\\",\\"data\\":{\\"argv\\":\\"$*\\"},\\"error_message\\":null}"
+`);
+    const res = await runAppleSubcommand(bin, 'note-create', { title: 'n' }, { dryRun: true });
+    expect((res.data as { argv: string }).argv).toBe('--dry-run note-create');
+  });
+});
+
+describe('ensureAppleRunner', () => {
+  const orig = Object.getOwnPropertyDescriptor(process, 'platform');
+  afterEach(() => {
+    if (orig) Object.defineProperty(process, 'platform', orig);
+  });
+
+  it('returns unsupported off macOS (no compile attempted)', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+    const handle = ensureAppleRunner();
+    expect(handle.status).toBe('unsupported');
+    expect(handle.message).toMatch(/macOS-only/);
+  });
+});

--- a/packages/core/src/integrations/apple-runner.ts
+++ b/packages/core/src/integrations/apple-runner.ts
@@ -1,0 +1,505 @@
+/**
+ * Apple Reminders / Notes runner bootstrap (macOS-only, experimental).
+ *
+ * Apple Reminders is reachable from Swift via EventKit; Apple Notes has no
+ * first-party API, so we drive Notes.app through AppleScript (`NSAppleScript`)
+ * from the same binary. We bridge by compiling a tiny Swift runner once per
+ * host and caching it under `~/.sua/runners/apple_reminders` — exactly the
+ * pattern used by `apple-foundationmodels-runner.ts`.
+ *
+ * Invocation contract (argv subcommand + JSON on stdin, one JSON line on
+ * stdout):
+ *
+ *   sua-apple <subcommand>        # reads one JSON object from stdin
+ *   sua-apple --version           # prints the version string for probing
+ *   sua-apple --dry-run <sub>     # validate + echo, NO EventKit/AppleScript, NO TCC
+ *
+ * Every response is a single JSON line:
+ *   { "status": "ok"|"denied"|"unsupported"|"error", "data": <any>, "error_message": null|string }
+ *
+ * Compilation requires `xcrun` (Apple Command Line Tools). Off macOS, or
+ * without `xcrun`, `ensureAppleRunner` returns `status: 'unsupported'` and
+ * callers surface a clear macOS-only error.
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { chmod600Safe, ensureDir, ensureParentDir } from '../fs-utils.js';
+import { spawnProcess } from '../node-spawner.js';
+
+const APPLE_RUNNER_VERSION_STRING = 'apple-runner 1.0.0';
+
+/**
+ * Swift source for the Reminders/Notes runner. Compiled once and cached at
+ * `~/.sua/runners/apple_reminders`, with a sidecar `.source-hash` recording
+ * the SHA-256 of this string so `ensureAppleRunner` recompiles on drift.
+ * This source is validated by compiling it directly before embedding.
+ */
+export const APPLE_SWIFT_SOURCE = `import Foundation
+import EventKit
+
+let RUNNER_VERSION = "apple-runner 1.0.0"
+
+// ── JSON I/O helpers ────────────────────────────────────────────────────
+
+func emit(status: String, data: Any?, error: String?) {
+    var obj: [String: Any] = ["status": status]
+    obj["data"] = data ?? NSNull()
+    obj["error_message"] = error ?? NSNull()
+    if JSONSerialization.isValidJSONObject(obj),
+       let d = try? JSONSerialization.data(withJSONObject: obj),
+       let s = String(data: d, encoding: .utf8) {
+        print(s)
+    } else {
+        print("{\\"status\\":\\"error\\",\\"data\\":null,\\"error_message\\":\\"failed to encode output\\"}")
+    }
+}
+
+func jsonValue(_ v: Any?) -> Any { return v ?? NSNull() }
+func emitOk(_ data: Any) { emit(status: "ok", data: data, error: nil) }
+func emitError(_ msg: String) { emit(status: "error", data: nil, error: msg) }
+func emitDenied(_ msg: String) { emit(status: "denied", data: nil, error: msg) }
+
+func readStdinJSON() -> [String: Any] {
+    let data = FileHandle.standardInput.readDataToEndOfFile()
+    if data.isEmpty { return [:] }
+    if let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+        return obj
+    }
+    return [:]
+}
+
+let iso = ISO8601DateFormatter()
+func parseDate(_ s: String?) -> Date? {
+    guard let s = s, !s.isEmpty else { return nil }
+    return iso.date(from: s)
+}
+func isoString(_ d: Date?) -> Any {
+    guard let d = d else { return NSNull() }
+    return iso.string(from: d)
+}
+
+// ── AppleScript helper (Notes has no first-party framework) ─────────────
+
+func runAppleScript(_ src: String) -> (String?, String?) {
+    guard let script = NSAppleScript(source: src) else {
+        return (nil, "could not compile AppleScript")
+    }
+    var errorDict: NSDictionary?
+    let result = script.executeAndReturnError(&errorDict)
+    if let err = errorDict {
+        let num = (err["NSAppleScriptErrorNumber"] as? Int) ?? 0
+        let msg = (err["NSAppleScriptErrorMessage"] as? String) ?? "AppleScript error"
+        return (nil, "AppleScript error \\(num): \\(msg)")
+    }
+    return (result.stringValue ?? "", nil)
+}
+
+// AppleScript string-literal escaping: backslash and double-quote.
+func asEscape(_ s: String) -> String {
+    return s.replacingOccurrences(of: "\\\\", with: "\\\\\\\\")
+            .replacingOccurrences(of: "\\"", with: "\\\\\\"")
+}
+
+// ── EventKit (Reminders) permission ─────────────────────────────────────
+
+func requestReminderAccess(_ store: EKEventStore) async -> Bool {
+    if #available(macOS 14.0, *) {
+        return (try? await store.requestFullAccessToReminders()) ?? false
+    } else {
+        return await withCheckedContinuation { cont in
+            store.requestAccess(to: .reminder) { granted, _ in cont.resume(returning: granted) }
+        }
+    }
+}
+
+func reminderCalendars(_ store: EKEventStore, named: String?) -> [EKCalendar] {
+    let all = store.calendars(for: .reminder)
+    if let named = named, !named.isEmpty {
+        return all.filter { $0.title == named }
+    }
+    return all
+}
+
+func fetchReminders(_ store: EKEventStore, predicate: NSPredicate) async -> [EKReminder] {
+    return await withCheckedContinuation { cont in
+        store.fetchReminders(matching: predicate) { cont.resume(returning: $0 ?? []) }
+    }
+}
+
+// ── Subcommand handlers ─────────────────────────────────────────────────
+
+func cmdLists(dryRun: Bool) async {
+    if dryRun { emitOk(["reminder_lists": [], "note_folders": []]); return }
+    let store = EKEventStore()
+    guard await requestReminderAccess(store) else {
+        emitDenied("Reminders access denied. Grant it in System Settings > Privacy & Security > Reminders, or run: sua apple authorize")
+        return
+    }
+    let lists = store.calendars(for: .reminder).map { ["id": $0.calendarIdentifier, "title": $0.title] }
+    // Notes folders via AppleScript (best-effort; Automation permission bucket).
+    var folders: [[String: String]] = []
+    let (out, err) = runAppleScript("set text item delimiters to \\"\\\\n\\"\\ntell application \\"Notes\\" to get name of folders as text")
+    if err == nil, let out = out {
+        for line in out.split(separator: "\\n") {
+            let name = String(line).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !name.isEmpty { folders.append(["id": name, "name": name]) }
+        }
+    }
+    emitOk(["reminder_lists": lists, "note_folders": folders])
+}
+
+func cmdReminderCreate(_ input: [String: Any], dryRun: Bool) async {
+    let title = (input["title"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    guard !title.isEmpty else { emitError("title is required"); return }
+    let notes = input["notes"] as? String
+    let listName = input["list"] as? String
+    let due = parseDate(input["dueDate"] as? String)
+    if dryRun {
+        emitOk(["id": NSNull(), "title": title, "list": jsonValue(listName), "dryRun": true])
+        return
+    }
+    let store = EKEventStore()
+    guard await requestReminderAccess(store) else {
+        emitDenied("Reminders access denied. Run: sua apple authorize")
+        return
+    }
+    let reminder = EKReminder(eventStore: store)
+    reminder.title = title
+    if let notes = notes { reminder.notes = notes }
+    if let listName = listName, !listName.isEmpty {
+        let matches = reminderCalendars(store, named: listName)
+        guard let cal = matches.first else { emitError("No reminder list named \\"\\(listName)\\""); return }
+        reminder.calendar = cal
+    } else {
+        guard let cal = store.defaultCalendarForNewReminders() else {
+            emitError("No default reminder list available")
+            return
+        }
+        reminder.calendar = cal
+    }
+    if let due = due {
+        reminder.dueDateComponents = Calendar.current.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second], from: due)
+    }
+    do {
+        try store.save(reminder, commit: true)
+        emitOk(["id": reminder.calendarItemIdentifier, "title": reminder.title ?? title, "list": reminder.calendar.title])
+    } catch {
+        emitError("Failed to save reminder: \\(error.localizedDescription)")
+    }
+}
+
+func cmdReminderRead(_ input: [String: Any], dryRun: Bool) async {
+    let listName = input["list"] as? String
+    let completedFilter = input["completed"] as? Bool
+    let limit = (input["limit"] as? Int) ?? 100
+    if dryRun { emitOk(["reminders": [], "count": 0, "dryRun": true]); return }
+    let store = EKEventStore()
+    guard await requestReminderAccess(store) else {
+        emitDenied("Reminders access denied. Run: sua apple authorize")
+        return
+    }
+    let cals = reminderCalendars(store, named: listName)
+    if let listName = listName, !listName.isEmpty, cals.isEmpty {
+        emitError("No reminder list named \\"\\(listName)\\"")
+        return
+    }
+    let predicate = store.predicateForReminders(in: cals.isEmpty ? nil : cals)
+    var reminders = await fetchReminders(store, predicate: predicate)
+    if let want = completedFilter {
+        reminders = reminders.filter { $0.isCompleted == want }
+    }
+    let capped = Array(reminders.prefix(max(0, limit)))
+    let rows: [[String: Any]] = capped.map { r in
+        return [
+            "id": r.calendarItemIdentifier,
+            "title": r.title ?? "",
+            "notes": r.notes ?? NSNull(),
+            "completed": r.isCompleted,
+            "dueDate": isoString(r.dueDateComponents?.date),
+            "list": r.calendar?.title ?? NSNull(),
+        ]
+    }
+    emitOk(["reminders": rows, "count": rows.count])
+}
+
+func cmdReminderUpdate(_ input: [String: Any], dryRun: Bool) async {
+    let id = (input["id"] as? String) ?? ""
+    guard !id.isEmpty else { emitError("id is required"); return }
+    if dryRun { emitOk(["id": id, "completed": input["completed"] ?? NSNull(), "dryRun": true]); return }
+    let store = EKEventStore()
+    guard await requestReminderAccess(store) else {
+        emitDenied("Reminders access denied. Run: sua apple authorize")
+        return
+    }
+    guard let reminder = store.calendarItem(withIdentifier: id) as? EKReminder else {
+        emitError("No reminder found with id \\"\\(id)\\"")
+        return
+    }
+    if let completed = input["completed"] as? Bool { reminder.isCompleted = completed }
+    if let title = input["title"] as? String { reminder.title = title }
+    if let notes = input["notes"] as? String { reminder.notes = notes }
+    if let due = parseDate(input["dueDate"] as? String) {
+        reminder.dueDateComponents = Calendar.current.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second], from: due)
+    }
+    do {
+        try store.save(reminder, commit: true)
+        emitOk(["id": reminder.calendarItemIdentifier, "completed": reminder.isCompleted])
+    } catch {
+        emitError("Failed to update reminder: \\(error.localizedDescription)")
+    }
+}
+
+func cmdNoteCreate(_ input: [String: Any], dryRun: Bool) {
+    let title = (input["title"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    guard !title.isEmpty else { emitError("title is required"); return }
+    let body = (input["body"] as? String) ?? ""
+    let folder = input["folder"] as? String
+    if dryRun { emitOk(["id": NSNull(), "title": title, "folder": jsonValue(folder), "dryRun": true]); return }
+    // Notes' AppleScript body is HTML; wrap plaintext minimally.
+    let htmlBody = "<div><b>" + asEscape(title) + "</b></div><div>" + asEscape(body) + "</div>"
+    let nameLit = "\\"" + asEscape(title) + "\\""
+    let bodyLit = "\\"" + asEscape(htmlBody) + "\\""
+    var script: String
+    if let folder = folder, !folder.isEmpty {
+        let folderLit = "\\"" + asEscape(folder) + "\\""
+        script = "tell application \\"Notes\\"\\ntell folder \\(folderLit)\\nmake new note with properties {name:\\(nameLit), body:\\(bodyLit)}\\nend tell\\nend tell"
+    } else {
+        script = "tell application \\"Notes\\"\\nmake new note with properties {name:\\(nameLit), body:\\(bodyLit)}\\nend tell"
+    }
+    let (_, err) = runAppleScript(script)
+    if let err = err {
+        emitDenied("Could not create note: \\(err). Grant Automation access for Notes in System Settings > Privacy & Security > Automation, or run: sua apple authorize")
+        return
+    }
+    emitOk(["id": NSNull(), "title": title, "folder": jsonValue(folder)])
+}
+
+func cmdNoteRead(_ input: [String: Any], dryRun: Bool) {
+    let folder = input["folder"] as? String
+    let limit = (input["limit"] as? Int) ?? 20
+    if dryRun { emitOk(["notes": [], "count": 0, "dryRun": true]); return }
+    // Best-effort: enumerate note names+bodies via AppleScript with field/record delimiters.
+    let scope: String
+    if let folder = folder, !folder.isEmpty {
+        scope = "notes of folder \\"" + asEscape(folder) + "\\""
+    } else {
+        scope = "notes"
+    }
+    let script = """
+    set out to ""
+    tell application "Notes"
+    set theNotes to \\(scope)
+    set n to count of theNotes
+    if n > \\(limit) then set n to \\(limit)
+    repeat with i from 1 to n
+    set aNote to item i of theNotes
+    set out to out & (name of aNote) & "\\\\t" & (body of aNote) & "\\\\n---REC---\\\\n"
+    end repeat
+    end tell
+    return out
+    """
+    let (out, err) = runAppleScript(script)
+    if let err = err {
+        emitDenied("Could not read notes: \\(err). Grant Automation access for Notes, or run: sua apple authorize")
+        return
+    }
+    var rows: [[String: Any]] = []
+    if let out = out {
+        let records = out.components(separatedBy: "\\n---REC---\\n")
+        for rec in records {
+            let trimmed = rec.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty { continue }
+            let parts = rec.components(separatedBy: "\\t")
+            let name = parts.first ?? ""
+            let bodyHtml = parts.count > 1 ? parts[1] : ""
+            rows.append(["id": NSNull(), "title": name, "body": bodyHtml, "folder": folder ?? NSNull()])
+        }
+    }
+    emitOk(["notes": rows, "count": rows.count])
+}
+
+// ── Entry point ─────────────────────────────────────────────────────────
+
+@main
+struct Runner {
+    static func main() async {
+        var args = Array(CommandLine.arguments.dropFirst())
+        if args.contains("--version") {
+            print(RUNNER_VERSION)
+            return
+        }
+        var dryRun = false
+        if let idx = args.firstIndex(of: "--dry-run") {
+            dryRun = true
+            args.remove(at: idx)
+        }
+        guard let sub = args.first else {
+            emitError("no subcommand given")
+            return
+        }
+        let input = (sub == "lists") ? [:] : readStdinJSON()
+        switch sub {
+        case "lists": await cmdLists(dryRun: dryRun)
+        case "reminder-create": await cmdReminderCreate(input, dryRun: dryRun)
+        case "reminder-read", "reminder-list": await cmdReminderRead(input, dryRun: dryRun)
+        case "reminder-update", "reminder-complete": await cmdReminderUpdate(input, dryRun: dryRun)
+        case "note-create": cmdNoteCreate(input, dryRun: dryRun)
+        case "note-read", "note-list": cmdNoteRead(input, dryRun: dryRun)
+        default: emit(status: "unsupported", data: nil, error: "unknown subcommand: \\(sub)")
+        }
+    }
+}
+`;
+
+/** Snapshot of what the owner authorized, stored on the integration row. */
+export interface AppleSnapshot {
+  reminderLists: { id: string; title: string }[];
+  noteFolders: { id: string; name: string }[];
+  introspectedAt: string;
+}
+
+export interface AppleRunnerHandle {
+  /** Absolute path to the compiled binary. Only meaningful when status === 'ready'. */
+  binaryPath: string;
+  status: 'ready' | 'compile-failed' | 'unsupported';
+  /** Human-readable message when status !== 'ready'. */
+  message?: string;
+}
+
+/** Where the compiled binary lives. Override via `SUA_APPLE_RUNNERS_DIR` for tests. */
+export function appleRunnersDir(): string {
+  return process.env.SUA_APPLE_RUNNERS_DIR ?? join(homedir(), '.sua', 'runners');
+}
+
+export function appleReminderBinaryPath(): string {
+  return join(appleRunnersDir(), 'apple_reminders');
+}
+
+function appleReminderSourceHashPath(): string {
+  return join(appleRunnersDir(), 'apple_reminders.source-hash');
+}
+
+function hashSource(): string {
+  return createHash('sha256').update(APPLE_SWIFT_SOURCE).digest('hex');
+}
+
+export function appleRunnerVersionString(): string {
+  return APPLE_RUNNER_VERSION_STRING;
+}
+
+/**
+ * Ensure the runner is compiled and cached. Idempotent (cache hit returns
+ * immediately). On non-macOS hosts, or hosts without `xcrun`, returns
+ * `status: 'unsupported'` without raising.
+ */
+export function ensureAppleRunner(): AppleRunnerHandle {
+  const binaryPath = appleReminderBinaryPath();
+
+  if (process.platform !== 'darwin') {
+    return { binaryPath, status: 'unsupported', message: 'Apple Reminders/Notes is macOS-only.' };
+  }
+
+  try {
+    execFileSync('xcrun', ['--version'], { stdio: ['ignore', 'pipe', 'ignore'] });
+  } catch {
+    return {
+      binaryPath,
+      status: 'unsupported',
+      message: 'xcrun not found. Install Apple Command Line Tools (`xcode-select --install`).',
+    };
+  }
+
+  const dir = appleRunnersDir();
+  ensureDir(dir);
+  const sourcePath = join(dir, 'apple_reminders.swift');
+  const hashPath = appleReminderSourceHashPath();
+  const currentHash = hashSource();
+
+  if (existsSync(binaryPath) && existsSync(hashPath)) {
+    try {
+      const cachedHash = readFileSync(hashPath, 'utf-8').trim();
+      if (cachedHash === currentHash) {
+        const binStat = statSync(binaryPath);
+        const hashStat = statSync(hashPath);
+        if (binStat.mtimeMs >= hashStat.mtimeMs - 5_000) {
+          return { binaryPath, status: 'ready' };
+        }
+      }
+    } catch {
+      // fall through to recompile
+    }
+  }
+
+  ensureParentDir(sourcePath);
+  writeFileSync(sourcePath, APPLE_SWIFT_SOURCE, 'utf-8');
+  chmod600Safe(sourcePath);
+
+  const compile = spawnSync('xcrun', ['swiftc', '-parse-as-library', sourcePath, '-o', binaryPath], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (compile.status !== 0) {
+    const stderr = (compile.stderr ?? '').trim() || (compile.stdout ?? '').trim();
+    return { binaryPath, status: 'compile-failed', message: stderr || `xcrun swiftc exited with code ${compile.status}` };
+  }
+
+  writeFileSync(hashPath, currentHash, 'utf-8');
+  chmod600Safe(hashPath);
+  return { binaryPath, status: 'ready' };
+}
+
+/** Parsed response from one runner subcommand invocation. */
+export interface AppleRunResult {
+  status: 'ok' | 'denied' | 'unsupported' | 'error';
+  data: unknown;
+  errorMessage: string | null;
+}
+
+export interface RunAppleOptions {
+  dryRun?: boolean;
+  timeoutSec?: number;
+}
+
+/**
+ * Run one runner subcommand: spawn the binary with `[subcommand]` (plus
+ * `--dry-run` when requested), pipe `payload` as JSON on stdin, and parse the
+ * last JSON line of stdout. Throws on spawn/timeout/parse failure so a tool's
+ * `execute()` fails the node visibly.
+ */
+export async function runAppleSubcommand(
+  binaryPath: string,
+  subcommand: string,
+  payload: unknown,
+  opts: RunAppleOptions = {},
+): Promise<AppleRunResult> {
+  const args = opts.dryRun ? ['--dry-run', subcommand] : [subcommand];
+  const res = await spawnProcess(binaryPath, args, {
+    env: {},
+    timeoutSec: opts.timeoutSec ?? 30,
+    stdinInput: JSON.stringify(payload ?? {}),
+  });
+  const stdout = (res.result ?? '').trim();
+  // Take the last non-empty line — the runner prints exactly one JSON line,
+  // but defend against stray framework logging on stderr/stdout.
+  const lines = stdout.split('\n').map((l) => l.trim()).filter(Boolean);
+  const last = lines[lines.length - 1];
+  if (!last) {
+    throw new Error(
+      `apple runner produced no output (exit ${res.exitCode})${res.error ? `: ${res.error}` : ''}`,
+    );
+  }
+  let parsed: { status?: string; data?: unknown; error_message?: string | null };
+  try {
+    parsed = JSON.parse(last) as typeof parsed;
+  } catch {
+    throw new Error(`apple runner returned non-JSON output: ${last.slice(0, 200)}`);
+  }
+  const status = (parsed.status as AppleRunResult['status']) ?? 'error';
+  return { status, data: parsed.data ?? null, errorMessage: parsed.error_message ?? null };
+}

--- a/packages/core/src/integrations/generated-tools.test.ts
+++ b/packages/core/src/integrations/generated-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
@@ -14,6 +14,7 @@ import {
   sqliteFindToolId,
   sqliteCountToolId,
   sqliteFindOneToolId,
+  appleToolId,
 } from './generated-tools.js';
 
 let dir: string;
@@ -290,5 +291,102 @@ describe('postgres tool synthesis', () => {
     seedPostgres();
     const find = getGeneratedTool(store, 'postgres.main-db.users.find')!;
     await expect(find.execute({}, {})).rejects.toThrow(/secretsStore/);
+  });
+});
+
+// ── Apple (Reminders & Notes) ─────────────────────────────────────────────
+
+function seedApple() {
+  store.upsertIntegration({
+    id: 'user:apple',
+    packId: null,
+    kind: 'apple',
+    name: 'My Apple',
+    config: {
+      schema: {
+        reminderLists: [{ id: 'L1', title: 'Groceries' }, { id: 'L2', title: 'Work' }],
+        noteFolders: [{ id: 'F1', name: 'Notes' }],
+        introspectedAt: '2026-06-11T00:00:00.000Z',
+      },
+    },
+    secretRefs: [],
+  });
+}
+
+/** Executable fake runner echoing a canned ok response per subcommand. */
+function fakeAppleBinary(): { binaryPath: string } {
+  const path = join(dir, 'fake-apple');
+  writeFileSync(path, `#!/usr/bin/env bash
+sub="\${@: -1}"
+payload=$(cat)
+case "$sub" in
+  reminder-create) echo '{"status":"ok","data":{"id":"r1","title":"t","list":"Groceries"},"error_message":null}' ;;
+  reminder-read) echo '{"status":"ok","data":{"reminders":[{"id":"r1","title":"t"}],"count":1},"error_message":null}' ;;
+  reminder-update) echo '{"status":"ok","data":{"id":"r1","completed":true},"error_message":null}' ;;
+  note-create) echo '{"status":"ok","data":{"id":null,"title":"t","folder":"Notes"},"error_message":null}' ;;
+  note-read) echo '{"status":"ok","data":{"notes":[],"count":0},"error_message":null}' ;;
+  *) echo '{"status":"error","data":null,"error_message":"unknown"}'; exit 1 ;;
+esac
+`, 'utf-8');
+  chmodSync(path, 0o755);
+  return { binaryPath: path };
+}
+
+describe('apple integration tools', () => {
+  beforeEach(() => { process.env.SUA_EXPERIMENTAL_APPLE = '1'; });
+  afterEach(() => { delete process.env.SUA_EXPERIMENTAL_APPLE; });
+
+  it('synthesises all five verbs when the flag is on', () => {
+    seedApple();
+    const tools = listGeneratedTools(store);
+    const appleIds = Array.from(tools.keys()).filter((k) => k.startsWith('apple.')).sort();
+    expect(appleIds).toEqual([
+      'apple.apple.note-create',
+      'apple.apple.note-read',
+      'apple.apple.reminder-create',
+      'apple.apple.reminder-read',
+      'apple.apple.reminder-update',
+    ]);
+  });
+
+  it('synthesises NOTHING when the flag is off', () => {
+    delete process.env.SUA_EXPERIMENTAL_APPLE;
+    seedApple();
+    const tools = listGeneratedTools(store);
+    expect(Array.from(tools.keys()).filter((k) => k.startsWith('apple.'))).toEqual([]);
+    expect(getGeneratedTool(store, appleToolId({ id: 'user:apple' }, 'reminder-create'))).toBeUndefined();
+  });
+
+  it('reminder-create executes through the runner and returns parsed data', async () => {
+    seedApple();
+    const tool = getGeneratedTool(store, 'apple.apple.reminder-create', { appleRunner: fakeAppleBinary() })!;
+    const out = await tool.execute({ title: 'Buy milk', list: 'Groceries' }, {});
+    expect(out.id).toBe('r1');
+    expect(out.list).toBe('Groceries');
+  });
+
+  it('rejects an unauthorized reminder list before spawning', async () => {
+    seedApple();
+    const tool = getGeneratedTool(store, 'apple.apple.reminder-create', { appleRunner: fakeAppleBinary() })!;
+    await expect(tool.execute({ title: 'x', list: 'Nonexistent' }, {})).rejects.toThrow(/No reminder list named "Nonexistent"/);
+  });
+
+  it('rejects an unauthorized note folder before spawning', async () => {
+    seedApple();
+    const tool = getGeneratedTool(store, 'apple.apple.note-create', { appleRunner: fakeAppleBinary() })!;
+    await expect(tool.execute({ title: 'x', folder: 'Secret' }, {})).rejects.toThrow(/No note folder named "Secret"/);
+  });
+
+  it('resolveAppleTool returns undefined for an unknown verb', () => {
+    seedApple();
+    expect(getGeneratedTool(store, 'apple.apple.bogus-verb')).toBeUndefined();
+  });
+
+  it('the reminder-create definition declares the documented io shape', () => {
+    seedApple();
+    const tool = getGeneratedTool(store, 'apple.apple.reminder-create', { appleRunner: fakeAppleBinary() })!;
+    expect(tool.definition.source).toBe('builtin');
+    expect(Object.keys(tool.definition.inputs ?? {})).toEqual(['title', 'notes', 'dueDate', 'list']);
+    expect(tool.definition.outputs?.id?.type).toBe('string');
   });
 });

--- a/packages/core/src/integrations/generated-tools.ts
+++ b/packages/core/src/integrations/generated-tools.ts
@@ -48,6 +48,8 @@ import {
   type SqliteTableSpec,
   type SqliteConnectionConfig,
 } from './sqlite-driver.js';
+import { ensureAppleRunner, runAppleSubcommand, type AppleSnapshot } from './apple-runner.js';
+import { isAppleIntegrationEnabled } from '../experimental.js';
 
 /**
  * Strip the `<owner>:` prefix from an integration id to get the
@@ -86,6 +88,9 @@ export function sqliteFindOneToolId(integration: Pick<Integration, 'id'>, table:
 export function sqliteCountToolId(integration: Pick<Integration, 'id'>, table: string): string {
   return `sqlite.${integrationSlug(integration.id)}.${table}.count`;
 }
+export function appleToolId(integration: Pick<Integration, 'id'>, verb: string): string {
+  return `apple.${integrationSlug(integration.id)}.${verb}`;
+}
 
 /**
  * Synthesis options shared by every kind. `secretsStore` is required
@@ -95,6 +100,12 @@ export function sqliteCountToolId(integration: Pick<Integration, 'id'>, table: s
  */
 export interface GeneratedToolDeps {
   secretsStore?: SecretsStore;
+  /**
+   * Override the compiled Apple runner binary. Tests inject a fake binary
+   * here so the apple tools exercise the spawn/JSON-parse path without
+   * compiling Swift or touching the developer's real Reminders/Notes.
+   */
+  appleRunner?: { binaryPath: string };
 }
 
 /**
@@ -117,6 +128,8 @@ export function listGeneratedTools(
       addPostgresEntries(out, integ, deps);
     } else if (integ.kind === 'sqlite') {
       addSqliteEntries(out, integ);
+    } else if (integ.kind === 'apple' && isAppleIntegrationEnabled()) {
+      addAppleEntries(out, integ, deps);
     }
   }
   return out;
@@ -134,6 +147,7 @@ export function getGeneratedTool(
   if (toolId.startsWith('csv.')) return resolveCsvTool(store, toolId);
   if (toolId.startsWith('postgres.')) return resolvePostgresTool(store, toolId, deps);
   if (toolId.startsWith('sqlite.')) return resolveSqliteTool(store, toolId);
+  if (toolId.startsWith('apple.') && isAppleIntegrationEnabled()) return resolveAppleTool(store, toolId, deps);
   return undefined;
 }
 
@@ -617,5 +631,256 @@ function buildSqliteCountEntry(
       return { count, result: JSON.stringify({ count }) };
     },
   };
+}
+
+// ── Apple (Reminders & Notes) resolution + synthesis ───────────────────
+//
+// Unlike csv/postgres/sqlite (read-only find/count), the apple kind exposes
+// WRITE / side-effecting verbs (reminder-create, reminder-update, note-create)
+// alongside reads. Each verb maps 1:1 to a subcommand of the compiled Swift
+// runner; `execute()` shells to the binary and parses one JSON line. The kind
+// is experimental and macOS-only — callers gate on `isAppleIntegrationEnabled()`
+// before reaching here.
+
+/** Pull the Apple snapshot (authorized lists/folders) off an integration row. */
+function readAppleSnapshot(integ: Integration): AppleSnapshot | undefined {
+  const raw = integ.config.schema;
+  if (!raw || typeof raw !== 'object') return undefined;
+  const obj = raw as Record<string, unknown>;
+  if (!Array.isArray(obj.reminderLists) || !Array.isArray(obj.noteFolders)) return undefined;
+  return obj as unknown as AppleSnapshot;
+}
+
+/** Resolve the runner binary — injected fake for tests, else compile-on-demand. */
+function resolveAppleBinary(deps: GeneratedToolDeps): string {
+  if (deps.appleRunner?.binaryPath) return deps.appleRunner.binaryPath;
+  const handle = ensureAppleRunner();
+  if (handle.status !== 'ready') {
+    throw new Error(`Apple runner unavailable: ${handle.message ?? handle.status}`);
+  }
+  return handle.binaryPath;
+}
+
+interface AppleVerbSpec {
+  verb: string;
+  subcommand: string;
+  name: string;
+  description: string;
+  inputs: Record<string, ToolInputField>;
+  outputs: Record<string, ToolOutputField>;
+  /** Map tool inputs → runner stdin payload. May throw on snapshot validation. */
+  buildPayload: (inputs: Record<string, unknown>, snapshot: AppleSnapshot) => Record<string, unknown>;
+}
+
+function assertReminderList(snapshot: AppleSnapshot, name: unknown): void {
+  if (typeof name !== 'string' || name === '') return;
+  if (!snapshot.reminderLists.some((l) => l.title === name)) {
+    const avail = snapshot.reminderLists.map((l) => l.title).join(', ') || '(none)';
+    throw new Error(`No reminder list named "${name}". Authorized lists: ${avail}`);
+  }
+}
+function assertNoteFolder(snapshot: AppleSnapshot, name: unknown): void {
+  if (typeof name !== 'string' || name === '') return;
+  if (!snapshot.noteFolders.some((f) => f.name === name)) {
+    const avail = snapshot.noteFolders.map((f) => f.name).join(', ') || '(none)';
+    throw new Error(`No note folder named "${name}". Authorized folders: ${avail}`);
+  }
+}
+
+const reminderRowProps: Record<string, ToolOutputField> = {
+  id: { type: 'string' },
+  title: { type: 'string' },
+  notes: { type: 'string' },
+  completed: { type: 'boolean' },
+  dueDate: { type: 'string', description: 'ISO 8601, or null' },
+  list: { type: 'string' },
+};
+const noteRowProps: Record<string, ToolOutputField> = {
+  id: { type: 'string' },
+  title: { type: 'string' },
+  body: { type: 'string', description: 'HTML body (best-effort)' },
+  folder: { type: 'string' },
+};
+
+const APPLE_VERBS: AppleVerbSpec[] = [
+  {
+    verb: 'reminder-create',
+    subcommand: 'reminder-create',
+    name: 'Create a reminder',
+    description: 'Create a reminder in macOS Reminders. Side-effecting.',
+    inputs: {
+      title: { type: 'string', description: 'Reminder title.', required: true },
+      notes: { type: 'string', description: 'Optional notes body.' },
+      dueDate: { type: 'string', description: 'Optional due date, ISO 8601 (e.g. 2026-06-12T17:00:00Z).' },
+      list: { type: 'string', description: 'Reminder list name. Defaults to the system default list.' },
+    },
+    outputs: {
+      id: { type: 'string', description: 'Identifier of the created reminder.' },
+      title: { type: 'string' },
+      list: { type: 'string' },
+    },
+    buildPayload: (inputs, snapshot) => {
+      assertReminderList(snapshot, inputs.list);
+      return {
+        title: inputs.title,
+        ...(inputs.notes !== undefined ? { notes: inputs.notes } : {}),
+        ...(inputs.dueDate !== undefined ? { dueDate: inputs.dueDate } : {}),
+        ...(inputs.list !== undefined ? { list: inputs.list } : {}),
+      };
+    },
+  },
+  {
+    verb: 'reminder-read',
+    subcommand: 'reminder-read',
+    name: 'Read reminders',
+    description: 'List reminders from macOS Reminders, optionally filtered by list and completion.',
+    inputs: {
+      list: { type: 'string', description: 'Restrict to this reminder list.' },
+      completed: { type: 'boolean', description: 'Filter by completion state. Omit for all.' },
+      limit: { type: 'number', description: 'Maximum reminders to return. Defaults to 100.', default: 100 },
+    },
+    outputs: {
+      reminders: { type: 'array', description: 'Matching reminders.', items: { type: 'object', properties: reminderRowProps } },
+      count: { type: 'number' },
+    },
+    buildPayload: (inputs, snapshot) => {
+      assertReminderList(snapshot, inputs.list);
+      return {
+        ...(inputs.list !== undefined ? { list: inputs.list } : {}),
+        ...(inputs.completed !== undefined ? { completed: inputs.completed } : {}),
+        limit: typeof inputs.limit === 'number' ? inputs.limit : 100,
+      };
+    },
+  },
+  {
+    verb: 'reminder-update',
+    subcommand: 'reminder-update',
+    name: 'Update a reminder',
+    description: 'Mark a reminder complete or edit its fields. Side-effecting.',
+    inputs: {
+      id: { type: 'string', description: 'Reminder identifier (from reminder-read/create).', required: true },
+      completed: { type: 'boolean', description: 'Set completion state.' },
+      title: { type: 'string', description: 'New title.' },
+      notes: { type: 'string', description: 'New notes body.' },
+      dueDate: { type: 'string', description: 'New due date, ISO 8601.' },
+    },
+    outputs: {
+      id: { type: 'string' },
+      completed: { type: 'boolean' },
+    },
+    buildPayload: (inputs) => ({
+      id: inputs.id,
+      ...(inputs.completed !== undefined ? { completed: inputs.completed } : {}),
+      ...(inputs.title !== undefined ? { title: inputs.title } : {}),
+      ...(inputs.notes !== undefined ? { notes: inputs.notes } : {}),
+      ...(inputs.dueDate !== undefined ? { dueDate: inputs.dueDate } : {}),
+    }),
+  },
+  {
+    verb: 'note-create',
+    subcommand: 'note-create',
+    name: 'Create a note',
+    description: 'Create a note in macOS Notes (via AppleScript, best-effort). Side-effecting.',
+    inputs: {
+      title: { type: 'string', description: 'Note title.', required: true },
+      body: { type: 'string', description: 'Note body (plain text; wrapped as HTML).' },
+      folder: { type: 'string', description: 'Notes folder. Defaults to the default account folder.' },
+    },
+    outputs: {
+      id: { type: 'string', description: 'Best-effort note id; may be null.' },
+      title: { type: 'string' },
+      folder: { type: 'string' },
+    },
+    buildPayload: (inputs, snapshot) => {
+      assertNoteFolder(snapshot, inputs.folder);
+      return {
+        title: inputs.title,
+        body: typeof inputs.body === 'string' ? inputs.body : '',
+        ...(inputs.folder !== undefined ? { folder: inputs.folder } : {}),
+      };
+    },
+  },
+  {
+    verb: 'note-read',
+    subcommand: 'note-read',
+    name: 'Read notes',
+    description: 'List notes from macOS Notes (via AppleScript, best-effort, slow). Side-effecting reads.',
+    inputs: {
+      folder: { type: 'string', description: 'Restrict to this Notes folder.' },
+      limit: { type: 'number', description: 'Maximum notes to return. Defaults to 20.', default: 20 },
+    },
+    outputs: {
+      notes: { type: 'array', description: 'Matching notes (best-effort).', items: { type: 'object', properties: noteRowProps } },
+      count: { type: 'number' },
+    },
+    buildPayload: (inputs, snapshot) => {
+      assertNoteFolder(snapshot, inputs.folder);
+      return {
+        ...(inputs.folder !== undefined ? { folder: inputs.folder } : {}),
+        limit: typeof inputs.limit === 'number' ? inputs.limit : 20,
+      };
+    },
+  },
+];
+
+function buildAppleEntry(
+  integ: Integration,
+  snapshot: AppleSnapshot,
+  spec: AppleVerbSpec,
+  deps: GeneratedToolDeps,
+): BuiltinToolEntry {
+  const id = appleToolId(integ, spec.verb);
+  const definition: ToolDefinition = {
+    id,
+    name: spec.name,
+    description: `${spec.description} (integration "${integ.id}")`,
+    source: 'builtin',
+    inputs: spec.inputs,
+    outputs: spec.outputs,
+    implementation: { type: 'builtin', builtinName: id },
+  };
+  return {
+    definition,
+    async execute(inputs) {
+      const payload = spec.buildPayload(inputs, snapshot); // may throw on validation
+      const binaryPath = resolveAppleBinary(deps);
+      const res = await runAppleSubcommand(binaryPath, spec.subcommand, payload, { timeoutSec: 30 });
+      if (res.status !== 'ok') {
+        throw new Error(res.errorMessage ?? `apple ${spec.subcommand} failed (${res.status})`);
+      }
+      const data = (res.data && typeof res.data === 'object' ? res.data : {}) as Record<string, unknown>;
+      return { ...data, result: JSON.stringify(data) };
+    },
+  };
+}
+
+function addAppleEntries(out: Map<string, BuiltinToolEntry>, integ: Integration, deps: GeneratedToolDeps): void {
+  const snapshot = readAppleSnapshot(integ);
+  if (!snapshot) return;
+  for (const spec of APPLE_VERBS) {
+    const entry = buildAppleEntry(integ, snapshot, spec, deps);
+    out.set(entry.definition.id, entry);
+  }
+}
+
+function resolveAppleTool(
+  store: IntegrationsStore,
+  toolId: string,
+  deps: GeneratedToolDeps,
+): BuiltinToolEntry | undefined {
+  // Format: apple.<integration-slug>.<verb>. Slugs have no dots; verbs have
+  // no dots (only hyphens), so the verb is everything after the last dot.
+  const rest = toolId.slice('apple.'.length);
+  const dot = rest.lastIndexOf('.');
+  if (dot <= 0) return undefined;
+  const slug = rest.slice(0, dot);
+  const verb = rest.slice(dot + 1);
+  const spec = APPLE_VERBS.find((v) => v.verb === verb);
+  if (!spec) return undefined;
+  const integ = store.getIntegration(`user:${slug}`);
+  if (!integ || integ.kind !== 'apple') return undefined;
+  const snapshot = readAppleSnapshot(integ);
+  if (!snapshot) return undefined;
+  return buildAppleEntry(integ, snapshot, spec, deps);
 }
 

--- a/packages/dashboard/src/routes/settings.ts
+++ b/packages/dashboard/src/routes/settings.ts
@@ -6,6 +6,10 @@ import {
   closePostgresPool,
   inferSqliteSnapshot,
   closeSqliteDatabase,
+  isAppleIntegrationEnabled,
+  ensureAppleRunner,
+  runAppleSubcommand,
+  type AppleSnapshot,
   LLM_PROVIDERS,
   isProvider,
   type LlmProvider,
@@ -314,7 +318,7 @@ settingsRouter.post('/settings/mcp-servers/delete', (req: Request, res: Response
 const INTEGRATION_SLUG_RE = /^[a-z0-9][a-z0-9_-]*$/;
 const INTEGRATION_SECRET_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
 
-const INTEGRATION_TABS = new Set(['all', 'slack', 'webhook', 'file', 'mcp-tool', 'csv', 'postgres', 'sqlite']);
+const INTEGRATION_TABS = new Set(['all', 'slack', 'webhook', 'file', 'mcp-tool', 'csv', 'postgres', 'sqlite', 'apple']);
 
 settingsRouter.get('/settings/integrations', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
@@ -336,7 +340,7 @@ settingsRouter.get('/settings/integrations', (req: Request, res: Response) => {
   // user sees their preserved values on the right form) or to "all".
   const rawTab = typeof req.query.tab === 'string' ? req.query.tab : undefined;
   const activeTab = (rawTab && INTEGRATION_TABS.has(rawTab) ? rawTab : errKind && INTEGRATION_TABS.has(errKind) ? errKind : 'all') as
-    'all' | 'slack' | 'webhook' | 'file' | 'mcp-tool' | 'csv' | 'postgres' | 'sqlite';
+    'all' | 'slack' | 'webhook' | 'file' | 'mcp-tool' | 'csv' | 'postgres' | 'sqlite' | 'apple';
 
   const integrations = ctx.integrationsStore.listIntegrations();
 
@@ -362,6 +366,7 @@ settingsRouter.get('/settings/integrations', (req: Request, res: Response) => {
 
   const body = renderSettingsIntegrations({
     integrations, activeTab, addError, mcpServers, mcpToolsByServer,
+    appleEnabled: isAppleIntegrationEnabled(),
   });
   res.type('html').send(renderSettingsShell({ active: 'integrations', body, flash }));
 });
@@ -546,6 +551,33 @@ settingsRouter.post('/settings/integrations/add', async (req: Request, res: Resp
         return fail('No tables found in this SQLite file (or every table name is unsafe to splice into SQL).');
       }
       config = { path, schema: snapshot };
+      secretRefs = [];
+      break;
+    }
+    case 'apple': {
+      if (!isAppleIntegrationEnabled()) {
+        return fail('The Apple integration is experimental and disabled. Enable it with experimental.apple in sua.config.json (or SUA_EXPERIMENTAL_APPLE=1) and restart.');
+      }
+      const handle = ensureAppleRunner();
+      if (handle.status !== 'ready') {
+        return fail(`Apple runner unavailable: ${handle.message ?? handle.status}`);
+      }
+      let snapshot: AppleSnapshot;
+      try {
+        const res = await runAppleSubcommand(handle.binaryPath, 'lists', {}, { timeoutSec: 120 });
+        if (res.status !== 'ok') {
+          return fail(`Could not read Reminders/Notes: ${res.errorMessage ?? res.status}. Run \`sua apple authorize\` in a Terminal first.`);
+        }
+        const data = (res.data ?? {}) as { reminder_lists?: { id: string; title: string }[]; note_folders?: { id: string; name: string }[] };
+        snapshot = {
+          reminderLists: Array.isArray(data.reminder_lists) ? data.reminder_lists : [],
+          noteFolders: Array.isArray(data.note_folders) ? data.note_folders : [],
+          introspectedAt: new Date().toISOString(),
+        };
+      } catch (err) {
+        return fail(`Could not reach the Apple runner: ${(err as Error).message}`);
+      }
+      config = { schema: snapshot };
       secretRefs = [];
       break;
     }

--- a/packages/dashboard/src/views/settings-integrations.ts
+++ b/packages/dashboard/src/views/settings-integrations.ts
@@ -1,7 +1,7 @@
 import type { Integration } from '@some-useful-agents/core';
 import { html, unsafeHtml, type SafeHtml } from './html.js';
 
-export type IntegrationsTab = 'all' | 'slack' | 'webhook' | 'file' | 'mcp-tool' | 'csv' | 'postgres' | 'sqlite';
+export type IntegrationsTab = 'all' | 'slack' | 'webhook' | 'file' | 'mcp-tool' | 'csv' | 'postgres' | 'sqlite' | 'apple';
 
 export interface SettingsIntegrationsArgs {
   integrations: Integration[];
@@ -15,6 +15,8 @@ export interface SettingsIntegrationsArgs {
   mcpServers?: Array<{ id: string; name: string }>;
   /** Cached MCP tools — populates the mcp-tool form's tool dropdown, keyed by server id. */
   mcpToolsByServer?: Record<string, Array<{ name: string; description?: string }>>;
+  /** When true, the experimental Apple (Reminders/Notes) tab is shown. Default off. */
+  appleEnabled?: boolean;
 }
 
 /**
@@ -43,7 +45,7 @@ export function renderSettingsIntegrations(args: SettingsIntegrationsArgs): Safe
         built-in. <a href="https://github.com/gregmeyer/some-useful-agents/blob/main/docs/integrations.md" target="_blank" rel="noopener">Learn more →</a>
       </p>
       ${args.inlineNote ? html`<div class="flash flash--${args.inlineNote.kind} mb-3">${args.inlineNote.message}</div>` : unsafeHtml('')}
-      ${renderTabStrip(tab, args.integrations)}
+      ${renderTabStrip(tab, args.integrations, args.appleEnabled ?? false)}
       ${renderIntegrationsTable(filtered, tab)}
     </div>
 
@@ -54,10 +56,11 @@ export function renderSettingsIntegrations(args: SettingsIntegrationsArgs): Safe
     ${tab === 'csv' ? renderCsvForm(args) : unsafeHtml('')}
     ${tab === 'postgres' ? renderPostgresForm(args) : unsafeHtml('')}
     ${tab === 'sqlite' ? renderSqliteForm(args) : unsafeHtml('')}
+    ${tab === 'apple' && (args.appleEnabled ?? false) ? renderAppleForm(args) : unsafeHtml('')}
   `;
 }
 
-function renderTabStrip(active: IntegrationsTab, integrations: Integration[]): SafeHtml {
+function renderTabStrip(active: IntegrationsTab, integrations: Integration[], appleEnabled: boolean): SafeHtml {
   const counts: Record<string, number> = {};
   for (const i of integrations) counts[i.kind] = (counts[i.kind] ?? 0) + 1;
   const tab = (id: IntegrationsTab, label: string) => {
@@ -75,6 +78,7 @@ function renderTabStrip(active: IntegrationsTab, integrations: Integration[]): S
       ${tab('csv', 'CSV')}
       ${tab('postgres', 'Postgres')}
       ${tab('sqlite', 'SQLite')}
+      ${appleEnabled ? tab('apple', 'Apple') : html``}
     </nav>
   `;
 }
@@ -165,6 +169,12 @@ function describeConfig(i: Integration): SafeHtml {
       const schema = i.config.schema as { tables?: Record<string, unknown> } | undefined;
       const tableCount = schema?.tables ? Object.keys(schema.tables).length : 0;
       return unsafeHtml(`<code>${esc(path)}</code> <span class="dim">(${tableCount} table${tableCount === 1 ? '' : 's'})</span>`);
+    }
+    case 'apple': {
+      const schema = i.config.schema as { reminderLists?: unknown[]; noteFolders?: unknown[] } | undefined;
+      const lists = Array.isArray(schema?.reminderLists) ? schema!.reminderLists.length : 0;
+      const folders = Array.isArray(schema?.noteFolders) ? schema!.noteFolders.length : 0;
+      return unsafeHtml(`<span class="dim">${lists} reminder list${lists === 1 ? '' : 's'}, ${folders} note folder${folders === 1 ? '' : 's'}</span>`);
     }
     default:
       return unsafeHtml('<span class="dim">—</span>');
@@ -489,6 +499,39 @@ function renderFileForm(args: SettingsIntegrationsArgs): SafeHtml {
 
         <div class="settings-form__actions">
           <button type="submit" class="btn btn--primary">Add File integration</button>
+        </div>
+      </form>
+    </div>
+  `;
+}
+
+function renderAppleForm(args: SettingsIntegrationsArgs): SafeHtml {
+  const err = args.addError?.kind === 'apple' ? args.addError : undefined;
+  const v = err?.values ?? {};
+  return html`
+    <div class="card">
+      <p class="card__title">Add Apple (Reminders &amp; Notes) integration</p>
+      <p class="dim">
+        <strong>Experimental · macOS-only.</strong> Connects to your local
+        Reminders (EventKit) and Notes (AppleScript). On add, sua introspects
+        the reminder lists and note folders you've authorized and generates
+        these tools your nodes can call:
+      </p>
+      <ul class="dim" style="margin: var(--space-1) 0 var(--space-3) var(--space-5); font-size: var(--font-size-sm);">
+        <li><code>apple.&lt;id&gt;.reminder-create</code> / <code>.reminder-read</code> / <code>.reminder-update</code></li>
+        <li><code>apple.&lt;id&gt;.note-create</code> / <code>.note-read</code> <span class="dim">(Notes is best-effort)</span></li>
+      </ul>
+      <p class="dim" style="font-size: var(--font-size-sm);">
+        Grant macOS access first by running <code>sua apple authorize</code> in a
+        Terminal. Adding this integration is what authorizes agents to create and
+        read your reminders/notes — no secret to manage.
+      </p>
+      ${err ? html`<div class="flash flash--error mb-3">${err.message}</div>` : unsafeHtml('')}
+      <form action="/settings/integrations/add" method="post" class="settings-form">
+        <input type="hidden" name="kind" value="apple">
+        ${idAndNameFields(v)}
+        <div class="settings-form__actions">
+          <button type="submit" class="btn btn--primary">Add Apple integration</button>
         </div>
       </form>
     </div>


### PR DESCRIPTION
Lets agents **create/read reminders** and **create/read notes** on the owner's Mac, through a tool the owner explicitly authorizes. macOS-only, **ships dormant** behind an experimental flag.

## How it composes existing patterns
- **Compile-on-demand Swift runner** — mirrors `apple-foundationmodels-runner.ts`: embeds Swift, compiles once via `xcrun swiftc` into `~/.sua/runners/apple_reminders`, hash-checks for drift, gates on darwin. Talks to **EventKit** (Reminders) and **NSAppleScript** (Notes).
- **Owner-authorized integration kind** — mirrors the `sqlite` kind. Adding the `apple` integration in the dashboard *is* the authorization gesture; tools are `source: 'builtin'` and dispatch through the unchanged `getGeneratedTool` seam.

## Ship boundary (local now → shippable later)
- **Engine ships dormant.** The `apple` kind, its tools, and the dashboard tab stay hidden until the owner sets `experimental.apple` in `sua.config.json` (bridged to `SUA_EXPERIMENTAL_APPLE` by `loadConfig`) or exports the env var. Defense in depth: `addAppleEntries`/`resolveAppleTool` early-return when off. Promotion to shipped = flip the default.
- **No personal data in the package.** Lists/folders are discovered at runtime via the `lists` subcommand and stored only in `data/runs.db`; binary cache lives in `~/.sua/runners/`. No shipped example agent.

## Tools (five verbs, first WRITE generated tools)
`apple.<slug>.reminder-create` · `reminder-read` · `reminder-update` · `note-create` · `note-read`. Snapshot validates list/folder names before spawning.

## Permissions
`sua apple authorize` — a foreground command that triggers the Reminders prompt (EventKit) and the Notes Automation prompt (AppleScript) so the first grant isn't silently denied by a headless daemon.

## Caveats (honest)
- **Reminders: solid** (EventKit). **Notes: best-effort** — no first-party API, so AppleScript; `note-create` returns no reliable id, `note-read` is slow + capped.
- Off macOS / without `xcrun`: tools fail with a clear macOS-only error (CI on Linux exercises this).

## Verification
- Swift validated by **direct compile + dry-run**; the embedded copy **round-trips byte-identical** and compiles via `ensureAppleRunner`.
- All five verbs dry-run cleanly through the real binary (no TCC).
- **21 new tests** (runner contract via injected fake binary + tool synthesis/ID-parsing/flag-gate/validation); full suite **2091 pass / 3 skip**; clean rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)