### PR TITLE
feat(inbox): triage resolves relative times into concrete due dates

### DIFF
--- a/.changeset/triage-current-time.md
+++ b/.changeset/triage-current-time.md
@@ -1,0 +1,16 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Triage can now resolve relative times into concrete due dates.
+
+The inbox triage agent gets the operator's current wall-clock time as a new
+`NOW` input (ISO 8601 with the local UTC offset). The prompt instructs it to
+turn relative phrasing — "before 4:30pm today", "tomorrow 9am", "in 2 hours" —
+into an absolute ISO 8601 timestamp it can hand to an agent that takes a due
+date (e.g. a reminder's `DUE_DATE`), instead of passing a vague phrase or
+guessing the date. Pairs with reminder agents that expose a due-date input.

--- a/agents/examples/inbox-triage.yaml
+++ b/agents/examples/inbox-triage.yaml
@@ -46,6 +46,16 @@ inputs:
       triage turn, but after the operator replies it is their latest
       message. When CURRENT_REQUEST and MESSAGE_BODY disagree, follow
       CURRENT_REQUEST — the operator has pivoted.
+  NOW:
+    type: string
+    required: false
+    default: ""
+    description: >
+      Current wall-clock time as ISO 8601 with the operator's local UTC
+      offset (e.g. 2026-06-14T14:50:00-07:00). Use it to resolve relative
+      times the operator gives ("before 4:30pm today", "tomorrow 9am",
+      "in 2 hours") into an absolute ISO 8601 timestamp for agents that
+      take a due date.
   MESSAGE_PRIORITY:
     type: string
     required: true
@@ -154,6 +164,17 @@ nodes:
       act on the CURRENT REQUEST and do not drag the thread back to the
       original goal. Use the conversation below for history and to see
       what already ran, not to re-derive the goal.
+
+      Current time (operator's local time, ISO 8601 with offset):
+      {{inputs.NOW}}
+
+      When the operator gives a relative time ("before 4:30pm today",
+      "tomorrow 9am", "in 2 hours", "next Monday"), resolve it against
+      NOW into an absolute ISO 8601 timestamp WITH the same offset, and
+      pass THAT as the target agent's due-date input (e.g. a reminder's
+      `DUE_DATE`). Never pass a vague phrase as a due date. If NOW is
+      empty and you can't resolve an absolute time, ask the operator for
+      a concrete date/time rather than guessing.
 
       Context (may be empty / JSON / arbitrary):
       {{inputs.CONTEXT_JSON}}

--- a/packages/dashboard/src/routes/inbox-local-iso-now.test.ts
+++ b/packages/dashboard/src/routes/inbox-local-iso-now.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Unit tests for localIsoNow — the local-offset ISO timestamp fed to triage as
+ * NOW so it can resolve relative times ("before 4:30pm today") into an absolute
+ * due date. Round-tripping is the real assertion: applying the offset must
+ * preserve the absolute instant on any machine timezone.
+ */
+import { describe, it, expect } from 'vitest';
+import { localIsoNow } from './inbox.js';
+
+describe('localIsoNow', () => {
+  it('emits ISO 8601 with a numeric UTC offset, not the Z/UTC form', () => {
+    const out = localIsoNow(new Date('2026-06-14T21:50:00.000Z'));
+    expect(out).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/);
+    expect(out).not.toMatch(/Z$/);
+  });
+
+  it('round-trips to the same absolute instant (offset applied correctly)', () => {
+    // Whatever the test machine's timezone, parsing the local-offset string
+    // back must equal the input instant (truncated to whole seconds).
+    const d = new Date('2026-06-14T21:50:33.000Z');
+    const parsedBack = new Date(localIsoNow(d)).getTime();
+    expect(parsedBack).toBe(Math.floor(d.getTime() / 1000) * 1000);
+  });
+
+  it('defaults to the current time when no date is passed', () => {
+    const before = Date.now();
+    const parsed = new Date(localIsoNow()).getTime();
+    const after = Date.now();
+    // Allow a 2s window and second-truncation slop.
+    expect(parsed).toBeGreaterThanOrEqual(Math.floor(before / 1000) * 1000 - 1000);
+    expect(parsed).toBeLessThanOrEqual(after + 1000);
+  });
+});

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -319,6 +319,24 @@ export function latestUserRequest(responses: readonly InboxResponse[]): string |
   return undefined;
 }
 
+/**
+ * Current wall-clock time as an ISO 8601 string WITH the machine's local UTC
+ * offset (e.g. `2026-06-14T14:50:00-07:00`), not the `Z`/UTC form. sua is
+ * local-first, so the dashboard process timezone IS the operator's, which
+ * lets triage turn relative phrasing ("before 4:30pm today", "tomorrow 9am")
+ * into a correct absolute timestamp it can hand to a reminder agent. The
+ * offset form round-trips through Swift's ISO8601DateFormatter (it accepts
+ * `.withInternetDateTime` offsets), so the computed due-date lands correctly.
+ * Takes an optional `now` so the formatting is unit-testable.
+ */
+export function localIsoNow(now: Date = new Date()): string {
+  const offsetMin = -now.getTimezoneOffset(); // minutes east of UTC
+  const sign = offsetMin >= 0 ? '+' : '-';
+  const pad = (n: number): string => String(Math.floor(Math.abs(n))).padStart(2, '0');
+  const local = new Date(now.getTime() + offsetMin * 60_000).toISOString().slice(0, 19);
+  return `${local}${sign}${pad(offsetMin / 60)}:${pad(offsetMin % 60)}`;
+}
+
 /** Parse a message's contextJson into a plain object (empty on absent/invalid). */
 function normalizeContextJson(raw: string | undefined): Record<string, unknown> {
   if (!raw) return {};
@@ -2560,6 +2578,7 @@ async function runTriageAgent(
           MESSAGE_TITLE: message.title,
           MESSAGE_BODY: message.body,
           CURRENT_REQUEST: currentRequest,
+          NOW: localIsoNow(),
           MESSAGE_PRIORITY: message.priority,
           MESSAGE_SOURCE: message.source,
           CONTEXT_JSON: message.contextJson ?? '',


### PR DESCRIPTION
## Summary

Triage couldn't reliably set a timed reminder ("remind me before 4:30pm today") because it had no notion of the current date/time — LLMs don't reliably know today's date, so it couldn't turn relative phrasing into an absolute timestamp.

This adds a `NOW` input to the inbox-triage agent: the operator's current wall-clock time as ISO 8601 **with the local UTC offset** (e.g. `2026-06-14T14:50:00-07:00`), produced by a new `localIsoNow()` helper. The prompt now instructs triage to resolve relative phrasing ("before 4:30pm today", "tomorrow 9am", "in 2 hours") against `NOW` into an absolute ISO timestamp and hand it to the target agent's due-date input — or ask for a concrete time if it can't resolve one, rather than guessing.

sua is local-first, so the dashboard process timezone is the operator's; the offset form round-trips through the Apple integration's Swift `ISO8601DateFormatter` so the computed due date lands correctly in EventKit.

## Files
- `packages/dashboard/src/routes/inbox.ts` — `localIsoNow()` (exported, takes an optional Date for testing) + `NOW` passed into the triage inputs alongside `CURRENT_REQUEST`.
- `agents/examples/inbox-triage.yaml` — declared `NOW`; prompt guidance to compute absolute timestamps and pass them as due dates.
- `packages/dashboard/src/routes/inbox-local-iso-now.test.ts` — format is local-offset (not `Z`), round-trips to the same absolute instant on any machine timezone, defaults to now.

## Test Coverage
- New unit tests: 3 (round-trip is the load-bearing one — proves the offset preserves the instant regardless of test-machine tz).
- Full suite: **2106 pass / 3 skip.**

## Verification (end to end, live)
Asked in an inbox thread: *"Remind me to buy ice before 4:30pm today."* (local now 14:59-0700). Triage proposed a reminder with `DUE_DATE: 2026-06-14T16:30:00-07:00`; running it created a macOS reminder whose due date read back (via EventKit/AppleScript) as **Jun 14 2026 4:30:00 PM**.

Note: the reminder *agent* used in that test (`make-a-reminder`) is a local/gitignored personal agent and is not part of this PR — this PR is just the triage time-awareness that any due-date-taking agent benefits from.

## Pre-Landing Review
Small, additive change. `localIsoNow` is pure and unit-tested; `NOW` is a new optional input (back-compat — absent → empty, prompt tells triage to ask for a concrete time). No behavior change to existing triage paths beyond the added context. No P1/critical findings.

## Out of scope (follow-ups)
- Intermittent "tool did not resolve" for Apple agents on the worker (the registration flakiness in #499) — orthogonal to this change; it hit make-a-note and make-a-reminder equally during testing.
- Triage error notes that say "click into Temporal" without a real link, and setup-failures having no `temporal_run_id` — triage should link the `/runs/...` page and only mention Temporal when an execution exists.

## Changeset
`.changeset/triage-current-time.md` (minor, all five workspace packages).

## Test plan
- [x] Full vitest suite: 2106 pass / 3 skip
- [x] Live: relative-time request → computed ISO DUE_DATE → real reminder with correct due time

🤖 Generated with [Claude Code](https://claude.com/claude-code)