### PR TITLE
fix(inbox): surface the agent-editor fix card when analyzing any agent

### DIFF
--- a/.changeset/analyzer-editor-manual-thread.md
+++ b/.changeset/analyzer-editor-manual-thread.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Inbox: the "approve YAML fix" card now appears when analyzing any agent.
+
+After agent-analyzer produced a corrected YAML, the auto-proposed `agent-editor`
+approve card was gated on `parsed.id === message.agentId`, so on a manual thread
+(no message agent) or when analyzing an agent other than the thread's, no card was
+created — triage kept saying "approve the queued fix" with nothing to approve.
+It now targets the corrected YAML's own agent id (resolving the fix target from
+the analysis, the same way #524 fixed analyzer dispatch), and only requires that
+agent to be installed.

--- a/packages/dashboard/src/routes/inbox-analyzer-editor.test.ts
+++ b/packages/dashboard/src/routes/inbox-analyzer-editor.test.ts
@@ -1,0 +1,110 @@
+/**
+ * After agent-analyzer completes, `maybeAutoProposeEditorAction` extracts the
+ * corrected `<yaml>` from the analyzer's run and auto-inserts the "approve the
+ * fix" `agent-editor` card. Regression: it must target the YAML's OWN agent id
+ * (the agent the analyzer corrected) so the card appears on a MANUAL thread
+ * (no message.agentId) and when analyzing any agent — not just the thread's.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AgentStore, InboxStore, RunStore, parseAgent, type InboxActionMeta } from '@some-useful-agents/core';
+import { maybeAutoProposeEditorAction } from './inbox-engine.js';
+import { parseActionMeta } from './inbox-shared.js';
+
+let dir: string;
+let agentStore: AgentStore;
+let inboxStore: InboxStore;
+let runStore: RunStore;
+
+function setup() {
+  dir = mkdtempSync(join(tmpdir(), 'sua-analyzer-editor-'));
+  const db = join(dir, 'runs.db');
+  agentStore = new AgentStore(db);
+  inboxStore = new InboxStore(db);
+  runStore = new RunStore(db);
+  return { agentStore, inboxStore, runStore } as never as ReturnType<typeof import('../context.js').getContext>;
+}
+
+afterEach(() => {
+  try { agentStore.close(); } catch { /* ignore */ }
+  try { inboxStore.close(); } catch { /* ignore */ }
+  try { runStore.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+const CORRECTED_YAML = [
+  'id: markets-today',
+  'name: Markets Today',
+  'description: fixed-marker',
+  'nodes:',
+  '  - id: noop',
+  '    type: shell',
+  '    command: echo ok',
+].join('\n');
+
+/** Seed a completed analyzer run whose `analyze` node emits the corrected YAML. */
+function seedAnalyzerRun(runId: string, yaml = CORRECTED_YAML): void {
+  const now = new Date().toISOString();
+  runStore.createRun({ id: runId, agentName: 'agent-analyzer', status: 'completed', startedAt: now, completedAt: now, triggeredBy: 'dashboard' });
+  runStore.createNodeExecution({
+    runId, nodeId: 'analyze', workflowVersion: 1, status: 'completed',
+    startedAt: now, completedAt: now, result: `<yaml>\n${yaml}\n</yaml>`,
+  });
+}
+
+describe('maybeAutoProposeEditorAction', () => {
+  it('proposes the agent-editor card on a MANUAL thread, targeting the YAML id', () => {
+    const ctx = setup();
+    agentStore.upsertAgent(parseAgent(CORRECTED_YAML), 'dashboard', 'fixture'); // markets-today installed
+    seedAnalyzerRun('an-1');
+    // Manual thread — no agentId. This is the case that used to drop the card.
+    const msg = inboxStore.add({ priority: 'medium', source: 'manual', title: 'chat', body: 'fix it' });
+
+    maybeAutoProposeEditorAction(ctx, msg.id, 'an-1');
+
+    const editor = inboxStore.listResponses(msg.id)
+      .map((r) => parseActionMeta(r))
+      .find((m): m is InboxActionMeta => Boolean(m && m.agentId === 'agent-editor'));
+    expect(editor).toBeDefined();
+    expect(editor!.status).toBe('proposed');
+    expect(editor!.inputs.AGENT_ID).toBe('markets-today');
+    expect(editor!.inputs.NEW_YAML).toContain('markets-today');
+  });
+
+  it('no-ops when the YAML targets an agent that is not installed', () => {
+    const ctx = setup();
+    seedAnalyzerRun('an-1'); // markets-today NOT installed
+    const msg = inboxStore.add({ priority: 'medium', source: 'manual', title: 'chat', body: 'fix it' });
+
+    maybeAutoProposeEditorAction(ctx, msg.id, 'an-1');
+
+    const hasEditor = inboxStore.listResponses(msg.id).some((r) => parseActionMeta(r)?.agentId === 'agent-editor');
+    expect(hasEditor).toBe(false);
+  });
+
+  it('no-ops when there is no <yaml> block in the run', () => {
+    const ctx = setup();
+    const now = new Date().toISOString();
+    runStore.createRun({ id: 'an-1', agentName: 'agent-analyzer', status: 'completed', startedAt: now, completedAt: now, triggeredBy: 'dashboard' });
+    runStore.createNodeExecution({ runId: 'an-1', nodeId: 'analyze', workflowVersion: 1, status: 'completed', startedAt: now, completedAt: now, result: 'no yaml here' });
+    const msg = inboxStore.add({ priority: 'medium', source: 'manual', title: 'chat', body: 'fix it' });
+
+    maybeAutoProposeEditorAction(ctx, msg.id, 'an-1');
+    expect(inboxStore.listResponses(msg.id).some((r) => parseActionMeta(r)?.agentId === 'agent-editor')).toBe(false);
+  });
+
+  it('does not double-propose the same YAML while one is still pending', () => {
+    const ctx = setup();
+    agentStore.upsertAgent(parseAgent(CORRECTED_YAML), 'dashboard', 'fixture');
+    seedAnalyzerRun('an-1');
+    const msg = inboxStore.add({ priority: 'medium', source: 'manual', title: 'chat', body: 'fix it' });
+
+    maybeAutoProposeEditorAction(ctx, msg.id, 'an-1');
+    maybeAutoProposeEditorAction(ctx, msg.id, 'an-1'); // re-run analyzer, same YAML
+
+    const editors = inboxStore.listResponses(msg.id).filter((r) => parseActionMeta(r)?.agentId === 'agent-editor');
+    expect(editors).toHaveLength(1);
+  });
+});

--- a/packages/dashboard/src/routes/inbox-engine.ts
+++ b/packages/dashboard/src/routes/inbox-engine.ts
@@ -956,13 +956,15 @@ function extractYamlBlockFromRunNodes(
 }
 
 /**
- * Extract a `<yaml>...</yaml>` block from agent-analyzer's run
- * result, validate it, and (if it targets the inbox message's agent)
- * auto-insert a proposed `agent-editor` action card. Silently no-ops
- * if no yaml block is present, if it doesn't parse, if it targets a
- * different agent, or if the per-message action cap has been hit.
+ * Extract a `<yaml>...</yaml>` block from agent-analyzer's run result, validate
+ * it, and (if its id is an installed agent) auto-insert a proposed
+ * `agent-editor` action card — the "approve the fix" button. Targets the YAML's
+ * own agent id (the agent the analyzer corrected), so it works on manual
+ * threads and when analyzing any agent, not just the thread's. Silently no-ops
+ * if no yaml block is present, if it doesn't parse, if its agent isn't
+ * installed, or if the per-message action cap has been hit.
  */
-function maybeAutoProposeEditorAction(
+export function maybeAutoProposeEditorAction(
   ctx: ReturnType<typeof getContext>,
   messageId: string,
   analyzerRunId: string,
@@ -973,8 +975,12 @@ function maybeAutoProposeEditorAction(
   let parsed;
   try { parsed = parseAgent(proposedYaml); } catch { return; }
 
-  const message = ctx.inboxStore.get(messageId);
-  if (!message?.agentId || parsed.id !== message.agentId) return;
+  // The analyzer produces a corrected version of the agent it analyzed, so the
+  // fix target is the YAML's own id. Resolve from there — NOT from
+  // message.agentId, which is empty on a manual thread and wrong when analyzing
+  // an agent other than the thread's (the #524 class of bug: it dropped the
+  // approve card entirely). Only require that agent to be installed.
+  if (!parsed.id || !ctx.agentStore.getAgent(parsed.id)) return;
 
   // Respect the cap so a chatty analyzer can't fan out unbounded edits.
   if (countActionsOnMessage(ctx, messageId) >= MAX_ACTIONS_PER_MESSAGE) return;
@@ -993,7 +999,7 @@ function maybeAutoProposeEditorAction(
     kind: 'action',
     status: 'proposed',
     agentId: 'agent-editor',
-    inputs: { AGENT_ID: message.agentId, NEW_YAML: proposedYaml },
+    inputs: { AGENT_ID: parsed.id, NEW_YAML: proposedYaml },
     rationale: `Apply the YAML fix that agent-analyzer produced.`,
   };
   const editorResp = ctx.inboxStore.addResponse(


### PR DESCRIPTION
## Symptom

Reported on thread `fe6412f5`: Markets Today hit a 429, triage ran `agent-analyzer` (completed), but **no "approve the fix" card ever appeared** — triage kept saying "approve the queued Markets Today YAML fix" / "click the Approve button" with nothing to approve. Re-running the analyzer didn't help.

## Root cause (a #524-class bug)

After agent-analyzer completes, `maybeAutoProposeEditorAction` extracts the corrected `<yaml>` and auto-inserts the `agent-editor` approve card. It was gated on:

```ts
if (!message?.agentId || parsed.id !== message.agentId) return;
```

This thread was a **manual thread** (no `message.agentId`) and the analyzed agent was `markets-today` (built earlier in the same conversation), so the guard bailed and the card was never created. Same class as #524 — assuming the target is the *message's* agent rather than the agent actually being analyzed.

## Fix

Target the corrected YAML's **own** agent id (the agent the analyzer fixed), and only require that agent to be installed:

```ts
if (!parsed.id || !ctx.agentStore.getAgent(parsed.id)) return;
...
inputs: { AGENT_ID: parsed.id, NEW_YAML: proposedYaml },
```

Now the approve card is created on manual threads and when analyzing any agent. (`agent-editor` is a trusted auto-approve agent, so the card then applies the fix automatically — which is the intended behavior; the bug was that it was never created.)

## Verification

- Exported `maybeAutoProposeEditorAction` + 4 focused unit tests (manual-thread happy path targeting the YAML id, not-installed no-op, no-`<yaml>` no-op, dedupe). Full suite **2073 pass / 3 skip** (was 2069).
- **Live on the reported thread:** re-ran the analyzer → agent-editor card created (AGENT_ID=markets-today) → auto-approved → `markets-today` bumped to **v2 "Inbox triage applied YAML fix"**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)