### PR TITLE
refactor(inbox): finish the split — drop shims, repoint tests, shape seams

### DIFF
--- a/.changeset/refactor-inbox-finish.md
+++ b/.changeset/refactor-inbox-finish.md
@@ -1,0 +1,21 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Refactor: finish the inbox route-file split (drop shims, repoint tests, shape seams).
+
+Final slice of the inbox.ts refactor. Drops the temporary re-export shims and repoints the
+9 sibling test files to import directly from the new modules (inbox-shared / inbox-catalog /
+inbox-plan / inbox-widgets / inbox-engine), so inbox.ts now exports only `inboxRouter`.
+
+Also shapes the seams for the planned "inbox span of control" work: a module-map header on
+inbox.ts (route layer only — compose the siblings, don't regrow the god file), labelled route
+bands (read · lifecycle · conversation+triage · metadata · actions · learnings), and a
+doc-comment marking inbox-widgets.ts as the single in-thread output-widget boundary.
+
+No behavior change. inbox.ts: 3217 (pre-refactor) -> 938. Full suite unchanged at 2018 pass /
+3 skip.

--- a/packages/dashboard/src/routes/inbox-build-commit.test.ts
+++ b/packages/dashboard/src/routes/inbox-build-commit.test.ts
@@ -10,7 +10,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { AgentStore, RunStore, InboxStore } from '@some-useful-agents/core';
-import { maybeCommitBuiltAgent } from './inbox.js';
+import { maybeCommitBuiltAgent } from './inbox-engine.js';
 
 let dir: string;
 let agentStore: AgentStore;

--- a/packages/dashboard/src/routes/inbox-crash-retry.test.ts
+++ b/packages/dashboard/src/routes/inbox-crash-retry.test.ts
@@ -6,7 +6,7 @@
  * here without forcing a real crash.
  */
 import { describe, it, expect } from 'vitest';
-import { planTriageCrashRecovery } from './inbox.js';
+import { planTriageCrashRecovery } from './inbox-plan.js';
 
 describe('planTriageCrashRecovery', () => {
   it('retries on the first crash (budget available)', () => {

--- a/packages/dashboard/src/routes/inbox-failed-action-guard.test.ts
+++ b/packages/dashboard/src/routes/inbox-failed-action-guard.test.ts
@@ -9,7 +9,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { AgentStore, InboxStore, type InboxActionMeta } from '@some-useful-agents/core';
-import { hasMatchingFailedAction } from './inbox.js';
+import { hasMatchingFailedAction } from './inbox-plan.js';
 
 let dir: string;
 let agentStore: AgentStore;

--- a/packages/dashboard/src/routes/inbox-latest-user-request.test.ts
+++ b/packages/dashboard/src/routes/inbox-latest-user-request.test.ts
@@ -10,7 +10,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import type { InboxResponse } from '@some-useful-agents/core';
-import { latestUserRequest } from './inbox.js';
+import { latestUserRequest } from './inbox-shared.js';
 
 const r = (role: InboxResponse['role'], body: string, createdAt: number): InboxResponse =>
   ({ id: `${role}-${createdAt}`, messageId: 'm', role, body, createdAt });

--- a/packages/dashboard/src/routes/inbox-learnings-format.test.ts
+++ b/packages/dashboard/src/routes/inbox-learnings-format.test.ts
@@ -5,7 +5,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import type { TriageLearning } from '@some-useful-agents/core';
-import { formatLearnings } from './inbox.js';
+import { formatLearnings } from './inbox-shared.js';
 
 const learning = (over: Partial<TriageLearning> = {}): TriageLearning => ({
   id: 'l', createdAt: 1, status: 'approved', source: 'run-failure',

--- a/packages/dashboard/src/routes/inbox-links.test.ts
+++ b/packages/dashboard/src/routes/inbox-links.test.ts
@@ -4,7 +4,7 @@
  * with inbox.test.ts's stateful afterEach teardown.
  */
 import { describe, it, expect } from 'vitest';
-import { parseTriageLinks } from './inbox.js';
+import { parseTriageLinks } from './inbox-plan.js';
 
 describe('parseTriageLinks', () => {
   it('keeps valid label + relative href entries', () => {

--- a/packages/dashboard/src/routes/inbox-local-iso-now.test.ts
+++ b/packages/dashboard/src/routes/inbox-local-iso-now.test.ts
@@ -5,7 +5,7 @@
  * preserve the absolute instant on any machine timezone.
  */
 import { describe, it, expect } from 'vitest';
-import { localIsoNow } from './inbox.js';
+import { localIsoNow } from './inbox-shared.js';
 
 describe('localIsoNow', () => {
   it('emits ISO 8601 with a numeric UTC offset, not the Z/UTC form', () => {

--- a/packages/dashboard/src/routes/inbox-request-to-run.test.ts
+++ b/packages/dashboard/src/routes/inbox-request-to-run.test.ts
@@ -9,7 +9,8 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { AgentStore } from '@some-useful-agents/core';
-import { parseProposedActions, getRunnableCandidates } from './inbox.js';
+import { parseProposedActions } from './inbox-plan.js';
+import { getRunnableCandidates } from './inbox-catalog.js';
 
 describe('parseProposedActions — candidates', () => {
   it('runs an allowlisted agent directly (no grant flag)', () => {

--- a/packages/dashboard/src/routes/inbox-widgets.ts
+++ b/packages/dashboard/src/routes/inbox-widgets.ts
@@ -1,3 +1,17 @@
+/**
+ * Inbox view-data + in-thread widget boundary.
+ *
+ * This is the SINGLE place "what the inbox renders for a thread" is assembled:
+ * the thread summary, the fork/retarget target list, and — most relevant for
+ * future work — the inline rendering of agent OUTPUT WIDGETS inside a
+ * conversation (`buildInlineActionWidgets` + `INLINE_INBOX_WIDGET_TYPES`, which
+ * already allows the `dashboard` widget type). Routes and the detail views call
+ * into here; they don't re-derive view data inline.
+ *
+ * Extension point: to surface dashboard/output widgets in threads more richly
+ * (a planned "inbox span of control" capability), widen `INLINE_INBOX_WIDGET_TYPES`
+ * and the render path HERE — not in the route file.
+ */
 import {
   exportAgent,
   unallowedWidgetImageHosts,

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -28,7 +28,7 @@ import { buildDashboardApp } from '../index.js';
 import type { DashboardContext } from '../context.js';
 import { SESSION_COOKIE } from '../auth-middleware.js';
 import { MemorySecretsSession } from '../secrets-session.js';
-import { getSubAgentAllowlist } from './inbox.js';
+import { getSubAgentAllowlist } from './inbox-catalog.js';
 
 const TOKEN = 'a'.repeat(64);
 const PORT = 3993;

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -20,6 +20,15 @@
  *     within the last 30s with no later triage/system reply. Covers
  *     the race where the dag-executor hasn't yet inserted its
  *     run-store row when the modal first polls.
+ *
+ * This file is the ROUTE LAYER only (handlers + router wiring). The
+ * supporting logic lives in cohesive siblings; add a new endpoint here and
+ * compose these — don't grow this file back into a god module:
+ *   - inbox-shared.ts   — http/util helpers + shared constants + formatters
+ *   - inbox-catalog.ts  — sub-agent allowlist / catalog / input enrichment
+ *   - inbox-plan.ts     — plan/action/link parsing + crash recovery
+ *   - inbox-widgets.ts  — thread view-data + in-thread widget assembly
+ *   - inbox-engine.ts   — triage + action-execution + learning-extraction engine
  */
 
 import { Router, type Request, type Response } from 'express';
@@ -58,26 +67,6 @@ import {
   isTriagePending,
 } from './inbox-engine.js';
 
-// Re-export shims so sibling test files that import these from './inbox.js'
-// keep resolving after the leaf split.
-export {
-  latestUserRequest,
-  localIsoNow,
-  formatLearnings,
-} from './inbox-shared.js';
-export {
-  getSubAgentAllowlist,
-  getRunnableCandidates,
-} from './inbox-catalog.js';
-export {
-  parseProposedActions,
-  parseTriageLinks,
-  planTriageCrashRecovery,
-  hasMatchingFailedAction,
-} from './inbox-plan.js';
-export { maybeCommitBuiltAgent } from './inbox-engine.js';
-export { type TriageLink } from './inbox-plan.js';
-
 export const inboxRouter: Router = Router();
 
 /**
@@ -87,6 +76,10 @@ export const inboxRouter: Router = Router();
  * placeholder with something derived from the operator's actual words.
  */
 const DEFAULT_NEW_CONVERSATION_TITLE = 'New conversation';
+
+// ════════════════════════════════════════════════════════════════
+// Read — list + thread views
+// ════════════════════════════════════════════════════════════════
 
 inboxRouter.get('/inbox', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
@@ -244,6 +237,10 @@ inboxRouter.get('/inbox/:id/fragment', (req: Request, res: Response) => {
  * gets a 303 redirect to `/inbox/:id`. Triage does NOT auto-fire
  * here — it kicks in normally on the operator's first POST /respond.
  */
+// ════════════════════════════════════════════════════════════════
+// Thread lifecycle — create, close, bulk
+// ════════════════════════════════════════════════════════════════
+
 inboxRouter.post('/inbox/new', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
   if (!ctx.inboxStore) {
@@ -368,6 +365,10 @@ inboxRouter.post('/inbox/bulk-dismiss', (req: Request, res: Response) => {
   const label = dismissed === 1 ? 'Dismissed 1 message.' : `Dismissed ${dismissed} messages.`;
   res.redirect(303, `${returnTo}${returnTo.includes('?') ? '&' : '?'}ok=${encodeURIComponent(label)}`);
 });
+
+// ════════════════════════════════════════════════════════════════
+// Conversation + triage
+// ════════════════════════════════════════════════════════════════
 
 inboxRouter.post('/inbox/:id/respond', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
@@ -576,6 +577,10 @@ inboxRouter.post('/inbox/:id/triage/cancel', async (req: Request, res: Response)
  * for AJAX, 303 for plain form posts (always back to /inbox so the
  * list reflects the new starred-sort position).
  */
+// ════════════════════════════════════════════════════════════════
+// Thread metadata + transforms — star, tags, reopen, summarize, fork, retarget
+// ════════════════════════════════════════════════════════════════
+
 inboxRouter.post('/inbox/:id/star', (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
   const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
@@ -780,6 +785,10 @@ inboxRouter.post('/inbox/:id/retarget', (req: Request, res: Response) => {
  * non-skipped actions for this message are in a terminal state, fires
  * a follow-up triage turn so the agent can summarize what came back.
  */
+// ════════════════════════════════════════════════════════════════
+// Sub-agent actions — run / skip a proposed action
+// ════════════════════════════════════════════════════════════════
+
 inboxRouter.post('/inbox/:id/actions/:rid/run', async (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
   const id = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
@@ -894,6 +903,10 @@ inboxRouter.post('/inbox/:id/actions/:rid/skip', (req: Request, res: Response) =
  * reject leaves it dead (never retrieved). Atomic via updateLearningStatus, so
  * a double-click resolves once.
  */
+// ════════════════════════════════════════════════════════════════
+// Learnings — approve / reject an extracted lesson (experimental)
+// ════════════════════════════════════════════════════════════════
+
 function handleLearningDecision(decision: 'approved' | 'rejected') {
   return (req: Request, res: Response): void => {
     const ctx = getContext(req.app.locals);


### PR DESCRIPTION
## What

**PR 3 of 3 — the finisher** for the inbox.ts split (after #516, #517). Drops the temporary scaffolding and shapes the seams for the planned span-of-control work.

## This PR

- **Drop the re-export shims** from `inbox.ts` and **repoint the 9 sibling test files** to import directly from the new modules (`inbox-shared` / `inbox-catalog` / `inbox-plan` / `inbox-widgets` / `inbox-engine`). `inbox.ts` now exports **only `inboxRouter`**.
- **Shape the seams** (per the approved plan) for the future "inbox controls dashboard views" + "output widgets in threads" capabilities:
  - **Module-map header** on `inbox.ts` — "route layer only; compose the siblings, don't regrow the god file."
  - **Labelled route bands** (read · lifecycle · conversation+triage · metadata · actions · learnings) so where-a-new-endpoint-goes is obvious. In-place banners — no route reordering, behavior-neutral.
  - **Doc-comment on `inbox-widgets.ts`** marking it the single in-thread output-widget boundary (the drop-in point for widgets-in-threads; `INLINE_INBOX_WIDGET_TYPES` already allows the `dashboard` type).

## Result of the full 3-PR refactor

`inbox.ts`: **3217 → 938 lines**, split into cohesive modules:

| file | lines | role |
|---|---|---|
| inbox.ts | 938 | route handlers + wiring |
| inbox-engine.ts | 1355 | triage/actions/extraction engine |
| inbox-catalog.ts | 395 | sub-agent allowlist/catalog/enrichment |
| inbox-shared.ts | 266 | http/util + shared consts + formatters |
| inbox-plan.ts | 252 | plan/action/link parsing + crash recovery |
| inbox-widgets.ts | 165 | thread view-data + in-thread widgets |

Module graph strictly acyclic: `shared ← {catalog, plan, widgets} ← engine ← routes`.

## Verification

- `rm -rf packages/*/dist packages/*/*.tsbuildinfo && npm run build` → exit 0.
- `npx vitest run packages/dashboard packages/core` → **2018 pass / 3 skip** (exact baseline). Tests now import from the real modules (no shims).

🤖 Generated with [Claude Code](https://claude.com/claude-code)