### PR TITLE
feat(inbox): triage run-awareness — report run failures instead of "run it and see"

### DIFF
--- a/.changeset/triage-run-awareness.md
+++ b/.changeset/triage-run-awareness.md
@@ -1,0 +1,18 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Inbox triage can now SEE an agent's latest run, and reports failures directly.
+
+Triage was blind to agent run outcomes, so when an agent in a thread failed it
+could only say "run it and see what happened" — the operator had to run the agent
+and paste the error back. Triage now receives `FOCUS_AGENT_RUN`: the latest run
+output of the agent the thread is about (the message target, or the most recent
+agent a thread action touched), including a "MOST RECENT RUN FAILED" block with
+the failing node and error. The kernel teaches triage to report the failure
+directly (node + error) and propose the fix, instead of asking the operator to
+re-run and report.

--- a/agents/examples/inbox-triage.yaml
+++ b/agents/examples/inbox-triage.yaml
@@ -87,6 +87,23 @@ inputs:
     description: >
       The conversation thread to date, one entry per line as
       `[ROLE] body`. Empty on the first triage of a fresh message.
+  FOCUS_AGENT:
+    type: string
+    required: false
+    default: ""
+    description: >
+      The id of the agent this thread is about (the message's target, or
+      the most recent agent a thread action touched). Empty when the
+      thread isn't about a specific agent.
+  FOCUS_AGENT_RUN:
+    type: string
+    required: false
+    default: ""
+    description: >
+      FOCUS_AGENT's latest run output, including a "MOST RECENT RUN
+      FAILED" block (error + failing node) when the last run failed. Lets
+      triage REPORT a run outcome directly instead of asking the operator
+      to run the agent and report back. Empty when there's no run yet.
   ALLOWED_SUB_AGENTS:
     type: string
     required: false
@@ -243,6 +260,13 @@ nodes:
 
       Conversation so far (may be empty — you are the first responder):
       {{inputs.CONVERSATION}}
+
+      Latest run of the agent this thread is about ({{inputs.FOCUS_AGENT}};
+      may be empty). When this shows "MOST RECENT RUN FAILED", REPORT that
+      failure (the failing node + error) in your recommendation directly —
+      do not tell the operator to run it and report back. See the kernel's
+      REPORTING A RUN OUTCOME section:
+      {{inputs.FOCUS_AGENT_RUN}}
 
       ────────────────────────────────────────────────────────────────
       Now respond with a single <plan>…</plan> block exactly as

--- a/agents/examples/inbox-triage/kernel.md
+++ b/agents/examples/inbox-triage/kernel.md
@@ -133,6 +133,30 @@ case, no trailing punctuation. Omit on text-only turns.
 
 
 ════════════════════════════════════════════════════════════════
+REPORTING A RUN OUTCOME — you can SEE the agent's last run
+════════════════════════════════════════════════════════════════
+
+`FOCUS_AGENT_RUN` (in THIS THREAD) is the latest run output of the
+agent this thread is about. You do NOT need the operator to run the
+agent and paste the result — you already have it.
+
+- When it contains "MOST RECENT RUN FAILED", REPORT the failure
+  directly: name the failing node and quote the actual error (e.g.
+  "the latest run failed at `fetch-quotes`: `curl: option --retry:
+  expected a proper numerical value`"), then propose the concrete
+  next step — usually a `run-agent` of `agent-analyzer` for that
+  agent (set `inputs.AGENT_ID`), which inspects the YAML + this run
+  output and returns a fix.
+- NEVER say "run it and see what happened" or "re-run it to check"
+  when FOCUS_AGENT_RUN already shows the outcome. That is the same
+  bug as a prose-only promise: the answer is in front of you, so give
+  it. Only ask the operator to run something when there is genuinely
+  no run yet (FOCUS_AGENT_RUN empty).
+- When the latest run SUCCEEDED, you may confirm the outcome from its
+  output rather than asking the operator to verify.
+
+
+════════════════════════════════════════════════════════════════
 RELEVANT LEARNINGS — operator-approved priors, advisory only
 ════════════════════════════════════════════════════════════════
 

--- a/packages/dashboard/src/routes/inbox-engine.ts
+++ b/packages/dashboard/src/routes/inbox-engine.ts
@@ -50,6 +50,7 @@ import {
   TRIAGE_REJECTION_RECOVERY_NOTE,
   PENDING_USER_REPLY_WINDOW_MS,
   TRIAGE_AGENT_ID,
+  SYSTEM_AGENT_IDS,
 } from './inbox-shared.js';
 import {
   getSubAgentAllowlist,
@@ -62,6 +63,7 @@ import {
   enrichAgentBuilderInputs,
   extractAgentBuilderProviderPin,
   deriveRunFailureReason,
+  collectRunSummary,
 } from './inbox-catalog.js';
 import {
   parseProposedActions,
@@ -1179,6 +1181,30 @@ export async function maybeExtractLearning(
 }
 
 /**
+ * The agent a thread is ABOUT — for injecting run-awareness into triage.
+ * Prefers the message's own target. On a manual thread (no target), walks the
+ * actions newest-first and returns the real agent the latest one touched: for a
+ * system/route-handled action (agent-analyzer/agent-editor/dashboard-editor)
+ * that's `inputs.AGENT_ID`; for a `run-agent` action it's the action's agentId.
+ * System pseudo-agents are skipped, and the candidate must be installed.
+ */
+export function resolveFocusAgentId(
+  ctx: ReturnType<typeof getContext>,
+  messageAgentId: string | undefined,
+  responses: readonly InboxResponse[],
+): string | undefined {
+  if (messageAgentId) return messageAgentId;
+  for (let i = responses.length - 1; i >= 0; i--) {
+    if (responses[i].role !== 'action') continue;
+    const m = parseActionMeta(responses[i]);
+    if (!m) continue;
+    const cand = (SYSTEM_AGENT_IDS.has(m.agentId) ? m.inputs.AGENT_ID : m.agentId)?.trim();
+    if (cand && !SYSTEM_AGENT_IDS.has(cand) && ctx.agentStore.getAgent(cand)) return cand;
+  }
+  return undefined;
+}
+
+/**
  * Spawn the inbox-triage system agent for a message. Lazy-installs the
  * YAML on first call (mirrors layout-planner). After the run
  * completes, parses the `<plan>{...}</plan>` block and appends a
@@ -1243,6 +1269,13 @@ export async function runTriageAgent(
   // when the operator hasn't replied yet (triage is first responder).
   const currentRequest = latestUserRequest(responsesSnapshot) ?? message.body;
 
+  // Run-awareness: the agent this thread is ABOUT (the message's target, or the
+  // most-recent agent a thread action touched). Inject its latest run output —
+  // including a "MOST RECENT RUN FAILED" block — so triage can REPORT a failure
+  // (node + error) directly instead of telling the operator to "run it and see".
+  const focusAgentId = resolveFocusAgentId(ctx, message.agentId, responsesSnapshot);
+  const focusAgentRun = focusAgentId ? collectRunSummary(ctx, focusAgentId) : '';
+
   const allowlist = getSubAgentAllowlist(ctx);
   const runnableAgentSpecs = buildRunnableAgentSpecsJson(ctx, allowlist);
   // Installed agents triage may propose running even though they aren't
@@ -1291,6 +1324,8 @@ export async function runTriageAgent(
           CONTEXT_JSON: message.contextJson ?? '',
           RELEVANT_LEARNINGS: relevantLearnings,
           CONVERSATION: conversation,
+          FOCUS_AGENT: focusAgentId ?? '',
+          FOCUS_AGENT_RUN: focusAgentRun,
           ALLOWED_SUB_AGENTS: allowlist.join(', '),
           RUNNABLE_AGENT_SPECS: runnableAgentSpecs,
           RUNNABLE_CANDIDATES: candidates.join(', '),

--- a/packages/dashboard/src/routes/inbox-focus-agent.test.ts
+++ b/packages/dashboard/src/routes/inbox-focus-agent.test.ts
@@ -1,0 +1,86 @@
+/**
+ * resolveFocusAgentId picks the agent a thread is ABOUT so triage can be given
+ * that agent's latest run output (run-awareness). Prefers the message target;
+ * on a manual thread it walks actions newest-first and returns the real agent
+ * the latest one touched — using inputs.AGENT_ID for system/route-handled
+ * actions (analyzer/editor) and skipping system pseudo-agents.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AgentStore, InboxStore, type InboxActionMeta } from '@some-useful-agents/core';
+import { resolveFocusAgentId } from './inbox-engine.js';
+
+let dir: string;
+let agentStore: AgentStore;
+let inboxStore: InboxStore;
+
+function setup() {
+  dir = mkdtempSync(join(tmpdir(), 'sua-focus-'));
+  const db = join(dir, 'runs.db');
+  agentStore = new AgentStore(db);
+  inboxStore = new InboxStore(db);
+  return { agentStore, inboxStore } as never as ReturnType<typeof import('../context.js').getContext>;
+}
+
+afterEach(() => {
+  try { agentStore.close(); } catch { /* ignore */ }
+  try { inboxStore.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+function mkAgent(id: string): void {
+  agentStore.createAgent({
+    id, name: id, status: 'active', source: 'local', mcp: false,
+    nodes: [{ id: 'n', type: 'shell', command: 'echo hi', dependsOn: [] }],
+  }, 'cli');
+}
+
+function addAction(msgId: string, meta: InboxActionMeta): void {
+  inboxStore.addResponse(msgId, 'action', 'a', JSON.stringify(meta));
+}
+
+describe('resolveFocusAgentId', () => {
+  it('returns the message target when present', () => {
+    const ctx = setup();
+    const r = resolveFocusAgentId(ctx, 'markets-today', []);
+    expect(r).toBe('markets-today');
+  });
+
+  it('on a manual thread, resolves an agent-editor action target (inputs.AGENT_ID)', () => {
+    const ctx = setup();
+    mkAgent('markets-today');
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    addAction(m.id, { kind: 'action', status: 'completed', agentId: 'agent-editor', inputs: { AGENT_ID: 'markets-today', NEW_YAML: 'x' } });
+    const r = resolveFocusAgentId(ctx, undefined, inboxStore.listResponses(m.id));
+    expect(r).toBe('markets-today');
+  });
+
+  it('resolves a run-agent action target (the action agentId)', () => {
+    const ctx = setup();
+    mkAgent('weather');
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    addAction(m.id, { kind: 'action', status: 'completed', agentId: 'weather', inputs: {} });
+    const r = resolveFocusAgentId(ctx, undefined, inboxStore.listResponses(m.id));
+    expect(r).toBe('weather');
+  });
+
+  it('prefers the NEWEST action and skips system pseudo-agents with no real target', () => {
+    const ctx = setup();
+    mkAgent('markets-today');
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    addAction(m.id, { kind: 'action', status: 'completed', agentId: 'weather', inputs: {} }); // older, weather not installed
+    addAction(m.id, { kind: 'action', status: 'completed', agentId: 'agent-analyzer', inputs: { AGENT_ID: 'markets-today' } });
+    const r = resolveFocusAgentId(ctx, undefined, inboxStore.listResponses(m.id));
+    expect(r).toBe('markets-today'); // newest action's real target
+  });
+
+  it('returns undefined when no action references an installed real agent', () => {
+    const ctx = setup();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    addAction(m.id, { kind: 'action', status: 'completed', agentId: 'agent-catalog-search', inputs: {} });
+    const r = resolveFocusAgentId(ctx, undefined, inboxStore.listResponses(m.id));
+    expect(r).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Symptom

Reported while dogfooding (thread `fe6412f5`): when `markets-today` kept failing, triage never reported the error — it told the operator to "re-run it and verify". The operator had to run the agent themselves and paste `curl: option --retry: expected a proper numerical value` for triage to even react.

## Root cause

Triage's prompt got MESSAGE / CONVERSATION / AGENT_CATALOG / runnable specs / learnings — but **zero run-result awareness**. With no way to see an agent's last run, it could only punt to the operator or propose `agent-analyzer` (which *does* read the last run).

## Fix — give triage the focus agent's latest run

- `resolveFocusAgentId` picks the agent a thread is about: the message target, or — on a manual thread — the most recent agent a thread action touched (using `inputs.AGENT_ID` for system/route-handled actions like analyzer/editor, skipping system pseudo-agents).
- Inject `FOCUS_AGENT_RUN` into the triage prompt via the existing `collectRunSummary` helper — the last completed output plus a "MOST RECENT RUN FAILED" block (failing node + error) when the latest run failed.
- New kernel section **REPORTING A RUN OUTCOME**: when `FOCUS_AGENT_RUN` shows a failure, report the node + error directly and propose the fix; never say "run it and see" when the outcome is already in front of you.
- New triage YAML inputs `FOCUS_AGENT` / `FOCUS_AGENT_RUN` (the system agent auto-refreshes from disk before each run).

## Verification

- 5 new `resolveFocusAgentId` unit tests (message target, manual-thread editor/run-agent targets, newest-wins, none-installed). Full suite **2078 pass / 3 skip** (was 2073).
- **Live on the reported thread:** asked "what is the current state of markets-today?" → triage replied *"the most recent run failed at `fetch-quotes`, and the last surfaced error was `curl: option --retry: expected a proper numerical parameter`…"* — reporting the failure directly instead of asking the operator to re-run.

Note: touches `inbox-engine.ts` in a different region than the open #529 (analyzer→editor card); both are against main (not stacked), so no orphan risk — just a possible trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)