### PR TITLE
fix(apple): fail fast on Notes AppleScript hang from headless worker

### DIFF
--- a/.changeset/apple-notes-fail-fast.md
+++ b/.changeset/apple-notes-fail-fast.md
@@ -1,0 +1,16 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Apple Notes: fail fast instead of hanging 30s when the worker lacks a GUI session.
+
+`note-create`/`note-read`/`lists` drive Notes.app via AppleScript. From a process
+without a GUI session or Automation grant (e.g. the background temporal worker),
+the Apple event blocks until the 30s spawn timeout ("produced no output"). The
+runner now wraps every AppleScript in `with timeout of 10 seconds` and maps the
+timeout (-1712) and not-permitted (-1743) errors to clear, actionable messages
+("run it via sua worker install-launchagent", or "grant Automation access").

--- a/packages/core/src/integrations/apple-runner.ts
+++ b/packages/core/src/integrations/apple-runner.ts
@@ -85,7 +85,11 @@ func isoString(_ d: Date?) -> Any {
 // ── AppleScript helper (Notes has no first-party framework) ─────────────
 
 func runAppleScript(_ src: String) -> (String?, String?) {
-    guard let script = NSAppleScript(source: src) else {
+    // Wrap in \`with timeout\` so a blocked Apple event — e.g. driving Notes.app
+    // from a process without a GUI session or Automation grant, which otherwise
+    // hangs until the caller's 30s spawn timeout — fails fast with a clear error.
+    let wrapped = "with timeout of 10 seconds\\n" + src + "\\nend timeout"
+    guard let script = NSAppleScript(source: wrapped) else {
         return (nil, "could not compile AppleScript")
     }
     var errorDict: NSDictionary?
@@ -93,6 +97,12 @@ func runAppleScript(_ src: String) -> (String?, String?) {
     if let err = errorDict {
         let num = (err["NSAppleScriptErrorNumber"] as? Int) ?? 0
         let msg = (err["NSAppleScriptErrorMessage"] as? String) ?? "AppleScript error"
+        if num == -1712 {
+            return (nil, "Notes did not respond (AppleEvent timed out after 10s). The worker likely lacks a GUI session — run it via \`sua worker install-launchagent\` and approve the macOS prompt.")
+        }
+        if num == -1743 {
+            return (nil, "Automation access to Notes is denied. Grant it in System Settings > Privacy & Security > Automation, or run \`sua apple authorize\`.")
+        }
         return (nil, "AppleScript error \\(num): \\(msg)")
     }
     return (result.stringValue ?? "", nil)


### PR DESCRIPTION
## Bug
A triage/dashboard `make-a-note` run on the background worker failed with:
```
apple runner produced no output (exit 124): Timed out after 30s
```
`note-create` drives Notes.app via AppleScript. From a process with **no GUI session / Automation grant** (the temporal worker), the Apple event **blocks for the full 30s spawn timeout** instead of failing cleanly — so the operator waits 30s for an opaque error.

## Fix
Wrap every AppleScript in the runner in `with timeout of 10 seconds`, and map the resulting errors to clear, actionable messages:
- `-1712` (AppleEvent timed out) → "Notes did not respond… run it via `sua worker install-launchagent` and approve the macOS prompt."
- `-1743` (not permitted) → "Automation access to Notes is denied… grant it in System Settings, or run `sua apple authorize`."

Now a headless note-create fails in ~10s with a message that tells you exactly what to do, instead of hanging 30s.

## Verification
- Swift re-validated by direct compile + dry-run; embedded copy **round-trips byte-identical**.
- 32 apple/generated-tools tests pass.

Note: the durable fix for actually *making* notes from the background worker is running it in a GUI session (`sua worker install-launchagent`, #496). This PR makes the failure fast + legible when it can't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)