### PR TITLE
feat(inbox): triage learnings store + retrieval + flag (dormant)

### DIFF
--- a/.changeset/triage-learnings-store.md
+++ b/.changeset/triage-learnings-store.md
@@ -1,0 +1,18 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Triage learnings: store + retrieval + flag (dormant plumbing).
+
+First slice of cross-thread triage learnings (experimental, off by default). Adds a
+`triage_learnings` table to InboxStore with `addLearning`/`getLearning`/`listLearnings`/
+`updateLearningStatus`/`deleteLearning` and a structured-retrieval query
+`listApprovedLearningsForTriage` (keys on agentId + source + scope, newest-approved first,
+capped). Lessons are deduped on a normalized form. Adds a generic `extractTaggedJson(raw, tag)`
+core helper (generalizes `extractPlanJson`) and the `isTriageLearningsEnabled()`
+(`SUA_EXPERIMENTAL_TRIAGE_LEARNINGS`) flag with the CLI config bridge. Nothing is wired into
+the inbox UI or triage prompt yet — that lands in follow-ups.

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -48,6 +48,13 @@ export interface SuaConfig {
      * off. Equivalent to `SUA_EXPERIMENTAL_APPLE=1`.
      */
     apple?: boolean;
+    /**
+     * Enable experimental cross-thread triage learnings (extract a lesson on
+     * resolve, hold pending approval, retrieve approved lessons into future
+     * triage prompts). Default off. Equivalent to
+     * `SUA_EXPERIMENTAL_TRIAGE_LEARNINGS=1`.
+     */
+    triageLearnings?: boolean;
   };
 }
 
@@ -91,6 +98,9 @@ export function loadConfig(): SuaConfig {
 function applyExperimentalFlags(config: SuaConfig): SuaConfig {
   if (config.experimental?.apple && process.env.SUA_EXPERIMENTAL_APPLE === undefined) {
     process.env.SUA_EXPERIMENTAL_APPLE = '1';
+  }
+  if (config.experimental?.triageLearnings && process.env.SUA_EXPERIMENTAL_TRIAGE_LEARNINGS === undefined) {
+    process.env.SUA_EXPERIMENTAL_TRIAGE_LEARNINGS = '1';
   }
   return config;
 }

--- a/packages/core/src/build-plan-schema.test.ts
+++ b/packages/core/src/build-plan-schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildPlanSchema, extractPlanJson, type BuildPlanInput } from './build-plan-schema.js';
+import { buildPlanSchema, extractPlanJson, extractTaggedJson, type BuildPlanInput } from './build-plan-schema.js';
 
 function basePlan(overrides: Partial<BuildPlanInput> = {}): BuildPlanInput {
   return {
@@ -158,5 +158,25 @@ describe('extractPlanJson', () => {
 
   it('returns null when no plan block is found', () => {
     expect(extractPlanJson('Sorry, I can\'t do that.')).toBeNull();
+  });
+});
+
+describe('extractTaggedJson', () => {
+  it('extracts from a custom <learning>…</learning> wrapper', () => {
+    const out = extractTaggedJson('Result:\n<learning>{"lesson":"do X"}</learning>\nok', 'learning');
+    expect(out).toBe('{"lesson":"do X"}');
+  });
+
+  it('is case-insensitive on the tag', () => {
+    expect(extractTaggedJson('<LEARNING>{"lesson":null}</LEARNING>', 'learning')).toBe('{"lesson":null}');
+  });
+
+  it('falls back to a ```json fence, then bare JSON', () => {
+    expect(extractTaggedJson('```json\n{"lesson":"y"}\n```', 'learning')).toBe('{"lesson":"y"}');
+    expect(extractTaggedJson('  {"lesson":"z"}  ', 'learning')).toBe('{"lesson":"z"}');
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(extractTaggedJson('no json here', 'learning')).toBeNull();
   });
 });

--- a/packages/core/src/build-plan-schema.ts
+++ b/packages/core/src/build-plan-schema.ts
@@ -146,3 +146,23 @@ export function extractPlanJson(raw: string): string | null {
 
   return null;
 }
+
+/**
+ * Generalized version of {@link extractPlanJson} for any XML-ish wrapper tag
+ * (e.g. `<learning>…</learning>`). Strips, in order: `<tag>…</tag>`, a ```json
+ * (or bare ```) fence, then a bare `{…}` blob. Returns the trimmed JSON text
+ * ready for `JSON.parse`, or null when nothing matches. The `tag` is matched
+ * case-insensitively; callers pass a simple alphanumeric tag name.
+ */
+export function extractTaggedJson(raw: string, tag: string): string | null {
+  const tagged = new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`, 'i').exec(raw);
+  if (tagged) return tagged[1].trim();
+
+  const fenced = /```(?:json)?\s*([\s\S]*?)```/i.exec(raw);
+  if (fenced) return fenced[1].trim();
+
+  const bare = raw.trim();
+  if (bare.startsWith('{') && bare.endsWith('}')) return bare;
+
+  return null;
+}

--- a/packages/core/src/experimental.ts
+++ b/packages/core/src/experimental.ts
@@ -26,3 +26,14 @@ function envTrue(name: string): boolean {
 export function isAppleIntegrationEnabled(): boolean {
   return envTrue('SUA_EXPERIMENTAL_APPLE');
 }
+
+/**
+ * True when the owner has enabled experimental cross-thread triage learnings —
+ * via `experimental.triageLearnings: true` in `sua.config.json` (bridged to the
+ * env var on load) or `SUA_EXPERIMENTAL_TRIAGE_LEARNINGS=1` directly. Default
+ * off. When off: no lessons are extracted on resolve and none are injected into
+ * triage prompts (the global kill switch).
+ */
+export function isTriageLearningsEnabled(): boolean {
+  return envTrue('SUA_EXPERIMENTAL_TRIAGE_LEARNINGS');
+}

--- a/packages/core/src/inbox-store.test.ts
+++ b/packages/core/src/inbox-store.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { InboxStore, normalizeTags, type InboxMessage } from './inbox-store.js';
+import { InboxStore, normalizeTags, normalizeLesson, type InboxMessage } from './inbox-store.js';
 
 let dir: string;
 let store: InboxStore;
@@ -503,5 +503,134 @@ describe('InboxStore.list filters (q, starred, tag)', () => {
     store.setTags(b.id, ['auth']);
     const out = store.list({ starred: true, tag: 'auth', q: 'auth' });
     expect(out.map((r) => r.title)).toEqual(['auth issue starred']);
+  });
+});
+
+describe('normalizeLesson', () => {
+  it('lowercases, strips punctuation, collapses whitespace', () => {
+    expect(normalizeLesson('Run  `brew install apod`, then retry!'))
+      .toBe('run brew install apod then retry');
+  });
+  it('collapses near-identical lessons to the same key', () => {
+    expect(normalizeLesson('Check the host allowlist.'))
+      .toBe(normalizeLesson('check the   host allowlist'));
+  });
+});
+
+describe('InboxStore triage learnings', () => {
+  it('addLearning round-trips with defaults + provenance', () => {
+    const l = store.addLearning({
+      source: 'run-failure',
+      agentId: 'news-digest',
+      category: 'fix',
+      lesson: 'Install the apod CLI before retrying.',
+      sourceMessageId: 'msg-1',
+      sourceRunId: 'run-1',
+    });
+    expect(l).not.toBeNull();
+    expect(l!.status).toBe('pending');
+    expect(l!.scope).toBe('agent');           // default
+    expect(l!.agentId).toBe('news-digest');
+    expect(l!.category).toBe('fix');
+    expect(l!.sourceMessageId).toBe('msg-1');
+    expect(l!.sourceRunId).toBe('run-1');
+    expect(store.getLearning(l!.id)).toEqual(l);
+  });
+
+  it('dedups a near-identical lesson on the same (agentId, source)', () => {
+    const a = store.addLearning({ source: 'run-failure', agentId: 'x', lesson: 'Fix the thing.' });
+    const dup = store.addLearning({ source: 'run-failure', agentId: 'x', lesson: 'fix   the THING!' });
+    expect(a).not.toBeNull();
+    expect(dup).toBeNull();
+    expect(store.listLearnings()).toHaveLength(1);
+  });
+
+  it('does NOT dedup the same lesson under a different agent or source', () => {
+    store.addLearning({ source: 'run-failure', agentId: 'x', lesson: 'Fix the thing.' });
+    expect(store.addLearning({ source: 'run-failure', agentId: 'y', lesson: 'Fix the thing.' })).not.toBeNull();
+    expect(store.addLearning({ source: 'permission-request', agentId: 'x', lesson: 'Fix the thing.' })).not.toBeNull();
+    expect(store.listLearnings()).toHaveLength(3);
+  });
+
+  it('listLearnings filters by messageId and status', () => {
+    store.addLearning({ source: 'run-failure', agentId: 'a', lesson: 'one', sourceMessageId: 'm1' });
+    store.addLearning({ source: 'run-failure', agentId: 'b', lesson: 'two', sourceMessageId: 'm2' });
+    expect(store.listLearnings({ messageId: 'm1' })).toHaveLength(1);
+    expect(store.listLearnings({ status: 'pending' })).toHaveLength(2);
+    expect(store.listLearnings({ status: 'approved' })).toHaveLength(0);
+  });
+
+  it('updateLearningStatus approves once (stamps approved_at) and is race-safe', () => {
+    const l = store.addLearning({ source: 'run-failure', agentId: 'a', lesson: 'lesson' })!;
+    expect(store.updateLearningStatus(l.id, 'approved')).toBe(true);
+    const approved = store.getLearning(l.id)!;
+    expect(approved.status).toBe('approved');
+    expect(approved.approvedAt).toBeGreaterThan(0);
+    // A second transition loses the race (already decided).
+    expect(store.updateLearningStatus(l.id, 'rejected')).toBe(false);
+    expect(store.getLearning(l.id)!.status).toBe('approved');
+  });
+
+  it('updateLearningStatus returns false for a missing row', () => {
+    expect(store.updateLearningStatus('nope', 'approved')).toBe(false);
+  });
+
+  it('deleteLearning removes the row', () => {
+    const l = store.addLearning({ source: 'run-failure', agentId: 'a', lesson: 'x' })!;
+    store.deleteLearning(l.id);
+    expect(store.getLearning(l.id)).toBeNull();
+  });
+
+  describe('listApprovedLearningsForTriage', () => {
+    const approve = (input: Parameters<InboxStore['addLearning']>[0]): void => {
+      const l = store.addLearning(input)!;
+      store.updateLearningStatus(l.id, 'approved');
+    };
+
+    it('matches agent-scoped lessons by agentId', () => {
+      approve({ source: 'run-failure', agentId: 'news', scope: 'agent', lesson: 'news lesson' });
+      approve({ source: 'run-failure', agentId: 'other', scope: 'agent', lesson: 'other lesson' });
+      const out = store.listApprovedLearningsForTriage({ agentId: 'news', source: 'run-failure' });
+      expect(out.map((l) => l.lesson)).toEqual(['news lesson']);
+    });
+
+    it('matches source-scoped lessons regardless of agent, and global always', () => {
+      approve({ source: 'run-failure', agentId: 'a', scope: 'source', lesson: 'src lesson' });
+      approve({ source: 'run-failure', agentId: 'b', scope: 'global', lesson: 'global lesson' });
+      const out = store.listApprovedLearningsForTriage({ agentId: 'zzz', source: 'run-failure' });
+      expect(out.map((l) => l.lesson).sort()).toEqual(['global lesson', 'src lesson']);
+    });
+
+    it('excludes pending and rejected lessons', () => {
+      store.addLearning({ source: 'run-failure', agentId: 'a', scope: 'agent', lesson: 'still pending' });
+      const rej = store.addLearning({ source: 'run-failure', agentId: 'a', scope: 'agent', lesson: 'will reject' })!;
+      store.updateLearningStatus(rej.id, 'rejected');
+      expect(store.listApprovedLearningsForTriage({ agentId: 'a', source: 'run-failure' })).toEqual([]);
+    });
+
+    it('does not match agent-scoped lessons when agentId is absent', () => {
+      approve({ source: 'cadence', agentId: 'a', scope: 'agent', lesson: 'agent lesson' });
+      approve({ source: 'cadence', scope: 'source', lesson: 'source lesson' });
+      const out = store.listApprovedLearningsForTriage({ source: 'cadence' });
+      expect(out.map((l) => l.lesson)).toEqual(['source lesson']);
+    });
+
+    it('orders newest-approved first and caps at the limit', () => {
+      for (let i = 0; i < 7; i += 1) approve({ source: 'run-failure', agentId: 'a', scope: 'agent', lesson: `lesson ${i}` });
+      const out = store.listApprovedLearningsForTriage({ agentId: 'a', source: 'run-failure' });
+      expect(out).toHaveLength(5);                 // default LIMIT
+      const limited = store.listApprovedLearningsForTriage({ agentId: 'a', source: 'run-failure' }, 2);
+      expect(limited).toHaveLength(2);
+    });
+  });
+
+  it('ensureSchema is idempotent across reopen (table + rows survive)', () => {
+    const dbPath = join(dir, 'reopen.db');
+    const s1 = new InboxStore(dbPath);
+    const l = s1.addLearning({ source: 'run-failure', agentId: 'a', lesson: 'persist me' })!;
+    s1.close();
+    const s2 = new InboxStore(dbPath);   // re-runs ensureSchema
+    expect(s2.getLearning(l.id)?.lesson).toBe('persist me');
+    s2.close();
   });
 });

--- a/packages/core/src/inbox-store.ts
+++ b/packages/core/src/inbox-store.ts
@@ -155,6 +155,53 @@ export interface InboxResponse {
   metaJson?: string;
 }
 
+/**
+ * Cross-thread triage learnings (experimental). A `pending` lesson is
+ * distilled by the extractor when a thread is resolved; the operator
+ * `approve`s or `reject`s it. Only `approved` lessons are ever retrieved
+ * into a future triage prompt — the approval gate is the trust boundary.
+ */
+export const LEARNING_STATUSES = ['pending', 'approved', 'rejected'] as const;
+export type LearningStatus = typeof LEARNING_STATUSES[number];
+
+/**
+ * How broadly a lesson applies, which decides its retrieval key:
+ *   `agent`  — keyed on `agentId` (default; most specific)
+ *   `source` — keyed on `source` only (any agent with that source)
+ *   `global` — matches every thread (use sparingly)
+ */
+export const LEARNING_SCOPES = ['agent', 'source', 'global'] as const;
+export type LearningScope = typeof LEARNING_SCOPES[number];
+
+export const LEARNING_CATEGORIES = ['fix', 'config', 'permission', 'workflow', 'other'] as const;
+export type LearningCategory = typeof LEARNING_CATEGORIES[number];
+
+export interface TriageLearning {
+  id: string;
+  createdAt: number;
+  status: LearningStatus;
+  source: InboxSource;
+  /** Retrieval key; present for run-failure / permission-request sources. */
+  agentId?: string;
+  scope: LearningScope;
+  category?: LearningCategory;
+  lesson: string;
+  /** Provenance: the thread + triage run this lesson was distilled from. */
+  sourceMessageId?: string;
+  sourceRunId?: string;
+  approvedAt?: number;
+}
+
+export interface AddLearningInput {
+  source: InboxSource;
+  agentId?: string;
+  scope?: LearningScope;
+  category?: LearningCategory;
+  lesson: string;
+  sourceMessageId?: string;
+  sourceRunId?: string;
+}
+
 export interface AddMessageInput {
   priority: InboxPriority;
   source: InboxSource;
@@ -399,6 +446,31 @@ export class InboxStore {
     this.db.exec(`
       CREATE INDEX IF NOT EXISTS idx_inbox_responses_msg
         ON inbox_responses(message_id, created_at)
+    `);
+    // Cross-thread triage learnings (experimental, flag-gated at the route
+    // layer). A lesson distilled from a resolved thread, held `pending` until
+    // an operator approves it, then retrieved by structured keys (agent_id,
+    // source) into future triage turns. See docs + the experimental flag
+    // SUA_EXPERIMENTAL_TRIAGE_LEARNINGS.
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS triage_learnings (
+        id TEXT PRIMARY KEY,
+        created_at INTEGER NOT NULL,
+        status TEXT NOT NULL,
+        source TEXT NOT NULL,
+        agent_id TEXT,
+        scope TEXT NOT NULL DEFAULT 'agent',
+        category TEXT,
+        lesson TEXT NOT NULL,
+        lesson_norm TEXT,
+        source_message_id TEXT,
+        source_run_id TEXT,
+        approved_at INTEGER
+      )
+    `);
+    this.db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_learnings_retrieval
+        ON triage_learnings(status, source, agent_id, approved_at DESC)
     `);
   }
 
@@ -752,10 +824,128 @@ export class InboxStore {
     return rows.map((r) => this.rowToResponse(r));
   }
 
-  /** Drop every row from both tables. Test + dev tooling. */
+  // ── triage learnings (experimental) ────────────────────────────────
+
+  /**
+   * Insert a `pending` learning. Dedups against existing `pending`/`approved`
+   * rows with the same `(agent_id, source)` and a matching normalized lesson —
+   * returns the existing row's id is NOT needed, so a dup simply yields `null`
+   * (nothing inserted). Returns the new learning on insert.
+   */
+  addLearning(input: AddLearningInput): TriageLearning | null {
+    this.validateSource(input.source);
+    if (!input.lesson || !input.lesson.trim()) {
+      throw new Error('InboxStore.addLearning: lesson is required');
+    }
+    const lesson = input.lesson.trim();
+    const norm = normalizeLesson(lesson);
+    const agentId = input.agentId ?? null;
+    // Dedup: same key + same normalized lesson, still live (pending/approved).
+    const dup = this.db.prepare(`
+      SELECT 1 FROM triage_learnings
+        WHERE status IN ('pending', 'approved')
+          AND source = ?
+          AND (agent_id IS ? OR agent_id = ?)
+          AND lesson_norm = ?
+        LIMIT 1
+    `).get(input.source, agentId, agentId, norm);
+    if (dup) return null;
+
+    const id = randomUUID();
+    const now = Date.now();
+    this.db.prepare(`
+      INSERT INTO triage_learnings (
+        id, created_at, status, source, agent_id, scope, category,
+        lesson, lesson_norm, source_message_id, source_run_id
+      ) VALUES (?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      id,
+      now,
+      input.source,
+      agentId,
+      input.scope ?? 'agent',
+      input.category ?? null,
+      lesson,
+      norm,
+      input.sourceMessageId ?? null,
+      input.sourceRunId ?? null,
+    );
+    return this.getLearning(id);
+  }
+
+  getLearning(id: string): TriageLearning | null {
+    const row = this.db.prepare(`SELECT * FROM triage_learnings WHERE id = ?`)
+      .get(id) as Record<string, unknown> | undefined;
+    return row ? this.rowToLearning(row) : null;
+  }
+
+  /** List learnings, optionally filtered by source thread and/or status. */
+  listLearnings(opts: { messageId?: string; status?: LearningStatus } = {}): TriageLearning[] {
+    const where: string[] = [];
+    const params: (string | number)[] = [];
+    if (opts.messageId !== undefined) {
+      where.push('source_message_id = ?');
+      params.push(opts.messageId);
+    }
+    if (opts.status !== undefined) {
+      where.push('status = ?');
+      params.push(opts.status);
+    }
+    const clause = where.length > 0 ? `WHERE ${where.join(' AND ')}` : '';
+    const rows = this.db.prepare(
+      `SELECT * FROM triage_learnings ${clause} ORDER BY created_at DESC`,
+    ).all(...params) as Array<Record<string, unknown>>;
+    return rows.map((r) => this.rowToLearning(r));
+  }
+
+  /**
+   * Atomically transition a `pending` learning to `approved` or `rejected`.
+   * Returns true when it committed, false when it lost the race (missing row
+   * or already decided). Approving stamps `approved_at`.
+   */
+  updateLearningStatus(id: string, status: 'approved' | 'rejected'): boolean {
+    const approvedAt = status === 'approved' ? Date.now() : null;
+    const result = this.db.prepare(`
+      UPDATE triage_learnings
+      SET status = ?, approved_at = ?
+      WHERE id = ? AND status = 'pending'
+    `).run(status, approvedAt, id);
+    return result.changes === 1;
+  }
+
+  deleteLearning(id: string): void {
+    this.db.prepare(`DELETE FROM triage_learnings WHERE id = ?`).run(id);
+  }
+
+  /**
+   * Retrieve approved lessons relevant to a thread being triaged, newest-
+   * approved first. Matches `global` always, `source` lessons by source, and
+   * `agent` lessons by `agentId` (when present). Capped at `limit` (default 5).
+   */
+  listApprovedLearningsForTriage(
+    opts: { agentId?: string; source: InboxSource },
+    limit = 5,
+  ): TriageLearning[] {
+    const agentId = opts.agentId ?? null;
+    const rows = this.db.prepare(`
+      SELECT * FROM triage_learnings
+        WHERE status = 'approved'
+          AND (
+            scope = 'global'
+            OR (scope = 'source' AND source = ?)
+            OR (scope = 'agent' AND agent_id IS NOT NULL AND agent_id = ?)
+          )
+        ORDER BY approved_at DESC
+        LIMIT ?
+    `).all(opts.source, agentId, limit) as Array<Record<string, unknown>>;
+    return rows.map((r) => this.rowToLearning(r));
+  }
+
+  /** Drop every row from all tables. Test + dev tooling. */
   clear(): void {
     this.db.exec(`DELETE FROM inbox_responses`);
     this.db.exec(`DELETE FROM inbox_messages`);
+    this.db.exec(`DELETE FROM triage_learnings`);
   }
 
   close(): void {
@@ -828,4 +1018,33 @@ export class InboxStore {
       metaJson: (row.meta_json as string | null) ?? undefined,
     };
   }
+
+  private rowToLearning(row: Record<string, unknown>): TriageLearning {
+    return {
+      id: row.id as string,
+      createdAt: row.created_at as number,
+      status: row.status as LearningStatus,
+      source: row.source as InboxSource,
+      agentId: (row.agent_id as string | null) ?? undefined,
+      scope: (row.scope as LearningScope | null) ?? 'agent',
+      category: (row.category as LearningCategory | null) ?? undefined,
+      lesson: row.lesson as string,
+      sourceMessageId: (row.source_message_id as string | null) ?? undefined,
+      sourceRunId: (row.source_run_id as string | null) ?? undefined,
+      approvedAt: (row.approved_at as number | null) ?? undefined,
+    };
+  }
+}
+
+/**
+ * Normalize a lesson for dedup: lowercase, strip punctuation, collapse
+ * whitespace. Two lessons that differ only in casing/punctuation/spacing
+ * collapse to the same key so near-identical lessons aren't stored twice.
+ */
+export function normalizeLesson(lesson: string): string {
+  return lesson
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, '')
+    .replace(/\s+/g, ' ')
+    .trim();
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -96,7 +96,11 @@ export {
   INBOX_SOURCES,
   INBOX_RESPONSE_ROLES,
   INBOX_ACTION_STATUSES,
+  LEARNING_STATUSES,
+  LEARNING_SCOPES,
+  LEARNING_CATEGORIES,
   normalizeTags,
+  normalizeLesson,
   type InboxMessage,
   type InboxResponse,
   type InboxPriority,
@@ -107,6 +111,11 @@ export {
   type InboxActionMeta,
   type AddMessageInput,
   type ListMessagesOpts,
+  type TriageLearning,
+  type LearningStatus,
+  type LearningScope,
+  type LearningCategory,
+  type AddLearningInput,
 } from './inbox-store.js';
 export {
   IntegrationsStore,
@@ -171,7 +180,7 @@ export {
   type AppleRunnerHandle,
   type AppleRunResult,
 } from './integrations/apple-runner.js';
-export { isAppleIntegrationEnabled } from './experimental.js';
+export { isAppleIntegrationEnabled, isTriageLearningsEnabled } from './experimental.js';
 export {
   PlannerTelemetryStore,
   type PlannerTelemetryRow,
@@ -202,6 +211,7 @@ export {
 export {
   buildPlanSchema,
   extractPlanJson,
+  extractTaggedJson,
   type BuildPlan,
   type BuildPlanInput,
 } from './build-plan-schema.js';


### PR DESCRIPTION
## What

**PR 1 of 3** for cross-conversation triage learnings (per the approved plan). This is the pure data layer + feature gate — **fully dormant, nothing user-visible**. PRs 2 (extractor + approval UX) and 3 (kernel wiring) follow.

Context: inbox triage is multiturn *within* a thread but has zero cross-thread memory. This feature lets an operator-approved "lesson" from a resolved thread inform future triage of similar issues. Ships behind `SUA_EXPERIMENTAL_TRIAGE_LEARNINGS`, off by default.

## This PR

- **`packages/core/src/inbox-store.ts`** — `triage_learnings` table in `ensureSchema` (`CREATE TABLE/INDEX IF NOT EXISTS`); types `TriageLearning` / `LearningStatus` / `LearningScope` / `LearningCategory` / `AddLearningInput`; methods:
  - `addLearning` — inserts `pending`, deduped on a normalized lesson form per `(agentId, source)`.
  - `getLearning` / `listLearnings({ messageId?, status? })` / `deleteLearning`.
  - `updateLearningStatus` — atomic `pending → approved|rejected` (race-safe, stamps `approved_at`).
  - `listApprovedLearningsForTriage({ agentId?, source }, limit=5)` — **structured retrieval**: matches `global` always, `source`-scoped by source, `agent`-scoped by agentId; newest-approved first; capped.
- **`packages/core/src/build-plan-schema.ts`** — `extractTaggedJson(raw, tag)` generalizing `extractPlanJson` (used by the extractor in PR2). `extractPlanJson` unchanged.
- **`packages/core/src/experimental.ts`** — `isTriageLearningsEnabled()` mirroring `isAppleIntegrationEnabled`.
- **`packages/cli/src/config.ts`** — `experimental.triageLearnings` → `SUA_EXPERIMENTAL_TRIAGE_LEARNINGS` bridge.

## Guardrails (foundation laid here)

Only `approved` lessons are ever returned by retrieval — the approval gate (PR2) is the trust boundary. `rejected` and `pending` lessons are never retrieved. Flag-off = global kill switch.

## Verification

`npx vitest run packages/core packages/cli` → **1494 pass / 3 skip**. New tests cover store round-trip + marshalling, dedup, retrieval (scope matching, rejected excluded, agentId-absent fallback, ordering, limit), `ensureSchema` idempotency across reopen, `normalizeLesson`, and `extractTaggedJson`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)