### PR TITLE
feat(inbox): triage can WRITE to dashboards (dashboard-editor action)

### DIFF
--- a/.changeset/dashboard-editor-inbox-action.md
+++ b/.changeset/dashboard-editor-inbox-action.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox triage can now WRITE to dashboards.
+
+A new `dashboard-editor` action lets the triage agent pin an agent's signal tile
+onto a user dashboard (creating the dashboard if it doesn't exist) or create an
+empty dashboard — e.g. "add the weather agent to my dashboard", "make a dashboard
+called Markets". It's route-handled and auto-approved like `agent-editor`, writes
+synchronously, and is sequenced as one write per turn. Agents without a Pulse
+signal are refused with a clear message (dashboards render signal tiles only).
+Shared slug + section-layout helpers moved into core.

--- a/agents/examples/inbox-triage/kernel.md
+++ b/agents/examples/inbox-triage/kernel.md
@@ -336,6 +336,34 @@ read-only and resolves instantly (no Run button, no waiting).
   agent with no widget.
 
 ════════════════════════════════════════════════════════════════
+WRITING TO A DASHBOARD — pin an agent's tile, or make a dashboard
+════════════════════════════════════════════════════════════════
+
+When the operator wants to PUT an agent on a dashboard or MAKE a
+dashboard — "add the weather agent to my dashboard", "pin this to a
+new dashboard called Markets", "create a dashboard" — propose a
+`dashboard-editor` action. It writes synchronously (it's route-handled,
+like agent-editor) and the operator confirms one write at a time.
+
+- Shape (add a tile, creating the dashboard if it doesn't exist):
+  `{ "type": "dashboard-editor", "rationale": "…",
+     "inputs": { "op": "add-tile", "DASHBOARD": "<name or user:slug>",
+                 "AGENT_ID": "<id>", "SECTION": "Widgets" } }`
+  `SECTION` is optional (defaults to "Widgets"). `DASHBOARD` may be a
+  display name (created if new) or an existing `user:<slug>` id.
+- Shape (create an empty dashboard):
+  `{ "type": "dashboard-editor", "rationale": "…",
+     "inputs": { "op": "create", "DASHBOARD": "<name>" } }`
+- A tile only renders if the agent has a Pulse signal — `hasSignal: true`
+  in AGENT_CATALOG. If it doesn't, DON'T propose add-tile (the write
+  will refuse); say so plainly and offer to show the widget inline
+  instead (`show-widget`).
+- This is a WRITE: at most one write action per turn. After it lands
+  you get a follow-up turn — confirm the result and offer a one-click
+  `links: [{ "label": "Open <name>", "href": "/dashboards/<id>" }]`
+  CTA using the id from the action result.
+
+════════════════════════════════════════════════════════════════
 OUTPUT FORMAT — exact shape, single <plan>...</plan> block
 ════════════════════════════════════════════════════════════════
 
@@ -515,13 +543,16 @@ VALIDATION RULES (failing these means the route discards the response):
   a known action to confirm the fix. Leave it absent for
   ambiguous or judgement-call recommendations.
 - `actions` is optional. When present, must be an array of 0..3
-  entries each with a `type` (`"run-agent"` or `"show-widget"`), a
-  string `agentId`, and a `rationale` string. A `run-agent` entry's
+  entries each with a `type` (`"run-agent"`, `"show-widget"`, or
+  `"dashboard-editor"`) and a `rationale` string. A `run-agent` entry's
   `agentId` must be in the allowlist/candidates and may carry an
   `inputs` map + an `effect` (`"read"`/`"write"`, absent ⇒ `"read"`;
   at most one `"write"` survives per turn). A `show-widget` entry
   targets any installed agent with a widget, takes no `inputs`/`effect`,
-  and renders that agent's latest output read-only.
+  and renders that agent's latest output read-only. A `dashboard-editor`
+  entry takes no top-level `agentId`; it carries an `inputs.op`
+  (`"add-tile"` | `"create"`) and counts as one `"write"` per turn (see
+  WRITING TO A DASHBOARD).
 - `commitmentSummary` is optional. When `actions` is non-empty,
   set this to a short (3..60 char) verb-led phrase describing
   the pending work for the operator chip. Omit when there are

--- a/packages/core/src/dashboard-layout.test.ts
+++ b/packages/core/src/dashboard-layout.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { slugifyDashboardName, allocateUserDashboardId, mutateSections } from './dashboard-layout.js';
+import type { DashboardLayout } from './dashboards-store.js';
+
+describe('slugifyDashboardName', () => {
+  it('lowercases and hyphenates punctuation runs', () => {
+    expect(slugifyDashboardName('Markets & Crypto!')).toBe('markets-crypto');
+  });
+  it('trims leading/trailing hyphens', () => {
+    expect(slugifyDashboardName('  --Hello--  ')).toBe('hello');
+  });
+  it('falls back to "dashboard" when nothing survives', () => {
+    expect(slugifyDashboardName('!!!')).toBe('dashboard');
+    expect(slugifyDashboardName('')).toBe('dashboard');
+  });
+  it('caps at 40 chars', () => {
+    const long = 'a'.repeat(60);
+    expect(slugifyDashboardName(long)).toHaveLength(40);
+  });
+});
+
+describe('allocateUserDashboardId', () => {
+  it('returns user:<slug> when free', () => {
+    expect(allocateUserDashboardId('Markets', () => false)).toBe('user:markets');
+  });
+  it('appends a base-36 timestamp suffix on collision', () => {
+    const id = allocateUserDashboardId('Markets', (cand) => cand === 'user:markets');
+    expect(id).toMatch(/^user:markets-[a-z0-9]+$/);
+    expect(id).not.toBe('user:markets');
+  });
+});
+
+describe('mutateSections', () => {
+  it('deep-copies sections and agentIds — input is untouched', () => {
+    const layout: DashboardLayout = { sections: [{ title: 'A', agentIds: ['x'] }] };
+    const out = mutateSections(layout, (arr) => {
+      arr[0].agentIds.push('y');
+      arr.push({ title: 'B', agentIds: ['z'] });
+    });
+    expect(out).toHaveLength(2);
+    expect(out[0].agentIds).toEqual(['x', 'y']);
+    // original untouched
+    expect(layout.sections).toHaveLength(1);
+    expect(layout.sections[0].agentIds).toEqual(['x']);
+  });
+});

--- a/packages/core/src/dashboard-layout.ts
+++ b/packages/core/src/dashboard-layout.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure, framework-free helpers for shaping dashboard ids and layouts.
+ *
+ * Extracted so BOTH the dashboard editor routes and the inbox-triage
+ * `dashboard-editor` action mutate layouts through one implementation rather
+ * than duplicating slug + section logic. No Express, no store, no context —
+ * just data in, data out.
+ */
+import type { DashboardLayout, DashboardSection } from './dashboards-store.js';
+
+/**
+ * Turn a human dashboard name into a url-safe slug. Lowercases, collapses any
+ * run of non-alphanumerics to a single hyphen, trims leading/trailing hyphens,
+ * caps at 40 chars, and falls back to `dashboard` when nothing survives.
+ */
+export function slugifyDashboardName(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 40) || 'dashboard'
+  );
+}
+
+/**
+ * Allocate a `user:<slug>` id for a new user dashboard. `exists` reports
+ * whether a candidate id is already taken; on collision we append a base-36
+ * timestamp suffix so a second "Markets" dashboard becomes
+ * `user:markets-<ts>` rather than clobbering the first.
+ */
+export function allocateUserDashboardId(
+  name: string,
+  exists: (id: string) => boolean,
+): string {
+  const base = `user:${slugifyDashboardName(name)}`;
+  return exists(base) ? `${base}-${Date.now().toString(36)}` : base;
+}
+
+/**
+ * Deep-copy a layout's sections, run `fn` over the copy, and return it — so
+ * callers can mutate freely without touching the stored layout. Copies each
+ * section AND its `agentIds` array (the part that's most often spliced).
+ */
+export function mutateSections(
+  layout: DashboardLayout,
+  fn: (arr: DashboardSection[]) => void,
+): DashboardSection[] {
+  const arr = layout.sections.map((s) => ({ ...s, agentIds: [...s.agentIds] }));
+  fn(arr);
+  return arr;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,6 +76,11 @@ export {
   type DashboardLayout,
 } from './dashboards-store.js';
 export {
+  slugifyDashboardName,
+  allocateUserDashboardId,
+  mutateSections,
+} from './dashboard-layout.js';
+export {
   LayoutHintsStore,
   type LayoutHint,
   type LayoutHintPatch,

--- a/packages/dashboard/src/routes/dashboard-first-run.ts
+++ b/packages/dashboard/src/routes/dashboard-first-run.ts
@@ -1,0 +1,42 @@
+/**
+ * First-add courtesy run for dashboard tiles.
+ *
+ * A tile renders blank until its agent has produced output, so a freshly added
+ * agent that has never run shows an empty card. This fires one fire-and-forget
+ * run so the tile populates in place on the next render. Shared by the dashboard
+ * editor routes and the inbox-triage `dashboard-editor` action so both populate
+ * tiles the same way. Not pure (it needs the full ctx store bundle +
+ * executeAgentWithRetry), so it lives in the dashboard package rather than core.
+ */
+import { executeAgentWithRetry } from '@some-useful-agents/core';
+import { type DashboardContext } from '../context.js';
+
+/**
+ * Fire one fire-and-forget run for `agentId` so its tile isn't blank. No-op
+ * when the agent has already run (avoids redundant work when an agent is
+ * re-added or shared across dashboards) and for community-shell agents that
+ * require explicit audit confirmation (those must be run by hand).
+ */
+export function maybeKickoffFirstRun(ctx: DashboardContext, agentId: string): void {
+  const agent = ctx.agentStore.getAgent(agentId);
+  if (!agent || !agent.signal) return;
+  if (ctx.runStore.listRuns({ agentName: agentId, limit: 1 }).length > 0) return;
+  if (agent.source === 'community' && agent.nodes.some((n) => n.type === 'shell')) return;
+
+  const abortController = new AbortController();
+  executeAgentWithRetry(
+    agent,
+    { triggeredBy: 'dashboard', inputs: {}, signal: abortController.signal },
+    {
+      runStore: ctx.runStore,
+      secretsStore: ctx.secretsStore,
+      variablesStore: ctx.variablesStore,
+      integrationsStore: ctx.integrationsStore,
+      toolStore: ctx.toolStore,
+      agentStore: ctx.agentStore,
+      allowUntrustedShell: ctx.allowUntrustedShell,
+      dashboardBaseUrl: ctx.dashboardBaseUrl,
+      dataRoot: ctx.agentStore.dataRoot,
+    },
+  ).catch(() => {});
+}

--- a/packages/dashboard/src/routes/dashboards-edit.ts
+++ b/packages/dashboard/src/routes/dashboards-edit.ts
@@ -7,44 +7,13 @@
  */
 
 import { Router, type Request, type Response } from 'express';
-import { executeAgentWithRetry, type DashboardLayout, type DashboardSection } from '@some-useful-agents/core';
-import { getContext, type DashboardContext } from '../context.js';
+import { allocateUserDashboardId, mutateSections } from '@some-useful-agents/core';
+import { getContext } from '../context.js';
 import { renderDashboardEditPage } from '../views/dashboard-edit.js';
 import { renderNotFoundPage } from '../views/not-found.js';
+import { maybeKickoffFirstRun } from './dashboard-first-run.js';
 
 export const dashboardsEditRouter: Router = Router();
-
-/**
- * First-add courtesy run: a tile renders blank until its agent has produced
- * output, so a freshly added agent that has never run shows an empty card.
- * Fire one fire-and-forget run so the tile populates in place on the next
- * render. No-op when the agent has already run (avoids redundant work when an
- * agent is re-added or shared across dashboards) and for agents that require
- * explicit community-shell audit confirmation (those must be run by hand).
- */
-function maybeKickoffFirstRun(ctx: DashboardContext, agentId: string): void {
-  const agent = ctx.agentStore.getAgent(agentId);
-  if (!agent || !agent.signal) return;
-  if (ctx.runStore.listRuns({ agentName: agentId, limit: 1 }).length > 0) return;
-  if (agent.source === 'community' && agent.nodes.some((n) => n.type === 'shell')) return;
-
-  const abortController = new AbortController();
-  executeAgentWithRetry(
-    agent,
-    { triggeredBy: 'dashboard', inputs: {}, signal: abortController.signal },
-    {
-      runStore: ctx.runStore,
-      secretsStore: ctx.secretsStore,
-      variablesStore: ctx.variablesStore,
-      integrationsStore: ctx.integrationsStore,
-      toolStore: ctx.toolStore,
-      agentStore: ctx.agentStore,
-      allowUntrustedShell: ctx.allowUntrustedShell,
-      dashboardBaseUrl: ctx.dashboardBaseUrl,
-      dataRoot: ctx.agentStore.dataRoot,
-    },
-  ).catch(() => {});
-}
 
 const DASHBOARD_ID_RE = /^[a-z0-9][a-z0-9:_-]*$/;
 
@@ -249,11 +218,7 @@ dashboardsEditRouter.post('/dashboards', (req: Request, res: Response) => {
     return;
   }
   // Generate a slug; collision-resistant via timestamp suffix if needed.
-  const baseSlug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 40) || 'dashboard';
-  let id = `user:${baseSlug}`;
-  if (ctx.dashboardsStore.getDashboard(id)) {
-    id = `user:${baseSlug}-${Date.now().toString(36)}`;
-  }
+  const id = allocateUserDashboardId(name, (cand) => Boolean(ctx.dashboardsStore!.getDashboard(cand)));
   ctx.dashboardsStore.upsertDashboard({ id, packId: null, name, layout: { sections: [] } });
   res.redirect(303, `/dashboards/${encodeURIComponent(id)}/edit?ok=Dashboard+created.`);
 });
@@ -285,15 +250,6 @@ function withDashboard(
   } catch (err) {
     redirectErr(res, id, err instanceof Error ? err.message : String(err));
   }
-}
-
-function mutateSections(
-  layout: DashboardLayout,
-  fn: (arr: DashboardSection[]) => void,
-): DashboardSection[] {
-  const arr = layout.sections.map((s) => ({ ...s, agentIds: [...s.agentIds] }));
-  fn(arr);
-  return arr;
 }
 
 function pickId(req: Request): string {

--- a/packages/dashboard/src/routes/inbox-catalog.ts
+++ b/packages/dashboard/src/routes/inbox-catalog.ts
@@ -273,6 +273,10 @@ export function buildTriageCatalogJson(
       // Whether this agent has an inline-able output widget — lets triage pick a
       // sensible target for a `show-widget` action. Omitted when false (token thrift).
       ...(canRenderInlineInboxWidget(a) ? { hasWidget: true } : {}),
+      // Whether this agent has a Pulse signal — only signal agents render as
+      // dashboard tiles, so triage uses this to pick valid `dashboard-editor`
+      // add-tile targets. Omitted when false (token thrift).
+      ...(a.signal ? { hasSignal: true } : {}),
     }));
     const payload: { agents: typeof shown; truncated?: number } = { agents: shown };
     if (all.length > shown.length) payload.truncated = all.length - shown.length;

--- a/packages/dashboard/src/routes/inbox-dashboard-editor.test.ts
+++ b/packages/dashboard/src/routes/inbox-dashboard-editor.test.ts
@@ -1,0 +1,179 @@
+/**
+ * dashboard-editor action: `executeDashboardEditor` writes a user dashboard
+ * (create an empty one, or add an agent's signal tile, creating the dashboard if
+ * needed). It refuses agents that aren't installed or have no Pulse signal —
+ * dashboards only render signal tiles. Plus a render assertion for the action
+ * card chrome.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AgentStore, InboxStore, RunStore, DashboardsStore, type InboxActionMeta, type InboxMessage, type InboxResponse } from '@some-useful-agents/core';
+import { executeDashboardEditor } from './inbox-engine.js';
+import { renderInboxDetailFragment } from '../views/inbox-detail.js';
+import { render } from '../views/html.js';
+
+let dir: string;
+let agentStore: AgentStore;
+let inboxStore: InboxStore;
+let runStore: RunStore;
+let dashboardsStore: DashboardsStore;
+
+function setup() {
+  dir = mkdtempSync(join(tmpdir(), 'sua-dash-editor-'));
+  const db = join(dir, 'runs.db');
+  agentStore = new AgentStore(db);
+  inboxStore = new InboxStore(db);
+  runStore = new RunStore(db);
+  dashboardsStore = new DashboardsStore(db);
+  return { agentStore, inboxStore, runStore, dashboardsStore } as never as ReturnType<typeof import('../context.js').getContext>;
+}
+
+afterEach(() => {
+  try { agentStore.close(); } catch { /* ignore */ }
+  try { inboxStore.close(); } catch { /* ignore */ }
+  try { runStore.close(); } catch { /* ignore */ }
+  try { dashboardsStore.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+/** Install an agent, optionally with a Pulse signal (required to render as a tile). */
+function mkAgent(id: string, withSignal: boolean): void {
+  agentStore.createAgent({
+    id, name: id, status: 'active', source: 'local', mcp: false,
+    nodes: [{ id: 'n', type: 'shell', command: 'echo hi', dependsOn: [] }],
+    ...(withSignal ? { signal: { title: id } } : {}),
+  }, 'cli');
+}
+
+/** A prior completed run so maybeKickoffFirstRun no-ops (keeps the test hermetic). */
+function mkCompletedRun(id: string, agentName: string): void {
+  const now = new Date().toISOString();
+  runStore.createRun({
+    id, agentName, status: 'completed',
+    startedAt: now, completedAt: now,
+    triggeredBy: 'dashboard', result: 'ok',
+  });
+}
+
+const addTile = (inputs: Record<string, string>): InboxActionMeta =>
+  ({ kind: 'action', status: 'proposed', agentId: 'dashboard-editor', inputs: { op: 'add-tile', ...inputs }, effect: 'write' });
+
+describe('executeDashboardEditor — create', () => {
+  it('creates an empty user dashboard', () => {
+    const ctx = setup();
+    const r = executeDashboardEditor(ctx, { kind: 'action', status: 'proposed', agentId: 'dashboard-editor', inputs: { op: 'create', DASHBOARD: 'Markets' } });
+    expect(r.status).toBe('completed');
+    expect(r.summary).toContain('/dashboards/user:markets');
+    const made = dashboardsStore.listUserDashboards();
+    expect(made.map((d) => d.id)).toContain('user:markets');
+    expect(made[0].layout.sections).toEqual([]);
+  });
+
+  it('refuses create with no DASHBOARD name', () => {
+    const ctx = setup();
+    const r = executeDashboardEditor(ctx, { kind: 'action', status: 'proposed', agentId: 'dashboard-editor', inputs: { op: 'create' } });
+    expect(r.status).toBe('failed');
+    expect(r.refusalReason).toContain('DASHBOARD name');
+  });
+});
+
+describe('executeDashboardEditor — add-tile', () => {
+  it('creates the dashboard and adds the tile to the default Widgets section', () => {
+    const ctx = setup();
+    mkAgent('weather', true);
+    mkCompletedRun('run-1', 'weather');
+    const r = executeDashboardEditor(ctx, addTile({ DASHBOARD: 'Markets', AGENT_ID: 'weather' }));
+    expect(r.status).toBe('completed');
+    expect(r.summary).toContain('/dashboards/user:markets');
+    const dash = dashboardsStore.getDashboard('user:markets')!;
+    expect(dash.layout.sections).toHaveLength(1);
+    expect(dash.layout.sections[0].title).toBe('Widgets');
+    expect(dash.layout.sections[0].agentIds).toEqual(['weather']);
+  });
+
+  it('honors a custom SECTION title', () => {
+    const ctx = setup();
+    mkAgent('weather', true);
+    mkCompletedRun('run-1', 'weather');
+    executeDashboardEditor(ctx, addTile({ DASHBOARD: 'Markets', AGENT_ID: 'weather', SECTION: 'Top' }));
+    const dash = dashboardsStore.getDashboard('user:markets')!;
+    expect(dash.layout.sections[0].title).toBe('Top');
+  });
+
+  it('adds to an EXISTING dashboard referenced by user:<slug> id', () => {
+    const ctx = setup();
+    mkAgent('weather', true);
+    mkCompletedRun('run-1', 'weather');
+    dashboardsStore.upsertDashboard({ id: 'user:markets', packId: null, name: 'Markets', layout: { sections: [] } });
+    const r = executeDashboardEditor(ctx, addTile({ DASHBOARD: 'user:markets', AGENT_ID: 'weather' }));
+    expect(r.status).toBe('completed');
+    expect(dashboardsStore.listUserDashboards()).toHaveLength(1); // no duplicate dashboard
+    expect(dashboardsStore.getDashboard('user:markets')!.layout.sections[0].agentIds).toEqual(['weather']);
+  });
+
+  it('refuses an agent that is not installed', () => {
+    const ctx = setup();
+    const r = executeDashboardEditor(ctx, addTile({ DASHBOARD: 'Markets', AGENT_ID: 'ghost' }));
+    expect(r.status).toBe('failed');
+    expect(r.refusalReason).toContain('not installed');
+  });
+
+  it('refuses an agent with no Pulse signal', () => {
+    const ctx = setup();
+    mkAgent('plain', false);
+    const r = executeDashboardEditor(ctx, addTile({ DASHBOARD: 'Markets', AGENT_ID: 'plain' }));
+    expect(r.status).toBe('failed');
+    expect(r.refusalReason).toContain('Pulse signal');
+  });
+
+  it('dedupes — adding an agent already on the dashboard is a no-op success', () => {
+    const ctx = setup();
+    mkAgent('weather', true);
+    mkCompletedRun('run-1', 'weather');
+    executeDashboardEditor(ctx, addTile({ DASHBOARD: 'Markets', AGENT_ID: 'weather' }));
+    const before = dashboardsStore.getDashboard('user:markets')!;
+    const r = executeDashboardEditor(ctx, addTile({ DASHBOARD: 'user:markets', AGENT_ID: 'weather' }));
+    expect(r.status).toBe('completed');
+    expect(r.summary).toContain('already on');
+    const after = dashboardsStore.getDashboard('user:markets')!;
+    expect(after.layout.sections).toHaveLength(before.layout.sections.length);
+    expect(after.layout.sections[0].agentIds).toEqual(['weather']); // unchanged
+  });
+
+  it('refuses an unknown op', () => {
+    const ctx = setup();
+    const r = executeDashboardEditor(ctx, { kind: 'action', status: 'proposed', agentId: 'dashboard-editor', inputs: { op: 'nuke', DASHBOARD: 'x' } });
+    expect(r.status).toBe('failed');
+    expect(r.refusalReason).toContain('Unknown dashboard-editor op');
+  });
+});
+
+describe('dashboard-editor card chrome', () => {
+  const message: InboxMessage = {
+    id: 'm1', createdAt: Date.now(), priority: 'medium', source: 'manual',
+    title: 't', body: 'b', status: 'awaiting_user', starred: false, tags: [],
+  };
+  const completedAddTile = (): InboxResponse => ({
+    id: 'resp-1', messageId: 'm1', createdAt: Date.now(), role: 'action',
+    body: 'Add weather to Markets.',
+    metaJson: JSON.stringify({
+      kind: 'action', status: 'completed', agentId: 'dashboard-editor',
+      inputs: { op: 'add-tile', DASHBOARD: 'Markets', AGENT_ID: 'weather' },
+      effect: 'write',
+      resultSummary: 'Added weather to new dashboard "Markets" — /dashboards/user:markets',
+    } satisfies InboxActionMeta),
+  });
+
+  it('renders the "Add tile" headline with the dashboard + agent', () => {
+    const out = render(renderInboxDetailFragment({
+      message,
+      responses: [completedAddTile()],
+      inlineActionWidgets: {},
+    }));
+    expect(out).toContain('Add tile');
+    expect(out).toContain('Markets');
+    expect(out).toContain('/dashboards/user:markets'); // summary preview
+  });
+});

--- a/packages/dashboard/src/routes/inbox-engine.ts
+++ b/packages/dashboard/src/routes/inbox-engine.ts
@@ -18,6 +18,8 @@ import {
   isAppleIntegrationEnabled,
   isTriageLearningsEnabled,
   parseAgent,
+  allocateUserDashboardId,
+  mutateSections,
   LEARNING_CATEGORIES,
   LEARNING_SCOPES,
   type Agent,
@@ -30,6 +32,7 @@ import {
   type LearningScope,
 } from '@some-useful-agents/core';
 import { getContext } from '../context.js';
+import { maybeKickoffFirstRun } from './dashboard-first-run.js';
 import { buildLlmSettingsSnapshot } from '../lib/llm-settings-snapshot.js';
 import { autoFixYaml } from './run-now-build.js';
 import { applyProviderPin } from './build-orchestrator.js';
@@ -108,6 +111,7 @@ const TRIAGE_AUTO_APPROVE_AGENTS: ReadonlySet<string> = new Set([
   'agent-editor',
   'agent-catalog-search',
   'agent-builder',
+  'dashboard-editor',
 ]);
 
 /**
@@ -117,7 +121,7 @@ const TRIAGE_AUTO_APPROVE_AGENTS: ReadonlySet<string> = new Set([
  * committing a YAML change via `agentStore.upsertAgent`) is performed
  * synchronously inside `runProposedAction`.
  */
-const ROUTE_HANDLED_AGENTS: ReadonlySet<string> = new Set(['agent-editor']);
+const ROUTE_HANDLED_AGENTS: ReadonlySet<string> = new Set(['agent-editor', 'dashboard-editor']);
 
 /**
  * Hard cap on `action`-role responses per inbox message. Triage gets a
@@ -663,10 +667,11 @@ function maybeRefireTriage(
 }
 
 /**
- * Synchronous executor for agents listed in `ROUTE_HANDLED_AGENTS`.
- * Today that's just `agent-editor`, which commits a YAML change via
- * `agentStore.upsertAgent` after validation. Returns the action's
- * terminal status + a summary line for the conversation thread.
+ * Synchronous executor for agents listed in `ROUTE_HANDLED_AGENTS`:
+ * `agent-editor` commits a YAML change via `agentStore.upsertAgent`, and
+ * `dashboard-editor` writes a user dashboard via `dashboardsStore`. Each runs
+ * after validation and returns the action's terminal status + a summary line
+ * for the conversation thread.
  */
 async function executeRouteHandledAgent(
   ctx: ReturnType<typeof getContext>,
@@ -676,10 +681,101 @@ async function executeRouteHandledAgent(
   if (meta.agentId === 'agent-editor') {
     return executeAgentEditor(ctx, messageId, meta);
   }
+  if (meta.agentId === 'dashboard-editor') {
+    return executeDashboardEditor(ctx, meta);
+  }
   return {
     status: 'failed',
     refusalReason: `Route-handled agent "${meta.agentId}" has no executor.`,
   };
+}
+
+/**
+ * Execute a `dashboard-editor` action — the WRITE counterpart to `show-widget`.
+ * Route-handled and synchronous (mirrors `executeAgentEditor`): mutates a user
+ * dashboard via `ctx.dashboardsStore`. Two ops carried in `meta.inputs.op`:
+ *
+ *   create   — make an empty `user:<slug>` dashboard from a DASHBOARD name.
+ *   add-tile — pin AGENT_ID's tile onto DASHBOARD (a name or an existing
+ *              `user:<slug>` id), creating the dashboard if it doesn't exist,
+ *              in section SECTION (default "Widgets").
+ *
+ * Dashboards only render tiles for agents that have a Pulse `signal`, so
+ * add-tile refuses an agent without one (the kernel pre-filters via the
+ * catalog's `hasSignal` flag; this is the backstop). On success the summary
+ * embeds `/dashboards/<id>` — the refire turn turns that into a one-click link.
+ */
+export function executeDashboardEditor(
+  ctx: ReturnType<typeof getContext>,
+  meta: InboxActionMeta,
+): { status: InboxActionStatus; summary?: string; refusalReason?: string } {
+  if (!ctx.dashboardsStore) {
+    return { status: 'failed', refusalReason: 'Dashboards store unavailable.' };
+  }
+  const store = ctx.dashboardsStore;
+  const op = meta.inputs.op;
+
+  if (op === 'create') {
+    const name = (meta.inputs.DASHBOARD ?? '').trim();
+    if (!name) return { status: 'failed', refusalReason: 'create requires a DASHBOARD name.' };
+    const id = allocateUserDashboardId(name, (c) => Boolean(store.getDashboard(c)));
+    store.upsertDashboard({ id, packId: null, name, layout: { sections: [] } });
+    return { status: 'completed', summary: `Created dashboard "${name}" — /dashboards/${id}` };
+  }
+
+  if (op === 'add-tile') {
+    const agentId = (meta.inputs.AGENT_ID ?? '').trim();
+    const target = (meta.inputs.DASHBOARD ?? '').trim();
+    const sectionTitle = (meta.inputs.SECTION ?? '').trim() || 'Widgets';
+    if (!agentId || !target) {
+      return { status: 'failed', refusalReason: 'add-tile requires AGENT_ID and DASHBOARD.' };
+    }
+    const agent = ctx.agentStore.getAgent(agentId);
+    if (!agent) return { status: 'failed', refusalReason: `Agent "${agentId}" is not installed.` };
+    if (!agent.signal) {
+      return {
+        status: 'failed',
+        refusalReason: `${agent.name || agentId} has no Pulse signal, so it can't show as a dashboard tile. Dashboards display signal tiles only.`,
+      };
+    }
+
+    // Resolve-or-create: target may be an existing `user:<slug>` id or a name.
+    let dash = store.getDashboard(target);
+    let id = target;
+    let created = false;
+    if (!dash) {
+      id = allocateUserDashboardId(target, (c) => Boolean(store.getDashboard(c)));
+      store.upsertDashboard({ id, packId: null, name: target, layout: { sections: [] } });
+      dash = store.getDashboard(id)!;
+      created = true;
+    }
+
+    // Dedupe: already on this dashboard (any section) → no-op success.
+    if (dash.layout.sections.some((s) => s.agentIds.includes(agentId))) {
+      return {
+        status: 'completed',
+        summary: `${agent.name || agentId} is already on "${dash.name}" — /dashboards/${id}`,
+      };
+    }
+
+    const sections = mutateSections(dash.layout, (arr) => {
+      let sec = arr.find((s) => s.title === sectionTitle);
+      if (!sec) {
+        sec = { title: sectionTitle, agentIds: [] };
+        arr.push(sec);
+      }
+      sec.agentIds = [...sec.agentIds, agentId];
+    });
+    store.updateLayout(id, { sections });
+    maybeKickoffFirstRun(ctx, agentId); // populate the freshly added blank tile
+
+    return {
+      status: 'completed',
+      summary: `Added ${agent.name || agentId} to ${created ? 'new dashboard' : 'dashboard'} "${dash.name}" — /dashboards/${id}`,
+    };
+  }
+
+  return { status: 'failed', refusalReason: `Unknown dashboard-editor op "${op}".` };
 }
 
 /**
@@ -1269,7 +1365,13 @@ export async function runTriageAgent(
     const planHasShowWidget = rawActionList.some(
       (a) => a && typeof a === 'object' && (a as { type?: unknown }).type === 'show-widget',
     );
-    if (allowlist.length > 0 || planHasShowWidget) {
+    // dashboard-editor is route-handled (not allowlist-gated), like show-widget,
+    // so a "create me a dashboard" plan on a thread with no runnable agents must
+    // still enter the action block.
+    const planHasDashboardEditor = rawActionList.some(
+      (a) => a && typeof a === 'object' && (a as { type?: unknown }).type === 'dashboard-editor',
+    );
+    if (allowlist.length > 0 || planHasShowWidget || planHasDashboardEditor) {
       const { accepted, rejected, deferred } = parseProposedActions(parsed.actions, allowlist, candidates);
       const dedupedAccepted: InboxActionMeta[] = [];
       for (const action of accepted) {

--- a/packages/dashboard/src/routes/inbox-plan.ts
+++ b/packages/dashboard/src/routes/inbox-plan.ts
@@ -202,6 +202,41 @@ export function parseProposedActions(
       });
       continue;
     }
+    // `dashboard-editor` WRITES to a user dashboard (route-handled pseudo-agent,
+    // like agent-editor). The op lives in `inputs.op`; the engine executor does
+    // the real validation (agent installed, has a signal). Not gated on the run
+    // allowlist. Parser checks shape only.
+    if (type === 'dashboard-editor') {
+      const inputs: Record<string, string> = {};
+      if (e.inputs && typeof e.inputs === 'object' && !Array.isArray(e.inputs)) {
+        for (const [k, v] of Object.entries(e.inputs as Record<string, unknown>)) {
+          if (typeof k === 'string' && typeof v === 'string') inputs[k] = v;
+        }
+      }
+      const op = inputs.op;
+      if (op !== 'add-tile' && op !== 'create') {
+        rejected.push({ agentId: 'dashboard-editor', reason: 'dashboard-editor needs inputs.op = add-tile | create' });
+        continue;
+      }
+      if (!inputs.DASHBOARD) {
+        rejected.push({ agentId: 'dashboard-editor', reason: 'dashboard-editor requires inputs.DASHBOARD' });
+        continue;
+      }
+      if (op === 'add-tile' && !inputs.AGENT_ID) {
+        rejected.push({ agentId: 'dashboard-editor', reason: 'add-tile requires inputs.AGENT_ID' });
+        continue;
+      }
+      accepted.push({
+        kind: 'action',
+        status: 'proposed',
+        agentId: 'dashboard-editor',
+        inputs,
+        rationale: rationaleRaw || undefined,
+        effect: 'write',
+        ctaLabel: op === 'create' ? 'Create dashboard' : 'Add tile',
+      });
+      continue;
+    }
     if (type !== 'run-agent' || !agentId) {
       rejected.push({ agentId: agentId || '<unknown>', reason: 'malformed action entry' });
       continue;

--- a/packages/dashboard/src/routes/inbox-request-to-run.test.ts
+++ b/packages/dashboard/src/routes/inbox-request-to-run.test.ts
@@ -104,6 +104,69 @@ describe('parseProposedActions — show-widget', () => {
   });
 });
 
+describe('parseProposedActions — dashboard-editor', () => {
+  it('accepts add-tile with op/DASHBOARD/AGENT_ID, marks it a write', () => {
+    const { accepted, rejected } = parseProposedActions(
+      [{ type: 'dashboard-editor', rationale: 'pin weather', inputs: { op: 'add-tile', DASHBOARD: 'Markets', AGENT_ID: 'weather', SECTION: 'Widgets' } }],
+      [], // route-handled, not allowlist-gated
+      [],
+    );
+    expect(rejected).toHaveLength(0);
+    expect(accepted).toHaveLength(1);
+    expect(accepted[0].agentId).toBe('dashboard-editor');
+    expect(accepted[0].effect).toBe('write');
+    expect(accepted[0].ctaLabel).toBe('Add tile');
+    expect(accepted[0].inputs).toEqual({ op: 'add-tile', DASHBOARD: 'Markets', AGENT_ID: 'weather', SECTION: 'Widgets' });
+  });
+
+  it('accepts create with just op/DASHBOARD', () => {
+    const { accepted } = parseProposedActions(
+      [{ type: 'dashboard-editor', inputs: { op: 'create', DASHBOARD: 'Markets' } }],
+      [],
+    );
+    expect(accepted).toHaveLength(1);
+    expect(accepted[0].ctaLabel).toBe('Create dashboard');
+    expect(accepted[0].effect).toBe('write');
+  });
+
+  it('rejects unknown / missing op', () => {
+    const { accepted, rejected } = parseProposedActions(
+      [{ type: 'dashboard-editor', inputs: { op: 'nuke', DASHBOARD: 'x' } }],
+      [],
+    );
+    expect(accepted).toHaveLength(0);
+    expect(rejected[0].reason).toContain('add-tile | create');
+  });
+
+  it('rejects missing DASHBOARD', () => {
+    const { rejected } = parseProposedActions(
+      [{ type: 'dashboard-editor', inputs: { op: 'create' } }],
+      [],
+    );
+    expect(rejected[0].reason).toContain('DASHBOARD');
+  });
+
+  it('rejects add-tile missing AGENT_ID', () => {
+    const { rejected } = parseProposedActions(
+      [{ type: 'dashboard-editor', inputs: { op: 'add-tile', DASHBOARD: 'x' } }],
+      [],
+    );
+    expect(rejected[0].reason).toContain('AGENT_ID');
+  });
+
+  it('defers a second write when a dashboard-editor write is already in the plan', () => {
+    const { accepted, deferred } = parseProposedActions(
+      [
+        { type: 'dashboard-editor', inputs: { op: 'create', DASHBOARD: 'a' } },
+        { type: 'run-agent', agentId: 'make-note', effect: 'write' },
+      ],
+      ['make-note'],
+    );
+    expect(accepted.map((a) => a.agentId)).toEqual(['dashboard-editor']);
+    expect(deferred).toEqual([{ agentId: 'make-note' }]);
+  });
+});
+
 describe('parseProposedActions — side-effect sequencing', () => {
   it('defaults a missing effect to read and batches reads', () => {
     const { accepted, deferred } = parseProposedActions(

--- a/packages/dashboard/src/views/inbox-detail.ts
+++ b/packages/dashboard/src/views/inbox-detail.ts
@@ -610,9 +610,11 @@ function renderActionEntry(r: InboxResponse, currentTargetYaml?: string, inlineW
         </div>
         <div class="inbox-action__card">
           <div class="inbox-action__headline">
-            ${meta.mode === 'show-widget'
-              ? html`Latest <span class="mono">${meta.agentId}</span> output`
-              : html`Run agent <span class="mono">${meta.agentId}</span>`}
+            ${meta.agentId === 'dashboard-editor'
+              ? html`${meta.inputs.op === 'create' ? 'Create dashboard' : 'Add tile'} · <span class="mono">${meta.inputs.DASHBOARD ?? ''}</span>${meta.inputs.AGENT_ID ? html` · <span class="mono">${meta.inputs.AGENT_ID}</span>` : html``}`
+              : meta.mode === 'show-widget'
+                ? html`Latest <span class="mono">${meta.agentId}</span> output`
+                : html`Run agent <span class="mono">${meta.agentId}</span>`}
             ${meta.runId ? html` · <a href="/runs/${meta.runId}" class="mono">run ${meta.runId.slice(0, 8)}</a>` : html``}
           </div>
           ${meta.rationale ? html`<div class="inbox-action__rationale">${mdBody(meta.rationale)}</div>` : html``}


### PR DESCRIPTION
## What

The WRITE half of inbox "span of control" — the counterpart to the read-only `show-widget` action (#519/#520). From a conversation thread, triage can now:
- **add-tile** — pin an agent's signal tile onto a user dashboard, creating the dashboard if it doesn't exist
- **create** — make an empty user dashboard

e.g. "add the weather agent to my dashboard", "make a dashboard called Markets".

## How

Mirrors the `agent-editor` lifecycle exactly: a route-handled, auto-approved, synchronous, store-mutating pseudo-agent. No new execution model, no `InboxActionMeta` change (`agentId:'dashboard-editor'` + `inputs.op`).

- **core** — extract slug + section-layout helpers into `dashboard-layout.ts` (`slugifyDashboardName`, `allocateUserDashboardId`, `mutateSections`), shared by the existing dashboard editor routes and the new engine executor (behavior-preserving refactor of `dashboards-edit.ts`).
- **parser** (`inbox-plan.ts`) — accept `type:'dashboard-editor'`, validate shape, mark `effect:'write'` (engages the one-write-per-turn sequencer).
- **engine** (`inbox-engine.ts`) — `executeDashboardEditor`, registered in `ROUTE_HANDLED_AGENTS` + `TRIAGE_AUTO_APPROVE_AGENTS`; `planHasDashboardEditor` gate so a "create me a dashboard" plan on a thread with no runnable agents still enters the action block. Refires triage to confirm (no `mode`, so it counts as executed).
- **catalog** (`inbox-catalog.ts`) — `hasSignal` flag so triage targets only agents that can actually render as tiles.
- **render** (`inbox-detail.ts`) — "Add tile" / "Create dashboard" card headline; result summary carries `/dashboards/<id>`.
- **kernel** — `WRITING TO A DASHBOARD` section + action-`type` enumeration.

### Key constraint
Dashboards only render tiles for agents with a Pulse `signal`. add-tile **refuses** a signal-less agent with a clear message; the kernel pre-filters via the new `hasSignal` catalog flag, with the executor refusal as backstop. No dashboard render-path changes. (`remove-tile`/`rename`/`delete` slot in later as new `op` values — no parser/meta churn.)

### Links
Action meta has no links field; the executor `summary` embeds `/dashboards/<id>` as text, and the refire turn emits the real one-click `links` CTA — same pattern agent-editor uses.

## Verification

- 23 new tests (core layout, executor happy/refuse-no-signal/refuse-not-installed/dedupe/create/by-id, parser, render). Full suite: **2062 pass / 3 skip** (was 2039).
- **Live dogfood:** "add the cocktail-of-the-day agent to a new dashboard called Happy Hour" → triage proposed `dashboard-editor` add-tile → auto-approved → completed → `user:happy-hour` created with the tile in a "Widgets" section → `/dashboards/user:happy-hour` renders the Cocktail of the Day tile → refire turn carried `{"label":"Open Happy Hour","href":"/dashboards/user:happy-hour"}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)