### PR TITLE
fix(inbox): run integration agents on the worker + run-scoped Apple gate

### DIFF
--- a/.changeset/apple-flag-run-scoped.md
+++ b/.changeset/apple-flag-run-scoped.md
@@ -1,0 +1,28 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Fix intermittent "tool did not resolve" for integration agents run from the inbox.
+
+Two related fixes for running integration-backed agents (Apple Reminders/Notes,
+and any csv/sqlite/postgres agent) from inbox action cards:
+
+1. **Run-scoped experimental gate.** Apple-tool availability was gated on the
+   worker process's `SUA_EXPERIMENTAL_APPLE` env, which varied by launch path —
+   so a worker that didn't inherit it would fail with "tool did not resolve."
+   The flag is now read once in the (reliable) dashboard process and threaded
+   through the run (`SubmitDagRunOptions` → the Temporal activity → the executor
+   gate), so resolution is identical wherever the run lands. The env remains a
+   fallback for local/CLI runs.
+
+2. **Inbox cards run integration agents on the worker.** Inbox action dispatch
+   orchestrated in-dashboard without an integrations store, so integration tools
+   never resolved there (and the Apple runner needs the worker's macOS grants).
+   Inbox-card runs of DAG agents now go through `submitDagRun` — the whole DAG
+   executes on the Temporal worker, exactly like the dashboard's "Run now" — and
+   the card status + triage follow-up are driven off the run's terminal state.
+   Local-backend runs execute in-process with the integration/tool/agent stores.

--- a/packages/core/src/dag-executor.ts
+++ b/packages/core/src/dag-executor.ts
@@ -155,6 +155,15 @@ export interface DagExecutorDeps {
    * so PR C can drop in real allow/deny logic without changing dispatch.
    */
   policyDocument?: PolicyDocument;
+  /**
+   * Run-scoped experimental Apple gate. Sourced from `experimental.apple`
+   * in config at run-submit time and threaded here so apple-tool resolution
+   * is identical on every worker, regardless of that process's environment.
+   * Undefined → fall back to the `SUA_EXPERIMENTAL_APPLE` env var (local/CLI
+   * runs that bridge config → env at startup). Fixes the intermittent
+   * "tool did not resolve" on the Temporal worker (#499).
+   */
+  experimentalApple?: boolean;
 }
 
 export interface DagExecuteOptions {
@@ -866,7 +875,7 @@ export async function executeAgentDag(
     const builtinEntry = toolId
       ? (getBuiltinTool(toolId)
         ?? (deps.integrationsStore
-          ? getGeneratedTool(deps.integrationsStore, toolId, { secretsStore: deps.secretsStore })
+          ? getGeneratedTool(deps.integrationsStore, toolId, { secretsStore: deps.secretsStore, experimentalApple: deps.experimentalApple })
           : undefined))
       : undefined;
 

--- a/packages/core/src/integrations/generated-tools.test.ts
+++ b/packages/core/src/integrations/generated-tools.test.ts
@@ -390,3 +390,30 @@ describe('apple integration tools', () => {
     expect(tool.definition.outputs?.id?.type).toBe('string');
   });
 });
+
+// Regression for the intermittent "tool did not resolve" on the Temporal
+// worker (#499): apple availability must travel WITH the run, not depend on
+// the worker process's SUA_EXPERIMENTAL_APPLE env. `deps.experimentalApple`
+// is run-scoped and wins over the env in both directions.
+describe('apple gate is run-scoped (deps.experimentalApple overrides env)', () => {
+  afterEach(() => { delete process.env.SUA_EXPERIMENTAL_APPLE; });
+
+  it('resolves apple tools via the run-scoped flag even when the env is unset', () => {
+    delete process.env.SUA_EXPERIMENTAL_APPLE;
+    seedApple();
+    // Env off → not available by default (a worker that never got the env)...
+    expect(getGeneratedTool(store, 'apple.apple.note-create')).toBeUndefined();
+    // ...but the run carries the flag, so the same worker resolves it.
+    expect(getGeneratedTool(store, 'apple.apple.note-create', { experimentalApple: true })).toBeDefined();
+    const appleIds = Array.from(listGeneratedTools(store, { experimentalApple: true }).keys())
+      .filter((k) => k.startsWith('apple.'));
+    expect(appleIds.length).toBe(5);
+  });
+
+  it('experimentalApple:false overrides the env being on', () => {
+    process.env.SUA_EXPERIMENTAL_APPLE = '1';
+    seedApple();
+    expect(getGeneratedTool(store, 'apple.apple.note-create')).toBeDefined(); // env on
+    expect(getGeneratedTool(store, 'apple.apple.note-create', { experimentalApple: false })).toBeUndefined();
+  });
+});

--- a/packages/core/src/integrations/generated-tools.ts
+++ b/packages/core/src/integrations/generated-tools.ts
@@ -106,6 +106,20 @@ export interface GeneratedToolDeps {
    * compiling Swift or touching the developer's real Reminders/Notes.
    */
   appleRunner?: { binaryPath: string };
+  /**
+   * Run-scoped override for the experimental Apple gate. When set, it wins
+   * over the `SUA_EXPERIMENTAL_APPLE` env var so apple-tool availability
+   * travels WITH the run instead of depending on the worker process's
+   * environment (which varied by launch path and caused intermittent
+   * "tool did not resolve" failures on the Temporal worker). Undefined →
+   * fall back to the env var (local/CLI runs that bridge config → env).
+   */
+  experimentalApple?: boolean;
+}
+
+/** Apple gate: run-scoped flag wins; otherwise the env-bridged config flag. */
+function appleEnabled(deps: GeneratedToolDeps): boolean {
+  return deps.experimentalApple ?? isAppleIntegrationEnabled();
 }
 
 /**
@@ -128,7 +142,7 @@ export function listGeneratedTools(
       addPostgresEntries(out, integ, deps);
     } else if (integ.kind === 'sqlite') {
       addSqliteEntries(out, integ);
-    } else if (integ.kind === 'apple' && isAppleIntegrationEnabled()) {
+    } else if (integ.kind === 'apple' && appleEnabled(deps)) {
       addAppleEntries(out, integ, deps);
     }
   }
@@ -147,7 +161,7 @@ export function getGeneratedTool(
   if (toolId.startsWith('csv.')) return resolveCsvTool(store, toolId);
   if (toolId.startsWith('postgres.')) return resolvePostgresTool(store, toolId, deps);
   if (toolId.startsWith('sqlite.')) return resolveSqliteTool(store, toolId);
-  if (toolId.startsWith('apple.') && isAppleIntegrationEnabled()) return resolveAppleTool(store, toolId, deps);
+  if (toolId.startsWith('apple.') && appleEnabled(deps)) return resolveAppleTool(store, toolId, deps);
   return undefined;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -181,4 +181,10 @@ export interface SubmitDagRunOptions {
   dataRoot?: string;
   llmProviders?: string[];
   allowUntrustedShell?: string[];
+  /**
+   * Run-scoped experimental Apple gate, from `experimental.apple` in config.
+   * Threaded to the worker so apple-tool resolution doesn't depend on the
+   * worker process's env (the cause of intermittent "tool did not resolve").
+   */
+  experimentalApple?: boolean;
 }

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -31,6 +31,7 @@ import {
   exportAgent,
   executeAgentDag,
   extractPlanJson,
+  isAppleIntegrationEnabled,
   isSafeUrl,
   listBuiltinTools,
   parseAgent,
@@ -38,6 +39,7 @@ import {
   unallowedWidgetImageHosts,
   type Agent,
   type LlmProvider,
+  type Run,
   type RunStatus,
   type InboxActionMeta,
   type InboxActionStatus,
@@ -49,6 +51,7 @@ import { buildLlmSettingsSnapshot } from '../lib/llm-settings-snapshot.js';
 import { formatToolCatalog, autoFixYaml } from './run-now-build.js';
 import { applyProviderPin } from './build-orchestrator.js';
 import { loadTriageKernel, loadTriagePlaybook } from './triage-prompt.js';
+import { resolveRunBackend } from '../lib/run-backend.js';
 import { TEMPLATE_REGISTRY } from '../views/pulse-templates.js';
 import {
   renderInboxList,
@@ -1830,11 +1833,89 @@ export function parseProposedActions(
   return { accepted, rejected };
 }
 
+/** Poll the shared run row until it reaches a terminal status (the worker
+ * activity owns the lifecycle for durable runs). Returns the last-seen run on
+ * timeout so a long build isn't mis-reported as failed prematurely. */
+async function awaitRunTerminal(
+  ctx: ReturnType<typeof getContext>,
+  runId: string,
+  capMs = 600_000,
+): Promise<Run | null> {
+  const terminal = new Set<RunStatus>(['completed', 'failed', 'cancelled']);
+  const deadline = Date.now() + capMs;
+  for (;;) {
+    let run: Run | null;
+    try { run = ctx.runStore.getRun(runId); } catch { run = null; }
+    if (run && terminal.has(run.status)) return run;
+    if (Date.now() >= deadline) return run;
+    await new Promise((r) => setTimeout(r, 750));
+  }
+}
+
+/**
+ * Run a dispatched sub-agent to completion via the right backend.
+ *
+ * Temporal: submit the WHOLE DAG to the worker (submitDagRun) and poll the run
+ * row to terminal — NOT per-node orchestration from the dashboard. Integration
+ * tools (apple, csv, sqlite, postgres) only resolve where an IntegrationsStore
+ * exists (the worker activity builds one), and the apple runner needs the GUI
+ * worker's TCC grants; orchestrating here would fail to resolve or execute in
+ * the grant-less dashboard. Local: no worker, so run in-process WITH the
+ * integration/tool/agent stores. Either way the experimental Apple gate is
+ * read from this (reliable) process and threaded to wherever the run lands.
+ */
+async function runDispatchedAgentToTerminal(
+  ctx: ReturnType<typeof getContext>,
+  agent: Agent,
+  inputs: Record<string, string>,
+): Promise<{ id: string; status: RunStatus; result?: string; error?: string }> {
+  if (resolveRunBackend(ctx.provider, agent) === 'temporal' && ctx.provider.submitDagRun) {
+    const submitted = await ctx.provider.submitDagRun(agent, {
+      inputs,
+      triggeredBy: 'dashboard',
+      variablesPath: ctx.variablesPath,
+      dataRoot: ctx.agentStore.dataRoot,
+      llmProviders: buildLlmSettingsSnapshot(ctx)?.providers,
+      allowUntrustedShell: ctx.allowUntrustedShell ? [...ctx.allowUntrustedShell] : undefined,
+      experimentalApple: isAppleIntegrationEnabled(),
+    });
+    const final = await awaitRunTerminal(ctx, submitted.id);
+    return {
+      id: submitted.id,
+      status: final?.status ?? 'failed',
+      result: typeof final?.result === 'string' ? final.result : undefined,
+      error: final?.error ?? (final ? undefined : 'Run did not finish within the dispatch window.'),
+    };
+  }
+  const run = await executeAgentDag(
+    agent,
+    { triggeredBy: 'dashboard', inputs },
+    {
+      runStore: ctx.runStore,
+      secretsStore: ctx.secretsStore,
+      variablesStore: ctx.variablesStore,
+      integrationsStore: ctx.integrationsStore,
+      toolStore: ctx.toolStore,
+      agentStore: ctx.agentStore,
+      dataRoot: ctx.agentStore.dataRoot,
+      llmSettings: buildLlmSettingsSnapshot(ctx),
+      onRunFailure: ctx.onRunFailure,
+      experimentalApple: isAppleIntegrationEnabled(),
+    },
+  );
+  return {
+    id: run.id,
+    status: run.status,
+    result: typeof run.result === 'string' ? run.result : undefined,
+    error: run.error,
+  };
+}
+
 /**
  * Execute a single proposed action: walks meta through `running`,
- * dispatches `executeAgentDag` on the sub-agent, then patches meta to
- * `completed | failed` with run lineage + a short result preview. When
- * all proposed actions on the parent message have resolved (any
+ * dispatches the sub-agent (on the Temporal worker when that's the backend),
+ * then patches meta to `completed | failed` with run lineage + a short result
+ * preview. When all proposed actions on the parent message have resolved (any
  * non-`proposed` state) AND at least one ran, re-fire triage so it can
  * summarize the outcome in the conversation.
  */
@@ -1998,26 +2079,11 @@ async function runProposedAction(
   let refusalReason: string | undefined;
   let fullResult = '';
   try {
-    const run = await executeAgentDag(
-      dispatchAgent,
-      {
-        triggeredBy: 'dashboard',
-        inputs: effectiveInputs,
-      },
-      {
-        runStore: ctx.runStore,
-        secretsStore: ctx.secretsStore,
-        variablesStore: ctx.variablesStore,
-        dataRoot: ctx.agentStore.dataRoot,
-        llmSettings: buildLlmSettingsSnapshot(ctx),
-        spawnNode: ctx.workflowSpawnNode,
-        onRunFailure: ctx.onRunFailure,
-      },
-    );
+    const run = await runDispatchedAgentToTerminal(ctx, dispatchAgent, effectiveInputs);
     runId = run.id;
     if (run.status === 'completed') {
       nextStatus = 'completed';
-      fullResult = typeof run.result === 'string' ? run.result : '';
+      fullResult = run.result ?? '';
       resultSummary = fullResult.length > ACTION_RESULT_PREVIEW_LIMIT
         ? fullResult.slice(0, ACTION_RESULT_PREVIEW_LIMIT) + '…'
         : fullResult;

--- a/packages/dashboard/src/routes/run-now.ts
+++ b/packages/dashboard/src/routes/run-now.ts
@@ -3,7 +3,7 @@
  */
 
 import { Router, type Request, type Response } from 'express';
-import { executeAgentWithRetry, type RunStatus } from '@some-useful-agents/core';
+import { executeAgentWithRetry, isAppleIntegrationEnabled, type RunStatus } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
 import { buildLlmSettingsSnapshot } from '../lib/llm-settings-snapshot.js';
 import { resolveRunBackend } from '../lib/run-backend.js';
@@ -66,6 +66,10 @@ runNowRouter.post('/agents/:name/run', async (req: Request, res: Response) => {
           dataRoot: ctx.agentStore.dataRoot,
           llmProviders: buildLlmSettingsSnapshot(ctx)?.providers,
           allowUntrustedShell: ctx.allowUntrustedShell ? [...ctx.allowUntrustedShell] : undefined,
+          // Source the apple gate from THIS process (the dashboard reliably has
+          // the env bridged from config at start) and thread it to the worker,
+          // so apple-tool resolution doesn't depend on the worker's own env.
+          experimentalApple: isAppleIntegrationEnabled(),
         });
         res.redirect(303, `/runs/${encodeURIComponent(run.id)}${fromSuffix}`);
       } catch (err) {
@@ -96,6 +100,7 @@ runNowRouter.post('/agents/:name/run', async (req: Request, res: Response) => {
         llmSettings: buildLlmSettingsSnapshot(ctx),
         spawnNode: ctx.workflowSpawnNode,
         onRunFailure: ctx.onRunFailure,
+        experimentalApple: isAppleIntegrationEnabled(),
       },
     );
 

--- a/packages/temporal-provider/src/activities.ts
+++ b/packages/temporal-provider/src/activities.ts
@@ -250,6 +250,12 @@ export interface RunDagActivityInput {
   llmProviders?: string[];
   /** Community shell agents pre-allowed by the operator. */
   allowUntrustedShell?: string[];
+  /**
+   * Run-scoped experimental Apple gate (from config at submit time). Lets the
+   * worker resolve apple tools regardless of its own process env — fixes the
+   * intermittent "tool did not resolve" on the Temporal worker.
+   */
+  experimentalApple?: boolean;
 }
 
 export interface RunDagActivityResult {
@@ -283,6 +289,7 @@ export async function runDagActivity(input: RunDagActivityInput): Promise<RunDag
     integrationsStore: quiet(() => new IntegrationsStore(input.dbPath)),
     variablesStore: input.variablesPath ? quiet(() => new VariablesStore(input.variablesPath as string)) : undefined,
     allowUntrustedShell: new Set(input.allowUntrustedShell ?? []),
+    experimentalApple: input.experimentalApple,
     llmSettings: input.llmProviders ? { providers: input.llmProviders } : undefined,
     dataRoot: input.dataRoot,
     // spawnNode omitted → spawnNodeReal (local execution on this worker).

--- a/packages/temporal-provider/src/provider.ts
+++ b/packages/temporal-provider/src/provider.ts
@@ -135,6 +135,7 @@ export class TemporalProvider implements Provider {
       dataRoot: opts.dataRoot ?? dirname(this.options.dbPath),
       llmProviders: opts.llmProviders,
       allowUntrustedShell: opts.allowUntrustedShell ?? [...this.allowUntrustedShell],
+      experimentalApple: opts.experimentalApple,
     };
 
     const handle = await this.client.workflow.start('runDagWorkflow', {


### PR DESCRIPTION
## Summary

Investigating a reported inbox failure ("made a note + reminder, both failed; triage didn't confirm one before the other") uncovered that inbox action cards **could not run integration-backed agents at all** — Apple Reminders/Notes, and by the same mechanism any csv/sqlite/postgres agent. Two root causes, both fixed here.

### 1. The experimental Apple gate was per-process, not per-run
Apple tools were gated on `process.env.SUA_EXPERIMENTAL_APPLE` ([experimental.ts](packages/core/src/experimental.ts)). That env is set reliably in some launch paths (the LaunchAgent plist) and not others, so a worker that didn't inherit it failed with "tool did not resolve" — intermittently, depending on which worker process picked up the task. This is the #499 gap.

Fix: the gate is now **run-scoped**. `appleEnabled(deps)` uses `deps.experimentalApple` when set, falling back to the env. The flag is read once in the **dashboard** (which reliably has it) and threaded through the run: `SubmitDagRunOptions.experimentalApple` → the Temporal activity input → `DagExecutorDeps.experimentalApple` → the generated-tools gate. Apple tools now resolve identically on any worker regardless of its environment.

### 2. Inbox dispatch never ran integration agents on the worker
`runProposedAction` orchestrated the run **in the dashboard** via `executeAgentDag` with a per-node `spawnNode` — but passed **no `integrationsStore`**, so generated tools (apple/csv/sqlite/postgres) could never resolve there. And even if resolved, the Apple Swift runner executes in-process, where the dashboard lacks the macOS TCC grants the GUI worker holds. That's why inbox cards always failed while "Run now" (which uses `submitDagRun` → the worker's `runDagActivity`, which builds an integrations store) succeeded.

Fix: inbox-card runs of DAG agents now route through **`submitDagRun`** — the whole DAG executes on the Temporal worker, exactly like "Run now" — and the card status + triage follow-up are driven off the run's terminal state (polled from the shared run row). Local-backend runs execute in-process **with** the integration/tool/agent stores.

## What this does NOT change
The "triage proposed both side-effecting actions at once instead of confirming one first" UX point from the same report is a **separate** triage-behavior gap, intentionally not in scope here.

## Test Coverage
- New regression in `generated-tools.test.ts`: the run-scoped gate resolves apple tools when `experimentalApple:true` even with the env unset, and `experimentalApple:false` overrides the env being on.
- Full suite: **2114 pass / 3 skip.**

## Verification (live)
Drove the exact failing path: inbox reply "make me an Apple note…" → triage proposed `make-a-note` → ran the card. Previously: `Failed at node create-note (setup) — tool did not resolve`. Now: card **completed**, and the note was actually created in Notes (verified via AppleScript). Cleaned up the test note + thread after.

## Pre-Landing Review
Threads a new optional field through typed seams (core → temporal-provider → dashboard); env fallback preserves existing local/CLI behavior. The inbox dispatch change reuses the proven run-now → worker path; completion is polled to terminal (600s cap) so a long build isn't mis-reported. No P1/critical findings.

## Changeset
`.changeset/apple-flag-run-scoped.md` (minor, all five packages).

## Test plan
- [x] Full vitest suite: 2114 pass / 3 skip
- [x] Clean rebuild
- [x] Live: integration agent runs from an inbox card and creates the note

🤖 Generated with [Claude Code](https://claude.com/claude-code)