### PR TITLE
fix(inbox): Stop halts the autonomous triage chain, not just one turn

### DIFF
--- a/.changeset/inbox-stop-halts-refire.md
+++ b/.changeset/inbox-stop-halts-refire.md
@@ -1,0 +1,18 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Inbox: Stop now halts the autonomous triage chain, not just one turn.
+
+The triage Stop/Cancel button only aborted the in-flight triage LLM run, but the
+runaway loop is driven by auto-approved actions (agent-analyzer → agent-editor)
+completing and refiring triage — so a fresh turn respawned right after Stop and
+the thread ran until the consecutive-turn cap. Cancel now sets a per-message stop
+flag that `maybeRefireTriage` and the auto-approve dispatch both honor, so the
+chain halts after the in-flight action; the flag is cleared when the operator
+replies. Stop also takes effect when the thing running is a sub-agent action
+(no triage run to abort), posting an acknowledgement note.

--- a/packages/dashboard/src/context.ts
+++ b/packages/dashboard/src/context.ts
@@ -206,6 +206,16 @@ export interface DashboardContext {
    */
   inboxTriagePendingRefires: Set<string>;
   /**
+   * Message ids the operator has explicitly STOPPED (clicked Cancel/Stop).
+   * While present, `maybeRefireTriage` will not auto-fire a follow-up triage
+   * turn and auto-approved actions will not auto-run — so the autonomous
+   * analyze→edit→refire chain halts after the in-flight step instead of running
+   * to the consecutive-turn cap. Cleared when the operator replies (a fresh
+   * user message is genuine re-engagement). Optional so existing test contexts
+   * that omit it simply behave as "nothing stopped".
+   */
+  inboxTriageStopped?: Set<string>;
+  /**
    * Per-message count of CONSECUTIVE triage runs that crashed with an infra
    * error (provider/worker/network), keyed by inbox message id. A transient
    * failure shouldn't permanently strand a thread, so the crash handler

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -564,6 +564,7 @@ export async function startDashboardServer(opts: StartDashboardOptions): Promise
     activeRuns: new Map(),
     inboxTriageAbortControllers: new Map(),
     inboxTriagePendingRefires: new Set(),
+    inboxTriageStopped: new Set(),
     inboxTriageCrashRetries: new Map(),
     dataDir: dirname(opts.dbPath),
     dashboardBaseUrl,

--- a/packages/dashboard/src/routes/inbox-engine.ts
+++ b/packages/dashboard/src/routes/inbox-engine.ts
@@ -653,6 +653,10 @@ function maybeRefireTriage(
   messageId: string,
 ): void {
   if (!ctx.inboxStore) return;
+  // Operator hit Stop — halt the autonomous analyze→edit→refire chain. The
+  // in-flight action still finishes (sub-agent runs aren't abortable mid-flight),
+  // but we do NOT spawn the next triage turn. Cleared when the operator replies.
+  if (ctx.inboxTriageStopped?.has(messageId)) return;
   if (!(allActionsResolved(ctx, messageId) && atLeastOneActionExecuted(ctx, messageId))) return;
   if (countConsecutiveTriageTurns(ctx, messageId) >= MAX_AUTO_TRIAGE_TURNS) {
     const note = `Auto-follow-up paused after ${MAX_AUTO_TRIAGE_TURNS} consecutive triage turns. Reply or dismiss to continue.`;
@@ -1564,7 +1568,7 @@ export async function runTriageAgent(
         // completion runProposedAction publishes the terminal
         // action:status event and (when all actions resolve) fires
         // the follow-up triage turn.
-        if (TRIAGE_AUTO_APPROVE_AGENTS.has(action.agentId)) {
+        if (TRIAGE_AUTO_APPROVE_AGENTS.has(action.agentId) && !ctx.inboxTriageStopped?.has(messageId)) {
           const startedAt = Date.now();
           const runningMeta: InboxActionMeta = { ...action, status: 'running', startedAt };
           const claimed = ctx.inboxStore.transitionActionStatus(

--- a/packages/dashboard/src/routes/inbox.test.ts
+++ b/packages/dashboard/src/routes/inbox.test.ts
@@ -685,6 +685,29 @@ describe('POST /inbox/:id/respond', () => {
   });
 });
 
+describe('POST /inbox/:id/triage/cancel — operator Stop halts the refire chain', () => {
+  it('marks the thread stopped even with no triage run in flight, and a reply lifts it', async () => {
+    const app = await makeApp();
+    const ctx = app.locals as DashboardContext;
+    const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+
+    // No triage LLM run in flight (the loop is driven by auto-approved actions),
+    // yet Stop must still take: it sets the flag + posts an ack note.
+    const cancel = await request(app)
+      .post(`/inbox/${m.id}/triage/cancel`)
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(cancel.status).toBe(204);
+    expect(ctx.inboxTriageStopped?.has(m.id)).toBe(true);
+    expect(inboxStore.listResponses(m.id).some((r) => r.role === 'system' && /stopped/i.test(r.body))).toBe(true);
+
+    // A fresh reply is re-engagement → the stop is lifted so triage can run again.
+    await request(app)
+      .post(`/inbox/${m.id}/respond`).type('form').send({ body: 'continue please' })
+      .set('X-Requested-With', 'fetch').set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+    expect(ctx.inboxTriageStopped?.has(m.id)).toBe(false);
+  });
+});
+
 describe('GET /inbox with filters', () => {
   it('filters by ?starred=1', async () => {
     const app = await makeApp();
@@ -1602,17 +1625,20 @@ describe('POST /inbox/:id/triage/cancel', () => {
     expect(sys?.body).toBe('Triage agent cancelled.');
   });
 
-  it('is idempotent: no in-flight controller returns 204 with "Nothing to cancel"', async () => {
+  it('with no in-flight triage run still STOPS the thread (204 + ack note)', async () => {
+    // Stop must take even when there's no triage LLM run to abort — the runaway
+    // loop is driven by auto-approved actions, so the stop flag is what halts it.
     const app = await makeApp();
+    const ctx = app.locals as DashboardContext;
     const m = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
     const res = await request(app)
       .post(`/inbox/${m.id}/triage/cancel`)
       .set('X-Requested-With', 'fetch')
       .set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
     expect(res.status).toBe(204);
-    // No system message inserted for a no-op cancel.
-    const responses = inboxStore.listResponses(m.id);
-    expect(responses.find((r) => r.role === 'system')).toBeUndefined();
+    expect(ctx.inboxTriageStopped?.has(m.id)).toBe(true);
+    const sys = inboxStore.listResponses(m.id).find((r) => r.role === 'system');
+    expect(sys?.body).toMatch(/stopped/i);
   });
 
   it('404 (AJAX) for unknown message id', async () => {

--- a/packages/dashboard/src/routes/inbox.ts
+++ b/packages/dashboard/src/routes/inbox.ts
@@ -390,6 +390,9 @@ inboxRouter.post('/inbox/:id/respond', (req: Request, res: Response) => {
     res.redirect(303, `${detailUrl}?error=${encodeURIComponent('Reply is too long (max 8 KB).')}`);
     return;
   }
+  // A fresh reply is genuine re-engagement, so lift any operator Stop and let
+  // triage run again for this turn.
+  ctx.inboxTriageStopped?.delete(id);
   let userResponse;
   try {
     userResponse = ctx.inboxStore.addResponse(id, 'user', bodyRaw);
@@ -514,10 +517,26 @@ inboxRouter.post('/inbox/:id/triage/cancel', async (req: Request, res: Response)
     res.redirect(303, `/inbox?error=${encodeURIComponent('Message not found.')}`);
     return;
   }
+  // Mark the thread STOPPED regardless of whether a triage run is in flight.
+  // The runaway loop is driven by auto-approved ACTIONS completing and
+  // refiring triage, so the stop must hold even when the thing running right
+  // now is a sub-agent action (no triage abort entry) — maybeRefireTriage and
+  // the auto-approve dispatch both honor this flag. Cleared on the next reply.
+  if (!ctx.inboxTriageStopped) ctx.inboxTriageStopped = new Set();
+  ctx.inboxTriageStopped.add(id);
   const entry = ctx.inboxTriageAbortControllers.get(id);
   if (!entry) {
+    // No triage LLM turn in flight, but the stop flag now halts the chain
+    // after the current action. Acknowledge it so the operator sees it took.
+    try {
+      const note = 'Auto-follow-up stopped. Reply to continue.';
+      const sysReply = ctx.inboxStore.addResponse(id, 'system', note);
+      publishInboxEvent(ctx, id, 'message:created', {
+        responseId: sysReply.id, role: 'system', body: note, createdAt: sysReply.createdAt,
+      });
+    } catch { /* ignore */ }
     if (isAjax(req)) { res.status(204).end(); return; }
-    res.redirect(303, `${detailUrl}?ok=${encodeURIComponent('Nothing to cancel.')}`);
+    res.redirect(303, `${detailUrl}?ok=${encodeURIComponent('Stopped.')}`);
     return;
   }
   ctx.inboxTriageAbortControllers.delete(id);


### PR DESCRIPTION
## Symptom

Reported live: a "fix markets-today" thread got stuck looping `agent-analyzer → agent-editor → refire → analyzer → editor …` and **wouldn't respond to Stop**. It only halted when it hit the `MAX_AUTO_TRIAGE_TURNS` (5) safety cap.

## Root cause

The triage Stop/Cancel button (`POST /inbox/:id/triage/cancel`) only aborted the in-flight triage **LLM run**. But the autonomous loop is driven by **auto-approved actions** (agent-analyzer, agent-editor) completing and calling `maybeRefireTriage`, which spawns a fresh triage turn. So:
- If the thing running when you click Stop is a sub-agent **action** (the common case), there's no triage run to abort — cancel returned "Nothing to cancel" and did nothing.
- Even when it aborted a triage turn, the next action completion refired triage again.

(Sub-agent action runs also aren't abortable mid-flight — `runDispatchedAgentToTerminal` calls `executeAgentDag` without threading a signal.)

## Fix

A per-message stop flag `ctx.inboxTriageStopped`:
- `/triage/cancel` sets it **unconditionally** (even with no triage run in flight) and posts an "Auto-follow-up stopped. Reply to continue." note.
- `maybeRefireTriage` and the auto-approve dispatch both honor it → the chain halts after the in-flight action instead of refiring.
- A fresh operator reply (`/respond`) clears it — genuine re-engagement.

The in-flight action still finishes (then the chain stops); threading an abort signal into action runs so they can be killed mid-flight is a noted follow-up.

## Verification

- New route test (cancel-with-no-triage-run sets the flag + posts the note; reply clears it) and updated the old idempotency test to the new "Stop always takes" behavior. Full suite **2082 pass / 3 skip**.
- The stuck thread was halted live by restarting the dashboard; with this fix the Stop button does it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)