### PR TITLE
fix(core): import node-cron ScheduledTask as a named type

### DIFF
--- a/.changeset/node-cron-types-namespace.md
+++ b/.changeset/node-cron-types-namespace.md
@@ -1,0 +1,15 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Fix node-cron type import so the build survives the 4.5.0 bump.
+
+node-cron 4.5.0 ships a bundled type declaration whose default export no
+longer doubles as a type namespace, so `cron.ScheduledTask` stopped
+resolving (`TS2503: Cannot find namespace 'cron'`). Import `ScheduledTask`
+as a named type instead. Backward compatible with 4.2.1; unblocks the
+Dependabot prod-minor-patch bump.

--- a/packages/core/src/scheduler.ts
+++ b/packages/core/src/scheduler.ts
@@ -1,4 +1,5 @@
 import cron from 'node-cron';
+import type { ScheduledTask } from 'node-cron';
 import type { AgentDefinition, Provider, Run } from './types.js';
 import type { Agent } from './agent-v2-types.js';
 import { validateScheduleInterval } from './cron-validator.js';
@@ -87,8 +88,8 @@ export interface LocalSchedulerOptions {
 const HEARTBEAT_INTERVAL_MS = 30_000;
 
 export class LocalScheduler {
-  private tasks: Array<{ agent: AgentDefinition; task: cron.ScheduledTask }> = [];
-  private v2Tasks: Array<{ agent: Agent; task: cron.ScheduledTask }> = [];
+  private tasks: Array<{ agent: AgentDefinition; task: ScheduledTask }> = [];
+  private v2Tasks: Array<{ agent: Agent; task: ScheduledTask }> = [];
   private readonly provider: Provider;
   private readonly agents: Map<string, AgentDefinition>;
   private readonly v2Agents: Agent[];


### PR DESCRIPTION
## What

node-cron 4.5.0 ships a bundled type declaration whose default export no longer doubles as a type namespace, so `cron.ScheduledTask` stopped resolving:

```
packages/core/src/scheduler.ts(90,56): error TS2503: Cannot find namespace 'cron'.
packages/core/src/scheduler.ts(91,48): error TS2503: Cannot find namespace 'cron'.
```

This breaks `build-and-test` and `validate-agents` on the Dependabot prod-minor-patch bump (#523, which bumps node-cron 4.2.1 → 4.5.0).

## Fix

Import `ScheduledTask` as a named type (`import type { ScheduledTask } from 'node-cron'`) instead of reaching through the default-export namespace. Both 4.2.1 and 4.5.0 export it as a named type, so this is backward compatible.

## Verification

- `tsc --build packages/core` green on the installed 4.2.1.
- Temporarily installed node-cron@4.5.0 + cron-parser@5.6.0: full `npm run build` green, `scheduler.test.ts` + `cron-validator.test.ts` = 17/17 pass. Lockfile restored after.

Once this lands on main, #523 builds green on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)