### PR TITLE
feat(inbox): triage learnings extractor + resolve trigger + approval UX

### DIFF
--- a/.changeset/triage-learnings-extractor.md
+++ b/.changeset/triage-learnings-extractor.md
@@ -1,0 +1,24 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Triage learnings: extractor + resolve trigger + approval UX (flag-gated).
+
+Second slice of cross-thread triage learnings (experimental). Adds the
+`inbox-learning-extractor` system agent and wires the loop end-to-end:
+
+- A new **Mark resolved** affordance + `POST /inbox/:id/resolve` route (finally
+  wiring up the long-dormant `resolved` status). On resolve, `maybeExtractLearning`
+  runs the extractor (gated cheapest-first: flag off → no-op; only run-failure /
+  permission-request threads with real triage activity reach the one LLM call) to
+  distill at most one durable lesson, stored as a `pending` learning.
+- The thread modal renders a **"Triage learned something"** card with Approve /
+  Discard; `POST /inbox/:id/learnings/:lid/(approve|reject)` routes decide it.
+  Approved lessons become retrievable; rejected ones are dead.
+
+Still dormant unless `SUA_EXPERIMENTAL_TRIAGE_LEARNINGS` is set, and learnings are
+not yet injected into the triage prompt (that lands in the final slice).

--- a/agents/examples/inbox-learning-extractor.yaml
+++ b/agents/examples/inbox-learning-extractor.yaml
@@ -1,0 +1,140 @@
+# Inbox Learning Extractor — distills at most one durable, reusable LESSON
+# from a RESOLVED inbox triage thread, or returns none.
+#
+# Experimental (flag-gated by SUA_EXPERIMENTAL_TRIAGE_LEARNINGS). The inbox
+# route runs this from `maybeExtractLearning` when a thread is marked resolved.
+# It is route-dispatched only — NOT in the triage sub-agent allowlist, never
+# proposed to the operator. Its `<learning>` output is parsed with
+# extractTaggedJson, validated, and stored as a `pending` learning that the
+# operator approves/rejects. Approved lessons are retrieved by structured keys
+# (agentId, source) into future triage turns.
+
+id: inbox-learning-extractor
+name: Inbox Learning Extractor
+description: >
+  Reads a resolved inbox triage thread and distills at most one durable,
+  reusable lesson for future triage of similar issues — or returns none when
+  the thread holds nothing generalizable.
+status: active
+source: examples
+
+inputs:
+  MESSAGE_SOURCE:
+    type: string
+    required: true
+    description: >
+      The thread's source — `run-failure` or `permission-request`. Tells you
+      what kind of incident this was.
+  AGENT_ID:
+    type: string
+    required: false
+    default: ""
+    description: The agent the thread is about (when known), e.g. `news-digest`.
+  TERMINAL_STATE:
+    type: string
+    required: true
+    description: How the thread ended — always `resolved` here.
+  CONVERSATION:
+    type: string
+    required: false
+    default: ""
+    description: >
+      The full thread transcript: `[user] …`, `[triage] …`, and `[action] …`
+      lines (actions carry their status + result). This is what you distill.
+  CONTEXT_JSON:
+    type: string
+    required: false
+    default: ""
+    description: >
+      Structured context for the source (e.g. run-failure:
+      `{exitCode, durationMs, lastErrorLine}`; permission-request:
+      `{host, blockedCount}`). May be empty.
+
+nodes:
+  - id: extract
+    type: llm-prompt
+    # No <learning> block means the model didn't produce a usable result.
+    outputContract:
+      mustMatch: '<learning>[\s\S]*?</learning>'
+      description: a <learning> JSON block
+    prompt: |
+      You are the Inbox Learning Extractor for the sua platform. A triage
+      thread was just RESOLVED. Your job: distill AT MOST ONE durable,
+      reusable lesson that would help triage a SIMILAR future issue — or
+      decide there's nothing worth remembering and return none.
+
+      IMPORTANT — TOOL USE POLICY: do NOT use Bash, Read, Grep, Glob, or any
+      file/search tools. Work only from the transcript and context below.
+
+      ════════════════════════════════════════════════════════════════
+      THREAD
+      ════════════════════════════════════════════════════════════════
+
+      Source: {{inputs.MESSAGE_SOURCE}}
+      Agent: {{inputs.AGENT_ID}}
+      Ended: {{inputs.TERMINAL_STATE}}
+
+      Context: {{inputs.CONTEXT_JSON}}
+
+      Transcript:
+      {{inputs.CONVERSATION}}
+
+      ════════════════════════════════════════════════════════════════
+      WHAT MAKES A GOOD LESSON
+      ════════════════════════════════════════════════════════════════
+
+      A lesson is a SHORT, GENERAL, ACTIONABLE rule a future triage turn
+      could apply — not a play-by-play of this thread.
+
+      - GOOD: "When this agent fails with `exit 1` on a missing CLI tool,
+        recommend installing it (e.g. `brew install <tool>`) before retrying."
+      - GOOD: "A CSP image-host block for this agent is fixed by adding the
+        host to permissions.imgSrc via agent-analyzer."
+      - BAD (too specific / not reusable): "The operator installed apod at
+        4:15pm and the run passed."
+      - BAD (no durable rule): "The thread was resolved after some back and
+        forth."
+
+      Return NO lesson (set "lesson": null) when:
+      - The resolution was a one-off with no generalizable rule.
+      - Nothing was actually diagnosed or fixed.
+      - The lesson would just restate what triage already does by default.
+
+      Be conservative: when in doubt, return null. One precise lesson beats
+      a vague one.
+
+      Keep `lesson` under ~280 characters, imperative voice, no thread-
+      specific timestamps or ids.
+
+      `category` (optional): one of fix | config | permission | workflow | other.
+      `scope` (optional, default "agent"): how broadly the lesson applies —
+        "agent"  → only this agent (most common; the default)
+        "source" → any thread of this source, regardless of agent
+        "global" → every thread (use VERY sparingly; only truly universal rules)
+
+      ════════════════════════════════════════════════════════════════
+      OUTPUT FORMAT — exact shape, single <learning>...</learning> block
+      ════════════════════════════════════════════════════════════════
+
+      Wrap the JSON in <learning>…</learning> tags. Output ONLY the
+      <learning> block — no preamble, no markdown fences.
+
+      A lesson worth keeping:
+
+      <learning>
+      {
+        "lesson": "When this agent fails with exit 1 on a missing CLI tool, recommend installing the tool (brew install <tool>) before retrying.",
+        "category": "fix",
+        "scope": "agent"
+      }
+      </learning>
+
+      Nothing durable to keep:
+
+      <learning>
+      {
+        "lesson": null
+      }
+      </learning>
+    maxTurns: 2
+    timeout: 60

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -2112,6 +2112,9 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
 .inbox-msg__avatar--triage { background: var(--color-info, #60a5fa); }
 .inbox-msg__avatar--system { background: var(--color-text-muted, #8b93a7); }
 .inbox-msg__avatar--action { background: var(--color-warn, #f59e0b); }
+.inbox-msg__avatar--learning { background: var(--color-primary, #2dd4bf); }
+.inbox-learnings { display: flex; flex-direction: column; gap: var(--space-2); margin-top: var(--space-2); }
+.inbox-learning__lesson { font-size: var(--font-size-sm); }
 .inbox-msg__body { flex: 1; min-width: 0; }
 .inbox-msg__meta {
   font-size: var(--font-size-xs);

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -22,6 +22,7 @@ import {
   buildLoopbackAllowlist,
   loadAgents,
   parseAgent,
+  type InboxMessage,
 } from '@some-useful-agents/core';
 import { buildDashboardApp } from '../index.js';
 import type { DashboardContext } from '../context.js';
@@ -512,6 +513,96 @@ describe('POST /inbox/bulk-dismiss', () => {
       .set('Host', `127.0.0.1:${PORT}`)
       .set('Cookie', COOKIE);
     expect(res.status).toBe(400);
+  });
+});
+
+describe('Triage learnings (PR2)', () => {
+  const LEARN_FLAG = 'SUA_EXPERIMENTAL_TRIAGE_LEARNINGS';
+  const post = (app: Awaited<ReturnType<typeof makeApp>>, path: string) =>
+    request(app).post(path).set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+
+  afterEach(() => { delete process.env[LEARN_FLAG]; });
+
+  // A run-failure thread with a triage reply — but extraction never fires in
+  // these tests because we keep the FLAG OFF (or trip an earlier gate), so the
+  // real extractor LLM is never invoked.
+  const seedFailureThread = (): InboxMessage => {
+    const m = inboxStore.add({ priority: 'high', source: 'run-failure', agentId: 'news-digest', title: 'fail', body: 'boom' });
+    inboxStore.addResponse(m.id, 'triage', 'Here is what went wrong.');
+    return m;
+  };
+
+  it('POST /resolve sets status=resolved; flag OFF creates no learning', async () => {
+    const app = await makeApp();
+    const m = seedFailureThread();
+    const res = await post(app, `/inbox/${m.id}/resolve`);
+    expect(res.status).toBe(204);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(inboxStore.get(m.id)!.status).toBe('resolved');
+    expect(inboxStore.listLearnings({ messageId: m.id })).toEqual([]);
+  });
+
+  it('flag ON but non-learnable source → no extraction (early gate)', async () => {
+    process.env[LEARN_FLAG] = '1';
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    inboxStore.addResponse(m.id, 'triage', 'noted');
+    await post(app, `/inbox/${m.id}/resolve`);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(inboxStore.listLearnings({ messageId: m.id })).toEqual([]);
+  });
+
+  it('flag ON, learnable source, but no triage activity → no extraction (early gate)', async () => {
+    process.env[LEARN_FLAG] = '1';
+    const app = await makeApp();
+    const m = inboxStore.add({ priority: 'high', source: 'run-failure', agentId: 'a', title: 'fail', body: 'boom' });
+    await post(app, `/inbox/${m.id}/resolve`);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(inboxStore.listLearnings({ messageId: m.id })).toEqual([]);
+  });
+
+  it('approve makes a pending learning retrievable; reject does not', async () => {
+    const app = await makeApp();
+    const m = seedFailureThread();
+    const approved = inboxStore.addLearning({ source: 'run-failure', agentId: 'news-digest', scope: 'agent', lesson: 'Install the CLI first.', sourceMessageId: m.id })!;
+    const rejected = inboxStore.addLearning({ source: 'run-failure', agentId: 'news-digest', scope: 'agent', lesson: 'A different lesson entirely.', sourceMessageId: m.id })!;
+
+    expect((await post(app, `/inbox/${m.id}/learnings/${approved.id}/approve`)).status).toBe(204);
+    expect((await post(app, `/inbox/${m.id}/learnings/${rejected.id}/reject`)).status).toBe(204);
+
+    expect(inboxStore.getLearning(approved.id)!.status).toBe('approved');
+    expect(inboxStore.getLearning(rejected.id)!.status).toBe('rejected');
+    const retrieved = inboxStore.listApprovedLearningsForTriage({ agentId: 'news-digest', source: 'run-failure' });
+    expect(retrieved.map((l) => l.lesson)).toEqual(['Install the CLI first.']);
+  });
+
+  it('approve is idempotent on a double-click (second is a stale no-op)', async () => {
+    const app = await makeApp();
+    const m = seedFailureThread();
+    const l = inboxStore.addLearning({ source: 'run-failure', agentId: 'a', lesson: 'x', sourceMessageId: m.id })!;
+    await post(app, `/inbox/${m.id}/learnings/${l.id}/approve`);
+    await post(app, `/inbox/${m.id}/learnings/${l.id}/reject`); // loses the race
+    expect(inboxStore.getLearning(l.id)!.status).toBe('approved');
+  });
+
+  it('404s a learning that belongs to a different thread', async () => {
+    const app = await makeApp();
+    const m = seedFailureThread();
+    const other = inboxStore.add({ priority: 'low', source: 'run-failure', agentId: 'a', title: 'o', body: 'o' });
+    const l = inboxStore.addLearning({ source: 'run-failure', agentId: 'a', lesson: 'x', sourceMessageId: other.id })!;
+    expect((await post(app, `/inbox/${m.id}/learnings/${l.id}/approve`)).status).toBe(404);
+  });
+
+  it('renders a pending-learning card with approve/discard in the fragment', async () => {
+    const app = await makeApp();
+    const m = seedFailureThread();
+    inboxStore.addLearning({ source: 'run-failure', agentId: 'news-digest', lesson: 'Install the apod CLI before retrying.', sourceMessageId: m.id });
+    const res = await request(app).get(`/inbox/${m.id}/fragment`).set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Triage learned something');
+    expect(res.text).toContain('Install the apod CLI before retrying.');
+    expect(res.text).toContain(`/inbox/${m.id}/learnings/`);
+    expect(res.text).toContain('Mark resolved');
   });
 });
 

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -31,11 +31,15 @@ import {
   exportAgent,
   executeAgentDag,
   extractPlanJson,
+  extractTaggedJson,
   isAppleIntegrationEnabled,
+  isTriageLearningsEnabled,
   isSafeUrl,
   listBuiltinTools,
   parseAgent,
   LLM_PROVIDERS,
+  LEARNING_CATEGORIES,
+  LEARNING_SCOPES,
   unallowedWidgetImageHosts,
   type Agent,
   type LlmProvider,
@@ -44,6 +48,8 @@ import {
   type InboxActionMeta,
   type InboxActionStatus,
   type InboxResponse,
+  type LearningCategory,
+  type LearningScope,
   type ToolDefinition,
 } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
@@ -69,6 +75,12 @@ export const inboxRouter: Router = Router();
 const SORT_KEYS = new Set<InboxSortKey>(['priority', 'source', 'agent', 'title', 'age', 'status']);
 const SORT_DIRS = new Set<InboxSortDir>(['asc', 'desc']);
 const TRIAGE_AGENT_ID = 'inbox-triage';
+/** Experimental learnings extractor — route-dispatched on thread resolve. */
+const LEARNING_EXTRACTOR_AGENT_ID = 'inbox-learning-extractor';
+/** Sources rich enough to learn from (agentId reliably present). */
+const LEARNING_SOURCES: ReadonlySet<string> = new Set(['run-failure', 'permission-request']);
+/** Cap a stored lesson; the extractor is told ~280, this is the hard limit. */
+const LEARNING_MAX_CHARS = 600;
 const PENDING_USER_REPLY_WINDOW_MS = 30_000;
 
 /**
@@ -157,6 +169,7 @@ const INLINE_INBOX_WIDGET_TYPES: ReadonlySet<string> = new Set([
  */
 const SYSTEM_AGENT_IDS: ReadonlySet<string> = new Set([
   'inbox-triage',
+  'inbox-learning-extractor',
   'agent-analyzer',
   'agent-editor',
   'agent-catalog-search',
@@ -507,6 +520,7 @@ inboxRouter.get('/inbox/:id', (req: Request, res: Response) => {
     inlineActionWidgets,
     threadSummary: responses.length >= 3 ? buildThreadSummary(message, responses) : undefined,
     forkableAgents: listForkableAgents(ctx),
+    pendingLearnings: ctx.inboxStore.listLearnings({ messageId: id, status: 'pending' }),
   }));
 });
 
@@ -534,6 +548,7 @@ inboxRouter.get('/inbox/:id/fragment', (req: Request, res: Response) => {
     inlineActionWidgets,
     threadSummary: responses.length >= 3 ? buildThreadSummary(message, responses) : undefined,
     forkableAgents: listForkableAgents(ctx),
+    pendingLearnings: ctx.inboxStore.listLearnings({ messageId: id, status: 'pending' }),
   })));
 });
 
@@ -592,6 +607,33 @@ inboxRouter.post('/inbox/:id/dismiss', (req: Request, res: Response) => {
     const msg = err instanceof Error ? err.message : String(err);
     if (isAjax(req)) { res.status(500).end(); return; }
     res.redirect(303, `/inbox/${encodeURIComponent(id)}?error=${encodeURIComponent(`Dismiss failed: ${msg}`)}`);
+  }
+});
+
+/**
+ * Mark a thread resolved (the operator fixed it). Distinct from dismiss
+ * ("I don't care") — resolve is the high-signal terminal state, so it's the
+ * trigger for learning extraction. Fire-and-forget: the extractor runs in the
+ * background (flag-gated; no-op when the flag is off), so the response returns
+ * immediately.
+ */
+inboxRouter.post('/inbox/:id/resolve', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  if (!ctx.inboxStore || !ctx.inboxStore.get(id)) {
+    if (isAjax(req)) { res.status(404).end(); return; }
+    res.redirect(303, `/inbox?error=${encodeURIComponent('Message not found.')}`);
+    return;
+  }
+  try {
+    ctx.inboxStore.updateStatus(id, 'resolved');
+    void maybeExtractLearning(ctx, id).catch(() => { /* logged in helper */ });
+    if (isAjax(req)) { res.status(204).end(); return; }
+    res.redirect(303, `/inbox?ok=${encodeURIComponent('Resolved.')}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (isAjax(req)) { res.status(500).end(); return; }
+    res.redirect(303, `/inbox/${encodeURIComponent(id)}?error=${encodeURIComponent(`Resolve failed: ${msg}`)}`);
   }
 });
 
@@ -1160,6 +1202,42 @@ inboxRouter.post('/inbox/:id/actions/:rid/skip', (req: Request, res: Response) =
   if (isAjax(req)) { res.status(204).end(); return; }
   res.redirect(303, `${detailUrl}?ok=${encodeURIComponent('Skipped.')}`);
 });
+
+/**
+ * POST /inbox/:id/learnings/:lid/(approve|reject) — operator decides on a
+ * `pending` triage learning. Approve makes it retrievable into future triage;
+ * reject leaves it dead (never retrieved). Atomic via updateLearningStatus, so
+ * a double-click resolves once.
+ */
+function handleLearningDecision(decision: 'approved' | 'rejected') {
+  return (req: Request, res: Response): void => {
+    const ctx = getContext(req.app.locals);
+    const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+    const lid = Array.isArray(req.params.lid) ? req.params.lid[0] : req.params.lid;
+    const detailUrl = `/inbox/${encodeURIComponent(id)}`;
+    if (!ctx.inboxStore || !ctx.inboxStore.get(id)) {
+      if (isAjax(req)) { res.status(404).end(); return; }
+      res.redirect(303, `/inbox?error=${encodeURIComponent('Message not found.')}`);
+      return;
+    }
+    const learning = ctx.inboxStore.getLearning(lid);
+    if (!learning || learning.sourceMessageId !== id) {
+      if (isAjax(req)) { res.status(404).end(); return; }
+      res.redirect(303, `${detailUrl}?error=${encodeURIComponent('Learning not found.')}`);
+      return;
+    }
+    const committed = ctx.inboxStore.updateLearningStatus(lid, decision);
+    if (committed) {
+      publishInboxEvent(ctx, id, 'learning:status', { learningId: lid, status: decision });
+    }
+    if (isAjax(req)) { res.status(204).end(); return; }
+    const ok = decision === 'approved' ? 'Learning approved.' : 'Learning discarded.';
+    const stale = 'Learning already decided.';
+    res.redirect(303, `${detailUrl}?ok=${encodeURIComponent(committed ? ok : stale)}`);
+  };
+}
+inboxRouter.post('/inbox/:id/learnings/:lid/approve', handleLearningDecision('approved'));
+inboxRouter.post('/inbox/:id/learnings/:lid/reject', handleLearningDecision('rejected'));
 
 // ── helpers ─────────────────────────────────────────────────────────
 
@@ -2624,6 +2702,85 @@ function countActionsOnMessage(
 }
 
 /**
+ * Render the thread transcript as `[role] body` lines for an LLM prompt.
+ * `action` rows carry their status + a result preview so the model sees what
+ * already ran. Shared by triage and the learning extractor.
+ */
+function formatConversationSnapshot(responses: readonly InboxResponse[]): string {
+  return responses
+    .map((r) => {
+      if (r.role === 'action') {
+        const m = parseActionMeta(r);
+        const suffix = m ? ` (status=${m.status}${m.resultSummary ? `; result=${m.resultSummary.slice(0, 200)}` : ''})` : '';
+        return `[action] ${r.body}${suffix}`;
+      }
+      return `[${r.role}] ${r.body}`;
+    })
+    .join('\n');
+}
+
+/**
+ * After a thread is RESOLVED, distill a durable lesson via the
+ * inbox-learning-extractor sub-agent and store it as a `pending` learning for
+ * the operator to approve. Experimental + flag-gated. Cheapest-first gates keep
+ * the common case free; only run-failure / permission-request threads with real
+ * triage activity ever reach the (one) LLM call. Best-effort — never throws
+ * into the resolve route.
+ */
+async function maybeExtractLearning(
+  ctx: ReturnType<typeof getContext>,
+  messageId: string,
+): Promise<void> {
+  if (!isTriageLearningsEnabled()) return;                 // global kill switch
+  if (!ctx.inboxStore) return;
+  const message = ctx.inboxStore.get(messageId);
+  if (!message) return;
+  if (!LEARNING_SOURCES.has(message.source)) return;       // only lesson-rich sources
+  const responses = ctx.inboxStore.listResponses(messageId);
+  if (!responses.some((r) => r.role === 'triage')) return; // nothing was triaged
+  if (!ensureSystemAgentCurrent(ctx, LEARNING_EXTRACTOR_AGENT_ID, 'inbox learning extraction')) return;
+  const extractor = ctx.agentStore.getAgent(LEARNING_EXTRACTOR_AGENT_ID);
+  if (!extractor) return;
+
+  try {
+    const run = await runDispatchedAgentToTerminal(ctx, extractor, {
+      MESSAGE_SOURCE: message.source,
+      AGENT_ID: message.agentId ?? '',
+      TERMINAL_STATE: 'resolved',
+      CONVERSATION: formatConversationSnapshot(responses),
+      CONTEXT_JSON: message.contextJson ?? '',
+    });
+    if (run.status !== 'completed' || !run.result) return;
+    const json = extractTaggedJson(run.result, 'learning');
+    if (!json) return;
+    let parsed: { lesson?: unknown; category?: unknown; scope?: unknown };
+    try { parsed = JSON.parse(json); } catch { return; }
+    const lesson = typeof parsed.lesson === 'string' ? parsed.lesson.trim() : '';
+    if (!lesson) return;                                    // null/empty ⇒ no durable lesson
+    const category = (LEARNING_CATEGORIES as readonly string[]).includes(parsed.category as string)
+      ? (parsed.category as LearningCategory) : undefined;
+    const scope = (LEARNING_SCOPES as readonly string[]).includes(parsed.scope as string)
+      ? (parsed.scope as LearningScope) : 'agent';
+    const created = ctx.inboxStore.addLearning({
+      source: message.source,
+      agentId: message.agentId,
+      scope,
+      category,
+      lesson: lesson.slice(0, LEARNING_MAX_CHARS),
+      sourceMessageId: messageId,
+      sourceRunId: message.triageRunId,
+    });
+    if (created) {
+      publishInboxEvent(ctx, messageId, 'learning:created', {
+        learningId: created.id, lesson: created.lesson, category: created.category,
+      });
+    }
+  } catch (err) {
+    process.stderr.write(`[inbox-learning] extraction failed for ${messageId}: ${(err as Error)?.message ?? err}\n`);
+  }
+}
+
+/**
  * Spawn the inbox-triage system agent for a message. Lazy-installs the
  * YAML on first call (mirrors layout-planner). After the run
  * completes, parses the `<plan>{...}</plan>` block and appends a
@@ -2679,16 +2836,7 @@ async function runTriageAgent(
   // include the structured status so the model can see what already
   // ran rather than just the rationale body.
   const responsesSnapshot = ctx.inboxStore.listResponses(messageId);
-  const conversation = responsesSnapshot
-    .map((r) => {
-      if (r.role === 'action') {
-        const m = parseActionMeta(r);
-        const suffix = m ? ` (status=${m.status}${m.resultSummary ? `; result=${m.resultSummary.slice(0, 200)}` : ''})` : '';
-        return `[action] ${r.body}${suffix}`;
-      }
-      return `[${r.role}] ${r.body}`;
-    })
-    .join('\n');
+  const conversation = formatConversationSnapshot(responsesSnapshot);
 
   // The operator's latest real ask is the authoritative current intent.
   // MESSAGE_BODY is frozen at thread creation, so on a mid-thread pivot

--- a/packages/dashboard/src/views/inbox-detail.ts
+++ b/packages/dashboard/src/views/inbox-detail.ts
@@ -5,6 +5,7 @@ import {
   type InboxResponseRole,
   type InboxActionMeta,
   type InboxActionStatus,
+  type TriageLearning,
 } from '@some-useful-agents/core';
 import { html, render, unsafeHtml, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
@@ -45,6 +46,12 @@ export interface InboxDetailOptions {
   };
   /** Installed non-system agents offered as fork/retarget targets. */
   forkableAgents?: { id: string; name: string }[];
+  /**
+   * Pending triage learnings extracted from this thread, awaiting the
+   * operator's approve/discard. Experimental (flag-gated); empty/absent when
+   * the feature is off or nothing was distilled.
+   */
+  pendingLearnings?: TriageLearning[];
 }
 
 const PRIORITY_BADGE: Record<string, string> = {
@@ -117,9 +124,12 @@ const ACTION_STATUS_LABEL: Record<InboxActionStatus, string> = {
  * standard dashboard layout for direct-link access + accessibility.
  */
 export function renderInboxDetailFragment(opts: InboxDetailOptions): SafeHtml {
-  const { message, responses, flash, triagePending, currentTargetYaml, inlineActionWidgets, threadSummary } = opts;
+  const { message, responses, flash, triagePending, currentTargetYaml, inlineActionWidgets, threadSummary, pendingLearnings } = opts;
   const badgeClass = PRIORITY_BADGE[message.priority] ?? 'badge--muted';
   const isTerminal = message.status === 'dismissed' || message.status === 'resolved';
+  const learningsBlock = (pendingLearnings ?? []).length > 0
+    ? html`<div class="inbox-learnings">${(pendingLearnings ?? []).map((l) => renderLearningCard(message.id, l)) as unknown as SafeHtml[]}</div>`
+    : html``;
 
   const flashBlock = flash ? html`
     <div class="flash flash--${flash.kind}" style="margin: 0 0 var(--space-2);">${flash.message}</div>
@@ -280,6 +290,9 @@ export function renderInboxDetailFragment(opts: InboxDetailOptions): SafeHtml {
               ${triagePending ? 'Triaging…' : 'Ask triage'}
             </button>
           </form>
+          <form method="POST" action="/inbox/${message.id}/resolve" data-inbox-modal-form data-inbox-modal-dismiss-on-success="1" style="margin: 0;">
+            <button type="submit" class="btn btn--sm btn--ghost" title="Mark this thread fixed">Mark resolved</button>
+          </form>
           <form method="POST" action="/inbox/${message.id}/dismiss" data-inbox-modal-form data-inbox-modal-dismiss-on-success="1" style="margin: 0;">
             <button type="submit" class="btn btn--sm btn--ghost">Dismiss</button>
           </form>
@@ -314,6 +327,7 @@ export function renderInboxDetailFragment(opts: InboxDetailOptions): SafeHtml {
       </div>
       <div class="inbox-detail__thread">
         ${timelineBlock}
+        ${learningsBlock}
       </div>
       ${composer}
     </div>
@@ -500,6 +514,47 @@ function parseActionMeta(r: InboxResponse): InboxActionMeta | null {
     }
   } catch { /* swallow */ }
   return null;
+}
+
+/**
+ * Render a pending triage-learning as an approve/discard card. Shown only
+ * when the experimental feature distilled a lesson from this thread. Approving
+ * makes the lesson retrievable into future triage; discarding kills it.
+ */
+function renderLearningCard(messageId: string, l: TriageLearning): SafeHtml {
+  const scopeNote = l.scope === 'agent' && l.agentId
+    ? html`agent <span class="mono">${l.agentId}</span>`
+    : l.scope === 'source'
+      ? html`any <span class="mono">${l.source}</span> thread`
+      : html`all threads`;
+  return html`
+    <div class="inbox-msg inbox-msg--learning inbox-learning" data-learning-id="${l.id}">
+      <div class="inbox-msg__avatar inbox-msg__avatar--learning">💡</div>
+      <div class="inbox-msg__body">
+        <div class="inbox-msg__meta">
+          <span class="inbox-msg__meta-name">Triage learned something</span>
+          ${l.category ? html`<span class="inbox-action__status">${l.category}</span>` : html``}
+          <span>applies to ${scopeNote}</span>
+        </div>
+        <div class="inbox-action__card">
+          <div class="inbox-learning__lesson">${mdBody(l.lesson)}</div>
+          <p class="dim" style="margin: var(--space-1) 0 0; font-size: var(--font-size-xs);">
+            Approve to let triage use this in future ${l.source} threads, or discard it.
+          </p>
+          <div class="inbox-action__controls">
+            <form method="POST" action="/inbox/${messageId}/learnings/${l.id}/approve"
+              data-inbox-modal-form data-inbox-modal-quiet="1" style="margin:0;">
+              <button type="submit" class="btn btn--xs btn--primary">Approve</button>
+            </form>
+            <form method="POST" action="/inbox/${messageId}/learnings/${l.id}/reject"
+              data-inbox-modal-form data-inbox-modal-quiet="1" style="margin:0;">
+              <button type="submit" class="btn btn--xs btn--ghost">Discard</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
 }
 
 /** Render an action-role row as a card whose body depends on status. */


### PR DESCRIPTION
## What

**PR 2 of 3** for cross-conversation triage learnings (builds on #512). Wires the loop from a resolved thread to a **pending, operator-approvable lesson**. Still flag-gated (`SUA_EXPERIMENTAL_TRIAGE_LEARNINGS`); PR3 injects approved lessons into the triage prompt.

## This PR

- **`agents/examples/inbox-learning-extractor.yaml`** (new) — single `llm-prompt` system agent that reads a resolved thread and emits one durable lesson in a `<learning>` block, or `{"lesson": null}`. Route-dispatched only (in `SYSTEM_AGENT_IDS`, **not** in the triage sub-agent allowlist — never proposed to the operator).
- **`POST /inbox/:id/resolve`** — a new **"Mark resolved"** affordance that finally wires up the long-dormant `resolved` status. Distinct from dismiss ("I don't care"); resolve is the high-signal trigger for extraction.
- **`maybeExtractLearning`** — gated cheapest-first: flag off → no-op; only `run-failure` / `permission-request` threads with ≥1 triage response reach the (one) LLM call. Distills via `runDispatchedAgentToTerminal`, parses with `extractTaggedJson`, validates, `addLearning` (pending).
- **Approval UX** — `renderLearningCard` ("Triage learned something" + Approve / Discard) surfaced in the thread modal; `POST /inbox/:id/learnings/:lid/(approve|reject)` decide it atomically via `updateLearningStatus`.
- Factored `formatConversationSnapshot` shared by triage + extractor. Token-based CSS for the card (teal accent, per DESIGN.md).

## Guardrails

Only **approved** lessons are ever retrievable (the approval card is the trust boundary). Extraction is bounded by the source/activity gates + the extractor's own "return null when nothing durable" instruction, so most resolves cost nothing.

## Verification

**Dogfooded live end-to-end** (flag on): resolved a `run-failure` thread for `make-a-note` → the extractor distilled a real lesson — *"When this agent uses AppleScript to control Notes, verify macOS Automation permission for Notes is granted and the Notes app is open before retrying"* (scope=agent, category=permission) → pending card rendered → Approve → retrievable via `listApprovedLearningsForTriage` for `make-a-note`, and correctly **not** for a different agent.

Tests: resolve sets status; flag-off + each early gate create nothing; approve→retrievable / reject→not; idempotent double-click; cross-thread 404; card renders. Full dashboard suite green (**591**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)