### PR TITLE
feat(dashboard): Apple integration — macOS access panel (check + authorize from Terminal)

### DIFF
--- a/.changeset/apple-authorize-dashboard.md
+++ b/.changeset/apple-authorize-dashboard.md
@@ -1,0 +1,19 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Apple integration: dashboard "macOS access" panel — check status + authorize from a Terminal.
+
+The Apple tab now shows a macOS-access card with per-bucket status (Reminders /
+Notes), a **Check access** button that probes both TCC buckets with zero-content
+reads, and an **Open Terminal & authorize** button that launches a Terminal
+running `sua apple authorize` (so the permission prompts appear in a foreground
+GUI session). The panel and docs explain the TCC + daemon gotcha: macOS ties the
+Reminders grant to the granting process tree, so a detached daemon (and the
+temporal worker that runs agent nodes) can show denied even after you authorized
+in a Terminal — run agents from a Terminal with `SUA_PROVIDER=local`, or start the
+worker in a foreground Terminal.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -93,11 +93,35 @@ authorized reminder lists and note folders and stores them as the snapshot.
 the ability to create/read your reminders and notes. No secret to manage; nothing
 personal is stored outside your local `data/runs.db`.
 
-**Caveats.** Reminders is solid (EventKit). **Notes is best-effort**: there is no
-first-party Notes API, so it goes through AppleScript — `note-create` works but
-returns no reliable id, and `note-read` is slow and capped (default 20). Off
-macOS, or without Xcode Command Line Tools (`xcrun`), the tools fail with a clear
-"macOS-only" error.
+From the dashboard you can also click **Check access** (probes both permission
+buckets with zero-content reads and shows granted/denied) and **Open Terminal &
+authorize** (launches a Terminal running `sua apple authorize` for you).
+
+### The TCC + daemon gotcha (important)
+
+macOS ties the **Reminders** grant to the *responsible process tree*. When you
+run `sua apple authorize` in Terminal, the grant attaches to **Terminal.app** —
+**not** to sua's background daemons. So a detached process (the dashboard, and
+the **temporal worker** that executes agent nodes) can report **denied** even
+after you authorized in a Terminal, and it can't show its own prompt. (Notes /
+Automation grants are broader and usually carry over.)
+
+What this means for actually running the tools:
+
+- **Reliable today:** run from a Terminal with the local provider, where the node
+  executes in Terminal's (granted) process tree:
+  `SUA_PROVIDER=local sua workflow run apple-reminder-demo`.
+- **For temporal / scheduled runs:** the worker daemon needs the grant too. Start
+  the worker in a **foreground Terminal** (`sua worker start`, not the detached
+  daemon) so it inherits Terminal's grant. The dashboard **Check access** button
+  reflects the daemon's state, so use it to confirm.
+- A durable fix (code-signing the runner with a stable identity + entitlements so
+  TCC keys on the binary) is out of scope for this experimental version.
+
+**Other caveats.** Reminders is solid (EventKit). **Notes is best-effort**: no
+first-party API, so AppleScript — `note-create` works but returns no reliable id,
+and `note-read` is slow and capped (default 20). Off macOS, or without Xcode
+Command Line Tools (`xcrun`), the tools fail with a clear "macOS-only" error.
 
 Common shapes:
 

--- a/packages/dashboard/src/routes/settings.ts
+++ b/packages/dashboard/src/routes/settings.ts
@@ -364,9 +364,14 @@ settingsRouter.get('/settings/integrations', (req: Request, res: Response) => {
     } catch { /* tools surface stays empty — form shows the empty hint */ }
   }
 
+  const appleRem = typeof req.query.appleRem === 'string' ? req.query.appleRem : undefined;
+  const appleNotes = typeof req.query.appleNotes === 'string' ? req.query.appleNotes : undefined;
+  const appleAccess = appleRem || appleNotes ? { reminders: appleRem, notes: appleNotes } : undefined;
+
   const body = renderSettingsIntegrations({
     integrations, activeTab, addError, mcpServers, mcpToolsByServer,
     appleEnabled: isAppleIntegrationEnabled(),
+    appleAccess,
   });
   res.type('html').send(renderSettingsShell({ active: 'integrations', body, flash }));
 });
@@ -594,6 +599,55 @@ settingsRouter.post('/settings/integrations/add', async (req: Request, res: Resp
     return fail(err instanceof Error ? err.message : String(err));
   }
   res.redirect(303, `/settings/integrations?tab=${kind}&flash=${encodeURIComponent(`Added ${kind} integration "${id}".`)}`);
+});
+
+// Probe the two macOS TCC buckets (Reminders, Notes/Automation) via the runner
+// with zero-content reads, and report per-bucket status back on the Apple tab.
+settingsRouter.post('/settings/integrations/apple/check', async (req: Request, res: Response) => {
+  if (!isAppleIntegrationEnabled()) {
+    res.redirect(303, '/settings/integrations?tab=apple');
+    return;
+  }
+  const handle = ensureAppleRunner();
+  if (handle.status !== 'ready') {
+    res.redirect(303, '/settings/integrations?tab=apple&appleRem=unsupported&appleNotes=unsupported');
+    return;
+  }
+  const probe = async (sub: string): Promise<string> => {
+    try {
+      const r = await runAppleSubcommand(handle.binaryPath, sub, { limit: 0 }, { timeoutSec: 120 });
+      return r.status;
+    } catch {
+      return 'error';
+    }
+  };
+  const reminders = await probe('reminder-read');
+  const notes = await probe('note-read');
+  res.redirect(303, `/settings/integrations?tab=apple&appleRem=${encodeURIComponent(reminders)}&appleNotes=${encodeURIComponent(notes)}`);
+});
+
+// Open a real Terminal window running `sua apple authorize` so the macOS
+// permission prompts appear in a foreground GUI session (a background daemon's
+// prompt is silently denied). macOS-only; needs the one-time Automation grant
+// to control Terminal the first time.
+settingsRouter.post('/settings/integrations/apple/open-terminal', (req: Request, res: Response) => {
+  if (!isAppleIntegrationEnabled()) {
+    res.redirect(303, '/settings/integrations?tab=apple');
+    return;
+  }
+  if (process.platform !== 'darwin') {
+    res.redirect(303, `/settings/integrations?tab=apple&errKind=apple&errMsg=${encodeURIComponent('Opening Terminal is macOS-only.')}`);
+    return;
+  }
+  const repo = process.cwd().replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const script = `tell application "Terminal"\nactivate\ndo script "cd \\"${repo}\\" && sua apple authorize"\nend tell`;
+  try {
+    const child = spawn('osascript', ['-e', script], { detached: true, stdio: 'ignore' });
+    child.unref();
+    res.redirect(303, `/settings/integrations?tab=apple&flash=${encodeURIComponent('Opened a Terminal running `sua apple authorize` — approve the macOS prompts there, then click “Check access”.')}`);
+  } catch (err) {
+    res.redirect(303, `/settings/integrations?tab=apple&errKind=apple&errMsg=${encodeURIComponent(`Could not open Terminal: ${(err as Error).message}`)}`);
+  }
 });
 
 settingsRouter.post('/settings/integrations/delete', (req: Request, res: Response) => {

--- a/packages/dashboard/src/views/settings-integrations.ts
+++ b/packages/dashboard/src/views/settings-integrations.ts
@@ -17,6 +17,8 @@ export interface SettingsIntegrationsArgs {
   mcpToolsByServer?: Record<string, Array<{ name: string; description?: string }>>;
   /** When true, the experimental Apple (Reminders/Notes) tab is shown. Default off. */
   appleEnabled?: boolean;
+  /** Last "Check access" result per TCC bucket (status strings from the runner). */
+  appleAccess?: { reminders?: string; notes?: string };
 }
 
 /**
@@ -505,10 +507,62 @@ function renderFileForm(args: SettingsIntegrationsArgs): SafeHtml {
   `;
 }
 
+function applePill(status?: string): SafeHtml {
+  if (status === 'ok') return html`<span class="badge badge--ok">granted</span>`;
+  if (status === 'denied') return html`<span class="badge badge--warn">denied</span>`;
+  if (status === 'unsupported') return html`<span class="badge">unavailable</span>`;
+  if (!status) return html`<span class="dim">not checked yet</span>`;
+  return html`<span class="badge">${status}</span>`;
+}
+
+function renderAppleAccessCard(args: SettingsIntegrationsArgs): SafeHtml {
+  const access = args.appleAccess;
+  const cmd = 'sua apple authorize';
+  const checked = !!access;
+  const denied = checked && (access!.reminders !== 'ok' || access!.notes !== 'ok');
+  return html`
+    <div class="card">
+      <p class="card__title">macOS access</p>
+      <p class="dim" style="font-size: var(--font-size-sm);">
+        Reminders and Notes each need a one-time macOS permission. Prompts only
+        appear from a foreground GUI session, so the reliable grant path is a
+        Terminal — the dashboard can open one running <code>${cmd}</code> for you.
+      </p>
+      <p class="dim" style="font-size: var(--font-size-xs);">
+        This check reflects the <strong>dashboard/worker daemon's</strong> access —
+        which is what background (scheduled / temporal) runs use. macOS ties the
+        Reminders grant to the granting process tree, so a detached daemon can show
+        <em>denied</em> even after you authorized in a Terminal. If so, run agents
+        from a Terminal with <code>SUA_PROVIDER=local</code>, or start the worker in
+        a foreground Terminal. See docs/integrations.md.
+      </p>
+      <div style="display: flex; gap: var(--space-4); align-items: center; margin: var(--space-2) 0 var(--space-3);">
+        <span>Reminders: ${applePill(access?.reminders)}</span>
+        <span>Notes: ${applePill(access?.notes)}</span>
+      </div>
+      <div style="display: flex; gap: var(--space-2); align-items: center; flex-wrap: wrap;">
+        <form action="/settings/integrations/apple/check" method="post" style="display: inline;">
+          <button type="submit" class="btn btn--sm">Check access</button>
+        </form>
+        <form action="/settings/integrations/apple/open-terminal" method="post" style="display: inline;">
+          <button type="submit" class="btn btn--sm btn--primary">Open Terminal &amp; authorize</button>
+        </form>
+        <code id="apple-authorize-cmd" style="padding: var(--space-1) var(--space-2); background: var(--color-surface-raised); border: 1px solid var(--color-border-strong); border-radius: var(--radius-sm); font-size: var(--font-size-xs);">${cmd}</code>
+        <button type="button" class="btn btn--sm btn--ghost"
+          onclick="navigator.clipboard.writeText('${cmd}').then(()=>{this.textContent='Copied';setTimeout(()=>{this.textContent='Copy';},1200);})">Copy</button>
+      </div>
+      ${denied ? html`<p class="dim" style="font-size: var(--font-size-xs); margin-top: var(--space-2);">
+        A bucket shows denied — click “Open Terminal &amp; authorize” (or run the command), approve the macOS dialog, then “Check access” again.
+      </p>` : unsafeHtml('')}
+    </div>
+  `;
+}
+
 function renderAppleForm(args: SettingsIntegrationsArgs): SafeHtml {
   const err = args.addError?.kind === 'apple' ? args.addError : undefined;
   const v = err?.values ?? {};
   return html`
+    ${renderAppleAccessCard(args)}
     <div class="card">
       <p class="card__title">Add Apple (Reminders &amp; Notes) integration</p>
       <p class="dim">


### PR DESCRIPTION
Follow-up to #492. Makes the Apple tab the place to **see** macOS permission status and **trigger** the grant, without leaving the dashboard.

## What's new on the Apple tab
- **Status pills** — Reminders / Notes, granted / denied / not-checked.
- **Check access** — `POST /settings/integrations/apple/check` probes both TCC buckets with **zero-content reads** (`reminder-read` / `note-read` with `limit: 0`) and reports per-bucket status.
- **Open Terminal & authorize** — `POST /settings/integrations/apple/open-terminal` runs `osascript` to launch Terminal.app running `sua apple authorize`, so the prompts appear in a foreground GUI session (a detached daemon's prompt is silently denied).
- **Copy** button for the `sua apple authorize` command.

Both routes + the tab are gated by `isAppleIntegrationEnabled()` (still experimental, default off).

## The TCC reality this surfaces (and documents)
Testing revealed the macOS gotcha worth being honest about: macOS ties the **Reminders** grant to the *granting process tree*, so the dashboard/worker daemon — and the **temporal worker that runs agent nodes** — can report **denied** even after you authorized in a Terminal. The card + `docs/integrations.md` now explain the working paths:
- run from a Terminal with `SUA_PROVIDER=local`, or
- start the worker in a **foreground** Terminal so it inherits the grant.

So "Check access" doubles as a diagnostic for whether background/scheduled runs will actually work.

## Verification
- Built clean; dashboard route tests **203 pass**; full suite green on re-run (2091 pass / 3 skip — the 2 transient failures were a live-dashboard port collision during the run, not a regression).
- Verified live: the card renders, **Check access** returned real per-bucket status (`reminders=denied, notes=ok` from the daemon — exactly the documented behavior), **Open Terminal** wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)