### PR TITLE
feat(inbox): summon an agent's latest output widget into a thread (mechanism)

### DIFF
--- a/.changeset/inbox-show-widget-mechanism.md
+++ b/.changeset/inbox-show-widget-mechanism.md
@@ -1,0 +1,18 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox: summon an agent's latest output widget into a thread (mechanism).
+
+First slice of "widgets in threads". Adds a `show-widget` action mode: instead of running an
+agent, it renders that agent's LATEST COMPLETED run's output widget inline in the conversation
+(read-only, no dispatch). New `InboxActionMeta.mode` field; `parseProposedActions` accepts
+`type: 'show-widget'`; a `resolveShowWidgetAction` resolver points the action at the latest
+completed run and auto-resolves `proposed → completed` (the existing inline-widget render path
+then displays it), or fails clearly ("no completed run yet — run it first"). The card drops the
+run chrome (duration, badge, raw preview) and reads "Latest <agent> output". Guarded against the
+dedup-block and refire-loop edge cases. Dormant until the triage kernel teaches it (next slice).

--- a/packages/core/src/inbox-store.ts
+++ b/packages/core/src/inbox-store.ts
@@ -88,6 +88,14 @@ export interface InboxActionMeta {
    */
   effect?: 'read' | 'write';
   /**
+   * What this action DOES. `run` (default; absent ⇒ run, back-compat) dispatches
+   * the agent. `show-widget` summons the agent's LATEST COMPLETED run's output
+   * widget inline WITHOUT dispatching — a read-only snapshot that resolves
+   * `proposed → completed` by pointing `runId` at that latest run, so the
+   * existing inline-widget render path displays it.
+   */
+  mode?: 'run' | 'show-widget';
+  /**
    * When true, approving this run first grants `permissions.inboxRunnable`
    * to `agentId` (a one-click "Enable & run"). Set by the dashboard when
    * triage proposes running an installed agent that hasn't been granted

--- a/packages/dashboard/src/routes/inbox-engine.ts
+++ b/packages/dashboard/src/routes/inbox-engine.ts
@@ -67,6 +67,7 @@ import {
   planTriageCrashRecovery,
   hasMatchingFailedAction,
 } from './inbox-plan.js';
+import { canRenderInlineInboxWidget } from './inbox-widgets.js';
 
 /** Experimental learnings extractor — route-dispatched on thread resolve. */
 const LEARNING_EXTRACTOR_AGENT_ID = 'inbox-learning-extractor';
@@ -660,6 +661,40 @@ async function executeRouteHandledAgent(
 }
 
 /**
+ * Resolve a `show-widget` action: point it at the target agent's LATEST
+ * COMPLETED run so the existing inline-widget render path
+ * (`buildInlineActionWidgets`) displays that run's output widget. Pure lookup —
+ * no dispatch, no run cost. Returns the resolved runId on success, or a clear
+ * reason when there's nothing to show.
+ */
+export function resolveShowWidgetAction(
+  ctx: ReturnType<typeof getContext>,
+  meta: InboxActionMeta,
+): { status: InboxActionStatus; runId?: string; summary?: string; refusalReason?: string } {
+  const agent = ctx.agentStore.getAgent(meta.agentId);
+  if (!agent) {
+    return { status: 'failed', refusalReason: `Agent "${meta.agentId}" is not installed.` };
+  }
+  if (!canRenderInlineInboxWidget(agent)) {
+    return { status: 'failed', refusalReason: `${agent.name || meta.agentId} has no inline output widget.` };
+  }
+  let latest;
+  try {
+    latest = ctx.runStore.listRuns({ agentName: meta.agentId, status: 'completed', limit: 1 })[0];
+  } catch {
+    latest = undefined;
+  }
+  if (!latest) {
+    return { status: 'failed', refusalReason: `No completed run yet for ${agent.name || meta.agentId} — run it first.` };
+  }
+  return {
+    status: 'completed',
+    runId: latest.id,
+    summary: `Latest output from ${agent.name || meta.agentId} · run ${latest.id.slice(0, 8)}.`,
+  };
+}
+
+/**
  * Apply a YAML change to an existing agent. Validates:
  *   - `AGENT_ID` input is present
  *   - `NEW_YAML` parses cleanly via `parseAgent`
@@ -861,7 +896,7 @@ function allActionsResolved(
   return true;
 }
 
-function atLeastOneActionExecuted(
+export function atLeastOneActionExecuted(
   ctx: ReturnType<typeof getContext>,
   messageId: string,
 ): boolean {
@@ -870,6 +905,10 @@ function atLeastOneActionExecuted(
   for (const r of responses) {
     if (r.role !== 'action') continue;
     const m = parseActionMeta(r);
+    // show-widget is a read-only snapshot, not an execution — it must not
+    // count as "something ran" (else it would trigger a follow-up triage turn,
+    // risking a show→refire→show loop).
+    if (m?.mode === 'show-widget') continue;
     if (m && (m.status === 'completed' || m.status === 'failed')) return true;
   }
   return false;
@@ -1201,10 +1240,21 @@ export async function runTriageAgent(
     // non-empty). Refusals (out-of-allowlist or malformed) get a
     // single grouped `system` note so the operator can see what was
     // declined and why.
-    if (allowlist.length > 0) {
+    // Enter when there are runnable sub-agents OR the plan summons a widget
+    // (show-widget is read-only and isn't gated on the run allowlist, so it
+    // works on threads with no runnable agents, e.g. a manual "show me X").
+    const rawActionList = Array.isArray(parsed.actions) ? parsed.actions : [];
+    const planHasShowWidget = rawActionList.some(
+      (a) => a && typeof a === 'object' && (a as { type?: unknown }).type === 'show-widget',
+    );
+    if (allowlist.length > 0 || planHasShowWidget) {
       const { accepted, rejected, deferred } = parseProposedActions(parsed.actions, allowlist, candidates);
       const dedupedAccepted: InboxActionMeta[] = [];
       for (const action of accepted) {
+        if (action.mode === 'show-widget' && !ctx.agentStore.getAgent(action.agentId)) {
+          rejected.push({ agentId: action.agentId, reason: 'agent is not installed' });
+          continue;
+        }
         if (hasMatchingFailedAction(ctx, messageId, action)) {
           rejected.push({
             agentId: action.agentId,
@@ -1220,7 +1270,9 @@ export async function runTriageAgent(
       const overflow = dedupedAccepted.length - toInsert.length;
       for (const action of toInsert) {
         const body = action.rationale
-          ?? `Run agent \`${action.agentId}\`.`;
+          ?? (action.mode === 'show-widget'
+            ? `Show the latest output from \`${action.agentId}\`.`
+            : `Run agent \`${action.agentId}\`.`);
         const actionResp = ctx.inboxStore.addResponse(messageId, 'action', body, JSON.stringify(action));
         publishInboxEvent(ctx, messageId, 'action:created', {
           responseId: actionResp.id,
@@ -1229,6 +1281,36 @@ export async function runTriageAgent(
           inputs: action.inputs,
           createdAt: actionResp.createdAt,
         });
+        // show-widget resolves synchronously to the agent's latest completed
+        // run (read-only, no dispatch) → proposed → completed/failed in one
+        // step. No `running` phase (a zero-latency lookup), and NO refire (it's
+        // a snapshot, not an outcome to summarize). The existing
+        // buildInlineActionWidgets then renders the widget on the next fragment.
+        if (action.mode === 'show-widget') {
+          const resolved = resolveShowWidgetAction(ctx, action);
+          const now = Date.now();
+          const resolvedMeta: InboxActionMeta = {
+            ...action,
+            status: resolved.status,
+            runId: resolved.runId,
+            resultSummary: resolved.summary,
+            refusalReason: resolved.refusalReason,
+            startedAt: now,
+            endedAt: now,
+          };
+          if (ctx.inboxStore.transitionActionStatus(actionResp.id, 'proposed', JSON.stringify(resolvedMeta))) {
+            publishInboxEvent(ctx, messageId, 'action:status', {
+              responseId: actionResp.id,
+              status: resolved.status,
+              agentId: action.agentId,
+              runId: resolved.runId,
+              resultSummary: resolved.summary,
+              refusalReason: resolved.refusalReason,
+              endedAt: now,
+            });
+          }
+          continue;
+        }
         // Auto-approve trusted system agents. The proposed -> running
         // transition is atomic via transitionActionStatus, so a
         // concurrent operator click on /run no-ops idempotently. The

--- a/packages/dashboard/src/routes/inbox-failed-action-guard.test.ts
+++ b/packages/dashboard/src/routes/inbox-failed-action-guard.test.ts
@@ -77,4 +77,14 @@ describe('hasMatchingFailedAction', () => {
     seedFailedAction(m.id, Date.now() - 60_000); // would clear IF we could read updatedAt
     expect(hasMatchingFailedAction(ctx, m.id, candidate())).toBe(true);
   });
+
+  it('NEVER blocks a show-widget re-proposal (read-only, empty inputs)', () => {
+    const ctx = setup();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    // A prior show-widget failed ("no completed run yet"), agent unedited since.
+    const failed: InboxActionMeta = { kind: 'action', mode: 'show-widget', status: 'failed', agentId: 'opener', inputs: {}, endedAt: Date.now() + 60_000 };
+    inboxStore.addResponse(m.id, 'action', 'no run yet', JSON.stringify(failed));
+    const reSummon: InboxActionMeta = { kind: 'action', mode: 'show-widget', status: 'proposed', agentId: 'opener', inputs: {} };
+    expect(hasMatchingFailedAction(ctx, m.id, reSummon)).toBe(false);
+  });
 });

--- a/packages/dashboard/src/routes/inbox-plan.ts
+++ b/packages/dashboard/src/routes/inbox-plan.ts
@@ -24,6 +24,12 @@ export function hasMatchingFailedAction(
   candidate: InboxActionMeta,
 ): boolean {
   if (!ctx.inboxStore) return false;
+  // show-widget actions are read-only with empty inputs, so every re-proposal
+  // looks identical — the dedup guard would block re-summon forever (and the
+  // agent-edit escape hatch below doesn't fire when "a new run appeared", which
+  // is exactly the change that unblocks a "no completed run yet" failure). Never
+  // treat a show-widget as a stale-failed match.
+  if (candidate.mode === 'show-widget') return false;
   const candidateInputs = stableStringifyInputs(candidate.inputs);
   // When the target agent was edited AFTER a failure, that failure is stale —
   // the operator fixing the agent is exactly the "something changed that would
@@ -174,6 +180,28 @@ export function parseProposedActions(
     const e = entry as Record<string, unknown>;
     const type = typeof e.type === 'string' ? e.type : '';
     const agentId = typeof e.agentId === 'string' ? e.agentId : '';
+    const rationaleRaw = typeof e.rationale === 'string' ? e.rationale.trim() : undefined;
+    // `show-widget` summons an agent's latest output widget inline (read-only,
+    // no dispatch). Not gated on the run allowlist — any INSTALLED agent is
+    // fair game (the engine's dedup loop rejects uninstalled ones, where it has
+    // agentStore access). No inputs (the agent isn't run).
+    if (type === 'show-widget') {
+      if (!agentId) {
+        rejected.push({ agentId: '<unknown>', reason: 'show-widget missing agentId' });
+        continue;
+      }
+      accepted.push({
+        kind: 'action',
+        mode: 'show-widget',
+        status: 'proposed',
+        agentId,
+        inputs: {},
+        rationale: rationaleRaw || undefined,
+        effect: 'read',
+        ctaLabel: 'Show widget',
+      });
+      continue;
+    }
     if (type !== 'run-agent' || !agentId) {
       rejected.push({ agentId: agentId || '<unknown>', reason: 'malformed action entry' });
       continue;

--- a/packages/dashboard/src/routes/inbox-request-to-run.test.ts
+++ b/packages/dashboard/src/routes/inbox-request-to-run.test.ts
@@ -65,6 +65,45 @@ describe('parseProposedActions — candidates', () => {
   });
 });
 
+describe('parseProposedActions — show-widget', () => {
+  it('accepts show-widget for any agent (not gated on the run allowlist)', () => {
+    const { accepted, rejected } = parseProposedActions(
+      [{ type: 'show-widget', agentId: 'weather-dashboard', rationale: 'show the latest weather' }],
+      [], // empty allowlist — show-widget is read-only, still accepted
+      [],
+    );
+    expect(rejected).toHaveLength(0);
+    expect(accepted).toHaveLength(1);
+    expect(accepted[0].mode).toBe('show-widget');
+    expect(accepted[0].agentId).toBe('weather-dashboard');
+    expect(accepted[0].effect).toBe('read');           // never deferred by the write-sequencer
+    expect(accepted[0].ctaLabel).toBe('Show widget');
+    expect(accepted[0].inputs).toEqual({});
+    expect(accepted[0].rationale).toBe('show the latest weather');
+  });
+
+  it('rejects a show-widget with no agentId', () => {
+    const { accepted, rejected } = parseProposedActions(
+      [{ type: 'show-widget' }],
+      ['x'],
+    );
+    expect(accepted).toHaveLength(0);
+    expect(rejected[0].reason).toContain('show-widget');
+  });
+
+  it('a show-widget never counts as a write (read effect) so it is not deferred', () => {
+    const { accepted, deferred } = parseProposedActions(
+      [
+        { type: 'show-widget', agentId: 'a' },
+        { type: 'show-widget', agentId: 'b' },
+      ],
+      [],
+    );
+    expect(accepted).toHaveLength(2);
+    expect(deferred).toHaveLength(0);
+  });
+});
+
 describe('parseProposedActions — side-effect sequencing', () => {
   it('defaults a missing effect to read and batches reads', () => {
     const { accepted, deferred } = parseProposedActions(

--- a/packages/dashboard/src/routes/inbox-show-widget.test.ts
+++ b/packages/dashboard/src/routes/inbox-show-widget.test.ts
@@ -1,0 +1,137 @@
+/**
+ * show-widget mechanism: `resolveShowWidgetAction` points a read-only action at
+ * an agent's latest completed run (so the existing inline-widget path renders
+ * it), and `atLeastOneActionExecuted` excludes show-widget so a snapshot never
+ * triggers a follow-up triage turn.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AgentStore, InboxStore, RunStore, type InboxActionMeta, type InboxMessage, type InboxResponse } from '@some-useful-agents/core';
+import { resolveShowWidgetAction, atLeastOneActionExecuted } from './inbox-engine.js';
+import { renderInboxDetailFragment } from '../views/inbox-detail.js';
+import { render, html } from '../views/html.js';
+
+let dir: string;
+let agentStore: AgentStore;
+let inboxStore: InboxStore;
+let runStore: RunStore;
+
+function setup() {
+  dir = mkdtempSync(join(tmpdir(), 'sua-show-widget-'));
+  const db = join(dir, 'runs.db');
+  agentStore = new AgentStore(db);
+  inboxStore = new InboxStore(db);
+  runStore = new RunStore(db);
+  return { agentStore, inboxStore, runStore } as never as ReturnType<typeof import('../context.js').getContext>;
+}
+
+afterEach(() => {
+  try { agentStore.close(); } catch { /* ignore */ }
+  try { inboxStore.close(); } catch { /* ignore */ }
+  try { runStore.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+/** Install an agent, optionally with an inline-able output widget. */
+function mkAgent(id: string, withWidget: boolean): void {
+  agentStore.createAgent({
+    id, name: id, status: 'active', source: 'local', mcp: false,
+    nodes: [{ id: 'n', type: 'shell', command: 'echo hi', dependsOn: [] }],
+    ...(withWidget
+      ? { outputWidget: { type: 'key-value', fields: [{ name: 'x', label: 'X', type: 'text' }] } }
+      : {}),
+  }, 'cli');
+}
+
+function mkCompletedRun(id: string, agentName: string, startedAt = new Date().toISOString()): void {
+  runStore.createRun({
+    id, agentName, status: 'completed',
+    startedAt, completedAt: startedAt,
+    triggeredBy: 'dashboard', result: 'x: hello',
+  });
+}
+
+const showWidget = (agentId: string): InboxActionMeta =>
+  ({ kind: 'action', mode: 'show-widget', status: 'proposed', agentId, inputs: {} });
+
+describe('resolveShowWidgetAction', () => {
+  it('fails when the agent is not installed', () => {
+    const ctx = setup();
+    const r = resolveShowWidgetAction(ctx, showWidget('ghost'));
+    expect(r.status).toBe('failed');
+    expect(r.refusalReason).toContain('not installed');
+  });
+
+  it('fails when the agent has no inline output widget', () => {
+    const ctx = setup();
+    mkAgent('plain', false);
+    mkCompletedRun('run-1', 'plain');
+    const r = resolveShowWidgetAction(ctx, showWidget('plain'));
+    expect(r.status).toBe('failed');
+    expect(r.refusalReason).toContain('no inline output widget');
+  });
+
+  it('fails when there is no completed run yet', () => {
+    const ctx = setup();
+    mkAgent('weather', true);
+    const r = resolveShowWidgetAction(ctx, showWidget('weather'));
+    expect(r.status).toBe('failed');
+    expect(r.refusalReason).toContain('No completed run yet');
+  });
+
+  it('resolves to the latest completed run on the happy path', () => {
+    const ctx = setup();
+    mkAgent('weather', true);
+    mkCompletedRun('run-old', 'weather', '2026-06-01T00:00:00.000Z');
+    mkCompletedRun('run-new', 'weather', '2026-06-20T00:00:00.000Z');
+    const r = resolveShowWidgetAction(ctx, showWidget('weather'));
+    expect(r.status).toBe('completed');
+    expect(r.runId).toBe('run-new');         // newest first (listRuns DESC)
+    expect(r.summary).toContain('Latest output');
+  });
+});
+
+describe('atLeastOneActionExecuted excludes show-widget', () => {
+  it('a resolved show-widget alone does NOT count as executed', () => {
+    const ctx = setup();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const meta: InboxActionMeta = { kind: 'action', mode: 'show-widget', status: 'completed', agentId: 'weather', inputs: {}, runId: 'run-new' };
+    inboxStore.addResponse(m.id, 'action', 'widget', JSON.stringify(meta));
+    expect(atLeastOneActionExecuted(ctx, m.id)).toBe(false);
+  });
+
+  it('a completed run-agent action DOES count as executed', () => {
+    const ctx = setup();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const meta: InboxActionMeta = { kind: 'action', status: 'completed', agentId: 'analyzer', inputs: {}, runId: 'r1' };
+    inboxStore.addResponse(m.id, 'action', 'ran', JSON.stringify(meta));
+    expect(atLeastOneActionExecuted(ctx, m.id)).toBe(true);
+  });
+});
+
+describe('show-widget card chrome', () => {
+  const message: InboxMessage = {
+    id: 'm1', createdAt: Date.now(), priority: 'medium', source: 'manual',
+    title: 't', body: 'b', status: 'awaiting_user', starred: false, tags: [],
+  };
+  const completedShowWidget = (): InboxResponse => ({
+    id: 'resp-1', messageId: 'm1', createdAt: Date.now(), role: 'action',
+    body: 'Show the latest output from `weather`.',
+    metaJson: JSON.stringify({ kind: 'action', mode: 'show-widget', status: 'completed', agentId: 'weather', inputs: {}, runId: 'run-x', resultSummary: 'Latest output from weather · run run-x.' } satisfies InboxActionMeta),
+  });
+
+  it('renders the widget slot and drops the run chrome', () => {
+    const out = render(renderInboxDetailFragment({
+      message,
+      responses: [completedShowWidget()],
+      inlineActionWidgets: { 'resp-1': html`<div class="test-widget">WIDGET</div>` },
+    }));
+    expect(out).toContain('Latest <span class="mono">weather</span> output'); // headline
+    expect(out).toContain('inbox-action__inline-widget');                      // widget slot
+    expect(out).toContain('WIDGET');
+    expect(out).not.toContain('>Completed<');                                  // no completed badge
+    expect(out).not.toContain('Raw result');                                   // no raw-result details
+  });
+});

--- a/packages/dashboard/src/views/inbox-detail.ts
+++ b/packages/dashboard/src/views/inbox-detail.ts
@@ -604,13 +604,15 @@ function renderActionEntry(r: InboxResponse, currentTargetYaml?: string, inlineW
       <div class="inbox-msg__avatar inbox-msg__avatar--action">Act</div>
       <div class="inbox-msg__body">
         <div class="inbox-msg__meta">
-          <span class="inbox-msg__meta-name">Triage proposed</span>
-          <span class="inbox-action__status">${statusLabel}</span>
+          <span class="inbox-msg__meta-name">${meta.mode === 'show-widget' ? 'Widget' : 'Triage proposed'}</span>
+          ${meta.mode === 'show-widget' ? html`` : html`<span class="inbox-action__status">${statusLabel}</span>`}
           <span>${formatAge(new Date(r.createdAt).toISOString())}</span>
         </div>
         <div class="inbox-action__card">
           <div class="inbox-action__headline">
-            Run agent <span class="mono">${meta.agentId}</span>
+            ${meta.mode === 'show-widget'
+              ? html`Latest <span class="mono">${meta.agentId}</span> output`
+              : html`Run agent <span class="mono">${meta.agentId}</span>`}
             ${meta.runId ? html` · <a href="/runs/${meta.runId}" class="mono">run ${meta.runId.slice(0, 8)}</a>` : html``}
           </div>
           ${meta.rationale ? html`<div class="inbox-action__rationale">${mdBody(meta.rationale)}</div>` : html``}
@@ -653,9 +655,18 @@ function renderActionStatusBody(meta: InboxActionMeta, inlineWidget?: SafeHtml):
         </div>
       `;
     case 'completed': {
+      const hasInlineWidget = !!inlineWidget;
+      // show-widget is a read-only snapshot — drop the run chrome (duration,
+      // "Completed" badge, raw-result preview) and show just the widget.
+      if (meta.mode === 'show-widget') {
+        return html`
+          <div class="inbox-action__result inbox-action__result--widget">
+            ${inlineWidget ? html`<div class="inbox-action__inline-widget">${inlineWidget}</div>` : html`<div class="inbox-action__reason dim">Widget could not be rendered.</div>`}
+          </div>
+        `;
+      }
       const dur = formatDuration(meta);
       const preview = meta.resultSummary?.trim();
-      const hasInlineWidget = !!inlineWidget;
       return html`
         <div class="inbox-action__result inbox-action__result--ok ${hasInlineWidget ? 'inbox-action__result--widget' : ''}">
           <div class="inbox-action__result-meta">


### PR DESCRIPTION
## What

**PR 1 of 2** for "widgets in threads" (the first inbox span-of-control capability). Adds a **`show-widget`** action: instead of *running* an agent, it renders that agent's **latest completed run's** output widget inline in the conversation — read-only, no dispatch, instant. **Dormant until PR2** teaches the triage kernel to propose it.

The elegant reuse: a `show-widget` action resolves by pointing its meta at the agent's latest completed run, so the **existing** `buildInlineActionWidgets` render path displays the widget for free.

## This PR

- **`core/inbox-store.ts`** — `InboxActionMeta.mode?: 'run' | 'show-widget'` (absent ⇒ `run`, back-compat, no migration).
- **`inbox-plan.ts`** — `parseProposedActions` accepts `type: 'show-widget'` (any *installed* agent, not gated on the run allowlist; `effect: 'read'` so the write-sequencer never defers it). `hasMatchingFailedAction` early-returns for show-widget — its empty inputs would otherwise block re-summon forever (and the agent-edit escape hatch doesn't fire when "a new run appeared").
- **`inbox-engine.ts`** — `resolveShowWidgetAction` (latest completed run via `runStore.listRuns`) + an auto-resolve branch that transitions `proposed → completed/failed` in one step (no `running` phase, **no `maybeRefireTriage`**). `atLeastOneActionExecuted` excludes show-widget (refire-loop guard); the dedup loop rejects uninstalled agents; the `allowlist.length > 0` gate is lifted when the plan summons a widget (so it works on no-runnable threads).
- **`views/inbox-detail.ts`** — the show-widget card reads "Latest \<agent\> output" and drops the run chrome (duration, "Completed" badge, raw-result preview) — widget only.

## Guardrails (the edge cases the design review caught)

Refire loop (two guards), permanent dedup block (bypass), misleading run chrome (suppressed) — all covered + tested.

## Verification

- Clean build, 0 errors.
- `npx vitest run packages/dashboard packages/core` → **2029 pass / 3 skip** (2018 baseline + 11 new). Tests cover parse accept/reject, dedup bypass, the resolver's 4 cases, the `atLeastOneActionExecuted` exclusion, and the card-chrome render.

Next: **PR2** — kernel teaches triage when to `show-widget` vs `run-agent`, a `hasWidget` flag in the agent catalog, and a live dogfood against the `weather-dashboard` agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)