### PR TITLE
fix(inbox): agent-analyzer can analyze any agent, not just the thread target

### DIFF
--- a/.changeset/fix-analyzer-target.md
+++ b/.changeset/fix-analyzer-target.md
@@ -1,0 +1,18 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Fix: inbox triage can analyze any agent, not just the thread's target.
+
+agent-analyzer's preflight node hard-requires AGENT_YAML, which the inbox route injected only from
+the thread MESSAGE's agentId. So on a manual thread (no agentId) — or when triage wanted to analyze
+a different agent than the thread's target, e.g. one it just built — the YAML was never injected
+and every analyzer run failed at preflight ("Process exited with code 1"). The route now resolves
+the target from an explicit `AGENT_ID` in the action inputs (falling back to the thread's agentId),
+injects that agent's YAML, and refuses up front with a clear message when no agent can be resolved
+instead of dispatching a doomed run. The triage kernel teaches setting `AGENT_ID` to the agent to
+analyze.

--- a/agents/examples/inbox-triage/kernel.md
+++ b/agents/examples/inbox-triage/kernel.md
@@ -219,10 +219,14 @@ Rules:
 
 Agent guide (when to propose which from the allowlist):
 - `agent-analyzer` → diagnose a failed run / suggest a YAML fix
-  for the inbox message's target agent. The dashboard
-  auto-injects AGENT_YAML + LAST_RUN_OUTPUT, so you only need
-  to set `FOCUS` to a one-sentence prompt steering the
-  analysis.
+  for an agent. Set `AGENT_ID` to the agent you want analyzed
+  (its id) and `FOCUS` to a one-sentence prompt steering the
+  analysis; the dashboard injects that agent's AGENT_YAML +
+  LAST_RUN_OUTPUT for you. `AGENT_ID` defaults to the thread's
+  target agent if you omit it — so on a run-failure thread you
+  can skip it, but on a manual thread (or when analyzing an
+  agent you just built / a DIFFERENT agent than the thread's),
+  you MUST set `AGENT_ID` or the run can't find a YAML to analyze.
 - `agent-catalog-search` → the operator is looking for an
   existing installed agent that matches a capability or topic
   ("find me an agent that does X", "any agent that monitors

--- a/packages/dashboard/src/routes/inbox-catalog.ts
+++ b/packages/dashboard/src/routes/inbox-catalog.ts
@@ -351,18 +351,18 @@ export function enrichAgentCatalogSearchInputs(
  */
 export function enrichAgentAnalyzerInputs(
   ctx: ReturnType<typeof getContext>,
-  messageAgentId: string | undefined,
+  targetAgentId: string | undefined,
   inputs: Record<string, string>,
 ): Record<string, string> {
   const out: Record<string, string> = { ...inputs };
-  if (!out.AGENT_YAML && messageAgentId) {
-    const target = ctx.agentStore.getAgent(messageAgentId);
+  if (!out.AGENT_YAML && targetAgentId) {
+    const target = ctx.agentStore.getAgent(targetAgentId);
     if (target) {
       try { out.AGENT_YAML = exportAgent(target); } catch { /* swallow */ }
     }
   }
-  if (!out.LAST_RUN_OUTPUT && messageAgentId) {
-    const summary = collectRunSummary(ctx, messageAgentId);
+  if (!out.LAST_RUN_OUTPUT && targetAgentId) {
+    const summary = collectRunSummary(ctx, targetAgentId);
     if (summary) out.LAST_RUN_OUTPUT = summary;
   }
   return out;

--- a/packages/dashboard/src/routes/inbox-engine.ts
+++ b/packages/dashboard/src/routes/inbox-engine.ts
@@ -354,8 +354,30 @@ export async function runProposedAction(
   let effectiveInputs = meta.inputs;
   if (meta.agentId === 'agent-analyzer') {
     const parentMessage = ctx.inboxStore.get(messageId);
-    const targetAgentId = parentMessage?.agentId;
-    if (targetAgentId && !ctx.agentStore.getAgent(targetAgentId)) {
+    // The agent to analyze: an explicit AGENT_ID from triage (so it can analyze
+    // ANY agent, e.g. one it just built, or on a manual thread) wins; otherwise
+    // fall back to the thread's own target agent. Without this, the analyzer's
+    // preflight node hard-fails (exit 1, "requires AGENT_YAML") whenever the
+    // thread has no agentId — the bug that made every analyzer run on a manual
+    // thread fail.
+    const targetAgentId = meta.inputs.AGENT_ID?.trim() || parentMessage?.agentId;
+    if (!targetAgentId) {
+      const reason = `Can't run agent-analyzer — there's no agent to analyze on this thread. Tell me which installed agent to look at (or run it from its /agents/<id> page).`;
+      const endedAt = Date.now();
+      ctx.inboxStore.updateResponse(response.id, {
+        metaJson: JSON.stringify({ ...meta, status: 'failed', startedAt, endedAt, refusalReason: reason }),
+      });
+      publishInboxEvent(ctx, messageId, 'action:status', {
+        responseId: response.id, status: 'failed', agentId: meta.agentId, startedAt, endedAt, refusalReason: reason,
+      });
+      const sysReply = ctx.inboxStore.addResponse(messageId, 'system', reason);
+      publishInboxEvent(ctx, messageId, 'message:created', {
+        responseId: sysReply.id, role: 'system', body: reason, createdAt: sysReply.createdAt,
+      });
+      maybeRefireTriage(ctx, messageId);
+      return;
+    }
+    if (!ctx.agentStore.getAgent(targetAgentId)) {
       const reason = `Can't dispatch agent-analyzer — the target agent "${targetAgentId}" is not installed in this catalog. Install it (e.g. from agents/examples or via the Agents → Import page) and try again.`;
       const endedAt = Date.now();
       ctx.inboxStore.updateResponse(response.id, {

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -1117,6 +1117,75 @@ describe('POST /inbox/:id/actions/:rid/run — agent-analyzer enrichment', () =>
     expect(systemReply).toBeDefined();
     expect(systemReply!.body).toMatch(/ghost-agent-not-installed/);
   });
+
+  it('injects AGENT_YAML from inputs.AGENT_ID on a thread with no target agent', async () => {
+    // The bug: agent-analyzer keyed its YAML off the MESSAGE's agentId, so on a
+    // MANUAL thread (no agentId) — e.g. analyzing an agent triage just built —
+    // AGENT_YAML was empty and preflight always exit-1'd. Now triage can name
+    // the agent via inputs.AGENT_ID and the route injects that agent's YAML.
+    const app = await makeApp();
+    agentStore.upsertAgent(parseAgent([
+      'id: built-by-triage', 'name: Built By Triage', 'description: token built-marker',
+      'nodes:', '  - id: noop', '    type: shell', '    command: echo ok',
+    ].join('\n')), 'dashboard', 'test fixture');
+    agentStore.upsertAgent(parseAgent([
+      'id: agent-analyzer', 'name: Agent Analyzer', 'description: echo stub',
+      'inputs:', '  AGENT_YAML:', '    type: string', '    required: true',
+      'nodes:', '  - id: echo', '    type: shell', '    command: "echo received: $AGENT_YAML"',
+    ].join('\n')), 'dashboard', 'test fixture');
+
+    // MANUAL thread — no agentId on the message.
+    const msg = inboxStore.add({ priority: 'medium', source: 'manual', title: 'chat', body: 'fix the opener' });
+    const proposed = inboxStore.addResponse(msg.id, 'action', 'analyze it', JSON.stringify({
+      kind: 'action', status: 'proposed', agentId: 'agent-analyzer',
+      inputs: { AGENT_ID: 'built-by-triage', FOCUS: 'why does it fail' },
+      rationale: 'diagnose the just-built agent',
+    }));
+
+    await request(app).post(`/inbox/${msg.id}/actions/${proposed.id}/run`)
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+
+    const deadline = Date.now() + 2000;
+    let after = inboxStore.getResponse(proposed.id);
+    while (Date.now() < deadline) {
+      after = inboxStore.getResponse(proposed.id);
+      const m = after?.metaJson ? JSON.parse(after.metaJson) : null;
+      if (m && m.status !== 'proposed' && m.status !== 'running') break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    const meta = JSON.parse(after!.metaJson!);
+    expect(meta.status).toBe('completed');
+    expect(meta.resultSummary).toContain('built-marker'); // YAML of built-by-triage reached the analyzer
+  });
+
+  it('refuses up front when there is NO agent to analyze (no AGENT_ID, no thread target)', async () => {
+    const app = await makeApp();
+    agentStore.upsertAgent(parseAgent([
+      'id: agent-analyzer', 'name: Agent Analyzer', 'description: stub',
+      'nodes:', '  - id: noop', '    type: shell', '    command: echo ok',
+    ].join('\n')), 'dashboard', 'test fixture');
+
+    const msg = inboxStore.add({ priority: 'medium', source: 'manual', title: 'chat', body: 'help' });
+    const proposed = inboxStore.addResponse(msg.id, 'action', 'analyze', JSON.stringify({
+      kind: 'action', status: 'proposed', agentId: 'agent-analyzer', inputs: { FOCUS: 'x' },
+    }));
+
+    await request(app).post(`/inbox/${msg.id}/actions/${proposed.id}/run`)
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+
+    const deadline = Date.now() + 1500;
+    let after = inboxStore.getResponse(proposed.id);
+    while (Date.now() < deadline) {
+      after = inboxStore.getResponse(proposed.id);
+      const m = after?.metaJson ? JSON.parse(after.metaJson) : null;
+      if (m && m.status !== 'proposed' && m.status !== 'running') break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    const meta = JSON.parse(after!.metaJson!);
+    expect(meta.status).toBe('failed');
+    expect(meta.refusalReason).toMatch(/no agent to analyze/i);
+    expect(inboxStore.listResponses(msg.id).some((r) => r.role === 'system')).toBe(true);
+  });
 });
 
 describe('POST /inbox/:id/actions/:rid/run — agent-catalog-search enrichment', () => {


### PR DESCRIPTION
## The bug

Found by investigating the `agent-analyzer` failures (the peanut-butter thread, where it died on every run). In the wild: **37 completed / 33 failed**, all failures at the `preflight` node with `exit_nonzero` / "Process exited with code 1".

## Root cause

`agent-analyzer`'s `preflight` node hard-requires `AGENT_YAML` (the YAML of the agent to analyze). The inbox route injects that via `enrichAgentAnalyzerInputs`, but it resolved the agent from **`message.agentId`** (the inbox thread's target):

- **Run-failure threads** carry the failing agent's id → YAML injected → works (the 37 completions).
- **Manual threads** (no `agentId`), or when triage wanted to analyze a *different* agent than the thread's target (e.g. one it just built) → no YAML → `preflight` exits 1 → `analyze`/`validate`/`fix`/`summarize` all skip → run fails (the 33 failures).

That's exactly the peanut-butter thread: a manual conversation where triage tried to diagnose `open-apple-notes` (which it had just built) — no thread `agentId`, so every attempt was doomed before it started, and triage could never produce a fix.

## The fix

- **`inbox-engine.ts`** `runProposedAction` — resolve the analyzer target from `inputs.AGENT_ID` (trimmed) first, falling back to `message.agentId`. **Refuse up front** with a clear in-thread message when *neither* resolves (instead of dispatching a run guaranteed to fail at preflight). The "not installed" guard now validates the resolved target.
- **`inbox-catalog.ts`** — `enrichAgentAnalyzerInputs` param `messageAgentId` → `targetAgentId` (it now receives the resolved id and injects *that* agent's YAML).
- **`kernel.md`** — the agent-analyzer guidance teaches setting `AGENT_ID` to the agent to analyze (defaults to the thread target when omitted; **required** on manual threads or when analyzing a different agent).

## Verification

- **Dogfooded the exact failure live:** a manual thread → "analyze the list-notes agent" → triage set `AGENT_ID=list-notes` → **`preflight` completed** (was exit-1) → `analyze`/`validate`/`fix`/`summarize` all completed.
- Tests: `AGENT_YAML` injection from `inputs.AGENT_ID` on a thread with no target agent; refuse-up-front when there's no agent to analyze. Full `dashboard` + `core` suite: **2039 pass / 3 skip**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)