### PR TITLE
feat(cli): add `sua apple connect` to register the Apple integration from a granted Terminal

### DIFF
--- a/.changeset/apple-connect-cli.md
+++ b/.changeset/apple-connect-cli.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Add `sua apple connect` to register the Apple integration from a granted Terminal.
+
+The dashboard "Add Apple integration" flow introspects via the background daemon,
+which usually lacks Reminders access (macOS ties the grant to the granting process
+tree). `sua apple connect` runs the `lists` introspection in the user's own
+Terminal — where `sua apple authorize` granted access — then upserts the `apple`
+integration (default id `apple`) with the discovered lists/folders, so the
+generated tools become available. Pairs with running agents via
+`SUA_PROVIDER=local` from the same Terminal.

--- a/packages/cli/src/commands/apple.ts
+++ b/packages/cli/src/commands/apple.ts
@@ -1,6 +1,15 @@
 import { Command } from 'commander';
-import { ensureAppleRunner, runAppleSubcommand, isAppleIntegrationEnabled } from '@some-useful-agents/core';
+import {
+  ensureAppleRunner,
+  runAppleSubcommand,
+  isAppleIntegrationEnabled,
+  IntegrationsStore,
+  type AppleSnapshot,
+} from '@some-useful-agents/core';
+import { loadConfig, getDbPath } from '../config.js';
 import * as ui from '../ui.js';
+
+const SLUG_RE = /^[a-z0-9][a-z0-9_-]*$/;
 
 /**
  * `sua apple` — manage the macOS Apple Reminders/Notes integration.
@@ -65,4 +74,69 @@ appleCommand
           '(Reminders, and Automation → Notes), then re-run `sua apple authorize`.',
       ),
     );
+    console.log(ui.dim('Next: `sua apple connect` (in this same Terminal) to register the integration.'));
+  });
+
+appleCommand
+  .command('connect')
+  .description('Register the Apple integration (introspects your lists/folders). Run in a granted Terminal.')
+  .option('--id <slug>', 'Integration id slug', 'apple')
+  .option('--name <name>', 'Display name', 'Apple')
+  .action(async (options: { id: string; name: string }) => {
+    if (!isAppleIntegrationEnabled()) {
+      ui.fail('The Apple integration is experimental and disabled.');
+      console.log(ui.dim('  Enable it with `experimental.apple: true` in sua.config.json or `export SUA_EXPERIMENTAL_APPLE=1`.'));
+      process.exit(1);
+    }
+    const slug = options.id.trim();
+    if (!SLUG_RE.test(slug)) {
+      ui.fail('ID must be lowercase letters/digits/dashes/underscores, starting with a letter or digit.');
+      process.exit(1);
+    }
+
+    const handle = ensureAppleRunner();
+    if (handle.status !== 'ready') {
+      ui.fail(`Apple runner unavailable: ${handle.message ?? handle.status}`);
+      process.exit(1);
+    }
+
+    // Introspect HERE (in the user's granted Terminal) — the dashboard daemon
+    // usually lacks Reminders access, so `lists` must run from a granted process.
+    ui.info('Reading your reminder lists and note folders…');
+    let snapshot: AppleSnapshot;
+    try {
+      const res = await runAppleSubcommand(handle.binaryPath, 'lists', {}, { timeoutSec: 120 });
+      if (res.status !== 'ok') {
+        ui.fail(`Could not read Reminders/Notes: ${res.errorMessage ?? res.status}`);
+        console.log(ui.dim('  Run `sua apple authorize` in this Terminal first, then retry.'));
+        process.exit(1);
+      }
+      const data = (res.data ?? {}) as { reminder_lists?: { id: string; title: string }[]; note_folders?: { id: string; name: string }[] };
+      snapshot = {
+        reminderLists: Array.isArray(data.reminder_lists) ? data.reminder_lists : [],
+        noteFolders: Array.isArray(data.note_folders) ? data.note_folders : [],
+        introspectedAt: new Date().toISOString(),
+      };
+    } catch (err) {
+      ui.fail(`Could not reach the Apple runner: ${(err as Error).message}`);
+      process.exit(1);
+    }
+
+    const config = loadConfig();
+    const store = new IntegrationsStore(getDbPath(config));
+    try {
+      const id = `user:${slug}`;
+      store.upsertIntegration({ id, packId: null, kind: 'apple', name: options.name, config: { schema: snapshot }, secretRefs: [] });
+      ui.ok(`Connected Apple integration "${id}".`);
+      console.log(ui.dim(`  ${snapshot.reminderLists.length} reminder list(s): ${snapshot.reminderLists.map((l) => l.title).join(', ') || '(none)'}`));
+      console.log(ui.dim(`  ${snapshot.noteFolders.length} note folder(s): ${snapshot.noteFolders.map((f) => f.name).join(', ') || '(none)'}`));
+      console.log('');
+      console.log(`Tools now available: ${ui.cmd(`apple.${slug}.reminder-create`)}, ${ui.cmd(`apple.${slug}.reminder-read`)}, ${ui.cmd(`apple.${slug}.reminder-update`)}, ${ui.cmd(`apple.${slug}.note-create`)}, ${ui.cmd(`apple.${slug}.note-read`)}`);
+      console.log(ui.dim('Run an agent from this Terminal with `SUA_PROVIDER=local` so reminder writes have access.'));
+    } catch (err) {
+      ui.fail(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    } finally {
+      store.close();
+    }
   });


### PR DESCRIPTION
Follow-up to #492/#493. Makes the Apple integration actually addable.

## Why
The dashboard "Add Apple integration" flow runs the `lists` introspection **in the background daemon** — which usually has **Reminders denied** (macOS ties the TCC grant to the granting process tree, so the Terminal `sua apple authorize` grant doesn't reach the daemon). So the dashboard add fails with "couldn't read Reminders," and there was no other way to register the integration.

## What
`sua apple connect` runs the introspection in the **user's own Terminal** — the one where `sua apple authorize` granted access — then upserts the `apple` integration (default id `apple`) with the discovered reminder lists + note folders. The generated tools become available immediately.

```
sua apple authorize     # grant (Terminal)
sua apple connect       # register (same Terminal) → tools created
SUA_PROVIDER=local sua workflow run <agent>   # run with access
```

Options: `--id <slug>` (default `apple`), `--name <name>`. Flag-gated (`isAppleIntegrationEnabled`). Fails gracefully with "run `sua apple authorize` first" when access is denied (verified from a non-granted shell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)