### PR TITLE
fix(executor): clear "tool did not resolve" error + multi-worker warning (#499)

### DIFF
--- a/.changeset/clear-unresolved-tool-error.md
+++ b/.changeset/clear-unresolved-tool-error.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Clearer error when a tool node fails to resolve + multi-worker warning.
+
+When a node references a `tool:` that doesn't resolve (integration disabled via the
+experimental flag, not installed, or the worker running stale code), the executor
+reported the misleading "Shell node X has no command" / "not found in registry or
+store". It now says: tool "<id>" did not resolve — integration may be disabled, not
+installed, or this worker may be stale (restart it). `sua daemon status` also warns
+when more than one worker is polling the Temporal queue, since competing workers are
+a common cause of these flaky failures (a run lands on an ungranted/stale worker).

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path';
 import { existsSync, readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { Command } from 'commander';
 import chalk from 'chalk';
 import Table from 'cli-table3';
@@ -236,8 +237,33 @@ daemonCommand
       }
     }
 
+    // Competing-worker guard: under Temporal, more than one worker polling the
+    // task queue means a run can land on an unintended (ungranted / stale)
+    // worker — the cause of flaky "tool did not resolve" failures. Warn loudly.
+    if (config.provider === 'temporal') {
+      const workers = countWorkerProcesses();
+      if (workers > 1) {
+        ui.warn(`${workers} worker processes are running.`);
+        console.error(ui.dim(
+          '  Multiple workers compete for the Temporal task queue, so a run can execute on an\n' +
+          '  unintended worker (e.g. one lacking macOS grants or running stale code). Keep exactly one:\n' +
+          '  stop extras with `sua daemon stop --service worker` / `sua worker uninstall-launchagent`.',
+        ));
+      }
+    }
+
     console.log(ui.dim(`\nLogs: ${daemonPaths(dataDir).logsDir}\n`));
   });
+
+/** Count host processes running a Temporal worker (`… worker start`). */
+function countWorkerProcesses(): number {
+  try {
+    const out = execFileSync('pgrep', ['-f', 'worker start'], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] });
+    return out.split('\n').map((s) => s.trim()).filter(Boolean).length;
+  } catch {
+    return 0; // pgrep exits non-zero when there are no matches (or isn't available)
+  }
+}
 
 // ── helpers ─────────────────────────────────────────────────────────────
 

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -940,7 +940,10 @@ export async function executeAgentDag(
       } else if (toolId && deps.toolStore) {
         const userTool = deps.toolStore.getTool(toolId);
         if (!userTool) {
-          throw new Error(`Tool "${toolId}" not found in registry or store.`);
+          throw new Error(
+            `Tool "${toolId}" did not resolve — not a built-in, a generated integration tool, or a stored tool. ` +
+              `The integration may be disabled (experimental flag off), not installed, or this worker may be running stale code (restart it).`,
+          );
         }
 
         if (userTool.implementation.type === 'mcp') {

--- a/packages/core/src/node-spawner.test.ts
+++ b/packages/core/src/node-spawner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { appleFoundationModelsSpawner, buildProviderChain, claudeSpawner, codexSpawner, classifyLlmFailure, shouldFallback, validateOutputContract, type SpawnResult } from './node-spawner.js';
+import { appleFoundationModelsSpawner, buildProviderChain, claudeSpawner, codexSpawner, classifyLlmFailure, shouldFallback, spawnNodeReal, validateOutputContract, type SpawnResult } from './node-spawner.js';
 
 function r(partial: Partial<SpawnResult>): SpawnResult {
   return {
@@ -422,3 +422,24 @@ describe('codexSpawner', () => {
   });
 });
 
+
+describe('spawnNodeReal — unresolved tool node', () => {
+  const opts = { agentId: 'a', agentSource: 'local' as const };
+
+  it('reports a clear "tool did not resolve" error when a tool node reaches the shell path', async () => {
+    const res = await spawnNodeReal(
+      { id: 'create', type: 'shell', tool: 'apple.apple.reminder-create' },
+      {},
+      opts,
+    );
+    expect(res.category).toBe('setup');
+    expect(res.error).toContain('Tool "apple.apple.reminder-create" did not resolve');
+    expect(res.error).toMatch(/disabled|not installed|stale/);
+    expect(res.error).not.toContain('has no command');
+  });
+
+  it('keeps "has no command" for a plain shell node with no tool', async () => {
+    const res = await spawnNodeReal({ id: 'x', type: 'shell' }, {}, opts);
+    expect(res.error).toBe('Shell node "x" has no command');
+  });
+});

--- a/packages/core/src/node-spawner.ts
+++ b/packages/core/src/node-spawner.ts
@@ -594,6 +594,18 @@ export async function spawnNodeReal(
 ): Promise<SpawnResult> {
   if (node.type === 'shell') {
     if (!node.command) {
+      // A node carrying a `tool:` reference should have been resolved + executed
+      // by the dag-executor before ever reaching the shell spawn path. If it
+      // lands here with no command, the tool did NOT resolve — give an
+      // actionable reason instead of the misleading "has no command".
+      if (node.tool) {
+        return {
+          result: '',
+          exitCode: 1,
+          error: `Tool "${node.tool}" did not resolve for node "${node.id}". The integration may be disabled (experimental flag off), not installed, or this worker may be running stale code (restart it).`,
+          category: 'setup',
+        };
+      }
       return { result: '', exitCode: 1, error: `Shell node "${node.id}" has no command`, category: 'setup' };
     }
     return spawnProcess('bash', ['-c', node.command], {


### PR DESCRIPTION
Closes the top two items from #499 — the parts that made the Apple-integration failures so hard to diagnose.

## 1. Clear error for unresolved tool nodes
A node with a `tool:` reference that doesn't resolve (experimental flag off in that process, integration not installed, or the worker running **stale code without the tool's dispatch branch**) fell through to the shell-spawn path and reported one of:
- `Shell node "create" has no command` (node-spawner)
- `Tool "…" not found in registry or store` (dag-executor)

Both now say:
> Tool "<id>" did not resolve … the integration may be disabled (experimental flag off), not installed, or this worker may be running stale code (restart it).

That single message would have turned this whole confusing session into a one-line diagnosis.

## 2. Multi-worker warning in `sua daemon status`
The root cause of the *flakiness* was **competing workers** on the Temporal queue — a run lands on whichever worker grabs it, and an ungranted/stale one fails. `sua daemon status` now warns when more than one worker is polling (Temporal provider only), pointing at `sua daemon stop --service worker` / `sua worker uninstall-launchagent`.

## Verification
- Regression tests: tool-node → clear error; plain shell node → unchanged "has no command".
- Full suite green (2098 pass / 3 skip; the one transient was the known live-dashboard flake).

Remaining #499 items (flag robustness, triage retry resilience) left for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)