### PR TITLE
feat(inbox): relevance + recency ranking for the triage agent catalog

### DIFF
--- a/.changeset/triage-catalog-relevance.md
+++ b/.changeset/triage-catalog-relevance.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox triage: reach the agent you mean, even with many installed.
+
+The triage AGENT_CATALOG used to be just the 40 newest agents by creation date, so an agent the
+operator named — but which was old and beyond the cap — was invisible to triage (it couldn't be
+targeted or summoned). The catalog is now selected by blending relevance to the operator's current
+request (keyword match on id/name/tags/description) + recency-of-use (a new
+`RunStore.latestRunAtByAgent()` aggregate) + a reserve of newest-created agents, capped at 40.
+Named/used agents reliably surface; the kernel now compares createdAt across entries for "newest"
+(not list position) and falls back to agent-catalog-search (full catalog) when an agent is elided.

--- a/agents/examples/inbox-triage/kernel.md
+++ b/agents/examples/inbox-triage/kernel.md
@@ -6,26 +6,33 @@
 INSTALLED AGENT CATALOG — answer lookups DIRECTLY, do not hedge
 ════════════════════════════════════════════════════════════════
 
-`AGENT_CATALOG` is the installed catalog, sorted newest-first, each
-entry with id, name, description, tags, createdAt, and `hasWidget`
-(present + true when the agent has an inline output widget you can
-summon with a `show-widget` action — see SHOWING A WIDGET). When the
-operator asks about installed agents, answer from it RIGHT NOW —
-do not dispatch agent-catalog-search and do not tell the operator
-to "open the catalog to confirm". You already have the answer.
+`AGENT_CATALOG` is a TRIMMED, RELEVANCE-RANKED view of installed
+agents — a blend of those matching the operator's current request +
+most recently used + most recently created. Each entry has id, name,
+description, tags, createdAt, and `hasWidget` (present + true when the
+agent has an inline output widget you can summon with a `show-widget`
+action — see SHOWING A WIDGET). It is NOT a full or pure-recency list,
+and a `truncated` count means older/unrelated agents were elided.
+When the operator asks about installed agents, answer from it RIGHT
+NOW where you can — do not tell the operator to "open the catalog to
+confirm".
 
-- "Newest / most recently installed agent?" → entry[0]. Give its
-  name, what it does (from `description`), when it was added
-  (humanized date), and a link to its page: `/agents/<id>`.
+- "Newest / most recently installed agent?" → compare `createdAt`
+  ACROSS entries and pick the max (do NOT assume entry[0] — the list
+  is relevance-ranked, not creation-ordered). Give its name, what it
+  does (from `description`), when it was added (humanized date), and a
+  link: `/agents/<id>`. If `truncated` > 0, note a newer one could be
+  outside this view and offer agent-catalog-search to be sure.
 - "What does agent X do?" → find it by id/name and summarize its
   `description`; link `/agents/<id>`.
 - Provide the link as a CTA so the operator can open it in one
   click (see FORMATTING + the `links` field below).
 
-Still dispatch `agent-catalog-search` (when allowed) for genuine
-capability/topic search across many descriptions ("find an agent
-that can summarize PDFs") — that path gets the full catalog. For a
-simple recency or named-agent lookup, answer inline; no round-trip.
+When the operator names an agent (or topic) you DON'T see in
+AGENT_CATALOG and `truncated` > 0, it was elided — dispatch
+`agent-catalog-search` (when allowed), which searches the FULL
+catalog, then act on what it finds. Also use catalog-search for
+genuine capability search ("find an agent that can summarize PDFs").
 If `AGENT_CATALOG` is empty and you truly cannot answer, say so
 plainly and point the operator at `/agents`.
 

--- a/packages/core/src/run-store.test.ts
+++ b/packages/core/src/run-store.test.ts
@@ -505,4 +505,20 @@ describe('RunStore retry chain', () => {
   it('getRetryChain returns empty array for unknown run id', () => {
     expect(store.getRetryChain('does-not-exist')).toEqual([]);
   });
+
+  describe('latestRunAtByAgent', () => {
+    it('returns the max startedAt per agent (any status)', () => {
+      store.createRun(makeRun({ id: 'a1', agentName: 'alpha', status: 'completed', startedAt: '2026-06-01T00:00:00.000Z' }));
+      store.createRun(makeRun({ id: 'a2', agentName: 'alpha', status: 'failed', startedAt: '2026-06-20T00:00:00.000Z' }));
+      store.createRun(makeRun({ id: 'b1', agentName: 'beta', status: 'running', startedAt: '2026-06-10T00:00:00.000Z' }));
+      const m = store.latestRunAtByAgent();
+      expect(m.get('alpha')).toBe('2026-06-20T00:00:00.000Z'); // newest wins, failed counts
+      expect(m.get('beta')).toBe('2026-06-10T00:00:00.000Z');  // running counts as "used"
+      expect(m.has('gamma')).toBe(false);                       // never-run agent absent
+    });
+
+    it('is empty when there are no runs', () => {
+      expect(store.latestRunAtByAgent().size).toBe(0);
+    });
+  });
 });

--- a/packages/core/src/run-store.ts
+++ b/packages/core/src/run-store.ts
@@ -367,6 +367,22 @@ export class RunStore {
   }
 
   /**
+   * Most-recent run `startedAt` per agent, keyed by `agentName`. Any status
+   * counts as "used" (a failed/running agent is still recently touched). One
+   * GROUP BY — avoids N per-agent `listRuns` calls when ranking the triage
+   * catalog by recency-of-use. `startedAt` is an ISO string, sortable
+   * lexicographically. Backed by the idx_runs_agent / idx_runs_startedAt indexes.
+   */
+  latestRunAtByAgent(): Map<string, string> {
+    const rows = this.db.prepare(
+      'SELECT agentName, MAX(startedAt) AS latestAt FROM runs GROUP BY agentName',
+    ).all() as Array<{ agentName: string; latestAt: string }>;
+    const out = new Map<string, string>();
+    for (const r of rows) out.set(r.agentName, r.latestAt);
+    return out;
+  }
+
+  /**
    * Richer query for the dashboard. Supports filter composition (AND across
    * fields, OR within `statuses`), pagination, and returns a total count
    * alongside the rows so callers can render "Showing N–M of T" without a

--- a/packages/dashboard/src/routes/inbox-catalog-select.test.ts
+++ b/packages/dashboard/src/routes/inbox-catalog-select.test.ts
@@ -1,0 +1,71 @@
+/**
+ * selectTriageCatalog — picks the agents triage sees by blending relevance to
+ * the operator's request + recency-of-use + newest-created, so a named/used
+ * agent isn't truncated out by a creation-order cut.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Agent } from '@some-useful-agents/core';
+import { selectTriageCatalog } from './inbox-catalog.js';
+
+/** Minimal Agent for selection tests (only id/name/description/tags/createdAt are read). */
+function mk(id: string, createdAt: string, extra: Partial<Agent> = {}): Agent {
+  return { id, name: id, status: 'active', source: 'local', mcp: false, nodes: [], createdAt, ...extra } as Agent;
+}
+
+const ids = (out: Agent[]): string[] => out.map((a) => a.id);
+
+describe('selectTriageCatalog', () => {
+  it('includes a named-but-old agent when the request mentions it', () => {
+    const agents = [
+      mk('weather-dashboard', '2026-01-01T00:00:00Z'), // old, never used
+      ...Array.from({ length: 50 }, (_, i) => mk(`agent-${i}`, `2026-06-${String((i % 28) + 1).padStart(2, '0')}T00:00:00Z`)),
+    ];
+    const out = selectTriageCatalog(agents, new Map(), 'show me the weather-dashboard output', 40);
+    expect(ids(out)).toContain('weather-dashboard');
+    expect(ids(out)[0]).toBe('weather-dashboard'); // relevance is front-loaded
+  });
+
+  it('ranks a recently-used agent above an old unused one', () => {
+    const agents = [
+      mk('old-unused', '2026-01-01T00:00:00Z'),
+      mk('used-recently', '2026-01-02T00:00:00Z'),
+    ];
+    const used = new Map([['used-recently', '2026-06-20T00:00:00Z']]);
+    const out = selectTriageCatalog(agents, used, 'unrelated request', 40);
+    expect(ids(out).indexOf('used-recently')).toBeLessThan(ids(out).indexOf('old-unused'));
+  });
+
+  it('keeps a brand-new never-run agent (created reserve) even when budget is tight', () => {
+    // 10 heavily-used agents + 1 brand-new never-run; max 6 → reserve guarantees the new one.
+    const used = new Map<string, string>();
+    const agents = Array.from({ length: 10 }, (_, i) => {
+      const id = `used-${i}`;
+      used.set(id, `2026-05-${String(i + 1).padStart(2, '0')}T00:00:00Z`);
+      return mk(id, '2026-01-01T00:00:00Z');
+    });
+    agents.push(mk('brand-new', '2026-06-30T00:00:00Z')); // newest createdAt, never run
+    const out = selectTriageCatalog(agents, used, 'no match', 6);
+    expect(out).toHaveLength(6);
+    expect(ids(out)).toContain('brand-new');
+  });
+
+  it('caps the total at max and dedupes', () => {
+    const agents = Array.from({ length: 100 }, (_, i) => mk(`a-${i}`, `2026-06-${String((i % 28) + 1).padStart(2, '0')}T00:00:00Z`));
+    const out = selectTriageCatalog(agents, new Map(), '', 40);
+    expect(out).toHaveLength(40);
+    expect(new Set(ids(out)).size).toBe(40);
+  });
+
+  it('returns all agents when there are fewer than max', () => {
+    const agents = [mk('a', '2026-01-01T00:00:00Z'), mk('b', '2026-02-01T00:00:00Z'), mk('c', '2026-03-01T00:00:00Z')];
+    const out = selectTriageCatalog(agents, new Map(), '', 40);
+    expect(ids(out).sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('ignores stopwords / short tokens so a vague ask does not match everything', () => {
+    const agents = [mk('weather-bot', '2026-01-01T00:00:00Z'), mk('pr-reviewer', '2026-01-02T00:00:00Z')];
+    // "show me the output" is all stopwords/short → no relevance signal → pure recency order.
+    const out = selectTriageCatalog(agents, new Map(), 'show me the output', 40);
+    expect(ids(out).sort()).toEqual(['pr-reviewer', 'weather-bot']); // both present, none "matched"
+  });
+});

--- a/packages/dashboard/src/routes/inbox-catalog.ts
+++ b/packages/dashboard/src/routes/inbox-catalog.ts
@@ -6,6 +6,7 @@ import {
   listBuiltinTools,
   parseAgent,
   LLM_PROVIDERS,
+  type Agent,
   type LlmProvider,
   type ToolDefinition,
 } from '@some-useful-agents/core';
@@ -167,18 +168,103 @@ export function buildAgentCatalogJson(ctx: ReturnType<typeof getContext>): strin
 // agent-catalog-search, which gets the full catalog.
 const TRIAGE_CATALOG_MAX_AGENTS = 40;
 const TRIAGE_CATALOG_DESC_CAP = 200;
+/** Most relevance matches surfaced for one request (so a vague ask can't flood). */
+const TRIAGE_RELEVANCE_CAP = 15;
+/** Slots reserved for newest-created agents so brand-new (never-run) ones appear. */
+const TRIAGE_CREATED_RESERVE = 6;
+
+/**
+ * Generic filler words to ignore when matching the operator's request against
+ * agent id/name/tags. Deliberately small — topic words like "weather",
+ * "dashboard", "pr", "review" must still match.
+ */
+const CATALOG_STOPWORDS: ReadonlySet<string> = new Set([
+  'show', 'the', 'and', 'for', 'with', 'from', 'this', 'that', 'what', 'does',
+  'are', 'you', 'can', 'get', 'see', 'pull', 'run', 'now', 'again', 'latest',
+  'current', 'output', 'please', 'give', 'tell', 'about', 'into', 'out', 'any',
+  'all', 'how', 'why', 'who', 'when', 'where', 'has', 'have', 'want', 'need',
+]);
+
+/** Meaningful tokens (≥3 chars, not stopwords) from free text. */
+function catalogTokens(text: string): string[] {
+  return Array.from(new Set(
+    text.toLowerCase().split(/[^a-z0-9]+/).filter((t) => t.length >= 3 && !CATALOG_STOPWORDS.has(t)),
+  ));
+}
+
+/** Relevance score of an agent to the request tokens: id/name/tags weigh more
+ *  than description. 0 = no signal. */
+function catalogRelevance(agent: Agent, tokens: readonly string[]): number {
+  if (tokens.length === 0) return 0;
+  const strong = `${agent.id} ${agent.name} ${(agent.tags ?? []).join(' ')}`.toLowerCase();
+  const weak = (agent.description ?? '').toLowerCase();
+  let score = 0;
+  for (const t of tokens) {
+    if (strong.includes(t)) score += 3;
+    else if (weak.includes(t)) score += 1;
+  }
+  return score;
+}
+
+/**
+ * Pick + order the agents triage sees, blending three signals so the operator
+ * can reach the agent they mean even with many installed (the createdAt-only
+ * cut truncated named/used agents). Pure + exported for testing.
+ *
+ *  1. RELEVANCE — agents matching the current request (front of the list so
+ *     triage sees the likely target), score-ranked, capped.
+ *  2. RECENTLY USED — fill by last-run recency (`lastUsedAt`, fallback createdAt).
+ *  3. RECENTLY CREATED — reserve a few tail slots for newest agents so brand-new
+ *     (never-run) ones and "what's the newest?" lookups still work.
+ *
+ * Deduped, capped at `max`. With ≤ max agents, all appear (just reordered).
+ */
+export function selectTriageCatalog(
+  agents: readonly Agent[],
+  lastUsedAt: ReadonlyMap<string, string>,
+  currentRequest: string,
+  max = TRIAGE_CATALOG_MAX_AGENTS,
+): Agent[] {
+  const tokens = catalogTokens(currentRequest);
+  const recencyKey = (a: Agent): string => lastUsedAt.get(a.id) ?? a.createdAt ?? '';
+
+  const relevant = agents
+    .map((a) => ({ a, score: catalogRelevance(a, tokens) }))
+    .filter((x) => x.score > 0)
+    .sort((x, y) => y.score - x.score || recencyKey(y.a).localeCompare(recencyKey(x.a)))
+    .slice(0, TRIAGE_RELEVANCE_CAP)
+    .map((x) => x.a);
+  const usedDesc = [...agents].sort((a, b) => recencyKey(b).localeCompare(recencyKey(a)));
+  const createdDesc = [...agents].sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? ''));
+
+  const selected: Agent[] = [];
+  const seen = new Set<string>();
+  const add = (a: Agent): void => { if (!seen.has(a.id) && selected.length < max) { seen.add(a.id); selected.push(a); } };
+
+  relevant.forEach(add);                                              // 1. relevance, front
+  for (const a of usedDesc) { if (selected.length >= max - TRIAGE_CREATED_RESERVE) break; add(a); } // 2. recently used
+  let reserved = 0;                                                  // 3. newest-created reserve
+  for (const a of createdDesc) { if (reserved >= TRIAGE_CREATED_RESERVE || selected.length >= max) break; if (!seen.has(a.id)) { add(a); reserved += 1; } }
+  usedDesc.forEach(add);                                             // 4. top off if reserve underfilled
+  return selected;
+}
 
 /**
  * Trimmed catalog for the triage turn: id, name, short description, createdAt,
- * tags — newest TRIAGE_CATALOG_MAX_AGENTS only. Drops source/status to save
- * tokens. Returns the JSON plus a flag noting whether older agents were elided.
+ * tags (+ hasWidget). Selected by relevance to `currentRequest` + recency-of-use
+ * + newest-created (see selectTriageCatalog), capped at TRIAGE_CATALOG_MAX_AGENTS.
+ * Returns the JSON plus a `truncated` count of elided agents. Deep capability
+ * search still dispatches agent-catalog-search, which gets the FULL catalog.
  */
-export function buildTriageCatalogJson(ctx: ReturnType<typeof getContext>): string {
+export function buildTriageCatalogJson(
+  ctx: ReturnType<typeof getContext>,
+  currentRequest = '',
+): string {
   try {
-    const all = ctx.agentStore.listAgents()
-      .filter((a) => !SYSTEM_AGENT_IDS.has(a.id))
-      .sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? ''));
-    const shown = all.slice(0, TRIAGE_CATALOG_MAX_AGENTS).map((a) => ({
+    const all = ctx.agentStore.listAgents().filter((a) => !SYSTEM_AGENT_IDS.has(a.id));
+    const lastUsedAt = ctx.runStore.latestRunAtByAgent();
+    const selected = selectTriageCatalog(all, lastUsedAt, currentRequest);
+    const shown = selected.map((a) => ({
       id: a.id,
       name: a.name,
       description: (a.description ?? '').slice(0, TRIAGE_CATALOG_DESC_CAP),

--- a/packages/dashboard/src/routes/inbox-engine.ts
+++ b/packages/dashboard/src/routes/inbox-engine.ts
@@ -1113,7 +1113,7 @@ export async function runTriageAgent(
           // Trimmed installed-agent catalog (newest first) so triage can answer
           // recency / "what does agent X do" directly, with a link, instead of
           // dispatching agent-catalog-search for a simple lookup.
-          AGENT_CATALOG: buildTriageCatalogJson(ctx),
+          AGENT_CATALOG: buildTriageCatalogJson(ctx, currentRequest),
           // Compose the prompt from fragments on disk: the shared kernel
           // (voice, action mechanics, <plan> schema) + the one playbook that
           // matches this thread's source. Deterministic — no classifier LLM.


### PR DESCRIPTION
## What

Fixes the gap surfaced during the show-widget dogfood (and flagged directly): triage's `AGENT_CATALOG` was just the **40 newest agents by `createdAt`**, so an agent the operator *names* — but which is old and beyond the cap — was invisible to triage. It couldn't be proposed, summoned, or answered about. With 88 agents installed, "show me the weather-dashboard" failed because `weather-dashboard` was truncated out.

## How

`buildTriageCatalogJson(ctx, currentRequest)` now **blends three signals**, capped at 40:

1. **Relevance** — keyword-match the operator's current request against agent `id`/`name`/`tags` (weighted) + `description`, score-ranked and **front-loaded** so triage sees the likely target. Capped at 15 (a vague "show me an agent" can't flood it); stopwords + min-length keep it from matching everything.
2. **Recently used** — fill remaining budget by last-run recency, via a new **`RunStore.latestRunAtByAgent()`** (one indexed `GROUP BY`; any status counts as "used").
3. **Recently created** — reserve ~6 slots so brand-new never-run agents (and "what's the newest?" lookups) still appear.

Deduped; with ≤40 agents all still appear (just reordered). The selection logic is a pure, exported `selectTriageCatalog()` for testing.

**Kernel:** the catalog is no longer pure-newest-first — compare `createdAt` *across* entries for "newest installed" (don't assume `entry[0]`), and dispatch `agent-catalog-search` (which gets the FULL catalog) when a named agent is elided (`truncated > 0`).

## Verification

- **Dogfooded the original failure live:** with 88 agents, `buildTriageCatalogJson(..., "show me the weather-dashboard output")` now puts `weather-dashboard` at **index 0** (relevance, `hasWidget: true`) despite 45 truncated → in a real thread triage proposed `show-widget` → it resolved to the latest run → the dashboard widget rendered inline ("Latest weather-dashboard output" + Temperature).
- Unit tests: `latestRunAtByAgent` (GROUP BY, any-status, empty); `selectTriageCatalog` (named-but-old included + front, used > old-unused, created-reserve survives a tight budget, total cap + dedup, ≤max passthrough, stopword/short-token guard).
- Full `dashboard` + `core` suite: **2037 pass / 3 skip**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)