### PR TITLE
feat(apple): note-update tool to edit an existing note

### DIFF
--- a/.changeset/apple-note-update.md
+++ b/.changeset/apple-note-update.md
@@ -1,0 +1,16 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Apple Notes: add a note-update tool to edit an existing note.
+
+The Apple integration now exposes `apple.apple.note-update` (a sixth generated
+verb): find a note by its current title and replace its body, optionally
+retitling it. Backed by a new `cmdNoteUpdate` in the embedded Swift runner
+(AppleScript; matches by name, signals not-found cleanly). Notes have no stable
+id, so editing targets the title. Pairs with local edit-a-note / list-notes
+agents (read the body, merge, update) for inbox-driven note editing.

--- a/packages/core/src/integrations/apple-runner.ts
+++ b/packages/core/src/integrations/apple-runner.ts
@@ -334,6 +334,40 @@ func cmdNoteRead(_ input: [String: Any], dryRun: Bool) {
     emitOk(["notes": rows, "count": rows.count])
 }
 
+func cmdNoteUpdate(_ input: [String: Any], dryRun: Bool) {
+    let title = (input["title"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    guard !title.isEmpty else { emitError("title is required"); return }
+    let body = (input["body"] as? String) ?? ""
+    let newTitle = (input["newTitle"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let folder = input["folder"] as? String
+    let heading = (newTitle != nil && !(newTitle!.isEmpty)) ? newTitle! : title
+    if dryRun { emitOk(["title": heading, "folder": jsonValue(folder), "dryRun": true]); return }
+    // Notes' AppleScript body is HTML; mirror cmdNoteCreate's wrapping so the
+    // edited note keeps a title heading (the name derives from the first line).
+    let htmlBody = "<div><b>" + asEscape(heading) + "</b></div><div>" + asEscape(body) + "</div>"
+    let nameLit = "\\"" + asEscape(title) + "\\""
+    let bodyLit = "\\"" + asEscape(htmlBody) + "\\""
+    let scope: String
+    if let folder = folder, !folder.isEmpty {
+        scope = "notes of folder \\"" + asEscape(folder) + "\\""
+    } else {
+        scope = "notes"
+    }
+    // Match by name; signal NOTFOUND rather than throwing on an empty match.
+    let script = "tell application \\"Notes\\"\\nset matches to (\\(scope) whose name is \\(nameLit))\\nif (count of matches) is 0 then\\nreturn \\"NOTFOUND\\"\\nend if\\nset theNote to item 1 of matches\\nset body of theNote to \\(bodyLit)\\nreturn \\"OK\\"\\nend tell"
+    let (out, err) = runAppleScript(script)
+    if let err = err {
+        emitDenied("Could not update note: \\(err). Grant Automation access for Notes, or run: sua apple authorize")
+        return
+    }
+    if (out?.trimmingCharacters(in: .whitespacesAndNewlines)) == "NOTFOUND" {
+        let where_ = (folder != nil && !(folder!.isEmpty)) ? " in folder \\"\\(folder!)\\"" : ""
+        emitError("No note named \\"\\(title)\\" found\\(where_).")
+        return
+    }
+    emitOk(["title": heading, "folder": jsonValue(folder)])
+}
+
 // ── Entry point ─────────────────────────────────────────────────────────
 
 @main
@@ -361,6 +395,7 @@ struct Runner {
         case "reminder-update", "reminder-complete": await cmdReminderUpdate(input, dryRun: dryRun)
         case "note-create": cmdNoteCreate(input, dryRun: dryRun)
         case "note-read", "note-list": cmdNoteRead(input, dryRun: dryRun)
+        case "note-update": cmdNoteUpdate(input, dryRun: dryRun)
         default: emit(status: "unsupported", data: nil, error: "unknown subcommand: \\(sub)")
         }
     }

--- a/packages/core/src/integrations/generated-tools.test.ts
+++ b/packages/core/src/integrations/generated-tools.test.ts
@@ -325,6 +325,7 @@ case "$sub" in
   reminder-update) echo '{"status":"ok","data":{"id":"r1","completed":true},"error_message":null}' ;;
   note-create) echo '{"status":"ok","data":{"id":null,"title":"t","folder":"Notes"},"error_message":null}' ;;
   note-read) echo '{"status":"ok","data":{"notes":[],"count":0},"error_message":null}' ;;
+  note-update) echo '{"status":"ok","data":{"title":"t","folder":"Notes"},"error_message":null}' ;;
   *) echo '{"status":"error","data":null,"error_message":"unknown"}'; exit 1 ;;
 esac
 `, 'utf-8');
@@ -336,13 +337,14 @@ describe('apple integration tools', () => {
   beforeEach(() => { process.env.SUA_EXPERIMENTAL_APPLE = '1'; });
   afterEach(() => { delete process.env.SUA_EXPERIMENTAL_APPLE; });
 
-  it('synthesises all five verbs when the flag is on', () => {
+  it('synthesises all six verbs when the flag is on', () => {
     seedApple();
     const tools = listGeneratedTools(store);
     const appleIds = Array.from(tools.keys()).filter((k) => k.startsWith('apple.')).sort();
     expect(appleIds).toEqual([
       'apple.apple.note-create',
       'apple.apple.note-read',
+      'apple.apple.note-update',
       'apple.apple.reminder-create',
       'apple.apple.reminder-read',
       'apple.apple.reminder-update',
@@ -380,6 +382,14 @@ describe('apple integration tools', () => {
   it('resolveAppleTool returns undefined for an unknown verb', () => {
     seedApple();
     expect(getGeneratedTool(store, 'apple.apple.bogus-verb')).toBeUndefined();
+  });
+
+  it('note-update resolves and executes (edit an existing note by title)', async () => {
+    seedApple();
+    const tool = getGeneratedTool(store, 'apple.apple.note-update', { appleRunner: fakeAppleBinary() })!;
+    const out = await tool.execute({ title: 'Old', body: 'new body', newTitle: 'New' }, {});
+    expect(out.title).toBe('t');
+    expect(Object.keys(tool.definition.inputs ?? {})).toEqual(['title', 'body', 'newTitle', 'folder']);
   });
 
   it('reminder-update omits empty optional fields so an edit does not clobber unset ones', async () => {
@@ -428,7 +438,7 @@ describe('apple gate is run-scoped (deps.experimentalApple overrides env)', () =
     expect(getGeneratedTool(store, 'apple.apple.note-create', { experimentalApple: true })).toBeDefined();
     const appleIds = Array.from(listGeneratedTools(store, { experimentalApple: true }).keys())
       .filter((k) => k.startsWith('apple.'));
-    expect(appleIds.length).toBe(5);
+    expect(appleIds.length).toBe(6);
   });
 
   it('experimentalApple:false overrides the env being on', () => {

--- a/packages/core/src/integrations/generated-tools.ts
+++ b/packages/core/src/integrations/generated-tools.ts
@@ -843,6 +843,32 @@ const APPLE_VERBS: AppleVerbSpec[] = [
       };
     },
   },
+  {
+    verb: 'note-update',
+    subcommand: 'note-update',
+    name: 'Update a note',
+    description: 'Replace the body (and optionally retitle) of an existing macOS note, matched by title. Side-effecting.',
+    inputs: {
+      title: { type: 'string', description: 'Title of the existing note to edit (matched by name).', required: true },
+      body: { type: 'string', description: 'New note body (plain text; wrapped as HTML). Replaces the current content.', required: true },
+      newTitle: { type: 'string', description: 'Optional new title/heading. Defaults to the matched title.' },
+      folder: { type: 'string', description: 'Folder to search in. Defaults to all folders.' },
+    },
+    outputs: {
+      title: { type: 'string', description: 'The note title after the update.' },
+      folder: { type: 'string' },
+    },
+    buildPayload: (inputs, snapshot) => {
+      assertNoteFolder(snapshot, inputs.folder);
+      const nonEmpty = (v: unknown): v is string => typeof v === 'string' && v.trim() !== '';
+      return {
+        title: inputs.title,
+        body: typeof inputs.body === 'string' ? inputs.body : '',
+        ...(nonEmpty(inputs.newTitle) ? { newTitle: inputs.newTitle } : {}),
+        ...(inputs.folder !== undefined ? { folder: inputs.folder } : {}),
+      };
+    },
+  },
 ];
 
 function buildAppleEntry(


### PR DESCRIPTION
## Summary

Adds the ability to **edit an existing Apple note** — the deferred half of the note/reminder editing work (reminders shipped in #508). The Apple integration now exposes a sixth generated verb, `apple.apple.note-update`: find a note by its current title and replace its body, optionally retitling it.

Notes (unlike reminders) have **no stable id** — `note-create` even returns `id: null` — so editing targets the note **by title**, consistent with how the AppleScript Notes model works (the note name derives from the first body line).

## Changes (published)
- **`apple-runner.ts`** — new `cmdNoteUpdate` in the embedded Swift runner. AppleScript: match `notes [of folder] whose name is <title>`, return `NOTFOUND` on an empty match (clean error, no throw), else set the body to HTML-wrapped content with the title heading preserved. Dispatched on `note-update`. The embedded source recompiles automatically when its SHA changes; I validated it with `xcrun swiftc -parse-as-library`.
- **`generated-tools.ts`** — `note-update` verb: `title` (match, required), `body` (required), `newTitle?`, `folder?`. Empty `newTitle` is omitted (defaults to the matched title).

## Local agents (gitignored, not in this PR)
- `edit-a-note` — `note-update` by `TITLE` + `BODY` (+ optional `NEW_TITLE`/`FOLDER`).
- `list-notes` — `note-read`, so triage can read a note's current body to **append** (read → merge → update), since `note-update` replaces the body wholesale.

## Test Coverage
- `note-update` resolves + executes; verb count updated 5 → 6; run-scoped gate count updated.
- Full suite: **2116 pass / 3 skip.**

## Verification (live, end to end)
Created a note "NoteEditTest", edited its body via `edit-a-note`, then **read it back through the worker** (`list-notes`) — the body was replaced with the new content and the `<b>NoteEditTest</b>` title heading preserved. (Unlike the reminder read-back, the Notes read worked here because it ran on the GUI worker, not my Terminal.)

## Notes / scope
- Body is replaced **wholesale** (AppleScript `body` is the whole note). Appending = read-first-then-merge, which is why `list-notes` exists.
- Matching is **by title**; ambiguous if two notes share a title (edits the first match).

## Test plan
- [x] `xcrun swiftc -parse-as-library` on the edited embedded source
- [x] Full vitest suite: 2116 pass / 3 skip
- [x] Live: create → edit body → read back confirms the change (title heading intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)