### PR TITLE
fix(inbox): don't render an output widget twice in a thread

### DIFF
--- a/.changeset/inbox-show-widget-dedup.md
+++ b/.changeset/inbox-show-widget-dedup.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Inbox: stop triage from rendering an output widget twice in a thread.
+
+After triage ran an agent in a thread, the follow-up triage turn would
+often propose a `show-widget` action pointing at that same just-completed
+run — but the run-agent card already renders that run's widget inline, so
+the widget appeared twice. The engine now declines a `show-widget` whose
+latest completed run is already shown inline on the thread
+(`showWidgetWouldDuplicate`), and the triage kernel teaches not to
+show-widget an agent it just ran in the same thread.

--- a/agents/examples/inbox-triage/kernel.md
+++ b/agents/examples/inbox-triage/kernel.md
@@ -334,6 +334,11 @@ read-only and resolves instantly (no Run button, no waiting).
 - If there's no completed run yet, the card says so — then offer to
   `run-agent` it to produce one. Don't propose show-widget for an
   agent with no widget.
+- Do NOT show-widget an agent you just `run-agent`'d in THIS thread:
+  the run-agent card already renders that run's widget inline, so a
+  show-widget would draw the same output twice. After running an
+  agent, the widget is already on screen — say so in text, don't
+  re-summon it.
 
 ════════════════════════════════════════════════════════════════
 OUTPUT FORMAT — exact shape, single <plan>...</plan> block

--- a/packages/dashboard/src/routes/inbox-engine.ts
+++ b/packages/dashboard/src/routes/inbox-engine.ts
@@ -717,6 +717,41 @@ export function resolveShowWidgetAction(
 }
 
 /**
+ * True when a `show-widget` for `agentId` would re-render a run that is ALREADY
+ * displayed inline in this thread. Triage tends to propose a show-widget right
+ * after a run-agent action completes — but the run action's own completed
+ * widget is already on screen, so the show-widget would draw the same run's
+ * widget a second time. We resolve to the same "latest completed run" the
+ * action would point at and check whether an earlier completed action
+ * (run-agent OR a prior show-widget) on this thread already renders it inline.
+ * Used to decline the redundant proposal before a duplicate card is created.
+ */
+export function showWidgetWouldDuplicate(
+  ctx: ReturnType<typeof getContext>,
+  messageId: string,
+  agentId: string,
+): boolean {
+  if (!ctx.inboxStore) return false;
+  const agent = ctx.agentStore.getAgent(agentId);
+  if (!agent || !canRenderInlineInboxWidget(agent)) return false;
+  let latest;
+  try {
+    latest = ctx.runStore.listRuns({ agentName: agentId, status: 'completed', limit: 1 })[0];
+  } catch {
+    latest = undefined;
+  }
+  if (!latest) return false;
+  for (const r of ctx.inboxStore.listResponses(messageId)) {
+    if (r.role !== 'action') continue;
+    const m = parseActionMeta(r);
+    // Mirror buildInlineActionWidgets' render predicate: a completed action
+    // pointing at this run renders its widget inline.
+    if (m && m.status === 'completed' && m.runId === latest.id) return true;
+  }
+  return false;
+}
+
+/**
  * Apply a YAML change to an existing agent. Validates:
  *   - `AGENT_ID` input is present
  *   - `NEW_YAML` parses cleanly via `parseAgent`
@@ -1275,6 +1310,13 @@ export async function runTriageAgent(
       for (const action of accepted) {
         if (action.mode === 'show-widget' && !ctx.agentStore.getAgent(action.agentId)) {
           rejected.push({ agentId: action.agentId, reason: 'agent is not installed' });
+          continue;
+        }
+        if (action.mode === 'show-widget' && showWidgetWouldDuplicate(ctx, messageId, action.agentId)) {
+          rejected.push({
+            agentId: action.agentId,
+            reason: 'its latest output is already shown in this thread',
+          });
           continue;
         }
         if (hasMatchingFailedAction(ctx, messageId, action)) {

--- a/packages/dashboard/src/routes/inbox-show-widget.test.ts
+++ b/packages/dashboard/src/routes/inbox-show-widget.test.ts
@@ -9,7 +9,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { AgentStore, InboxStore, RunStore, type InboxActionMeta, type InboxMessage, type InboxResponse } from '@some-useful-agents/core';
-import { resolveShowWidgetAction, atLeastOneActionExecuted } from './inbox-engine.js';
+import { resolveShowWidgetAction, atLeastOneActionExecuted, showWidgetWouldDuplicate } from './inbox-engine.js';
 import { renderInboxDetailFragment } from '../views/inbox-detail.js';
 import { render, html } from '../views/html.js';
 
@@ -90,6 +90,39 @@ describe('resolveShowWidgetAction', () => {
     expect(r.status).toBe('completed');
     expect(r.runId).toBe('run-new');         // newest first (listRuns DESC)
     expect(r.summary).toContain('Latest output');
+  });
+});
+
+describe('showWidgetWouldDuplicate', () => {
+  it('is true when a completed action on the thread already shows the latest run', () => {
+    const ctx = setup();
+    mkAgent('hn', true);
+    mkCompletedRun('run-1', 'hn');
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    // a run-agent action that produced run-1 already renders its widget inline
+    const ranMeta: InboxActionMeta = { kind: 'action', status: 'completed', agentId: 'hn', inputs: {}, runId: 'run-1' };
+    inboxStore.addResponse(m.id, 'action', 'ran hn', JSON.stringify(ranMeta));
+    expect(showWidgetWouldDuplicate(ctx, m.id, 'hn')).toBe(true);
+  });
+
+  it('is false when the thread has no action showing the latest run', () => {
+    const ctx = setup();
+    mkAgent('hn', true);
+    mkCompletedRun('run-1', 'hn');
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    expect(showWidgetWouldDuplicate(ctx, m.id, 'hn')).toBe(false);
+  });
+
+  it('is false when the shown run is older than the latest completed run', () => {
+    const ctx = setup();
+    mkAgent('hn', true);
+    mkCompletedRun('run-old', 'hn', '2026-06-01T00:00:00.000Z');
+    mkCompletedRun('run-new', 'hn', '2026-06-20T00:00:00.000Z');
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    // an action shows the OLD run; show-widget would surface run-new → not a dup
+    const oldMeta: InboxActionMeta = { kind: 'action', status: 'completed', agentId: 'hn', inputs: {}, runId: 'run-old' };
+    inboxStore.addResponse(m.id, 'action', 'ran hn', JSON.stringify(oldMeta));
+    expect(showWidgetWouldDuplicate(ctx, m.id, 'hn')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Symptom

On thread `33a6e126` (a manual "latest hacker news headlines" thread), the HN Top Stories output widget rendered **twice**. Reported as "triage extra eager or a race."

## Root cause — not a race

Both action responses pointed at the **same run** (`e0f98a01`):

1. A `run-agent` action ran `hn-top-stories` → completed. Its card renders that run's widget inline.
2. `maybeRefireTriage` fired after the run completed; the follow-up triage turn proposed a `show-widget` for "the latest HN Top Stories output" — **the very run it just produced**. `buildInlineActionWidgets` keys widgets by `response.id`, so two actions referencing one run each emit a widget → the duplicate.

## Fix (defense in depth)

- **Engine guard (load-bearing):** `showWidgetWouldDuplicate(ctx, messageId, agentId)` resolves the same "latest completed run" a show-widget would point at and checks whether an earlier completed action on the thread already renders it inline (mirrors `buildInlineActionWidgets`' predicate). The action dedup loop declines such proposals → a grouped "declined" note, **no duplicate card**.
- **Kernel teaching:** triage is told not to `show-widget` an agent it just `run-agent`'d in the same thread — the widget is already on screen.

## Verification

- New unit tests for `showWidgetWouldDuplicate` (already-shown / not-shown / older-run-not-a-dup) + existing show-widget suite: 10/10. All inbox route suites: 153/153.
- **Live dogfood:** reproduced the exact HN flow on a fresh thread (create → "latest hacker news headlines" → run the proposed action → refire). Rendered fragment now has **1 inline-widget slot, 0 redundant show-widget cards** (was 2 widgets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)