### PR TITLE
feat(inbox): confirm one side-effecting action before firing the next

### DIFF
--- a/.changeset/triage-sequence-side-effects.md
+++ b/.changeset/triage-sequence-side-effects.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox triage: confirm one side-effecting action before firing the next.
+
+When triage would propose several mutations in a single turn (e.g. "make a note
+AND set a reminder"), it now proposes only the first. Each proposed action
+declares an `effect` (`read` or `write`); the route keeps at most one `write`
+card per turn and holds the rest, surfacing a neutral "holding N more…" note.
+Once the operator runs the first write and it completes, the follow-up triage
+turn re-plans and proposes the next from the updated state. Read-only actions
+(catalog search, run analysis, list probes) still batch freely.

--- a/agents/examples/inbox-triage/kernel.md
+++ b/agents/examples/inbox-triage/kernel.md
@@ -151,6 +151,20 @@ Rules:
   variants like `JOKE_1` when the schema says `JOKE_A`.
 - At most 3 actions per turn. Keep them tight and complementary,
   not redundant.
+- Declare each action's `effect`: `"write"` if running it MUTATES
+  external state (creates/edits an Apple note or reminder, completes
+  a reminder, sends or posts anything, edits an agent), or `"read"`
+  if it only inspects/searches/diagnoses (catalog-search, analyzer,
+  list-* probes). When in doubt, mark it `"write"`.
+- SEQUENCE side effects: propose AT MOST ONE `write` action per
+  turn. When the operator asks for several mutations at once ("make
+  a note AND set a reminder"), propose only the FIRST write this
+  turn; once the operator runs it and it completes you are
+  re-invoked, and you then propose the next from the updated state.
+  `read` actions still batch — you may pair one `write` with reads,
+  or send up to 3 reads together. (The route enforces this too: it
+  holds extra `write` cards, so proposing two only delays the
+  second — declare them honestly and lead with the most important.)
 - `inputs` keys must be plausible inputs for the target agent
   (use the agent id + your prior knowledge). Values must be strings.
 - `rationale` is shown to the operator under the Run/Skip
@@ -321,6 +335,7 @@ chip while the sub-agent runs:
     {
       "type": "run-agent",
       "agentId": "agent-catalog-search",
+      "effect": "read",
       "inputs": { "QUERY": "trivia — generate trivia questions, host a quiz, or answer trivia" },
       "rationale": "Search the installed catalog for any agent that already covers trivia."
     }
@@ -426,7 +441,9 @@ VALIDATION RULES (failing these means the route discards the response):
 - `actions` is optional. When present, must be an array of 0..3
   entries each with `type: "run-agent"`, a string `agentId` in
   the allowlist, an optional string-to-string `inputs` map, and
-  a `rationale` string.
+  a `rationale` string. Each entry SHOULD carry `effect`
+  (`"read"` or `"write"`); absent is treated as `"read"`. At most
+  one `"write"` entry per turn survives — extra writes are held.
 - `commitmentSummary` is optional. When `actions` is non-empty,
   set this to a short (3..60 char) verb-led phrase describing
   the pending work for the operator chip. Omit when there are

--- a/packages/core/src/inbox-store.ts
+++ b/packages/core/src/inbox-store.ts
@@ -78,6 +78,16 @@ export interface InboxActionMeta {
    */
   ctaLabel?: string;
   /**
+   * Whether running this action mutates external state (`write` — e.g. creating
+   * or editing an Apple note/reminder, sending something) or only reads/diagnoses
+   * (`read` — catalog search, run analysis, list-* probes). Triage declares it in
+   * the `<plan>`; the route uses it to sequence side effects: at most ONE `write`
+   * action is proposed per turn so the operator confirms one before the next
+   * fires, while `read` actions still batch. Absent → treated as `read` for
+   * back-compat (older proposals never set it).
+   */
+  effect?: 'read' | 'write';
+  /**
    * When true, approving this run first grants `permissions.inboxRunnable`
    * to `agentId` (a one-click "Enable & run"). Set by the dashboard when
    * triage proposes running an installed agent that hasn't been granted

--- a/packages/dashboard/src/routes/inbox-request-to-run.test.ts
+++ b/packages/dashboard/src/routes/inbox-request-to-run.test.ts
@@ -64,6 +64,47 @@ describe('parseProposedActions — candidates', () => {
   });
 });
 
+describe('parseProposedActions — side-effect sequencing', () => {
+  it('defaults a missing effect to read and batches reads', () => {
+    const { accepted, deferred } = parseProposedActions(
+      [
+        { type: 'run-agent', agentId: 'a' },
+        { type: 'run-agent', agentId: 'b', effect: 'read' },
+      ],
+      ['a', 'b'],
+    );
+    expect(accepted).toHaveLength(2);
+    expect(accepted[0].effect).toBe('read');
+    expect(deferred).toHaveLength(0);
+  });
+
+  it('keeps only the first write and defers the rest', () => {
+    const { accepted, deferred } = parseProposedActions(
+      [
+        { type: 'run-agent', agentId: 'make-note', effect: 'write' },
+        { type: 'run-agent', agentId: 'make-reminder', effect: 'write' },
+      ],
+      ['make-note', 'make-reminder'],
+    );
+    expect(accepted.map((a) => a.agentId)).toEqual(['make-note']);
+    expect(accepted[0].effect).toBe('write');
+    expect(deferred).toEqual([{ agentId: 'make-reminder' }]);
+  });
+
+  it('pairs one write with reads, deferring only extra writes', () => {
+    const { accepted, deferred } = parseProposedActions(
+      [
+        { type: 'run-agent', agentId: 'search', effect: 'read' },
+        { type: 'run-agent', agentId: 'write-1', effect: 'write' },
+        { type: 'run-agent', agentId: 'write-2', effect: 'write' },
+      ],
+      ['search', 'write-1', 'write-2'],
+    );
+    expect(accepted.map((a) => a.agentId)).toEqual(['search', 'write-1']);
+    expect(deferred).toEqual([{ agentId: 'write-2' }]);
+  });
+});
+
 describe('getRunnableCandidates', () => {
   let dir: string;
   let agentStore: AgentStore;

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -1785,10 +1785,15 @@ export function parseProposedActions(
   rawActions: unknown,
   allowlist: readonly string[],
   candidates: readonly string[] = [],
-): { accepted: InboxActionMeta[]; rejected: { agentId: string; reason: string }[] } {
+): {
+  accepted: InboxActionMeta[];
+  rejected: { agentId: string; reason: string }[];
+  deferred: { agentId: string }[];
+} {
   const accepted: InboxActionMeta[] = [];
   const rejected: { agentId: string; reason: string }[] = [];
-  if (!Array.isArray(rawActions)) return { accepted, rejected };
+  const deferred: { agentId: string }[] = [];
+  if (!Array.isArray(rawActions)) return { accepted, rejected, deferred };
   const allowSet = new Set(allowlist);
   const candidateSet = new Set(candidates);
   for (const entry of rawActions.slice(0, 3)) {
@@ -1818,19 +1823,39 @@ export function parseProposedActions(
     }
     const rationale = typeof e.rationale === 'string' ? e.rationale.trim() : undefined;
     const ctaLabel = typeof e.ctaLabel === 'string' ? e.ctaLabel.trim().slice(0, 40) : undefined;
+    // `write` mutates external state; anything else (incl. absent) is `read`.
+    const effect: 'read' | 'write' = e.effect === 'write' ? 'write' : 'read';
     accepted.push({
       kind: 'action',
       status: 'proposed',
       agentId,
       inputs,
       rationale: rationale || undefined,
+      effect,
       // For a candidate, override the CTA so the operator sees they're
       // granting run permission, not just running.
       ctaLabel: isCandidate ? (ctaLabel || 'Enable & run') : (ctaLabel || undefined),
       ...(isCandidate ? { grantsInboxRunnable: true } : {}),
     });
   }
-  return { accepted, rejected };
+  // Sequence side effects: keep at most ONE `write` action per turn so the
+  // operator confirms one mutation before the next is even proposed. Extra
+  // writes are deferred — once the first completes, the follow-up triage turn
+  // re-plans and proposes the next from the updated state. `read` actions
+  // (search, diagnosis, list probes) still batch freely.
+  let sawWrite = false;
+  const sequenced: InboxActionMeta[] = [];
+  for (const action of accepted) {
+    if (action.effect === 'write') {
+      if (sawWrite) {
+        deferred.push({ agentId: action.agentId });
+        continue;
+      }
+      sawWrite = true;
+    }
+    sequenced.push(action);
+  }
+  return { accepted: sequenced, rejected, deferred };
 }
 
 /** Poll the shared run row until it reaches a terminal status (the worker
@@ -2802,7 +2827,7 @@ async function runTriageAgent(
     // single grouped `system` note so the operator can see what was
     // declined and why.
     if (allowlist.length > 0) {
-      const { accepted, rejected } = parseProposedActions(parsed.actions, allowlist, candidates);
+      const { accepted, rejected, deferred } = parseProposedActions(parsed.actions, allowlist, candidates);
       const dedupedAccepted: InboxActionMeta[] = [];
       for (const action of accepted) {
         if (hasMatchingFailedAction(ctx, messageId, action)) {
@@ -2864,6 +2889,9 @@ async function runTriageAgent(
       }
       if (overflow > 0) {
         notes.push(`Skipped ${overflow} additional proposed action${overflow === 1 ? '' : 's'} — message has reached the per-thread action cap (${MAX_ACTIONS_PER_MESSAGE}).`);
+      }
+      if (deferred.length > 0) {
+        notes.push(`Holding ${deferred.length} more side-effecting action${deferred.length === 1 ? '' : 's'} until the one above completes — I'll propose the next once it's done.`);
       }
       if (notes.length > 0) {
         const sysReply = ctx.inboxStore.addResponse(messageId, 'system', notes.join('\n'));


### PR DESCRIPTION
## What

Inbox triage now **leads with one side-effecting action and queues the rest**. When the operator asks for several mutations in a single turn (e.g. "make a note AND set a reminder"), triage proposes only the first write; once it completes, the existing follow-up turn re-plans and proposes the next.

Closes queued follow-up #1 from the 2026-06-16 handoff (the last open thread from the barbecue bug report).

## How

- **`InboxActionMeta.effect?: 'read' | 'write'`** (core) — each proposed action declares whether running it mutates external state.
- **`parseProposedActions`** (dashboard) — keeps at most one `write` action per turn, moving extras to a new `deferred` list. Reads still batch. The route surfaces a neutral *"Holding N more side-effecting action(s) until the one above completes…"* note — not a refusal, so it does **not** trigger the rejection-recovery refire.
- **`kernel.md`** — teaches triage to declare `effect` (default `read`) and propose at most one `write` per turn; reads can still pair/batch. The route is the deterministic backstop.

## Verification

- Unit: `inbox-request-to-run.test.ts` +3 cases (default-read batching, keep-first-write/defer-rest, one-write-plus-reads). Full inbox + inbox-store suites green (127 + the new 3).
- **Dogfooded live**: a "make a note AND remind me…" thread proposed only `make-a-note` (effect=`write`) with "I'll create the note first. After that completes, I can queue the reminder." Running the note → follow-up turn proposed `make-a-reminder`. One mutation confirmed before the next was even offered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)