### PR TITLE
fix(inbox): triage follows the latest request + retires superseded cards

### DIFF
--- a/.changeset/triage-latest-intent.md
+++ b/.changeset/triage-latest-intent.md
@@ -1,0 +1,18 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Fix triage reverting to an earlier goal when the operator pivots mid-thread.
+
+Inbox triage was anchored to the original message body (`MESSAGE_BODY`), which
+is frozen at thread creation. When the operator changed their mind partway
+through a thread, triage kept pursuing the first request and, on auto-follow-up
+turns, re-proposed stale actions (including ones that had already failed),
+ignoring the newer ask. Triage now receives the operator's latest message as a
+first-class `CURRENT_REQUEST` input that takes precedence over the frozen
+original, and the inbox-triage prompt no longer re-proposes failed actions the
+current request has moved past.

--- a/.changeset/triage-supersede-pending-card.md
+++ b/.changeset/triage-supersede-pending-card.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Inbox: a reply over a pending proposed action now retires the card and re-plans.
+
+Previously, replying while a triage-proposed Run/Skip card was still pending did
+nothing — triage was suppressed until you manually skipped the card. Now a reply
+auto-retires any pending *proposed* card (shown as "Superseded by your reply",
+attributed to triage rather than the operator) and immediately fires a fresh
+triage turn that plans against your latest message. Running actions are left
+untouched — they can't be safely cancelled mid-flight. Manual skips are now
+explicitly attributed to the operator.

--- a/agents/examples/inbox-triage.yaml
+++ b/agents/examples/inbox-triage.yaml
@@ -32,7 +32,20 @@ inputs:
   MESSAGE_BODY:
     type: string
     required: true
-    description: The producer's short markdown summary.
+    description: >
+      The producer's short markdown summary — the ORIGINAL request that
+      opened the thread. Frozen at creation; it does NOT change as the
+      conversation evolves. Treat it as background, not current intent.
+  CURRENT_REQUEST:
+    type: string
+    required: false
+    default: ""
+    description: >
+      The operator's most recent real ask in the thread — the
+      AUTHORITATIVE current intent. Equals MESSAGE_BODY on the first
+      triage turn, but after the operator replies it is their latest
+      message. When CURRENT_REQUEST and MESSAGE_BODY disagree, follow
+      CURRENT_REQUEST — the operator has pivoted.
   MESSAGE_PRIORITY:
     type: string
     required: true
@@ -130,8 +143,17 @@ nodes:
       source:   {{inputs.MESSAGE_SOURCE}}
       title:    {{inputs.MESSAGE_TITLE}}
 
-      Body:
+      Original request (frozen at thread creation — background, may be stale):
       {{inputs.MESSAGE_BODY}}
+
+      ── CURRENT REQUEST — the operator's latest ask, AUTHORITATIVE ──
+      {{inputs.CURRENT_REQUEST}}
+
+      The CURRENT REQUEST is what the operator wants RIGHT NOW. If it
+      differs from the Original request above, the operator has pivoted —
+      act on the CURRENT REQUEST and do not drag the thread back to the
+      original goal. Use the conversation below for history and to see
+      what already ran, not to re-derive the goal.
 
       Context (may be empty / JSON / arbitrary):
       {{inputs.CONTEXT_JSON}}
@@ -362,6 +384,13 @@ nodes:
       - If the conversation already shows a prior action of the same
         kind that ran and completed, DO NOT propose it again — instead
         summarize its result in `recommendation`.
+      - Do NOT blindly re-propose an action that already FAILED. A failed
+        action that the CURRENT REQUEST no longer asks for is dead — drop
+        it. Only retry a failed action when the CURRENT REQUEST still wants
+        that exact outcome AND something has changed that would make the
+        retry succeed (e.g. the operator supplied a missing input or fixed
+        a setup issue). If neither holds, move on to the CURRENT REQUEST
+        instead of looping on the stale failure.
       - DO NOT propose `agent-editor` directly. It is managed by the
         dashboard: when `agent-analyzer` produces a corrected YAML in
         its run output, the route automatically inserts an

--- a/packages/core/src/inbox-store.ts
+++ b/packages/core/src/inbox-store.ts
@@ -92,6 +92,14 @@ export interface InboxActionMeta {
   resultSummary?: string;
   /** Set when status is `refused` or `failed`. */
   refusalReason?: string;
+  /**
+   * Who skipped this action (only meaningful when status is `skipped`).
+   * `operator` = the operator clicked Skip. `triage` = the action was
+   * auto-retired because the operator's newer reply superseded it (the
+   * route skips it, then fires a fresh triage turn). Absent → treat as
+   * `operator` for back-compat with cards skipped before this field.
+   */
+  skippedBy?: 'operator' | 'triage';
 }
 
 export interface InboxMessage {

--- a/packages/dashboard/src/routes/inbox-latest-user-request.test.ts
+++ b/packages/dashboard/src/routes/inbox-latest-user-request.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Unit tests for latestUserRequest — the triage "current intent" selector.
+ *
+ * Regression for the "triage reverts to an earlier goal on a mid-thread
+ * pivot" bug (thread 7537638c): triage was anchored to the frozen original
+ * MESSAGE_BODY and re-proposed a stale (failed) action, ignoring the
+ * operator's newer ask. The fix feeds triage the LATEST real user message
+ * as the authoritative CURRENT_REQUEST. This helper is that selection, so
+ * it gets focused, deterministic coverage here (no DB / no provider).
+ */
+import { describe, it, expect } from 'vitest';
+import type { InboxResponse } from '@some-useful-agents/core';
+import { latestUserRequest } from './inbox.js';
+
+const r = (role: InboxResponse['role'], body: string, createdAt: number): InboxResponse =>
+  ({ id: `${role}-${createdAt}`, messageId: 'm', role, body, createdAt });
+
+describe('latestUserRequest — triage current-intent selection', () => {
+  it('returns the most recent real user message, not the first', () => {
+    const responses: InboxResponse[] = [
+      r('user', 'make me a barbecue grocery list note', 1),
+      r('triage', 'I can make that note', 2),
+      r('action', 'create-note', 3),
+      r('user', 'actually, run the hacker news summary and put it in a note', 4),
+    ];
+    expect(latestUserRequest(responses)).toBe('actually, run the hacker news summary and put it in a note');
+  });
+
+  it('skips the synthetic "Asked triage" marker and finds the real ask', () => {
+    const responses: InboxResponse[] = [
+      r('user', 'run the hacker news summary into a note', 1),
+      r('triage', 'on it', 2),
+      r('user', '(Asked triage to take another look.)', 3),
+    ];
+    expect(latestUserRequest(responses)).toBe('run the hacker news summary into a note');
+  });
+
+  it('skips trailing empty/whitespace user rows', () => {
+    const responses: InboxResponse[] = [
+      r('user', 'summarize the latest run', 1),
+      r('user', '   ', 2),
+    ];
+    expect(latestUserRequest(responses)).toBe('summarize the latest run');
+  });
+
+  it('returns undefined when the operator has not replied (triage is first responder)', () => {
+    const responses: InboxResponse[] = [
+      r('triage', 'here is what I see', 1),
+      r('action', 'do-thing', 2),
+    ];
+    expect(latestUserRequest(responses)).toBeUndefined();
+  });
+});

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -204,6 +204,24 @@ describe('GET /inbox/:id and /:id/fragment', () => {
     expect(res.text).toContain('id="inbox-modal-title"');
   });
 
+  it('attributes a skipped action card to triage vs operator', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 'skip-attr', body: 'b' });
+    inboxStore.addResponse(m.id, 'action', 'op skip', JSON.stringify({
+      kind: 'action', status: 'skipped', skippedBy: 'operator', agentId: 'a', inputs: {},
+    }));
+    inboxStore.addResponse(m.id, 'action', 'triage skip', JSON.stringify({
+      kind: 'action', status: 'skipped', skippedBy: 'triage', agentId: 'b', inputs: {},
+    }));
+    inboxStore.addResponse(m.id, 'action', 'legacy skip', JSON.stringify({
+      kind: 'action', status: 'skipped', agentId: 'c', inputs: {},
+    }));
+    const res = await request(app).get(`/inbox/${m.id}/fragment`).set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Superseded by your reply.');   // skippedBy: triage
+    expect(res.text).toContain('Skipped by operator.');        // skippedBy: operator AND legacy (absent → operator)
+  });
+
   it('renders conversation entries with data-msg-id + role avatars', async () => {
     const app = await makeApp();
     const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
@@ -1426,10 +1444,10 @@ describe('POST /inbox/:id/triage/cancel', () => {
 });
 
 describe('Concurrent-triage guard (POST /respond)', () => {
-  it('does NOT auto-fire triage when a proposed action is pending', async () => {
+  it('retires a pending PROPOSED action (skipped by triage) on reply, then re-plans', async () => {
     const app = await makeApp();
     const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
-    inboxStore.addResponse(m.id, 'action', 'rationale', JSON.stringify({
+    const action = inboxStore.addResponse(m.id, 'action', 'rationale', JSON.stringify({
       kind: 'action',
       status: 'proposed',
       agentId: 'agent-analyzer',
@@ -1437,28 +1455,29 @@ describe('Concurrent-triage guard (POST /respond)', () => {
       rationale: 'rationale',
     }));
 
-    const app2 = app as unknown as { locals: { inboxTriageAbortControllers: Map<string, unknown> } };
-    expect(app2.locals.inboxTriageAbortControllers.has(m.id)).toBe(false);
-
     await request(app)
       .post(`/inbox/${m.id}/respond`)
-      .type('form').send({ body: 'follow-up reply' })
+      .type('form').send({ body: 'actually never mind, do this instead' })
       .set('X-Requested-With', 'fetch')
       .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
 
-    // Give the fire-and-forget a tick to land if it were going to.
-    await new Promise((r) => setTimeout(r, 50));
-    expect(app2.locals.inboxTriageAbortControllers.has(m.id)).toBe(false);
+    // The proposed card is retired synchronously by the route, attributed
+    // to triage (a supersede, not an operator decline). This is the
+    // race-free signal of the new behavior; the triage re-plan that
+    // follows is the same fire-and-forget path covered elsewhere.
+    const retired = JSON.parse(inboxStore.getResponse(action.id)!.metaJson!);
+    expect(retired.status).toBe('skipped');
+    expect(retired.skippedBy).toBe('triage');
 
     // The user reply still landed on the thread.
     const userReplies = inboxStore.listResponses(m.id).filter((r) => r.role === 'user');
-    expect(userReplies.map((r) => r.body)).toEqual(['follow-up reply']);
+    expect(userReplies.map((r) => r.body)).toEqual(['actually never mind, do this instead']);
   });
 
-  it('does NOT auto-fire triage when a running action is pending', async () => {
+  it('does NOT auto-fire triage or touch the card when a RUNNING action is pending', async () => {
     const app = await makeApp();
     const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
-    inboxStore.addResponse(m.id, 'action', 'rationale', JSON.stringify({
+    const action = inboxStore.addResponse(m.id, 'action', 'rationale', JSON.stringify({
       kind: 'action',
       status: 'running',
       agentId: 'agent-analyzer',
@@ -1468,34 +1487,19 @@ describe('Concurrent-triage guard (POST /respond)', () => {
     }));
 
     const app2 = app as unknown as { locals: { inboxTriageAbortControllers: Map<string, unknown> } };
-    await request(app)
+    const res = await request(app)
       .post(`/inbox/${m.id}/respond`)
       .type('form').send({ body: 'follow-up reply' })
       .set('X-Requested-With', 'fetch')
       .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
-    await new Promise((r) => setTimeout(r, 50));
-    expect(app2.locals.inboxTriageAbortControllers.has(m.id)).toBe(false);
-  });
-
-  it('still records the user reply when triage is skipped', async () => {
-    const app = await makeApp();
-    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
-    inboxStore.addResponse(m.id, 'action', 'rationale', JSON.stringify({
-      kind: 'action',
-      status: 'proposed',
-      agentId: 'agent-analyzer',
-      inputs: {},
-      rationale: 'r',
-    }));
-
-    const res = await request(app)
-      .post(`/inbox/${m.id}/respond`)
-      .type('form').send({ body: 'guarded reply' })
-      .set('X-Requested-With', 'fetch')
-      .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
     expect(res.status).toBe(204);
+    await new Promise((r) => setTimeout(r, 50));
+    // Triage did not fire and the mid-flight card was left running.
+    expect(app2.locals.inboxTriageAbortControllers.has(m.id)).toBe(false);
+    expect(JSON.parse(inboxStore.getResponse(action.id)!.metaJson!).status).toBe('running');
+    // The user reply still landed on the thread.
     const userReplies = inboxStore.listResponses(m.id).filter((r) => r.role === 'user');
-    expect(userReplies.map((r) => r.body)).toEqual(['guarded reply']);
+    expect(userReplies.map((r) => r.body)).toEqual(['follow-up reply']);
   });
 
   it('runTriageAgent re-entry queues a pending refire (idempotent)', async () => {

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -672,21 +672,33 @@ inboxRouter.post('/inbox/:id/respond', (req: Request, res: Response) => {
     body: bodyRaw,
     createdAt: userResponse.createdAt,
   });
-  // Auto-fire triage UNLESS a proposed-or-running action is pending
-  // on this thread. The prior action either is awaiting an operator
-  // click (proposed) or is mid-execution (running); auto-firing
-  // triage now would race against the action's lifecycle and could
-  // pile up redundant proposals. The follow-up triage turn that
-  // `maybeRefireTriage` schedules at action-completion picks up the
-  // operator's reply (it lives in the same CONVERSATION snapshot)
-  // so nothing is lost. Operator can still hit "Ask triage"
-  // explicitly when they want a fresh turn now.
+  // A RUNNING action is mid-execution — we can't safely yank it, so
+  // hold off: don't fire triage and don't touch the card. The
+  // follow-up turn `maybeRefireTriage` schedules at completion picks
+  // up this reply (same CONVERSATION snapshot), so nothing is lost.
+  //
+  // A PROPOSED action is just awaiting a click. The operator typing a
+  // reply instead of clicking Run usually means they've redirected, so
+  // we auto-retire the proposed card (attributed to triage — it's a
+  // supersede, not the operator declining) and fire a fresh triage
+  // turn that re-plans against their latest request (CURRENT_REQUEST).
+  // If the reply didn't actually supersede it, triage just re-proposes.
   const responsesNow = ctx.inboxStore.listResponses(id);
-  const actionPending = responsesNow.some((r) => {
-    const m = parseActionMeta(r);
-    return m && (m.status === 'proposed' || m.status === 'running');
-  });
-  if (!actionPending) {
+  const runningPending = responsesNow.some((r) => parseActionMeta(r)?.status === 'running');
+  if (!runningPending) {
+    for (const r of responsesNow) {
+      const m = parseActionMeta(r);
+      if (!m || m.status !== 'proposed') continue;
+      const superseded: InboxActionMeta = { ...m, status: 'skipped', skippedBy: 'triage', endedAt: Date.now() };
+      if (ctx.inboxStore.transitionActionStatus(r.id, 'proposed', JSON.stringify(superseded))) {
+        publishInboxEvent(ctx, id, 'action:status', {
+          responseId: r.id,
+          status: 'skipped',
+          agentId: m.agentId,
+          endedAt: superseded.endedAt,
+        });
+      }
+    }
     // Fire-and-forget; the modal polls /fragment for the response.
     // The conversation thread itself signals "in progress" via the
     // user-reply-within-30s heuristic in isTriagePending.
@@ -1105,7 +1117,7 @@ inboxRouter.post('/inbox/:id/actions/:rid/skip', (req: Request, res: Response) =
     return;
   }
   // Atomic claim — same race-free transition as /run uses.
-  const skippedMeta: InboxActionMeta = { ...meta, status: 'skipped', endedAt: Date.now() };
+  const skippedMeta: InboxActionMeta = { ...meta, status: 'skipped', skippedBy: 'operator', endedAt: Date.now() };
   const claimed = ctx.inboxStore.transitionActionStatus(rid, 'proposed', JSON.stringify(skippedMeta));
   if (!claimed) {
     if (isAjax(req)) { res.status(204).end(); return; }

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -296,6 +296,29 @@ function buildThreadSummary(
   return { currentGoal, latestResult, currentStatus: humanInboxStatus(message.status), nextStep };
 }
 
+/**
+ * The operator's most recent real ask in the thread — the authoritative
+ * "current intent" for triage. Scans responses newest-first for a `user`
+ * row, skipping the synthetic "Ask triage" marker. Returns undefined when
+ * the operator hasn't replied yet (triage is the first responder), in
+ * which case the original message body is the only intent on record.
+ *
+ * Triage gets this as a first-class `CURRENT_REQUEST` input so a mid-thread
+ * pivot ("actually, run the HN summary instead") wins over the frozen
+ * original `MESSAGE_BODY`, which never changes after the thread is created.
+ */
+export function latestUserRequest(responses: readonly InboxResponse[]): string | undefined {
+  for (let i = responses.length - 1; i >= 0; i -= 1) {
+    const response = responses[i];
+    if (response.role !== 'user') continue;
+    const body = response.body.trim();
+    if (body === '(Asked triage to take another look.)') continue;
+    if (!body) continue;
+    return body;
+  }
+  return undefined;
+}
+
 /** Parse a message's contextJson into a plain object (empty on absent/invalid). */
 function normalizeContextJson(raw: string | undefined): Record<string, unknown> {
   if (!raw) return {};
@@ -2469,7 +2492,8 @@ async function runTriageAgent(
   // Build conversation snapshot for the prompt. For action-role rows,
   // include the structured status so the model can see what already
   // ran rather than just the rationale body.
-  const conversation = ctx.inboxStore.listResponses(messageId)
+  const responsesSnapshot = ctx.inboxStore.listResponses(messageId);
+  const conversation = responsesSnapshot
     .map((r) => {
       if (r.role === 'action') {
         const m = parseActionMeta(r);
@@ -2479,6 +2503,13 @@ async function runTriageAgent(
       return `[${r.role}] ${r.body}`;
     })
     .join('\n');
+
+  // The operator's latest real ask is the authoritative current intent.
+  // MESSAGE_BODY is frozen at thread creation, so on a mid-thread pivot
+  // (or an auto-follow-up turn after a pivot) it would otherwise pull
+  // triage back to the original request. Falls back to the message body
+  // when the operator hasn't replied yet (triage is first responder).
+  const currentRequest = latestUserRequest(responsesSnapshot) ?? message.body;
 
   const allowlist = getSubAgentAllowlist(ctx);
   const runnableAgentSpecs = buildRunnableAgentSpecsJson(ctx, allowlist);
@@ -2516,6 +2547,7 @@ async function runTriageAgent(
           MESSAGE_ID: message.id,
           MESSAGE_TITLE: message.title,
           MESSAGE_BODY: message.body,
+          CURRENT_REQUEST: currentRequest,
           MESSAGE_PRIORITY: message.priority,
           MESSAGE_SOURCE: message.source,
           CONTEXT_JSON: message.contextJson ?? '',

--- a/packages/dashboard/src/views/inbox-detail.ts
+++ b/packages/dashboard/src/views/inbox-detail.ts
@@ -622,7 +622,9 @@ function renderActionStatusBody(meta: InboxActionMeta, inlineWidget?: SafeHtml):
         </div>
       `;
     case 'skipped':
-      return html`<div class="inbox-action__result inbox-action__result--muted">Skipped by operator.</div>`;
+      return html`<div class="inbox-action__result inbox-action__result--muted">${
+        meta.skippedBy === 'triage' ? 'Superseded by your reply.' : 'Skipped by operator.'
+      }</div>`;
     case 'refused':
       return html`
         <div class="inbox-action__result inbox-action__result--err">


### PR DESCRIPTION
## Summary

Two related inbox-triage fixes, found by root-causing a thread where triage abandoned a mid-conversation pivot and looped on a stale failed action.

**Triage follows the latest request, not the frozen original** (`39dc9af`)
Triage was fed `MESSAGE_BODY` — frozen at thread creation — as its primary intent on every turn, with the newer ask buried in `CONVERSATION` and no rule saying the latest turn wins. On a pivot, auto-follow-up turns reverted to the original goal and re-proposed its (already failed) action. Fix: derive the operator's latest real message as a first-class `CURRENT_REQUEST` input (falls back to the message body when they haven't replied), surface it in the prompt as authoritative over the now-relabeled "original, may be stale" body, and widen the anti-repeat rule to cover failed actions the current request has moved past.

**A reply over a pending card retires it (by triage) and re-plans** (`5c6e17e`)
Replying while a proposed Run/Skip card was pending did nothing — triage was suppressed until you manually skipped the card. Now a reply auto-retires any pending *proposed* card (rendered "Superseded by your reply", attributed to triage via a new `InboxActionMeta.skippedBy` field) and fires a fresh triage turn that plans against your latest message. **Running** actions are left untouched — they can't be safely cancelled mid-flight. Manual skips are now explicitly attributed to the operator.

## Test Coverage

- `inbox-latest-user-request.test.ts` (new): latest-vs-first selection, "Ask triage" marker skip, empty-row skip, no-reply fallback.
- `inbox.test.ts`: updated the concurrent-guard tests — a proposed card now auto-retires by triage on reply (reply still lands); a running action is left untouched and still suppresses triage. New fragment test asserts the triage-vs-operator skip attribution (incl. legacy `skippedBy`-absent → operator).
- Full suite: **2102 pass / 3 skip.**

## Pre-Landing Review

Reviewed for races (atomic proposed→skipped claim), re-entrant triage (existing in-flight guard), running+proposed mix (running short-circuits), trust boundary (no new prompt surface), and back-compat (legacy skipped cards). No P1/critical findings. Minor nit: the "Asked triage" marker literal now appears in 3 spots — could be a shared constant.

## Verification

Verified live against the worker/temporal path: created a thread, got an `hn-classified` card proposed, replied "tell me a joke" — the card flipped to skipped-by-triage immediately and triage re-planned, proposing `dadjoke` ("instead of the Hacker News summary"). No manual skip needed.

## Changesets

`.changeset/triage-latest-intent.md` (patch) and `.changeset/triage-supersede-pending-card.md` (patch), both listing all five workspace packages.

## Test plan
- [x] Full vitest suite: 2102 pass / 3 skip
- [x] Live dogfood of the pivot + supersede flow through the GUI worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)