### PR TITLE
feat(cli): `sua worker install-launchagent` + ADR-0026 (durable Reminders access for background agents)

### DIFF
--- a/.changeset/worker-launchagent.md
+++ b/.changeset/worker-launchagent.md
@@ -1,0 +1,18 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Add `sua worker install-launchagent` for a durable, GUI-session worker (macOS).
+
+A detached daemon worker can't get the macOS Reminders TCC grant, so background
+agents using the Apple integration's reminder tools were denied. The new
+`sua worker install-launchagent` writes a user LaunchAgent that runs the worker
+in your GUI login session (via `launchctl bootstrap gui/$UID`), where macOS can
+surface the permission prompt and persist the grant across reboots — so
+scheduled/temporal reminder agents work. Paired with `uninstall-launchagent` and
+`launchagent-status`. The fully distributable fix (code-signing the runner) is
+captured in ADR-0026.

--- a/docs/adr/0026-apple-runner-code-signing.md
+++ b/docs/adr/0026-apple-runner-code-signing.md
@@ -1,0 +1,88 @@
+# ADR-0026: Code-sign the Apple runner for daemon + distributed TCC access
+
+## Status
+
+Proposed (roadmap — implement when un-gating the experimental Apple integration for distribution)
+
+## Context
+
+The experimental Apple Reminders/Notes integration (the `apple` integration
+kind) drives EventKit and AppleScript through a small Swift runner that
+`apple-runner.ts` **compiles on demand** per machine via `xcrun swiftc` and
+caches at `~/.sua/runners/apple_reminders`. This mirrors the Apple Foundation
+Models runner and needs no toolchain shipping — but it collides with macOS TCC
+(Transparency, Consent & Control) in two ways:
+
+1. **Daemons can't get Reminders access.** EventKit's Reminders grant is keyed
+   on the *responsible process*. When the owner runs `sua apple authorize` in
+   Terminal, the grant attaches to **Terminal.app**, not to sua's detached
+   worker daemon. The temporal worker that executes agent nodes is therefore
+   **denied** — verified live: `reminder-read` from the daemon returns
+   "Reminders access denied," while the same call from a Terminal-rooted process
+   succeeds. (Notes/Automation grants are broader and *do* carry to the daemon.)
+   Net: reminder tools only work from a granted Terminal (`SUA_PROVIDER=local`),
+   not from scheduled/background agents.
+
+2. **Ad-hoc signatures aren't stable.** A `swiftc -o` binary is ad-hoc signed;
+   its code-signing identity changes on every recompile, so even a granted TCC
+   entry is invalidated whenever the source hash drifts and we rebuild.
+
+Two interim mitigations exist and ship today:
+
+- **Terminal + local provider** — run reminder agents via
+  `SUA_PROVIDER=local sua workflow run` from the authorized Terminal.
+- **LaunchAgent in the GUI session** (`sua worker install-launchagent`) — runs
+  the worker under `launchctl ... gui/$UID`, where macOS *can* surface a TCC
+  prompt and persist the grant. Durable per-machine, no certificate, but
+  per-user-setup and not distributable.
+
+Neither makes the integration "just work" for someone who installs sua from npm
+and wants autonomous reminder agents.
+
+## Decision
+
+To make Reminders work from any process (daemon included) and for distributed
+users, **ship a Developer ID–signed, notarized, prebuilt Apple runner** with an
+embedded `Info.plist` (carrying `NSRemindersUsageDescription`) and the Reminders
+entitlement, **replacing compile-on-demand for the signed distribution path**.
+
+Because TCC then keys on the stable code-signing identity rather than the
+responsible parent process:
+
+- The owner approves a single proper prompt (with our usage string), and the
+  grant persists across updates and applies under **any** launching process —
+  detached daemon, LaunchDaemon, or Terminal.
+- The same build+sign+notarize pipeline is reused by every native helper sua
+  ships (the Foundation Models runner today; future macOS helpers).
+
+Concrete shape (to detail at implementation time):
+
+1. Build the runner as a signed Mach-O (or minimal `.app` bundle so an
+   `Info.plist` + entitlements can be embedded) in CI on a macOS runner.
+2. Sign with a **Developer ID Application** certificate; staple notarization.
+3. Ship the prebuilt artifact (in the package or as a versioned download);
+   `ensureAppleRunner` prefers the signed artifact and falls back to
+   compile-on-demand only for local development.
+4. Keep the source hash check for the dev path; the shipped path verifies the
+   signature instead.
+
+## Consequences
+
+- **Pro:** background/scheduled reminder agents work; one grant per user; no
+  per-machine LaunchAgent setup; reusable signing pipeline across native helpers.
+- **Con:** requires an Apple Developer Program membership ($99/yr) + Developer
+  ID cert managed as a CI secret; adds a notarization step (minutes per release);
+  shifts distribution from "compile locally" to "ship a signed binary" (a real
+  architectural change with a fallback to preserve the dev experience).
+- **Scope gate:** only worth doing alongside un-gating `experimental.apple` for
+  real distribution. Until then, the Terminal/local and LaunchAgent paths cover
+  single-machine use.
+
+## Alternatives considered
+
+- **LaunchAgent only (ADR-less, shipped as Stage 2):** durable per-machine, no
+  cert — but not distributable and requires the owner to wire it up.
+- **Ad-hoc / self-signed:** unstable identity (recompile invalidates the grant)
+  or not trusted off-machine. Rejected.
+- **Stay Terminal-only:** simplest, but reminders never run autonomously.
+  Acceptable for the experimental phase, not for shipping.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -111,12 +111,23 @@ What this means for actually running the tools:
 - **Reliable today:** run from a Terminal with the local provider, where the node
   executes in Terminal's (granted) process tree:
   `SUA_PROVIDER=local sua workflow run apple-reminder-demo`.
-- **For temporal / scheduled runs:** the worker daemon needs the grant too. Start
-  the worker in a **foreground Terminal** (`sua worker start`, not the detached
-  daemon) so it inherits Terminal's grant. The dashboard **Check access** button
-  reflects the daemon's state, so use it to confirm.
-- A durable fix (code-signing the runner with a stable identity + entitlements so
-  TCC keys on the binary) is out of scope for this experimental version.
+- **For temporal / scheduled runs**, the worker that executes nodes needs the
+  grant too. Two options, easiest first:
+  - **Quick:** run the worker in a **foreground Terminal** (`sua worker start`,
+    not the detached daemon) so it inherits Terminal's grant.
+  - **Durable (recommended):** `sua worker install-launchagent` installs a user
+    LaunchAgent that runs the worker in your **GUI login session**, where macOS
+    *can* surface the permission prompt and persist the grant across reboots. The
+    first reminder run prompts once; approve it. Stop the detached daemon worker
+    first (`sua daemon stop --service worker`) so they don't both consume the
+    queue. Manage it with `sua worker launchagent-status` /
+    `sua worker uninstall-launchagent`.
+  The dashboard **Check access** button reflects the daemon's state, so use it to
+  confirm which path the worker is on.
+- The fully distributable fix — code-signing the runner so TCC keys on the binary
+  regardless of launching process — is captured in
+  [ADR-0026](adr/0026-apple-runner-code-signing.md), to do when the integration
+  is un-gated for distribution.
 
 **Other caveats.** Reminders is solid (EventKit). **Notes is best-effort**: no
 first-party API, so AppleScript — `note-create` works but returns no reliable id,

--- a/packages/cli/src/commands/worker.test.ts
+++ b/packages/cli/src/commands/worker.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { buildWorkerPlist } from './worker.js';
+
+describe('buildWorkerPlist', () => {
+  const plist = buildWorkerPlist({
+    nodePath: '/usr/bin/node',
+    cliEntry: '/repo/packages/cli/dist/index.js',
+    cwd: '/repo',
+    env: { SUA_EXPERIMENTAL_APPLE: '1', PATH: '/opt/homebrew/bin:/usr/bin' },
+    logPath: '/repo/data/daemon/logs/worker-launchagent.log',
+  });
+
+  it('declares the worker label and program arguments', () => {
+    expect(plist).toContain('<string>com.some-useful-agents.worker</string>');
+    expect(plist).toContain('<string>/usr/bin/node</string>');
+    expect(plist).toContain('<string>/repo/packages/cli/dist/index.js</string>');
+    expect(plist).toContain('<string>worker</string>');
+    expect(plist).toContain('<string>start</string>');
+  });
+
+  it('runs at load, keeps alive, and sets the working directory', () => {
+    expect(plist).toContain('<key>RunAtLoad</key>\n  <true/>');
+    expect(plist).toContain('<key>KeepAlive</key>\n  <true/>');
+    expect(plist).toContain('<key>WorkingDirectory</key>\n  <string>/repo</string>');
+  });
+
+  it('renders the environment (so the flag + temporal config reach the worker)', () => {
+    expect(plist).toContain('<key>SUA_EXPERIMENTAL_APPLE</key>');
+    expect(plist).toContain('<string>1</string>');
+    expect(plist).toContain('<key>PATH</key>');
+  });
+
+  it('xml-escapes special characters in paths', () => {
+    const p = buildWorkerPlist({
+      nodePath: '/usr/bin/node', cliEntry: '/a & b/cli.js', cwd: '/a & b',
+      env: {}, logPath: '/a & b/w.log',
+    });
+    expect(p).toContain('/a &amp; b/cli.js');
+    expect(p).not.toContain('/a & b/cli.js');
+  });
+});

--- a/packages/cli/src/commands/worker.ts
+++ b/packages/cli/src/commands/worker.ts
@@ -1,6 +1,75 @@
 import { Command } from 'commander';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { loadConfig } from '../config.js';
 import * as ui from '../ui.js';
+
+const LAUNCH_AGENT_LABEL = 'com.some-useful-agents.worker';
+
+function launchAgentPlistPath(): string {
+  return join(homedir(), 'Library', 'LaunchAgents', `${LAUNCH_AGENT_LABEL}.plist`);
+}
+
+function xmlEscape(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * Build a user LaunchAgent plist that runs `sua worker start` in the user's
+ * GUI (Aqua) session. Running there — vs. a detached daemon — is what lets
+ * macOS surface TCC prompts (Reminders/Automation) and persist the grant, so
+ * a background worker can actually drive the Apple integration.
+ */
+export function buildWorkerPlist(opts: {
+  nodePath: string;
+  cliEntry: string;
+  cwd: string;
+  env: Record<string, string>;
+  logPath: string;
+}): string {
+  const envEntries = Object.entries(opts.env)
+    .map(([k, v]) => `      <key>${xmlEscape(k)}</key>\n      <string>${xmlEscape(v)}</string>`)
+    .join('\n');
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LAUNCH_AGENT_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${xmlEscape(opts.nodePath)}</string>
+    <string>${xmlEscape(opts.cliEntry)}</string>
+    <string>worker</string>
+    <string>start</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>${xmlEscape(opts.cwd)}</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+${envEntries}
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>${xmlEscape(opts.logPath)}</string>
+  <key>StandardErrorPath</key>
+  <string>${xmlEscape(opts.logPath)}</string>
+</dict>
+</plist>
+`;
+}
+
+function requireDarwin(): void {
+  if (process.platform !== 'darwin') {
+    ui.fail('LaunchAgents are macOS-only.');
+    process.exit(1);
+  }
+}
 
 export const workerCommand = new Command('worker')
   .description('Temporal worker management');
@@ -43,5 +112,92 @@ workerCommand
         console.error(ui.dim(`\nIs Temporal running? Start it with: ${ui.cmd('docker compose up -d')}`));
       }
       process.exit(1);
+    }
+  });
+
+workerCommand
+  .command('install-launchagent')
+  .description('Install a user LaunchAgent so the worker runs in your GUI session (persistent macOS Reminders/Notes access)')
+  .action(() => {
+    requireDarwin();
+    const uid = process.getuid?.() ?? 0;
+    const cwd = process.cwd();
+    const nodePath = process.execPath;
+    // The CLI entry (dist/index.js) — resolve through the `sua` symlink.
+    let cliEntry: string;
+    try {
+      cliEntry = realpathSync(process.argv[1]);
+    } catch {
+      cliEntry = process.argv[1];
+    }
+
+    const config = loadConfig();
+    // WorkingDirectory makes the worker's loadConfig find this sua.config.json,
+    // which bridges experimental.apple → SUA_EXPERIMENTAL_APPLE. We also pass the
+    // env explicitly so it works even if the flag is only set via env right now.
+    const env: Record<string, string> = {
+      PATH: ['/opt/homebrew/bin', '/usr/local/bin', '/usr/bin', '/bin', process.env.PATH ?? ''].filter(Boolean).join(':'),
+    };
+    if (process.env.SUA_EXPERIMENTAL_APPLE) env.SUA_EXPERIMENTAL_APPLE = process.env.SUA_EXPERIMENTAL_APPLE;
+    else if (config.experimental?.apple) env.SUA_EXPERIMENTAL_APPLE = '1';
+    if (config.temporalAddress) env.SUA_TEMPORAL_ADDRESS = config.temporalAddress;
+
+    const logPath = join(cwd, 'data', 'daemon', 'logs', 'worker-launchagent.log');
+    mkdirSync(dirname(logPath), { recursive: true });
+
+    const plistPath = launchAgentPlistPath();
+    mkdirSync(dirname(plistPath), { recursive: true });
+    writeFileSync(plistPath, buildWorkerPlist({ nodePath, cliEntry, cwd, env, logPath }), 'utf-8');
+    ui.ok(`Wrote ${plistPath}`);
+
+    // Reload: bootout first (ignore "not loaded"), then bootstrap into the GUI domain.
+    spawnSync('launchctl', ['bootout', `gui/${uid}`, plistPath], { stdio: 'ignore' });
+    const boot = spawnSync('launchctl', ['bootstrap', `gui/${uid}`, plistPath], { encoding: 'utf-8' });
+    if (boot.status !== 0) {
+      ui.fail(`launchctl bootstrap failed: ${(boot.stderr || boot.stdout || '').trim()}`);
+      console.log(ui.dim('  Try: launchctl bootout gui/$(id -u) "' + plistPath + '" then re-run.'));
+      process.exit(1);
+    }
+    ui.ok('Loaded LaunchAgent into your GUI session.');
+    console.log('');
+    ui.warn('Stop the detached daemon worker so they do not both consume the queue:');
+    console.log(`  ${ui.cmd('sua daemon stop --service worker')}`);
+    console.log('');
+    console.log(ui.dim('The first reminder run will trigger a macOS permission prompt — approve it once.'));
+    console.log(ui.dim(`Logs: ${logPath}`));
+    console.log(ui.dim(`Status: ${ui.cmd('sua worker launchagent-status')}  ·  Remove: ${ui.cmd('sua worker uninstall-launchagent')}`));
+  });
+
+workerCommand
+  .command('uninstall-launchagent')
+  .description('Remove the worker LaunchAgent')
+  .action(() => {
+    requireDarwin();
+    const uid = process.getuid?.() ?? 0;
+    const plistPath = launchAgentPlistPath();
+    spawnSync('launchctl', ['bootout', `gui/${uid}`, plistPath], { stdio: 'ignore' });
+    if (existsSync(plistPath)) {
+      rmSync(plistPath, { force: true });
+      ui.ok(`Removed ${plistPath} and unloaded it.`);
+    } else {
+      ui.warn('No worker LaunchAgent installed.');
+    }
+  });
+
+workerCommand
+  .command('launchagent-status')
+  .description('Show whether the worker LaunchAgent is loaded')
+  .action(() => {
+    requireDarwin();
+    const uid = process.getuid?.() ?? 0;
+    const plistPath = launchAgentPlistPath();
+    ui.kv('Plist', existsSync(plistPath) ? plistPath : 'not installed');
+    try {
+      const out = execFileSync('launchctl', ['print', `gui/${uid}/${LAUNCH_AGENT_LABEL}`], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] });
+      const state = /state = (\S+)/.exec(out)?.[1] ?? 'loaded';
+      const pid = /pid = (\d+)/.exec(out)?.[1];
+      ui.ok(`LaunchAgent loaded (state: ${state}${pid ? `, pid ${pid}` : ''}).`);
+    } catch {
+      ui.warn('LaunchAgent not loaded.');
     }
   });


### PR DESCRIPTION
Follow-up to the Apple integration. Gives the **background worker** a path to the macOS Reminders grant, so reminder agents run autonomously — not just from a Terminal.

## Problem
EventKit ties the Reminders TCC grant to the *responsible process*. A detached daemon worker isn't in a granted tree and can't prompt, so background/scheduled reminder agents are **denied** (verified live; Notes/Automation is broader and does work from the daemon).

## Stage 2 (this PR): LaunchAgent in the GUI session
`sua worker install-launchagent` writes `~/Library/LaunchAgents/com.some-useful-agents.worker.plist` and loads it via `launchctl bootstrap gui/$UID`, running the worker in your **GUI login session** — where macOS *can* surface the permission prompt and **persist the grant across reboots**.
- Carries `WorkingDirectory` + env (`SUA_EXPERIMENTAL_APPLE`, temporal address) so the worker resolves config and the `apple` kind.
- `RunAtLoad` + `KeepAlive`; logs to `data/daemon/logs/worker-launchagent.log`.
- Plus `uninstall-launchagent` and `launchagent-status`.
- **Verified live**: full install → worker connected to temporal (RUNNING, flag present) → uninstall cycle. Pure plist builder has unit tests.

Usage: `sua daemon stop --service worker` → `sua worker install-launchagent` → run a reminder agent → approve the one-time prompt.

## Stage 3 (planned): [ADR-0026](docs/adr/0026-apple-runner-code-signing.md)
Captures the fully distributable fix — Developer ID–sign + notarize a prebuilt runner so TCC keys on the binary regardless of launching process (works for any daemon, any user, one grant). To do when un-gating the experimental flag for distribution.

## Verification
- Clean build; cli tests **74 pass** (incl. new plist-builder test); install/uninstall exercised on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)