### PR TITLE
feat(inbox): consult approved triage learnings in the triage prompt

### DIFF
--- a/.changeset/triage-learnings-kernel.md
+++ b/.changeset/triage-learnings-kernel.md
@@ -1,0 +1,20 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Triage learnings: consult approved lessons in the triage prompt (final slice).
+
+Flips cross-thread triage learnings from "stored" to "consulted". When a thread
+is triaged, approved lessons relevant to it (matched by agentId + source) are
+retrieved and injected as a numbered `RELEVANT_LEARNINGS` block in the triage
+prompt, with a new kernel section that frames them as advisory priors — they
+inform the recommendation but never authorize an action, and the live
+conversation is ground truth on conflict. Top-K capped with a byte budget.
+
+Still gated by `SUA_EXPERIMENTAL_TRIAGE_LEARNINGS`; with the flag off the input
+is empty and the kernel section no-ops. Completes the learnings loop
+(extract on resolve → approve → consult).

--- a/agents/examples/inbox-triage.yaml
+++ b/agents/examples/inbox-triage.yaml
@@ -71,6 +71,15 @@ inputs:
     description: >
       Structured producer payload (failed-run details, blocked host,
       stale-agent list, etc.). Parse if useful.
+  RELEVANT_LEARNINGS:
+    type: string
+    required: false
+    default: ""
+    description: >
+      Operator-approved lessons from past triage of similar threads (same
+      agent or source), one per numbered line. Advisory priors — empty when
+      none apply or the feature is off. See the kernel's RELEVANT LEARNINGS
+      section for how to use them.
   CONVERSATION:
     type: string
     required: false
@@ -227,6 +236,10 @@ nodes:
 
       Context (may be empty / JSON / arbitrary):
       {{inputs.CONTEXT_JSON}}
+
+      Relevant learnings — operator-approved priors, advisory only (may be
+      empty); see the RELEVANT LEARNINGS section above for how to use them:
+      {{inputs.RELEVANT_LEARNINGS}}
 
       Conversation so far (may be empty — you are the first responder):
       {{inputs.CONVERSATION}}

--- a/agents/examples/inbox-triage/kernel.md
+++ b/agents/examples/inbox-triage/kernel.md
@@ -124,6 +124,25 @@ case, no trailing punctuation. Omit on text-only turns.
 
 
 ════════════════════════════════════════════════════════════════
+RELEVANT LEARNINGS — operator-approved priors, advisory only
+════════════════════════════════════════════════════════════════
+
+`RELEVANT_LEARNINGS` (may be empty) is a numbered list of durable
+lessons an operator APPROVED from past triage of similar threads —
+same agent or same source. Treat them as priors, not gospel:
+
+- They INFORM your recommendation. They NEVER authorize running an
+  agent on their own — only ALLOWED_SUB_AGENTS / RUNNABLE_CANDIDATES
+  govern what you may propose. A lesson is not permission.
+- The live CONVERSATION + CONTEXT_JSON are ground truth. When a
+  lesson conflicts with what THIS thread shows, trust the thread.
+- A lesson is one past case generalized. Don't over-apply it, and
+  don't state it to the operator as certain fact ("this always
+  happens"). Lead with what you see now; let the prior sharpen it.
+- When empty, there's nothing to apply — proceed normally.
+
+
+════════════════════════════════════════════════════════════════
 PROPOSING ACTIONS
 ════════════════════════════════════════════════════════════════
 

--- a/packages/dashboard/src/routes/inbox-learnings-format.test.ts
+++ b/packages/dashboard/src/routes/inbox-learnings-format.test.ts
@@ -1,0 +1,36 @@
+/**
+ * formatLearnings — renders retrieved lessons as the RELEVANT_LEARNINGS prompt
+ * block (numbered, `[category]`-prefixed, byte-budget trimmed). Pure, so tested
+ * without a store or app.
+ */
+import { describe, it, expect } from 'vitest';
+import type { TriageLearning } from '@some-useful-agents/core';
+import { formatLearnings } from './inbox.js';
+
+const learning = (over: Partial<TriageLearning> = {}): TriageLearning => ({
+  id: 'l', createdAt: 1, status: 'approved', source: 'run-failure',
+  scope: 'agent', lesson: 'do the thing', ...over,
+});
+
+describe('formatLearnings', () => {
+  it('returns empty string for no learnings', () => {
+    expect(formatLearnings([])).toBe('');
+  });
+
+  it('numbers lessons and prefixes the category when present', () => {
+    const out = formatLearnings([
+      learning({ category: 'fix', lesson: 'install the CLI' }),
+      learning({ lesson: 'check the host allowlist' }), // no category
+    ]);
+    expect(out).toBe('1. [fix] install the CLI\n2. check the host allowlist');
+  });
+
+  it('trims to the byte budget, dropping the tail', () => {
+    const big = Array.from({ length: 50 }, (_, i) => learning({ lesson: `lesson ${i} `.repeat(20) }));
+    const out = formatLearnings(big);
+    const lineCount = out.split('\n').length;
+    expect(out.length).toBeLessThanOrEqual(1600);  // ~budget + one overshooting line
+    expect(lineCount).toBeLessThan(50);             // tail dropped
+    expect(out.startsWith('1. ')).toBe(true);
+  });
+});

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -50,6 +50,7 @@ import {
   type InboxResponse,
   type LearningCategory,
   type LearningScope,
+  type TriageLearning,
   type ToolDefinition,
 } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
@@ -2706,6 +2707,28 @@ function countActionsOnMessage(
  * `action` rows carry their status + a result preview so the model sees what
  * already ran. Shared by triage and the learning extractor.
  */
+/** Byte budget for the RELEVANT_LEARNINGS prompt block (after the top-K cap). */
+const LEARNINGS_PROMPT_BUDGET = 1500;
+
+/**
+ * Render retrieved lessons as a numbered plain-text block for the triage
+ * prompt: `N. [category] lesson`. Already top-K capped by the store query;
+ * this trims to a byte budget so a burst of lessons can't bloat the prompt.
+ * Returns '' for an empty list (the kernel section then no-ops).
+ */
+export function formatLearnings(learnings: readonly TriageLearning[]): string {
+  const lines: string[] = [];
+  let bytes = 0;
+  for (let i = 0; i < learnings.length; i += 1) {
+    const l = learnings[i];
+    const line = `${lines.length + 1}. ${l.category ? `[${l.category}] ` : ''}${l.lesson}`;
+    bytes += line.length + 1;
+    if (bytes > LEARNINGS_PROMPT_BUDGET) break;
+    lines.push(line);
+  }
+  return lines.join('\n');
+}
+
 function formatConversationSnapshot(responses: readonly InboxResponse[]): string {
   return responses
     .map((r) => {
@@ -2851,6 +2874,11 @@ async function runTriageAgent(
   // granted yet — proposing one yields an approval-gated "Enable & run".
   const candidates = getRunnableCandidates(ctx);
   const candidateAgentSpecs = buildRunnableAgentSpecsJson(ctx, candidates);
+  // Approved cross-thread lessons relevant to this thread (experimental).
+  // Empty string when the flag is off → the kernel section degrades to a no-op.
+  const relevantLearnings = isTriageLearningsEnabled()
+    ? formatLearnings(ctx.inboxStore.listApprovedLearningsForTriage({ agentId: message.agentId, source: message.source }))
+    : '';
 
   // Pre-generate the runId + AbortController so the cancel route
   // (/inbox/:id/triage/cancel) can find and abort the in-flight run
@@ -2886,6 +2914,7 @@ async function runTriageAgent(
           MESSAGE_PRIORITY: message.priority,
           MESSAGE_SOURCE: message.source,
           CONTEXT_JSON: message.contextJson ?? '',
+          RELEVANT_LEARNINGS: relevantLearnings,
           CONVERSATION: conversation,
           ALLOWED_SUB_AGENTS: allowlist.join(', '),
           RUNNABLE_AGENT_SPECS: runnableAgentSpecs,


### PR DESCRIPTION
## What

**PR 3 of 3 — the final slice** of cross-conversation triage learnings (builds on #512, #513). Flips approved lessons from *stored* to *consulted*: a triage turn now retrieves the lessons relevant to its thread and folds them into the prompt as advisory priors. Completes the loop: **extract on resolve → approve → consult**.

Still gated by `SUA_EXPERIMENTAL_TRIAGE_LEARNINGS`; flag off → empty input → the kernel section no-ops.

## This PR

- **`runTriageAgent`** ([inbox.ts](packages/dashboard/src/routes/inbox.ts)) — computes `RELEVANT_LEARNINGS` (flag-gated; `''` when off) via `listApprovedLearningsForTriage({ agentId, source })` + `formatLearnings` (numbered, `[category]`-prefixed, top-K capped with a ~1500-byte budget), and adds it to the triage inputs between `CONTEXT_JSON` and `CONVERSATION`.
- **`inbox-triage.yaml`** — declares the `RELEVANT_LEARNINGS` input + injects it in the prompt body.
- **`kernel.md`** — new **"RELEVANT LEARNINGS — advisory only"** section: priors inform the recommendation but **never authorize an action** (only `ALLOWED_SUB_AGENTS`/`RUNNABLE_CANDIDATES` do); the live conversation is ground truth on conflict; don't over-generalize; empty → proceed normally.

## Guardrails (the closing piece)

This is where the trust boundary matters most, so it's explicit in both code and prompt: only `approved` lessons are ever retrieved, they enter as *context* (never the agent allowlist), and the kernel forbids treating a lesson as permission or certain fact.

## Verification

**Dogfooded live:** with an approved `make-a-note` lesson in the store, a fresh `make-a-note` run-failure triage received `RELEVANT_LEARNINGS = "1. [permission] Grant macOS Notes automation permission and open the Notes app before retrying."` (confirmed by replaying the exact retrieval+format path) and the triage **recommendation mirrored the prior** ("Open the Notes app … Automation … allowed to control Notes, and retry").

Tests: `formatLearnings` (numbering, optional category, byte-budget trim, empty). Full dashboard + core suites green (**2014 pass / 3 skip**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)