### PR TITLE
fix(inbox): preserve scroll position when reading a tall inline widget

### DIFF
--- a/.changeset/inbox-modal-scroll-preserve.md
+++ b/.changeset/inbox-modal-scroll-preserve.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Inbox modal: don't yank the operator to the bottom when reading a tall widget.
+
+When an inline output widget (e.g. a cocktail card) is taller than the thread
+viewport, scrolling up to read its top was repeatedly fought by the poll-driven
+refresh, which swapped the DOM and forced a scroll-to-bottom every tick. The
+refresh now preserves scroll position and only follows the latest content when
+the operator is already near the bottom; the streaming-reply bubble does the
+same; and the post-refresh focus no longer scrolls the composer into view
+(`focus({ preventScroll: true })`).

--- a/packages/dashboard/src/views/inbox-modal.js.ts
+++ b/packages/dashboard/src/views/inbox-modal.js.ts
@@ -295,8 +295,12 @@ export const INBOX_MODAL_JS = `
     msg.appendChild(body);
     li.appendChild(msg);
     ul.appendChild(li);
+    // Only follow the new streaming bubble down if the operator was already at
+    // the bottom. If they've scrolled up to read a tall widget, a triage reply
+    // starting to stream must not yank them to the bottom.
+    var nearBottom = content.scrollHeight - content.scrollTop - content.clientHeight < 80;
     requestAnimationFrame(function () {
-      content.scrollTop = content.scrollHeight;
+      if (nearBottom) content.scrollTop = content.scrollHeight;
     });
     return text;
   }
@@ -498,9 +502,20 @@ export const INBOX_MODAL_JS = `
           maybeSchedulePoll();
           return;
         }
+        // Preserve the operator's reading position across the DOM swap.
+        // Only stick to the bottom if they were ALREADY near it (the chat
+        // "follow the latest" pattern). If they've scrolled up — e.g. to read
+        // a tall inline widget whose top is above the fold — keep their
+        // position instead of yanking them back down on every poll refresh.
+        var prevScrollTop = content.scrollTop;
+        var wasNearBottom = content.scrollHeight - content.scrollTop - content.clientHeight < 80;
         content.innerHTML = text;
         applyAnimations();
-        scrollToBottom();
+        if (wasNearBottom) {
+          scrollToBottom();
+        } else {
+          content.scrollTop = prevScrollTop;
+        }
         focusFirstInteractive();
         maybeSchedulePoll();
       })
@@ -557,10 +572,13 @@ export const INBOX_MODAL_JS = `
   }
 
   function focusFirstInteractive() {
+    // preventScroll: focusing the composer (at the bottom) must NOT scroll the
+    // thread — it would override the scroll-position preservation in refresh()
+    // and yank an operator reading a tall widget back down to the textarea.
     var ta = content.querySelector('textarea[name="body"]');
-    if (ta && !ta.disabled) { ta.focus(); return; }
+    if (ta && !ta.disabled) { ta.focus({ preventScroll: true }); return; }
     var btn = content.querySelector('button:not([disabled]), a');
-    if (btn) btn.focus();
+    if (btn) btn.focus({ preventScroll: true });
   }
 
   function openFor(id, opts) {


### PR DESCRIPTION
## Symptom

In a thread with an inline widget taller than the viewport (e.g. the cocktail card from `show-widget`), scrolling up to read the widget's top immediately autoscrolled back to the bottom — you could never get to the top and read down manually.

## Root cause

The modal's poll-driven `refresh()` swaps `content.innerHTML` and then calls `scrollToBottom()` **unconditionally** on every tick. `userIsInteracting()` skips the swap during text-selection/typing, but not when the operator has simply scrolled up to read. So every poll yanked them back down. `focusFirstInteractive()` compounded it by calling `.focus()` on the composer (at the bottom), which scrolls it into view.

## Fix

- `refresh()` captures `scrollTop` + a `wasNearBottom` flag before the DOM swap; afterward it sticks to the bottom only if the operator was already near it (the chat "follow the latest" pattern), else restores their position.
- The streaming-reply "Writing…" bubble gets the same near-bottom guard.
- `focusFirstInteractive()` uses `focus({ preventScroll: true })`.

## Verification

- `tsc` clean; the change is present in the served inbox JS bundle (`wasNearBottom`, `preventScroll: true`). This is client-side scroll behavior — best confirmed visually: open a thread with a tall inline widget, scroll up, and confirm it stays put while triage polls/streams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)