### PR TITLE
fix(apple): reminder-update treats empty optional fields as no-change

### DIFF
--- a/.changeset/reminder-update-skip-empty.md
+++ b/.changeset/reminder-update-skip-empty.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Apple reminder-update: empty optional fields mean "leave unchanged".
+
+The `apple.apple.reminder-update` tool now omits `title`/`notes`/`dueDate` from
+the payload when they arrive empty, instead of forwarding `""` and blanking the
+field. Tool inputs come through as templated strings with no type coercion, so
+an "edit a reminder" agent that maps every field would otherwise erase the ones
+the operator didn't set. Now only the fields you actually provide are changed —
+which is what makes a single edit-reminder agent (reschedule / retitle / re-note)
+safe.

--- a/packages/core/src/integrations/generated-tools.test.ts
+++ b/packages/core/src/integrations/generated-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, chmodSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
@@ -380,6 +380,27 @@ describe('apple integration tools', () => {
   it('resolveAppleTool returns undefined for an unknown verb', () => {
     seedApple();
     expect(getGeneratedTool(store, 'apple.apple.bogus-verb')).toBeUndefined();
+  });
+
+  it('reminder-update omits empty optional fields so an edit does not clobber unset ones', async () => {
+    seedApple();
+    // Fake runner that captures the JSON payload it receives on stdin.
+    const payloadFile = join(dir, 'update-payload.json');
+    const bin = join(dir, 'fake-apple-capture');
+    writeFileSync(bin, `#!/usr/bin/env bash
+payload=$(cat)
+echo "$payload" > "${payloadFile}"
+echo '{"status":"ok","data":{"id":"r1","completed":false},"error_message":null}'
+`, 'utf-8');
+    chmodSync(bin, 0o755);
+    const tool = getGeneratedTool(store, 'apple.apple.reminder-update', { appleRunner: { binaryPath: bin } })!;
+    // Reschedule only: TITLE/NOTES come through empty (operator didn't set them).
+    await tool.execute({ id: 'r1', dueDate: '2026-06-15T19:00:00-07:00', title: '', notes: '' }, {});
+    const sent = JSON.parse(readFileSync(payloadFile, 'utf-8'));
+    expect(sent.id).toBe('r1');
+    expect(sent.dueDate).toBe('2026-06-15T19:00:00-07:00');
+    expect('title' in sent).toBe(false); // empty → omitted, would otherwise blank the title
+    expect('notes' in sent).toBe(false);
   });
 
   it('the reminder-create definition declares the documented io shape', () => {

--- a/packages/core/src/integrations/generated-tools.ts
+++ b/packages/core/src/integrations/generated-tools.ts
@@ -782,13 +782,21 @@ const APPLE_VERBS: AppleVerbSpec[] = [
       id: { type: 'string' },
       completed: { type: 'boolean' },
     },
-    buildPayload: (inputs) => ({
-      id: inputs.id,
-      ...(inputs.completed !== undefined ? { completed: inputs.completed } : {}),
-      ...(inputs.title !== undefined ? { title: inputs.title } : {}),
-      ...(inputs.notes !== undefined ? { notes: inputs.notes } : {}),
-      ...(inputs.dueDate !== undefined ? { dueDate: inputs.dueDate } : {}),
-    }),
+    buildPayload: (inputs) => {
+      // Empty-string optional fields mean "leave unchanged", not "blank it".
+      // Tool inputs arrive as templated strings (no type coercion), so an
+      // edit agent that maps every field would otherwise clobber the ones the
+      // operator didn't set — e.g. an unset TITLE would erase the title. Only
+      // forward fields that carry a real value.
+      const nonEmpty = (v: unknown): v is string => typeof v === 'string' && v.trim() !== '';
+      return {
+        id: inputs.id,
+        ...(inputs.completed !== undefined ? { completed: inputs.completed } : {}),
+        ...(nonEmpty(inputs.title) ? { title: inputs.title } : {}),
+        ...(nonEmpty(inputs.notes) ? { notes: inputs.notes } : {}),
+        ...(nonEmpty(inputs.dueDate) ? { dueDate: inputs.dueDate } : {}),
+      };
+    },
   },
   {
     verb: 'note-create',


### PR DESCRIPTION
## Summary

Adds the ability to **edit an existing reminder** (reschedule / retitle / change notes) and **mark one done** from the inbox. The `apple.apple.reminder-update` tool already existed; the one blocker was that tool inputs arrive as **templated strings with no type coercion**, so a generic "edit a reminder" agent that maps `title`/`notes`/`dueDate` would forward `""` for the fields the operator didn't set — and the Swift runner would dutifully **blank** them.

This PR makes `reminder-update`'s `buildPayload` treat empty optional string fields as **"leave unchanged"** (omit them from the payload). Now only the fields you actually provide get changed, which is what makes a single edit agent safe.

## What ships here (published)
Just the one-function change in `generated-tools.ts` + a regression test. No published agent.

## What's local (gitignored, not in this PR)
Three personal agents under `agents/local/` that drive the existing tools, all `inboxRunnable`:
- `list-reminders` — `reminder-read`, so triage can surface a reminder's **id**.
- `edit-a-reminder` — `reminder-update` by `ID` + optional `DUE_DATE`/`TITLE`/`NOTES` (empty = unchanged, thanks to this fix).
- `complete-a-reminder` — `reminder-update` with a **literal** `completed: true` (booleans can't ride a templated string input, so "mark done" is its own agent).

The inbox flow: triage runs `list-reminders` to find the id, then proposes `edit-a-reminder`/`complete-a-reminder` with it.

## Test Coverage
- New regression: a captured `reminder-update` payload omits empty `title`/`notes` while keeping `id` + `dueDate`.
- Full suite: **2115 pass / 3 skip.**

## Verification (live, partial)
Created a reminder via `make-a-reminder` (due 5pm, notes "original notes"), then ran `edit-a-reminder` with only a new `DUE_DATE` (7pm) — the edit run **completed** with no error. I could **not** read the reminder back to eyeball "due moved, title/notes intact": reading Reminders via AppleScript from a non-foreground Terminal hits `-1712` (AppleEvent timed out) — a known read-back limitation, not the agent. The no-clobber behavior is pinned by the unit test instead.

## Notes / scope
- **Notes editing is intentionally not here** (per the earlier "reminders now, notes next" call) — that needs a new `note-update` verb in the embedded Swift runner + title-based targeting.
- Booleans through templated inputs remain un-coerced generally; "mark done" is handled by a literal-valued agent rather than changing the executor's input typing.

## Test plan
- [x] Full vitest suite: 2115 pass / 3 skip
- [x] Clean rebuild
- [x] Live: edit run completes against an existing reminder by id (read-back blocked by Terminal AppleScript timeout; covered by unit test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)