### PR TITLE
feat(inbox): activate show-widget — catalog hasWidget flag + kernel teaching

### DIFF
--- a/.changeset/inbox-show-widget-activate.md
+++ b/.changeset/inbox-show-widget-activate.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Inbox: triage can now summon an agent's widget into a thread.
+
+Activates the show-widget mechanism. The triage AGENT_CATALOG now carries a `hasWidget` flag
+(true when an agent has an inline output widget), and the triage kernel teaches when to propose
+`show-widget` ("show me X's output" → display the latest run read-only) vs `run-agent` ("run/refresh
+X" → execute). Dogfooded live: asking "show me the <agent> output" surfaces that agent's latest
+output widget inline as a card, with no re-run and no extra triage turn.

--- a/agents/examples/inbox-triage/kernel.md
+++ b/agents/examples/inbox-triage/kernel.md
@@ -7,7 +7,9 @@ INSTALLED AGENT CATALOG — answer lookups DIRECTLY, do not hedge
 ════════════════════════════════════════════════════════════════
 
 `AGENT_CATALOG` is the installed catalog, sorted newest-first, each
-entry with id, name, description, tags, and createdAt. When the
+entry with id, name, description, tags, createdAt, and `hasWidget`
+(present + true when the agent has an inline output widget you can
+summon with a `show-widget` action — see SHOWING A WIDGET). When the
 operator asks about installed agents, answer from it RIGHT NOW —
 do not dispatch agent-catalog-search and do not tell the operator
 to "open the catalog to confirm". You already have the answer.
@@ -301,6 +303,28 @@ If `ALLOWED_SUB_AGENTS` is empty OR no action would help, omit
 recommendations are perfectly fine.
 
 ════════════════════════════════════════════════════════════════
+SHOWING A WIDGET — display existing output, don't re-run
+════════════════════════════════════════════════════════════════
+
+When the operator wants to SEE an agent's current output, dashboard,
+or widget inline — "show me the weather dashboard", "pull up the
+portfolio agent's output", "what does X show right now" — propose a
+`show-widget` action instead of `run-agent`. It displays the agent's
+LATEST COMPLETED run as an inline card WITHOUT re-running it. It's
+read-only and resolves instantly (no Run button, no waiting).
+
+- show-widget when the operator wants to LOOK at existing output.
+  run-agent when they want NEW / refreshed output. "Show me the
+  dashboard" → show-widget. "Refresh it" / "run it again" → run-agent.
+- Target any INSTALLED agent with `hasWidget: true` in AGENT_CATALOG.
+  It is NOT restricted to ALLOWED_SUB_AGENTS (showing is read-only).
+- Shape: `{ "type": "show-widget", "agentId": "<id>", "rationale": "…" }`.
+  No `inputs` (the agent isn't run), no `effect` (always read).
+- If there's no completed run yet, the card says so — then offer to
+  `run-agent` it to produce one. Don't propose show-widget for an
+  agent with no widget.
+
+════════════════════════════════════════════════════════════════
 OUTPUT FORMAT — exact shape, single <plan>...</plan> block
 ════════════════════════════════════════════════════════════════
 
@@ -360,6 +384,25 @@ chip while the sub-agent runs:
       "effect": "read",
       "inputs": { "QUERY": "trivia — generate trivia questions, host a quiz, or answer trivia" },
       "rationale": "Search the installed catalog for any agent that already covers trivia."
+    }
+  ]
+}
+</plan>
+
+Example summoning a widget (operator wants to SEE an agent's
+current output — `weather-dashboard` has `hasWidget: true` in
+AGENT_CATALOG). No inputs, no effect; it auto-resolves to the
+latest completed run and renders inline:
+
+<plan>
+{
+  "messageId": "{{inputs.MESSAGE_ID}}",
+  "recommendation": "Here's the latest from **weather-dashboard**.",
+  "actions": [
+    {
+      "type": "show-widget",
+      "agentId": "weather-dashboard",
+      "rationale": "Show the latest weather-dashboard output inline."
     }
   ]
 }
@@ -461,11 +504,13 @@ VALIDATION RULES (failing these means the route discards the response):
   a known action to confirm the fix. Leave it absent for
   ambiguous or judgement-call recommendations.
 - `actions` is optional. When present, must be an array of 0..3
-  entries each with `type: "run-agent"`, a string `agentId` in
-  the allowlist, an optional string-to-string `inputs` map, and
-  a `rationale` string. Each entry SHOULD carry `effect`
-  (`"read"` or `"write"`); absent is treated as `"read"`. At most
-  one `"write"` entry per turn survives — extra writes are held.
+  entries each with a `type` (`"run-agent"` or `"show-widget"`), a
+  string `agentId`, and a `rationale` string. A `run-agent` entry's
+  `agentId` must be in the allowlist/candidates and may carry an
+  `inputs` map + an `effect` (`"read"`/`"write"`, absent ⇒ `"read"`;
+  at most one `"write"` survives per turn). A `show-widget` entry
+  targets any installed agent with a widget, takes no `inputs`/`effect`,
+  and renders that agent's latest output read-only.
 - `commitmentSummary` is optional. When `actions` is non-empty,
   set this to a short (3..60 char) verb-led phrase describing
   the pending work for the operator chip. Omit when there are

--- a/packages/dashboard/src/routes/inbox-catalog.ts
+++ b/packages/dashboard/src/routes/inbox-catalog.ts
@@ -13,6 +13,7 @@ import { getContext } from '../context.js';
 import { formatToolCatalog } from './run-now-build.js';
 import { TEMPLATE_REGISTRY } from '../views/pulse-templates.js';
 import { SYSTEM_AGENT_IDS, TRIAGE_AGENT_ID } from './inbox-shared.js';
+import { canRenderInlineInboxWidget } from './inbox-widgets.js';
 
 const TRIAGE_SUB_AGENT_ALLOWLIST: readonly string[] = [
   'agent-analyzer',
@@ -183,6 +184,9 @@ export function buildTriageCatalogJson(ctx: ReturnType<typeof getContext>): stri
       description: (a.description ?? '').slice(0, TRIAGE_CATALOG_DESC_CAP),
       tags: a.tags ?? [],
       createdAt: a.createdAt,
+      // Whether this agent has an inline-able output widget — lets triage pick a
+      // sensible target for a `show-widget` action. Omitted when false (token thrift).
+      ...(canRenderInlineInboxWidget(a) ? { hasWidget: true } : {}),
     }));
     const payload: { agents: typeof shown; truncated?: number } = { agents: shown };
     if (all.length > shown.length) payload.truncated = all.length - shown.length;


### PR DESCRIPTION
## What

**PR 2 of 2** for "widgets in threads" — activates the `show-widget` mechanism from #519. Triage can now **summon an agent's latest output widget into a thread** when the operator asks to see it.

## This PR

- **`inbox-catalog.ts`** — `buildTriageCatalogJson` emits `hasWidget: true` for each agent that has an inline-able output widget (reusing `canRenderInlineInboxWidget`), so triage picks sensible targets. Omitted when false (token thrift).
- **`agents/examples/inbox-triage/kernel.md`** — new **SHOWING A WIDGET** section: propose `show-widget` when the operator wants to SEE existing output ("show me X"), `run-agent` for NEW output ("run/refresh X"); target any installed agent with `hasWidget`; no `inputs`/`effect`; fall back to `run-agent` when there's no completed run yet. Plus a worked `<plan>` example and an OUTPUT FORMAT note that `type` may be `run-agent` OR `show-widget`.

## Verification — dogfooded live

Created a widget agent + ran it once, opened a thread, replied **"show me the \<agent\> output"**:
- triage proposed a `show-widget` action (mode `show-widget`),
- it auto-resolved to the agent's latest completed run (`status: completed`, `runId` = latest),
- the dashboard widget rendered inline as **"Latest \<agent\> output"** (no run chrome — no duration/Completed badge/raw preview),
- **exactly one triage turn** — no refire loop.

Full dashboard + core suite: **2029 pass / 3 skip**.

## Known limitation (follow-up)

Triage can only target agents visible in its `AGENT_CATALOG`, which is capped at the 40 newest. An agent beyond that (e.g. an old example) can't be summoned by name. This affects all triage agent-targeting, not just show-widget — a catalog relevance/recency improvement is a sensible next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)