### PR TITLE
fix(executor): apply input defaults to {{inputs.X}} in builtin tool nodes

### DIFF
--- a/.changeset/tool-node-input-defaults.md
+++ b/.changeset/tool-node-input-defaults.md
@@ -1,0 +1,16 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Fix: apply agent input defaults to `{{inputs.X}}` in builtin/generated tool nodes.
+
+The builtin-tool execution path resolved `{{inputs.X}}` templates against the
+caller's `--input` pairs only, ignoring declared input defaults — so a tool node
+templating a defaulted input received an empty string (e.g. a required field
+failing with "title is required"). Shell/LLM nodes already applied defaults via
+node-env; the tool path now uses the same `mergedInputs` merge, so defaults and
+required-input validation are consistent across node types.

--- a/packages/core/src/dag-executor.test.ts
+++ b/packages/core/src/dag-executor.test.ts
@@ -468,6 +468,28 @@ describe('executeAgentDag — inputs', () => {
     expect(env!.STYLE).toBe('haiku');
   });
 
+  it('applies agent-level input defaults to {{inputs.X}} in a builtin tool node', async () => {
+    // Regression: the builtin-tool path resolved {{inputs.X}} against the
+    // caller's --input pairs only, ignoring declared defaults — so a tool node
+    // templating a defaulted input got an empty string. It must match the
+    // shell/llm path and apply defaults.
+    const agent: Agent = {
+      id: 'parser', name: 'Parser', status: 'active', source: 'local', mcp: false, version: 1,
+      inputs: { PAYLOAD: { type: 'string', default: '{"ok":true}' } },
+      nodes: [{ id: 'parse', type: 'shell', tool: 'json-parse', toolInputs: { text: '{{inputs.PAYLOAD}}' } }],
+    };
+    const run = await executeAgentDag(
+      agent,
+      { triggeredBy: 'cli' },
+      { runStore, spawnNode: cannedSpawner({}) },
+    );
+    expect(run.status).toBe('completed');
+    const node = runStore.listNodeExecutions(run.id).find((n) => n.nodeId === 'parse');
+    expect(node?.status).toBe('completed');
+    // json-parse re-serializes the parsed default; empty input would have thrown.
+    expect(node?.result).toContain('"ok":true');
+  });
+
   it('fails with setup when a required input is missing at runtime', async () => {
     const agent: Agent = {
       id: 'weather', name: 'Weather', status: 'active', source: 'local', mcp: false, version: 1,

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -38,7 +38,7 @@ import { resolveUpstreamTemplate, resolveVarsTemplate, resolveStateTemplate } fr
 import { substituteInputs } from './input-resolver.js';
 import { stateDirFor, stateDirSize, formatBytes, DEFAULT_STATE_MAX_BYTES } from './agent-state.js';
 import { UntrustedCommunityShellError } from './agent-executor.js';
-import { buildNodeEnv, buildUpstreamSnapshot, filterEnvForLog } from './node-env.js';
+import { buildNodeEnv, buildUpstreamSnapshot, filterEnvForLog, mergedInputs } from './node-env.js';
 import { unallowedWidgetImageHosts, formatBlockedImageError } from './widget-image-hosts.js';
 import { type SpawnResult, type SpawnNodeFn, type SpawnProgress, spawnNodeReal } from './node-spawner.js';
 import { resolveToolId, resolveToolInputs } from './tool-dispatch.js';
@@ -906,7 +906,11 @@ export async function executeAgentDag(
         // like file-write can template path/content from upstream
         // output, inputs, and the per-agent state directory.
         const vars = deps.variablesStore ? deps.variablesStore.getAll() : {};
-        const resolvedInputs = options.inputs ?? {};
+        // Apply agent-level input defaults (and required-input validation) the
+        // same way shell/llm nodes do via node-env — so `{{inputs.X}}` in a
+        // tool node's toolInputs resolves declared defaults, not just the
+        // caller's --input pairs.
+        const resolvedInputs = mergedInputs(agent, options.inputs ?? {});
         const stateDir = deps.dataRoot ? stateDirFor(agent.id, deps.dataRoot) : undefined;
         const resolveStr = (s: string): string =>
           substituteInputs(


### PR DESCRIPTION
## Bug
Found while dogfooding the Apple integration: `apple-reminder-demo` failed at the `reminder-create` node with **"title is required"** even though `TITLE` declares a default. Root cause is general, not Apple-specific.

At [dag-executor.ts](packages/core/src/dag-executor.ts) the builtin/generated-tool path resolved `{{inputs.X}}` templates against `options.inputs` — the caller's `--input KEY=value` pairs **only**. So a tool node templating an input that was *declared with a default but not passed* received an **empty string**. Shell/LLM nodes don't have this bug: they apply defaults via `node-env`'s `mergedInputs`.

## Fix
Route the tool path through the same `mergedInputs(agent, options.inputs ?? {})` helper, so input defaults **and** required-input validation are consistent across shell / LLM / tool nodes. One-line behavioral change + a regression test (`json-parse` tool node templating a defaulted input completes instead of throwing on empty input).

## Verification
- New regression test passes with the fix (would fail without — empty `text` throws in `JSON.parse`).
- Full suite green: **2091 pass / 3 skip**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)