### PR TITLE
fix(inbox): reset the per-thread action cap on each operator reply

### DIFF
--- a/.changeset/action-cap-per-burst.md
+++ b/.changeset/action-cap-per-burst.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Inbox: the per-thread action cap now resets on each operator reply.
+
+The runaway-fan-out guard counted actions over the thread's whole lifetime, so a
+long, actively-driven debugging thread (build → run → analyze → fix → run → …)
+would eventually hit the 10-action cap and refuse to propose further steps even
+though the operator was actively engaging. It now counts actions since the
+operator's last message, so a fresh reply resets the budget — while an autonomous
+refire chain still can't fan out unbounded between replies. The skip note now
+explains that replying continues the thread.

--- a/packages/dashboard/src/routes/inbox-action-cap.test.ts
+++ b/packages/dashboard/src/routes/inbox-action-cap.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The per-thread action cap is a runaway-fan-out guard. countActionsSinceLastUser
+ * counts actions only since the operator's last message, so a long thread where
+ * the operator keeps replying isn't blocked — each reply resets the budget —
+ * while an autonomous refire chain still can't fan out unbounded between replies.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { InboxStore, type InboxActionMeta } from '@some-useful-agents/core';
+import { countActionsSinceLastUser } from './inbox-engine.js';
+
+let dir: string;
+let inboxStore: InboxStore;
+
+function setup() {
+  dir = mkdtempSync(join(tmpdir(), 'sua-cap-'));
+  inboxStore = new InboxStore(join(dir, 'runs.db'));
+  return { inboxStore } as never as ReturnType<typeof import('../context.js').getContext>;
+}
+
+afterEach(() => {
+  try { inboxStore.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+const action = (i: number): string =>
+  JSON.stringify({ kind: 'action', status: 'completed', agentId: `a${i}`, inputs: {} } satisfies InboxActionMeta);
+
+describe('countActionsSinceLastUser', () => {
+  it('counts actions after the last user message, not lifetime', () => {
+    const ctx = setup();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    inboxStore.addResponse(m.id, 'user', 'first ask');
+    for (let i = 0; i < 6; i++) inboxStore.addResponse(m.id, 'action', 'a', action(i));
+    inboxStore.addResponse(m.id, 'user', 'second ask'); // resets the burst
+    for (let i = 0; i < 2; i++) inboxStore.addResponse(m.id, 'action', 'a', action(i));
+    // 8 actions lifetime, but only 2 since the last user message.
+    expect(countActionsSinceLastUser(ctx, m.id)).toBe(2);
+  });
+
+  it('counts all actions when there is no user message yet', () => {
+    const ctx = setup();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    for (let i = 0; i < 3; i++) inboxStore.addResponse(m.id, 'action', 'a', action(i));
+    expect(countActionsSinceLastUser(ctx, m.id)).toBe(3);
+  });
+
+  it('is zero right after a fresh user reply', () => {
+    const ctx = setup();
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    for (let i = 0; i < 5; i++) inboxStore.addResponse(m.id, 'action', 'a', action(i));
+    inboxStore.addResponse(m.id, 'user', 'keep going');
+    expect(countActionsSinceLastUser(ctx, m.id)).toBe(0);
+  });
+});

--- a/packages/dashboard/src/routes/inbox-engine.ts
+++ b/packages/dashboard/src/routes/inbox-engine.ts
@@ -985,7 +985,7 @@ export function maybeAutoProposeEditorAction(
   if (!parsed.id || !ctx.agentStore.getAgent(parsed.id)) return;
 
   // Respect the cap so a chatty analyzer can't fan out unbounded edits.
-  if (countActionsOnMessage(ctx, messageId) >= MAX_ACTIONS_PER_MESSAGE) return;
+  if (countActionsSinceLastUser(ctx, messageId) >= MAX_ACTIONS_PER_MESSAGE) return;
 
   // Avoid duplicate proposals if the same YAML was already proposed
   // and is still pending — operator might be mid-decision.
@@ -1038,7 +1038,7 @@ function maybeAutoProposeBuilderInstallAction(
   };
   const proposedYaml = exportAgent(parsed);
 
-  if (countActionsOnMessage(ctx, messageId) >= MAX_ACTIONS_PER_MESSAGE) return;
+  if (countActionsSinceLastUser(ctx, messageId) >= MAX_ACTIONS_PER_MESSAGE) return;
 
   for (const r of ctx.inboxStore.listResponses(messageId)) {
     if (r.role !== 'action') continue;
@@ -1108,19 +1108,26 @@ export function atLeastOneActionExecuted(
 }
 
 /**
- * Count `action`-role responses for a message regardless of status.
- * Used to enforce MAX_ACTIONS_PER_MESSAGE — once we've fanned out N
- * actions on a single thread, refuse new proposals as a runaway
- * guard.
+ * Count `action`-role responses SINCE the operator's last message. The cap
+ * (MAX_ACTIONS_PER_MESSAGE) is a runaway-fan-out guard: it bounds how many
+ * actions an AUTONOMOUS refire chain can produce without operator input. A fresh
+ * user reply is genuine engagement, not runaway, so it resets the budget — a
+ * long, actively-driven debugging thread isn't blocked, but triage still can't
+ * silently fan out unbounded actions between replies.
  */
-function countActionsOnMessage(
+export function countActionsSinceLastUser(
   ctx: ReturnType<typeof getContext>,
   messageId: string,
 ): number {
   if (!ctx.inboxStore) return 0;
+  const responses = ctx.inboxStore.listResponses(messageId);
+  let lastUserIdx = -1;
+  for (let i = responses.length - 1; i >= 0; i--) {
+    if (responses[i].role === 'user') { lastUserIdx = i; break; }
+  }
   let n = 0;
-  for (const r of ctx.inboxStore.listResponses(messageId)) {
-    if (r.role === 'action') n++;
+  for (let i = lastUserIdx + 1; i < responses.length; i++) {
+    if (responses[i].role === 'action') n++;
   }
   return n;
 }
@@ -1503,7 +1510,7 @@ export async function runTriageAgent(
         }
         dedupedAccepted.push(action);
       }
-      const existing = countActionsOnMessage(ctx, messageId);
+      const existing = countActionsSinceLastUser(ctx, messageId);
       const budget = Math.max(0, MAX_ACTIONS_PER_MESSAGE - existing);
       const toInsert = dedupedAccepted.slice(0, budget);
       const overflow = dedupedAccepted.length - toInsert.length;
@@ -1584,7 +1591,7 @@ export async function runTriageAgent(
         notes.push(`Refused action on \`${r.agentId}\`: ${r.reason}.`);
       }
       if (overflow > 0) {
-        notes.push(`Skipped ${overflow} additional proposed action${overflow === 1 ? '' : 's'} — message has reached the per-thread action cap (${MAX_ACTIONS_PER_MESSAGE}).`);
+        notes.push(`Skipped ${overflow} additional proposed action${overflow === 1 ? '' : 's'} — ${MAX_ACTIONS_PER_MESSAGE} actions already ran since your last message. Reply to continue and the next steps can be proposed.`);
       }
       if (deferred.length > 0) {
         notes.push(`Holding ${deferred.length} more side-effecting action${deferred.length === 1 ? '' : 's'} until the one above completes — I'll propose the next once it's done.`);


### PR DESCRIPTION
## Symptom

> "Skipped 1 additional proposed action — message has reached the per-thread action cap (10)."

On a long, actively-driven debugging thread (build → run → fail → analyze → fix → run → …), the per-thread action cap blocked triage from proposing further steps — even though the operator kept replying and driving the thread.

## Root cause

`countActionsOnMessage` counted **lifetime** action responses. The cap is meant as a *runaway-fan-out* guard (bound how many actions an autonomous refire chain can produce without operator input), but lifetime counting also punishes a legitimately long, operator-driven thread.

## Fix

`countActionsSinceLastUser`: count only actions **since the operator's last message**. A fresh reply is genuine engagement, not runaway, so it resets the budget — while an autonomous refire chain still can't fan out more than 10 actions between replies. The three cap-check sites and the skip note are updated; the note now tells the operator that replying continues the thread.

## Verification

- 3 new unit tests (lifetime vs since-last-user, no-user-yet, zero-after-reply). Full suite **2081 pass / 3 skip** (was 2078).

🤖 Generated with [Claude Code](https://claude.com/claude-code)