### PR TITLE
feat(inbox): harden triage failure paths (auto-retry transient crashes, gate Temporal links)

### DIFF
--- a/.changeset/triage-failure-path-hardening.md
+++ b/.changeset/triage-failure-path-hardening.md
@@ -1,0 +1,23 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox triage failure-path hardening.
+
+Two fixes so a failure no longer leaves the operator stuck or chasing dead links:
+
+- **Transient triage crashes auto-retry instead of stranding the thread.** A
+  crashed triage run (provider hiccup, worker dispatch race, network) now
+  retries once with a short backoff before posting a terminal note, and the
+  thread is always left `awaiting_user` so it stays actionable. A fresh reply
+  or "ask triage" refreshes the retry budget.
+- **Run-failure inbox alerts only mention Temporal when there's a real workflow.**
+  The note always links the `/runs/<id>` page; it now offers a Temporal UI deep
+  link (and the "ran on Temporal" wording) only when the run reached a durable
+  workflow (`temporalRunId` set). Setup failures that never dispatched a
+  workflow no longer send the operator hunting for a `sua-node-…` execution
+  that was never created.

--- a/packages/dashboard/src/context.ts
+++ b/packages/dashboard/src/context.ts
@@ -206,6 +206,18 @@ export interface DashboardContext {
    */
   inboxTriagePendingRefires: Set<string>;
   /**
+   * Per-message count of CONSECUTIVE triage runs that crashed with an infra
+   * error (provider/worker/network), keyed by inbox message id. A transient
+   * failure shouldn't permanently strand a thread, so the crash handler
+   * auto-retries triage a bounded number of times before posting a terminal
+   * "crashed" note. Reset to 0 on the first successful turn and whenever the
+   * operator posts a fresh reply / asks triage to re-look. In-memory only — a
+   * dashboard restart resets the budget, which is the desired behavior (a
+   * restart is itself a recovery). Optional so existing ctx literals (tests)
+   * compile; `runTriageAgent` lazily initializes it.
+   */
+  inboxTriageCrashRetries?: Map<string, number>;
+  /**
    * Data directory path. Used by the health endpoint to read the scheduler
    * heartbeat file and report scheduler status.
    */

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -564,6 +564,7 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     activeRuns: new Map(),
     inboxTriageAbortControllers: new Map(),
     inboxTriagePendingRefires: new Set(),
+    inboxTriageCrashRetries: new Map(),
     dataDir: dirname(opts.dbPath),
     dashboardBaseUrl,
   };

--- a/packages/dashboard/src/lib/run-failure-inbox.test.ts
+++ b/packages/dashboard/src/lib/run-failure-inbox.test.ts
@@ -33,6 +33,31 @@ describe('buildRunFailureMessage', () => {
     expect(msg.body).toContain('boom');
     expect(msg.body).toContain('/runs/run-abc12345-xyz'); // trailing slash on base url normalized
   });
+
+  it('omits the Temporal mention + UI link for a setup failure (no temporalRunId)', () => {
+    const msg = buildRunFailureMessage(
+      { run: run({ usedWorkflowProvider: 'temporal', error: 'gate rejected' }) },
+      'http://127.0.0.1:3000',
+    );
+    expect(msg.title).toBe('Run failed: news-digest');
+    expect(msg.title).not.toContain('Temporal');
+    expect(msg.body).not.toContain('Temporal');
+    expect(msg.body).not.toContain('localhost:8233');
+    expect(msg.body).toContain('/runs/run-abc12345-xyz'); // run page still linked
+  });
+
+  it('mentions Temporal + deep-links the workflow when temporalRunId is present', () => {
+    const msg = buildRunFailureMessage(
+      { run: run({ usedWorkflowProvider: 'temporal', temporalRunId: 'exec-99' }) },
+      'http://127.0.0.1:3000',
+    );
+    expect(msg.title).toBe('Temporal run failed: news-digest');
+    expect(msg.body).toContain('Temporal worker');
+    // Real deep link to the sua-run-<id> workflow history in the Temporal UI.
+    expect(msg.body).toContain('localhost:8233');
+    expect(msg.body).toContain('sua-run-run-abc12345-xyz');
+    expect(msg.body).toContain('exec-99');
+  });
 });
 
 describe('raiseRunFailureInbox', () => {

--- a/packages/dashboard/src/lib/run-failure-inbox.ts
+++ b/packages/dashboard/src/lib/run-failure-inbox.ts
@@ -1,4 +1,5 @@
 import type { AddMessageInput, InboxStore, Run } from '@some-useful-agents/core';
+import { temporalWorkflowLink } from './temporal-link.js';
 
 export interface RunFailureInfo {
   run: Run;
@@ -11,23 +12,41 @@ export interface RunFailureInfo {
  * unit-tested without a store. `dedupeKey` follows the documented
  * `run-failure:<runId>` convention so a run only ever opens one conversation,
  * even if the failure path fires more than once.
+ *
+ * The `/runs/<id>` dashboard page is ALWAYS the primary link — it works for
+ * every failure. We only mention Temporal (and offer a Temporal UI deep link)
+ * when the run actually reached a durable workflow, i.e. `run.temporalRunId` is
+ * set. A setup failure (gate rejected, worker never dispatched the workflow)
+ * has `usedWorkflowProvider === 'temporal'` but NO `temporalRunId`, so sending
+ * the operator to the Temporal UI to hunt for a `sua-node-…` workflow that was
+ * never created is a dead end — for those we stop at the run page.
  */
-export function buildRunFailureMessage(info: RunFailureInfo, dashboardBaseUrl?: string): AddMessageInput {
+export function buildRunFailureMessage(
+  info: RunFailureInfo,
+  dashboardBaseUrl?: string,
+  namespace = 'default',
+): AddMessageInput {
   const { run } = info;
   const runLink = dashboardBaseUrl ? `${dashboardBaseUrl.replace(/\/$/, '')}/runs/${run.id}` : `/runs/${run.id}`;
+  // A real durable workflow exists only when we persisted its execution runId.
+  const temporalLink = run.temporalRunId ? temporalWorkflowLink(run, namespace) : undefined;
   const lines = [
-    `Agent **${run.agentName}** failed a run on the Temporal worker.`,
+    temporalLink
+      ? `Agent **${run.agentName}** failed a run on the Temporal worker.`
+      : `Agent **${run.agentName}** failed a run.`,
     '',
     `- Run: [${run.id.slice(0, 8)}](${runLink})`,
     ...(info.failedNodeId ? [`- Failed node: \`${info.failedNodeId}\`${info.errorCategory ? ` (${info.errorCategory})` : ''}`] : []),
     ...(run.error ? [`- Error: ${run.error}`] : []),
     '',
-    'This ran on a Temporal worker — open the run for details, or check the Temporal UI (the per-node workflow is named `sua-node-…`).',
+    temporalLink
+      ? `Open the [run page](${runLink}) for details, or [view the workflow in the Temporal UI](${temporalLink}).`
+      : `Open the [run page](${runLink}) for details.`,
   ];
   return {
     priority: 'high',
     source: 'run-failure',
-    title: `Temporal run failed: ${run.agentName}`,
+    title: temporalLink ? `Temporal run failed: ${run.agentName}` : `Run failed: ${run.agentName}`,
     body: lines.join('\n'),
     agentId: run.agentName,
     runId: run.id,
@@ -46,11 +65,12 @@ export function raiseRunFailureInbox(
   inboxStore: InboxStore | undefined,
   info: RunFailureInfo,
   dashboardBaseUrl?: string,
+  namespace = 'default',
 ): void {
   if (!inboxStore) return;
   if (info.run.usedWorkflowProvider !== 'temporal') return;
   try {
-    inboxStore.add(buildRunFailureMessage(info, dashboardBaseUrl));
+    inboxStore.add(buildRunFailureMessage(info, dashboardBaseUrl, namespace));
   } catch {
     // Inbox creation is best-effort; never let it bubble into the run path.
   }

--- a/packages/dashboard/src/routes/inbox-crash-retry.test.ts
+++ b/packages/dashboard/src/routes/inbox-crash-retry.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Triage crash recovery: a transient infra failure (provider hiccup, worker
+ * dispatch race, network) shouldn't permanently strand a thread. The crash
+ * handler auto-retries a bounded number of times before posting a terminal
+ * note. `planTriageCrashRecovery` is the pure decision behind that — tested
+ * here without forcing a real crash.
+ */
+import { describe, it, expect } from 'vitest';
+import { planTriageCrashRecovery } from './inbox.js';
+
+describe('planTriageCrashRecovery', () => {
+  it('retries on the first crash (budget available)', () => {
+    const plan = planTriageCrashRecovery(0, 'ECONNRESET');
+    expect(plan.willRetry).toBe(true);
+    expect(plan.noteBody).toContain('transient');
+    expect(plan.noteBody).toContain('Retrying');
+    expect(plan.noteBody).toContain('ECONNRESET');
+  });
+
+  it('posts a terminal note once the budget is spent', () => {
+    const plan = planTriageCrashRecovery(1, 'worker gone');
+    expect(plan.willRetry).toBe(false);
+    expect(plan.noteBody).toContain('crashed after 2 attempts');
+    expect(plan.noteBody).toContain('worker gone');
+    expect(plan.noteBody).toMatch(/reply|ask triage/i);
+  });
+});

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -1465,6 +1465,35 @@ describe('POST /inbox/:id/triage/cancel', () => {
   });
 });
 
+describe('Triage crash-retry budget reset', () => {
+  it('a fresh reply clears a thread\'s crash-retry budget', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const app2 = app as unknown as { locals: { inboxTriageCrashRetries?: Map<string, number> } };
+    // Simulate a thread that already burned its auto-retry budget.
+    (app2.locals.inboxTriageCrashRetries ??= new Map()).set(m.id, 1);
+
+    await request(app)
+      .post(`/inbox/${m.id}/respond`).type('form').send({ body: 'try again please' })
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+
+    expect(app2.locals.inboxTriageCrashRetries?.has(m.id)).toBe(false);
+  });
+
+  it('the explicit /triage path clears the crash-retry budget', async () => {
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const app2 = app as unknown as { locals: { inboxTriageCrashRetries?: Map<string, number> } };
+    (app2.locals.inboxTriageCrashRetries ??= new Map()).set(m.id, 1);
+
+    await request(app)
+      .post(`/inbox/${m.id}/triage`)
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+
+    expect(app2.locals.inboxTriageCrashRetries?.has(m.id)).toBe(false);
+  });
+});
+
 describe('Concurrent-triage guard (POST /respond)', () => {
   it('retires a pending PROPOSED action (skipped by triage) on reply, then re-plans', async () => {
     const app = await makeApp();

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -721,6 +721,9 @@ inboxRouter.post('/inbox/:id/respond', (req: Request, res: Response) => {
         });
       }
     }
+    // A fresh operator reply restores the transient-crash retry budget — this
+    // is genuine new input, not a crash loop, so it deserves a clean slate.
+    resetTriageCrashRetries(ctx, id);
     // Fire-and-forget; the modal polls /fragment for the response.
     // The conversation thread itself signals "in progress" via the
     // user-reply-within-30s heuristic in isTriagePending.
@@ -752,6 +755,8 @@ inboxRouter.post('/inbox/:id/triage', (req: Request, res: Response) => {
       createdAt: marker.createdAt,
     });
   } catch { /* swallow */ }
+  // Operator explicitly asked for another look — fresh retry budget.
+  resetTriageCrashRetries(ctx, id);
   void runTriageAgent(ctx, id).catch(() => { /* swallow */ });
   if (isAjax(req)) { res.status(204).end(); return; }
   res.redirect(303, `${detailUrl}?ok=${encodeURIComponent('Triage agent invoked.')}`);
@@ -2183,6 +2188,48 @@ async function runProposedAction(
 const MAX_AUTO_TRIAGE_TURNS = 5;
 
 /**
+ * How many times a triage run may crash with an infra error before we stop
+ * auto-retrying and post a terminal "crashed" note. A transient blip
+ * (provider hiccup, worker dispatch race, network) shouldn't permanently
+ * strand the thread; a persistent outage shouldn't spin forever. One retry
+ * (two attempts total) covers the overwhelming majority of transient cases.
+ */
+const MAX_TRIAGE_CRASH_RETRIES = 1;
+
+/** Delay before an auto-retry so a transient backend has a moment to recover. */
+const TRIAGE_CRASH_RETRY_DELAY_MS = 2000;
+
+/** Lazily-initialized per-message crash-retry counter (see DashboardContext). */
+function triageCrashRetries(ctx: ReturnType<typeof getContext>): Map<string, number> {
+  return (ctx.inboxTriageCrashRetries ??= new Map());
+}
+
+/** Clear a thread's crash-retry budget (a fresh user turn or a success). */
+function resetTriageCrashRetries(ctx: ReturnType<typeof getContext>, messageId: string): void {
+  triageCrashRetries(ctx).delete(messageId);
+}
+
+/**
+ * Decide how to recover from a crashed triage run, given how many auto-retries
+ * have already been spent on this thread. Pure so the branching (retry vs.
+ * terminal note, the operator-facing copy) is unit-testable without forcing a
+ * real crash. `willRetry` true → schedule another attempt and bump the count;
+ * false → the budget is spent, post a terminal note and clear the count.
+ */
+export function planTriageCrashRecovery(
+  used: number,
+  errorMessage: string,
+): { willRetry: boolean; noteBody: string } {
+  if (used < MAX_TRIAGE_CRASH_RETRIES) {
+    return { willRetry: true, noteBody: `Triage hit a transient error (${errorMessage}). Retrying…` };
+  }
+  return {
+    willRetry: false,
+    noteBody: `Triage agent crashed after ${used + 1} attempts: ${errorMessage}. Reply or ask triage to try again.`,
+  };
+}
+
+/**
  * Count the number of `triage` responses since the most recent `user`
  * response (or message creation if no user reply yet). Drives the
  * auto-refire cap — the operator hitting Reply resets the counter so
@@ -2911,6 +2958,9 @@ async function runTriageAgent(
     try {
       ctx.inboxStore.updateStatus(messageId, 'awaiting_user', { recommendation: rec, triageRunId: runId });
     } catch { /* ignore */ }
+    // A turn completed cleanly — the thread isn't in a crash loop, so refund
+    // the auto-retry budget for any future transient failure.
+    resetTriageCrashRetries(ctx, messageId);
     publishInboxEvent(ctx, messageId, 'state', { phase: 'done', since: Date.now() });
   } catch (err) {
     // Operator-cancelled exceptions look like crashes here (the
@@ -2921,12 +2971,33 @@ async function runTriageAgent(
     if (!abortController.signal.aborted) {
       const msg = err instanceof Error ? err.message : String(err);
       process.stderr.write(`[inbox-triage] run failed: ${msg}\n${(err as Error)?.stack ?? ''}\n`);
+      // A triage crash is almost always a transient infra failure (provider
+      // hiccup, worker dispatch race, network). Don't strand the thread on the
+      // first blip: auto-retry a bounded number of times with a short backoff,
+      // and only post a terminal "crashed" note once the budget is spent. The
+      // thread is left `awaiting_user` either way so it stays actionable (the
+      // operator can reply or hit "ask triage" even if the retry never lands).
+      const retries = triageCrashRetries(ctx);
+      const used = retries.get(messageId) ?? 0;
+      const { willRetry, noteBody } = planTriageCrashRecovery(used, msg);
       try {
-        const sysReply = ctx.inboxStore.addResponse(messageId, 'system', `Triage agent crashed: ${msg}`);
+        const sysReply = ctx.inboxStore.addResponse(messageId, 'system', noteBody);
         publishInboxEvent(ctx, messageId, 'message:created', {
           responseId: sysReply.id, role: 'system', body: sysReply.body, createdAt: sysReply.createdAt,
         });
       } catch { /* ignore */ }
+      try { ctx.inboxStore.updateStatus(messageId, 'awaiting_user'); } catch { /* ignore */ }
+      if (willRetry) {
+        retries.set(messageId, used + 1);
+        // Fire AFTER this run's `finally` clears the abort-controller guard
+        // (the delay comfortably outlasts the synchronous teardown), so the
+        // retry isn't deferred as a concurrent run.
+        setTimeout(() => {
+          void runTriageAgent(ctx, messageId).catch(() => { /* swallow — terminal note posts on final failure */ });
+        }, TRIAGE_CRASH_RETRY_DELAY_MS);
+      } else {
+        retries.delete(messageId);
+      }
     }
     publishInboxEvent(ctx, messageId, 'state', { phase: 'done', since: Date.now() });
   } finally {


### PR DESCRIPTION
## What

Two queued follow-ups from the 2026-06-16 handoff — both about not leaving the operator stuck when something fails.

### 1. Transient triage crashes auto-retry instead of stranding the thread (follow-up #2, #499 leftover)

A crashed triage run was previously terminal: it posted *"Triage agent crashed"* and left the thread sitting there. But a crash is almost always a transient infra failure (provider hiccup, worker dispatch race, network). Now:

- The crash handler **auto-retries once** with a short backoff (`MAX_TRIAGE_CRASH_RETRIES = 1`, 2s delay), bounded by an in-memory per-message counter so a persistent outage can't spin forever.
- The thread is **always left `awaiting_user`** so it stays actionable even if the retry never lands.
- A fresh operator reply (`/respond`) or explicit *"ask triage"* (`/triage`) **refreshes the budget** — genuine new input deserves a clean slate.
- The decision (retry vs. terminal note + the operator-facing copy) is extracted as pure `planTriageCrashRecovery(used, msg)` and unit-tested.

### 2. Run-failure inbox alerts only mention Temporal when there's a real workflow (follow-up #3)

`buildRunFailureMessage` unconditionally told the operator to *"check the Temporal UI for the `sua-node-…` workflow"* — a dead end for a setup failure that never dispatched a workflow. Now:

- The `/runs/<id>` dashboard page is **always** the primary link.
- The Temporal mention + a **real deep link** (via the existing `temporalWorkflowLink`) appear only when `run.temporalRunId` is set (a durable workflow actually ran). Setup failures stop at the run page.

## How

- `DashboardContext.inboxTriageCrashRetries?: Map<string, number>` — optional (lazy `??=`) so existing ctx literals/tests compile untouched.
- `run-failure-inbox.ts` imports `temporalWorkflowLink`; title + body branch on `temporalRunId`.

## Verification

- New tests: `planTriageCrashRecovery` branches; crash-budget reset on `/respond` + `/triage`; run-failure message shapes with/without `temporalRunId`.
- Full `dashboard` + `core` suites green: **1985 pass / 3 skip**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)