### PR TITLE
fix(inbox): editing a failed agent unblocks retrying it from the thread

### DIFF
--- a/.changeset/stale-failed-action-guard.md
+++ b/.changeset/stale-failed-action-guard.md
@@ -1,0 +1,22 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox: editing a failed agent unblocks retrying it from the thread.
+
+The thread-level "same action already failed here" guard (hasMatchingFailedAction)
+keyed only on agent id + inputs, so once an action failed it was blocked forever —
+and for an agent that takes no inputs, every re-proposal looked identical, leaving
+"revise the inputs or choose a different next step" impossible to follow even after
+the operator fixed the agent.
+
+The guard now clears once the target agent was edited after the failure: it
+compares the agent's `updatedAt` against the failed action's end time, so fixing
+the agent (a new version or a metadata edit, both bump `updatedAt`) makes the retry
+a legitimately new action. Exposes `Agent.updatedAt` from the store, and the triage
+kernel now tells triage to re-propose a run when the operator says they fixed the
+agent.

--- a/agents/examples/inbox-triage/kernel.md
+++ b/agents/examples/inbox-triage/kernel.md
@@ -195,9 +195,12 @@ Rules:
   action that the CURRENT REQUEST no longer asks for is dead — drop
   it. Only retry a failed action when the CURRENT REQUEST still wants
   that exact outcome AND something has changed that would make the
-  retry succeed (e.g. the operator supplied a missing input or fixed
-  a setup issue). If neither holds, move on to the CURRENT REQUEST
-  instead of looping on the stale failure.
+  retry succeed (e.g. the operator supplied a missing input, fixed a
+  setup issue, or EDITED THE TARGET AGENT). When the operator says
+  they fixed the agent, re-propose the run — the route allows the
+  retry once the agent was edited after the failure (it no longer
+  treats it as the same dead action). If nothing changed, move on to
+  the CURRENT REQUEST instead of looping on the stale failure.
 - DO NOT propose `agent-editor` directly. It is managed by the
   dashboard: when `agent-analyzer` produces a corrected YAML in
   its run output, the route automatically inserts an

--- a/packages/core/src/agent-store.ts
+++ b/packages/core/src/agent-store.ts
@@ -449,6 +449,7 @@ export class AgentStore {
       dashboardVisible: row.dashboard_visible == null ? undefined : (row.dashboard_visible as number) === 1,
       stateMaxBytes: row.state_max_bytes == null ? undefined : (row.state_max_bytes as number),
       createdAt: (row.created_at as string | null) ?? undefined,
+      updatedAt: (row.updated_at as string | null) ?? undefined,
       version: row.current_version as number,
       provider: dag.provider,
       model: dag.model,

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -386,6 +386,14 @@ export interface Agent {
    */
   createdAt?: string;
 
+  /**
+   * ISO timestamp of the most recent change to the agent (the `agents` row's
+   * `updated_at`; bumped by both metadata edits and new versions). Populated on
+   * read from the store; absent on YAML-parsed agents not yet persisted. Lets
+   * callers tell whether an agent changed since some earlier event.
+   */
+  updatedAt?: string;
+
   /** Default LLM provider for all claude-code nodes. Nodes can override. */
   provider?: LlmProvider;
   /** Default model for all claude-code nodes. Nodes can override. */

--- a/packages/dashboard/src/routes/inbox-failed-action-guard.test.ts
+++ b/packages/dashboard/src/routes/inbox-failed-action-guard.test.ts
@@ -1,0 +1,80 @@
+/**
+ * hasMatchingFailedAction — the thread-level guard that refuses to re-propose
+ * an action that already failed here with the same inputs. The fix under test:
+ * the block CLEARS once the target agent was edited after the failure (so an
+ * operator fixing the agent unblocks the retry, even for an inputs-less agent).
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AgentStore, InboxStore, type InboxActionMeta } from '@some-useful-agents/core';
+import { hasMatchingFailedAction } from './inbox.js';
+
+let dir: string;
+let agentStore: AgentStore;
+let inboxStore: InboxStore;
+
+function setup() {
+  dir = mkdtempSync(join(tmpdir(), 'sua-guard-'));
+  const db = join(dir, 'runs.db');
+  agentStore = new AgentStore(db);
+  inboxStore = new InboxStore(db);
+  agentStore.createAgent({
+    id: 'opener', name: 'opener', status: 'draft', source: 'local', mcp: false,
+    nodes: [{ id: 'n', type: 'shell', command: 'open -a Notes', dependsOn: [] }],
+  }, 'cli');
+  const ctx = { inboxStore, agentStore } as never;
+  return ctx as ReturnType<typeof import('../context.js').getContext>;
+}
+
+afterEach(() => {
+  try { agentStore.close(); } catch { /* ignore */ }
+  try { inboxStore.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+/** Seed a failed action row whose failure ended at `endedAt`. */
+function seedFailedAction(messageId: string, endedAt: number, inputs: Record<string, string> = {}): void {
+  const meta: InboxActionMeta = { kind: 'action', status: 'failed', agentId: 'opener', inputs, endedAt };
+  inboxStore.addResponse(messageId, 'action', 'failed run', JSON.stringify(meta));
+}
+
+const candidate = (inputs: Record<string, string> = {}): InboxActionMeta =>
+  ({ kind: 'action', status: 'proposed', agentId: 'opener', inputs });
+
+describe('hasMatchingFailedAction', () => {
+  it('blocks a re-proposal when the agent has NOT been edited since the failure', () => {
+    const ctx = setup();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    // Failure ended in the "future" relative to the agent's updatedAt (created now)
+    // → the agent predates the failure → still blocked.
+    seedFailedAction(m.id, Date.now() + 60_000);
+    expect(hasMatchingFailedAction(ctx, m.id, candidate())).toBe(true);
+  });
+
+  it('CLEARS the block once the agent was edited after the failure', () => {
+    const ctx = setup();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    // Failure ended a minute ago; the agent's updatedAt (now) is later → edited
+    // since the failure → no longer the same dead action → not blocked.
+    seedFailedAction(m.id, Date.now() - 60_000);
+    expect(hasMatchingFailedAction(ctx, m.id, candidate())).toBe(false);
+  });
+
+  it('still distinguishes by inputs', () => {
+    const ctx = setup();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    seedFailedAction(m.id, Date.now() + 60_000, { A: '1' });
+    expect(hasMatchingFailedAction(ctx, m.id, candidate({ A: '2' }))).toBe(false); // different inputs
+    expect(hasMatchingFailedAction(ctx, m.id, candidate({ A: '1' }))).toBe(true);  // same inputs
+  });
+
+  it('falls back to blocking when the agent no longer exists', () => {
+    const ctx = setup();
+    agentStore.deleteAgent('opener');
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    seedFailedAction(m.id, Date.now() - 60_000); // would clear IF we could read updatedAt
+    expect(hasMatchingFailedAction(ctx, m.id, candidate())).toBe(true);
+  });
+});

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -1302,19 +1302,32 @@ function stableStringifyInputs(inputs: Record<string, string>): string {
   );
 }
 
-function hasMatchingFailedAction(
+export function hasMatchingFailedAction(
   ctx: ReturnType<typeof getContext>,
   messageId: string,
   candidate: InboxActionMeta,
 ): boolean {
   if (!ctx.inboxStore) return false;
   const candidateInputs = stableStringifyInputs(candidate.inputs);
+  // When the target agent was edited AFTER a failure, that failure is stale —
+  // the operator fixing the agent is exactly the "something changed that would
+  // make a retry succeed" case. Without this, an inputs-less agent (every
+  // re-proposal looks identical) is blocked forever even after a fix, and the
+  // "revise the inputs" advice is impossible to follow. Compare the agent's
+  // updatedAt against the failed action's end time.
+  let agentUpdatedAt = 0;
+  try {
+    const raw = ctx.agentStore.getAgent(candidate.agentId)?.updatedAt;
+    if (raw) agentUpdatedAt = Date.parse(raw);
+  } catch { /* agent gone — fall through, treat as no edit */ }
   for (const response of ctx.inboxStore.listResponses(messageId)) {
     const existing = parseActionMeta(response);
     if (!existing) continue;
     if (existing.agentId !== candidate.agentId) continue;
     if (existing.status !== 'failed' && existing.status !== 'refused') continue;
     if (stableStringifyInputs(existing.inputs) !== candidateInputs) continue;
+    // Agent changed since this failure → the prior failure no longer applies.
+    if (agentUpdatedAt && existing.endedAt && agentUpdatedAt > existing.endedAt) continue;
     return true;
   }
   return false;


### PR DESCRIPTION
## The bug

Found by dogfooding: a thread where the operator asked for an `open-apple-notes` agent, its first run failed (a bash heredoc syntax error), the operator **fixed the agent**, said "I fixed that opener so you can use it now" — and the thread **refused to ever run it again**, endlessly redirecting to the agent page.

## Root cause

The thread-level guard [`hasMatchingFailedAction`](packages/dashboard/src/routes/inbox.ts) refuses to re-propose an action when the same agent + same inputs already failed on the thread. It exists to stop triage looping on a stale failure — but it keyed **only** on `(agentId, inputs)`:

- `open-apple-notes` declares **no inputs**, so every re-proposal is byte-identical to the first failed one → permanent block.
- The guard has **no awareness that the agent was edited**. Fixing the agent (the literal "something changed that would make a retry succeed" case) didn't reset it, and triage's advice — *"revise the inputs"* — is impossible when the agent takes no inputs and the fix was to the agent itself.

## The fix

The guard now **clears once the target agent was edited after the failure**: it compares the agent's `updatedAt` against the failed action's `endedAt`. A new version or a metadata edit (both bump `updated_at`) makes the retry a legitimately new action.

- **core** — expose `Agent.updatedAt` (map `agents.updated_at` in `mergeRowWithVersion`).
- **dashboard** — `hasMatchingFailedAction` skips a stale failure when `agentUpdatedAt > existing.endedAt`; falls back to blocking if the agent no longer exists.
- **kernel.md** — tells triage to re-propose a run when the operator says they fixed the agent (the route now allows it).

## Verification

**Against the real stuck thread**: the guard returned `true` (block) before; after the fix it returns `false` (allow) — the agent was edited at 03:42:47, 9 minutes after the failure at 03:33:46.

(That specific thread's triage still redirects because its 20-turn history of refusals conditions it to self-censor; the kernel nudge + route fix give new threads the full fix: fix agent → "I fixed it" → triage proposes → route allows → it runs.)

Unit tests: block when unedited, clear when edited-after-failure, still distinguishes inputs, falls back to blocking when the agent is deleted. Full dashboard + core suites green (**2018 pass / 3 skip**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)