### PR TITLE
feat(inbox): clean up thread-actions UI — one agent dropdown for fork/retarget

### DIFF
--- a/.changeset/inbox-thread-actions-cleanup.md
+++ b/.changeset/inbox-thread-actions-cleanup.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Clean up the inbox thread-actions UI (fork / retarget).
+
+Replaced the two free-text "agent id" boxes with a single labeled "Move to"
+dropdown listing installed agents by name, shared by the Fork and Retarget
+buttons (Retarget uses the submit button's formaction so one select drives both
+routes). The inbox AJAX form handler now honors a submitter's formaction. Clearer,
+no more typing exact agent ids.

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -3785,17 +3785,27 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
 }
 .inbox-thread-actions__move {
   display: inline-flex;
-  gap: var(--space-1);
+  gap: var(--space-2);
   align-items: center;
   margin: 0;
 }
-.inbox-thread-actions__input {
-  min-width: 9rem;
+.inbox-thread-actions__move-label {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+}
+.inbox-thread-actions__select {
+  min-width: 10rem;
   padding: var(--space-1) var(--space-2);
   border: 1px solid var(--color-border-strong);
   border-radius: var(--radius-sm);
   font-size: var(--font-size-xs);
-  font-family: var(--font-mono);
+  font-family: var(--font-sans);
+  background: var(--color-surface);
+  color: var(--color-text);
 }
 
 .inbox-modal__timeline-section {

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -243,12 +243,12 @@ function summarizeInline(text: string | undefined, max = 180): string | undefine
 }
 
 /** Installed non-system agents a thread can be forked/retargeted to. */
-function listForkableAgentIds(ctx: ReturnType<typeof getContext>): string[] {
+function listForkableAgents(ctx: ReturnType<typeof getContext>): { id: string; name: string }[] {
   try {
     return ctx.agentStore.listAgents()
       .filter((agent) => !SYSTEM_AGENT_IDS.has(agent.id))
-      .map((agent) => agent.id)
-      .sort((a, b) => a.localeCompare(b));
+      .map((agent) => ({ id: agent.id, name: agent.name || agent.id }))
+      .sort((a, b) => a.name.localeCompare(b.name));
   } catch {
     return [];
   }
@@ -461,7 +461,7 @@ inboxRouter.get('/inbox/:id', (req: Request, res: Response) => {
     currentTargetYaml,
     inlineActionWidgets,
     threadSummary: responses.length >= 3 ? buildThreadSummary(message, responses) : undefined,
-    forkableAgentIds: listForkableAgentIds(ctx),
+    forkableAgents: listForkableAgents(ctx),
   }));
 });
 
@@ -488,7 +488,7 @@ inboxRouter.get('/inbox/:id/fragment', (req: Request, res: Response) => {
     currentTargetYaml,
     inlineActionWidgets,
     threadSummary: responses.length >= 3 ? buildThreadSummary(message, responses) : undefined,
-    forkableAgentIds: listForkableAgentIds(ctx),
+    forkableAgents: listForkableAgents(ctx),
   })));
 });
 

--- a/packages/dashboard/src/views/inbox-detail.ts
+++ b/packages/dashboard/src/views/inbox-detail.ts
@@ -43,8 +43,8 @@ export interface InboxDetailOptions {
     currentStatus: string;
     nextStep?: string;
   };
-  /** Installed non-system agent ids offered as fork/retarget targets. */
-  forkableAgentIds?: string[];
+  /** Installed non-system agents offered as fork/retarget targets. */
+  forkableAgents?: { id: string; name: string }[];
 }
 
 const PRIORITY_BADGE: Record<string, string> = {
@@ -117,7 +117,7 @@ const ACTION_STATUS_LABEL: Record<InboxActionStatus, string> = {
  * standard dashboard layout for direct-link access + accessibility.
  */
 export function renderInboxDetailFragment(opts: InboxDetailOptions): SafeHtml {
-  const { message, responses, flash, triagePending, currentTargetYaml, inlineActionWidgets, threadSummary, forkableAgentIds = [] } = opts;
+  const { message, responses, flash, triagePending, currentTargetYaml, inlineActionWidgets, threadSummary, forkableAgents = [] } = opts;
   const badgeClass = PRIORITY_BADGE[message.priority] ?? 'badge--muted';
   const isTerminal = message.status === 'dismissed' || message.status === 'resolved';
 
@@ -213,26 +213,26 @@ export function renderInboxDetailFragment(opts: InboxDetailOptions): SafeHtml {
   // work to another agent — fork (new thread, keeps provenance) or retarget
   // (rewrite this thread's agent link). Each is a small AJAX form reusing the
   // existing inbox-modal submit pattern; no new client JS.
-  const forkOptions = forkableAgentIds.map((agentId) => html`<option value="${agentId}"></option>`);
+  const agentOptions = forkableAgents.map((a) => html`<option value="${a.id}">${a.name}</option>`);
   const threadActions = html`
     <section class="inbox-thread-actions">
       <form method="POST" action="/inbox/${message.id}/summarize" data-inbox-modal-form style="margin: 0;">
-        <button type="submit" class="btn btn--sm btn--ghost">Summarize</button>
+        <button type="submit" class="btn btn--sm btn--ghost" title="Pin a derived goal/status/next-step summary into the thread">Summarize</button>
       </form>
       ${isTerminal ? html`
         <form method="POST" action="/inbox/${message.id}/reopen" data-inbox-modal-form style="margin: 0;">
           <button type="submit" class="btn btn--sm btn--ghost">Reopen</button>
         </form>
       ` : html``}
-      ${forkableAgentIds.length > 0 ? html`
-        <datalist id="forkable-agents-${message.id}">${forkOptions as unknown as SafeHtml[]}</datalist>
+      ${forkableAgents.length > 0 ? html`
         <form method="POST" action="/inbox/${message.id}/fork" data-inbox-modal-form class="inbox-thread-actions__move">
-          <input type="text" name="agentId" list="forkable-agents-${message.id}" class="inbox-thread-actions__input" placeholder="agent id" aria-label="Fork to agent id" required>
-          <button type="submit" class="btn btn--sm btn--ghost" title="Create a new thread targeting this agent, carrying a summary of this one">Fork to agent</button>
-        </form>
-        <form method="POST" action="/inbox/${message.id}/retarget" data-inbox-modal-form class="inbox-thread-actions__move">
-          <input type="text" name="agentId" list="forkable-agents-${message.id}" class="inbox-thread-actions__input" placeholder="agent id" aria-label="Retarget to agent id" required>
-          <button type="submit" class="btn btn--sm btn--ghost" title="Point THIS thread at a different agent (rewrites the agent link)">Retarget</button>
+          <span class="inbox-thread-actions__move-label">Move to</span>
+          <select name="agentId" class="inbox-thread-actions__select" required aria-label="Target agent">
+            <option value="" disabled selected>Choose agent…</option>
+            ${agentOptions as unknown as SafeHtml[]}
+          </select>
+          <button type="submit" class="btn btn--sm btn--ghost" title="Fork: start a new thread for the chosen agent, carrying a summary of this one (this thread is untouched)">Fork</button>
+          <button type="submit" formaction="/inbox/${message.id}/retarget" class="btn btn--sm btn--ghost" title="Retarget: point THIS thread at the chosen agent (no new thread)">Retarget</button>
         </form>
       ` : html``}
     </section>

--- a/packages/dashboard/src/views/inbox-modal.js.ts
+++ b/packages/dashboard/src/views/inbox-modal.js.ts
@@ -784,7 +784,10 @@ export const INBOX_MODAL_JS = `
     if (form.getAttribute('data-inflight') === '1') return;
     form.setAttribute('data-inflight', '1');
 
-    var action = form.getAttribute('action');
+    // Respect a submit button's formaction so one form can drive multiple
+    // routes (e.g. the thread-actions Fork/Retarget buttons share one select).
+    var submitter = e.submitter || null;
+    var action = (submitter && submitter.getAttribute('formaction')) || form.getAttribute('action');
     var method = (form.getAttribute('method') || 'POST').toUpperCase();
     var formData = new FormData(form);
     var submits = form.querySelectorAll('button[type="submit"]');


### PR DESCRIPTION
The inbox thread-actions row had **two free-text "agent id" boxes** (a datalist with empty-label options) for Fork and Retarget — you had to know and type an exact agent id. Science project.

## Cleanup
- **One labeled "Move to" dropdown** listing installed agents **by name**, shared by **Fork** and **Retarget** buttons.
- Retarget uses the submit button's `formaction` so a single `<select>` drives both routes; the inbox-modal AJAX handler now reads `e.submitter.formAction` (falls back to the form action).
- Route returns `{ id, name }` instead of bare ids; options show names.
- Summarize / Reopen unchanged.

Before: `Summarize  [agent id____]  Fork to agent  [agent id____]  Retarget`
After:  `Summarize   MOVE TO [Choose agent… ▼]  Fork  Retarget`

## Verification
- 159 inbox tests pass; clean build.
- Rendered + screenshotted live: dropdown shows agent names, formaction wired, old free-text/datalist fully removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)