### PR TITLE
feat(dashboard): one dashboard surface — Mission Control home (collapse /, /pulse, /inbox)

### DIFF
--- a/.changeset/mission-control-home.md
+++ b/.changeset/mission-control-home.md
@@ -1,0 +1,19 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Unify the dashboard front door: a Mission Control home.
+
+The root `/` was a stripped-down Pulse (system stat tiles only) while the
+inbox — the most powerful surface — was a quiet nav link with no presence. `/`
+is now an attention-ordered front door: a "Needs you" strip of inbox threads
+awaiting your reply on top, the live Pulse board (system + agent signal tiles,
+reused read-only) in the middle, and a collapsed recent-activity feed at the
+bottom. A global Inbox badge (count from the new `/inbox/needs-you-count`) shows
+on every page. `/pulse` stays as the focused, fully-editable board-only view —
+both render the identical board via a shared `renderPulseBoard`. New core inbox
+queries `countNeedsYou` / `listNeedsYou` back the badge and preview.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -12,16 +12,28 @@ The footer shows a **build stamp** (`sua vX · <sha>`) so you can tell which bui
 
 The top bar leads with the daily-driver surfaces: `sua · Pulse · Agents · Settings · Help`. The `sua` brand links to the **Home feed** (`/`). **Agents** links to the agents list and groups the building blocks and executions — on each of those landing pages an in-page tab strip (**Agents · Tools · Nodes · Runs · Packs · Scheduled**) sits under the page header, mirroring the Settings tabs, with the current page highlighted. There's no separate global subnav bar. URLs are unchanged (`/agents`, `/tools`, `/nodes`, `/runs`, `/packs`, `/scheduled`); the grouping just keeps the top bar uncluttered.
 
-## `/` — Home feed
+## `/` — Mission Control home
 
-What's happening right now. Shows:
+The unified front door, ordered by attention. Three zones, top to bottom:
 
-- **Today's stats** — runs today, total runs, in-flight count, scheduler status
-- **Recent activity** — paginated feed of runs with agent link, status, duration
-- **Scheduled today** — agents with cron expressions, next-fire time
-- **Getting started** — the tutorial CTA if you're new
+- **Needs you** — the inbox's threads awaiting your reply (a count + up to four
+  preview cards + an **Open inbox →** CTA). When nothing's waiting it collapses
+  to a slim "Inbox clear" line. This surfaces the inbox — the conversational
+  control plane — at the front door instead of leaving it a quiet nav link.
+- **Live Pulse** — the real Pulse board (system metric tiles + per-agent signal
+  tiles), embedded read-only: per-tile controls work, but board-level
+  arrangement (Edit layout / Improve layout / + Add group) lives on `/pulse`.
+  With no agents installed this becomes the Build-from-goal empty state.
+- **Recent activity** — the paginated run feed, collapsed by default.
 
-Good landing page when you want "what shipped since I last looked."
+This replaced the old system-stat-only home, which was a strict subset of Pulse.
+A global **Inbox badge** in the nav (amber pill, count from
+`/inbox/needs-you-count`, polled ~30s) shows on every page so you always know
+when the inbox needs you.
+
+`/pulse` remains the focused board-only view — identical board, full editing
+chrome, no Needs-you/activity wrapper — for when you want the radiator
+full-screen.
 
 ## `/agents` — Agents list
 

--- a/packages/core/src/inbox-store.test.ts
+++ b/packages/core/src/inbox-store.test.ts
@@ -27,6 +27,36 @@ function addMinimal(overrides: Partial<Parameters<InboxStore['add']>[0]> = {}): 
   });
 }
 
+describe('InboxStore.countNeedsYou + listNeedsYou', () => {
+  it('counts and lists only awaiting_user threads', () => {
+    expect(store.countNeedsYou()).toBe(0);
+    expect(store.listNeedsYou()).toEqual([]);
+
+    const a = addMinimal({ title: 'needs reply a' });
+    const b = addMinimal({ title: 'needs reply b' });
+    addMinimal({ title: 'still open' });            // stays 'open'
+    const resolved = addMinimal({ title: 'done' });
+
+    store.updateStatus(a.id, 'awaiting_user');
+    store.updateStatus(b.id, 'awaiting_user');
+    store.updateStatus(resolved.id, 'resolved');
+
+    expect(store.countNeedsYou()).toBe(2);
+    const needs = store.listNeedsYou();
+    expect(needs.every((m) => m.status === 'awaiting_user')).toBe(true);
+    expect(needs.map((m) => m.id).sort()).toEqual([a.id, b.id].sort());
+  });
+
+  it('listNeedsYou honors the limit', () => {
+    for (let i = 0; i < 6; i++) {
+      const m = addMinimal({ title: `t${i}` });
+      store.updateStatus(m.id, 'awaiting_user');
+    }
+    expect(store.countNeedsYou()).toBe(6);
+    expect(store.listNeedsYou(4)).toHaveLength(4);
+  });
+});
+
 describe('InboxStore.add + get', () => {
   it('writes a row, get round-trips it, default status is open', () => {
     const msg = addMinimal();

--- a/packages/core/src/inbox-store.ts
+++ b/packages/core/src/inbox-store.ts
@@ -593,6 +593,25 @@ export class InboxStore {
     return rows.map((r) => this.rowToMessage(r));
   }
 
+  /**
+   * Count threads awaiting an operator reply (`awaiting_user`). Cheap COUNT —
+   * no row materialization — for the high-frequency global inbox badge.
+   */
+  countNeedsYou(): number {
+    const row = this.db.prepare(
+      `SELECT COUNT(*) AS n FROM inbox_messages WHERE status = 'awaiting_user'`,
+    ).get() as { n: number };
+    return row.n;
+  }
+
+  /**
+   * The `awaiting_user` ("Your turn") threads, for the Mission Control
+   * "Needs you" preview. Reuses `list`'s ordering; capped small.
+   */
+  listNeedsYou(limit = 4): InboxMessage[] {
+    return this.list({ status: 'awaiting_user', limit });
+  }
+
   /** Set or clear the star flag. */
   setStarred(id: string, starred: boolean): void {
     const result = this.db.prepare(`UPDATE inbox_messages SET starred = ? WHERE id = ?`)

--- a/packages/dashboard/src/assets/components.css
+++ b/packages/dashboard/src/assets/components.css
@@ -38,6 +38,24 @@
   font-weight: var(--weight-semibold);
 }
 
+/* Global inbox "needs you" badge on the Inbox nav link. Populated client-side
+   (inbox-badge.js); hidden when the count is zero. */
+.nav-badge {
+  display: inline-block;
+  margin-left: var(--space-1);
+  min-width: 1.1em;
+  padding: 0 0.35em;
+  border-radius: var(--radius-sm);
+  background: var(--color-warn-soft);
+  color: var(--color-warn);
+  font-size: var(--font-size-xs);
+  font-weight: var(--weight-semibold);
+  line-height: 1.5;
+  text-align: center;
+  vertical-align: middle;
+}
+.nav-badge[hidden] { display: none; }
+
 .topbar__theme-toggle {
   margin-left: auto;
   background: none;

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -3869,3 +3869,81 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
   padding-top: var(--space-3);
   margin-top: var(--space-3);
 }
+
+/* ── Mission Control home (/) ─────────────────────────────────────────────
+   The unified front door: a "Needs you" inbox strip, the live Pulse board,
+   and a collapsed recent-activity section. Reuses badge--warn + the inbox
+   priority dots so it inherits the design system. */
+.home-needs {
+  margin-bottom: var(--space-6);
+  padding: var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+.home-needs--clear {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+.home-needs__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+.home-needs__heading {
+  margin: 0;
+  font-size: var(--font-size-md);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.home-needs__open {
+  font-size: var(--font-size-sm);
+  font-weight: var(--weight-medium);
+  white-space: nowrap;
+}
+.home-needs__cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: var(--space-2);
+}
+.home-needs__card {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-raised);
+  color: var(--color-text);
+  text-decoration: none;
+  min-width: 0;
+}
+.home-needs__card:hover { border-color: var(--color-border-strong); }
+.home-needs__title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: var(--weight-medium);
+}
+.home-needs__meta {
+  flex-shrink: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+.home-activity__summary {
+  cursor: pointer;
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-muted);
+  padding: var(--space-2) 0;
+}
+.home-activity[open] .home-activity__summary { color: var(--color-text); }

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -30,7 +30,6 @@ import {
   type SecretsStore,
   type Provider,
   type RunStatus,
-  getSchedulerStatus,
 } from '@some-useful-agents/core';
 import type { DashboardContext } from './context.js';
 import { getContext } from './context.js';
@@ -61,6 +60,7 @@ import { versionsRouter } from './routes/versions.js';
 import { imgBlockReportRouter } from './routes/img-block-report.js';
 import { inboxRouter } from './routes/inbox.js';
 import { inboxEventsRouter } from './routes/inbox-events.js';
+import { inboxCountRouter } from './routes/inbox-count.js';
 import { InboxEventBus } from './lib/inbox-event-bus.js';
 import { seedInboxDemoIfRequested } from './inbox-demo-seed.js';
 import { raiseRunFailureInbox } from './lib/run-failure-inbox.js';
@@ -205,59 +205,48 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   // Home page with today's stats + recent activity (paginated).
   app.get('/', (req, res) => {
     // Dynamic import to avoid circular deps at module load.
-    import('./views/home.js').then(({ renderHomePage }) => {
-      const ctx = getContext(req.app.locals);
-      const agents = ctx.agentStore.listAgents();
-      const now = new Date();
-      const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).toISOString();
+    Promise.all([import('./views/home.js'), import('./routes/pulse.js')])
+      .then(([{ renderHomePage }, { buildPulseBoardData }]) => {
+        const ctx = getContext(req.app.locals);
+        const agents = ctx.agentStore.listAgents();
 
-      // Activity feed pagination.
-      const page = Math.max(1, parseInt(req.query.page as string, 10) || 1);
-      const pageSize = Math.max(1, Math.min(50, parseInt(req.query.pageSize as string, 10) || 10));
-      const offset = (page - 1) * pageSize;
+        // Activity feed pagination (the collapsed "Recent activity" zone).
+        const page = Math.max(1, parseInt(req.query.page as string, 10) || 1);
+        const pageSize = Math.max(1, Math.min(50, parseInt(req.query.pageSize as string, 10) || 10));
+        const offset = (page - 1) * pageSize;
+        const recentResult = ctx.runStore.queryRuns({ limit: pageSize, offset, statuses: [] as RunStatus[] });
 
-      const recentResult = ctx.runStore.queryRuns({ limit: pageSize, offset, statuses: [] as RunStatus[] });
-      // Separate query for today's stats (always from the start, not paginated).
-      const todayResult = ctx.runStore.queryRuns({ limit: 200, offset: 0, statuses: [] as RunStatus[] });
-      const inFlightResult = ctx.runStore.queryRuns({ limit: 20, offset: 0, statuses: ['running', 'pending'] as RunStatus[] });
-      const todayRuns = todayResult.rows.filter((r: { startedAt: string }) => r.startedAt >= todayStart);
-      // Widget surfaces every agent with a schedule (active + paused). The
-      // previous active-only filter hid paused agents that the user might
-      // want to resume, which was misleading — see #365. /scheduled is the
-      // fuller management page; this widget is the at-a-glance summary.
-      const scheduledAgents = agents.filter((a: { schedule?: string; status: string }) => a.schedule && (a.status === 'active' || a.status === 'paused'));
+        // Live Pulse board — the same data /pulse renders.
+        const board = buildPulseBoardData(ctx);
 
-      // Scheduler status from heartbeat file.
-      const { status: schedulerStatus, heartbeat: schedulerHeartbeat } = getSchedulerStatus(ctx.dataDir);
+        // Inbox "Needs you" — count for the badge-adjacent header + a small preview.
+        const needsYou = ctx.inboxStore
+          ? { count: ctx.inboxStore.countNeedsYou(), top: ctx.inboxStore.listNeedsYou(4) }
+          : { count: 0, top: [] };
 
-      // Last scheduled fire per agent.
-      const lastScheduledFires: Record<string, string> = {};
-      for (const a of scheduledAgents) {
-        const result = ctx.runStore.queryRuns({ agentName: a.id, triggeredBy: 'schedule', limit: 1 });
-        if (result.rows[0]?.startedAt) lastScheduledFires[a.id] = result.rows[0].startedAt;
-      }
+        const availableDashboards = ctx.dashboardsStore
+          ? ctx.dashboardsStore.listDashboards().filter((d) => !d.packId).map((d) => ({ id: d.id, name: d.name }))
+          : [];
 
-      const availableDashboards = ctx.dashboardsStore
-        ? ctx.dashboardsStore.listDashboards().filter((d) => !d.packId).map((d) => ({ id: d.id, name: d.name }))
-        : [];
-
-      res.type('html').send(renderHomePage({
-        agents,
-        recentRuns: recentResult.rows,
-        todayRuns,
-        inFlightRuns: inFlightResult.rows,
-        scheduledAgents,
-        activityPage: page,
-        activityPageSize: pageSize,
-        totalRunCount: recentResult.total,
-        schedulerStatus,
-        schedulerHeartbeat,
-        lastScheduledFires,
-        availableDashboards,
-      }));
-    }).catch(() => {
-      res.redirect(302, '/agents');
-    });
+        res.type('html').send(renderHomePage({
+          board,
+          needsYou,
+          activity: {
+            agents,
+            recentRuns: recentResult.rows,
+            todayRuns: [],
+            inFlightRuns: [],
+            scheduledAgents: [],
+            activityPage: page,
+            activityPageSize: pageSize,
+            totalRunCount: recentResult.total,
+          },
+          agentCount: agents.length,
+          availableDashboards,
+        }));
+      }).catch(() => {
+        res.redirect(302, '/agents');
+      });
   });
 
   app.use(agentInstallRouter);
@@ -279,6 +268,9 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
   // SSE before the main inbox router so the more specific
   // `/inbox/:id/events` route resolves before any catch-all paths
   // in the inbox router try to claim it.
+  // Count endpoint first so `/inbox/needs-you-count` isn't shadowed by
+  // the inbox router's `/inbox/:id`.
+  app.use(inboxCountRouter);
   app.use(inboxEventsRouter);
   app.use(inboxRouter);
   app.use(toolsRouter);

--- a/packages/dashboard/src/routes/home-mission-control.test.ts
+++ b/packages/dashboard/src/routes/home-mission-control.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Mission Control home (`/`) + the global inbox badge count endpoint.
+ * Verifies the unified front door composes the three zones (Needs you / live
+ * Pulse board / collapsed activity) and that /inbox/needs-you-count drives the
+ * nav badge.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import request from 'supertest';
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AgentStore,
+  InboxStore,
+  LocalProvider,
+  MemorySecretsStore,
+  RunStore,
+  buildLoopbackAllowlist,
+  loadAgents,
+} from '@some-useful-agents/core';
+import { buildDashboardApp } from '../index.js';
+import type { DashboardContext } from '../context.js';
+import { SESSION_COOKIE } from '../auth-middleware.js';
+import { MemorySecretsSession } from '../secrets-session.js';
+
+const TOKEN = 'a'.repeat(64);
+const PORT = 3994;
+const COOKIE = `${SESSION_COOKIE}=${TOKEN}`;
+
+let dir: string;
+let provider: LocalProvider;
+let runStore: RunStore;
+let agentStore: AgentStore;
+let inboxStore: InboxStore;
+
+async function makeApp() {
+  dir = mkdtempSync(join(tmpdir(), 'sua-home-mc-'));
+  const dbPath = join(dir, 'runs.db');
+  const agentsDir = join(dir, 'agents', 'local');
+  mkdirSync(agentsDir, { recursive: true });
+
+  const secretsStore = new MemorySecretsStore();
+  runStore = new RunStore(dbPath);
+  agentStore = new AgentStore(dbPath);
+  inboxStore = new InboxStore(dbPath);
+  provider = new LocalProvider(dbPath, secretsStore);
+  await provider.initialize();
+
+  const ctx: DashboardContext = {
+    token: TOKEN,
+    allowlist: buildLoopbackAllowlist(PORT),
+    port: PORT,
+    provider,
+    runStore,
+    agentStore,
+    loadAgents: () => loadAgents({ directories: [agentsDir] }),
+    secretsStore,
+    secretsSession: new MemorySecretsSession({ backing: secretsStore }),
+    tokenPath: join(dir, 'mcp-token'),
+    retentionDays: 30,
+    dbPath,
+    secretsPath: join(dir, 'secrets.enc'),
+    rotateToken: () => 'r'.repeat(64),
+    inboxStore,
+    allowUntrustedShell: new Set(),
+    activeRuns: new Map(),
+    inboxTriageAbortControllers: new Map(),
+    inboxTriagePendingRefires: new Set(),
+    inboxTriageStopped: new Set(),
+    dataDir: dir,
+    dashboardBaseUrl: `http://127.0.0.1:${PORT}`,
+  };
+  return buildDashboardApp(ctx);
+}
+
+afterEach(() => {
+  try { runStore?.close(); } catch { /* ignore */ }
+  try { agentStore?.close(); } catch { /* ignore */ }
+  try { inboxStore?.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+const get = (app: ReturnType<typeof buildDashboardApp>, path: string) =>
+  request(app).get(path).set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
+
+describe('GET / — Mission Control home', () => {
+  it('renders the live Pulse board, the Needs-you strip, and collapsed activity', async () => {
+    const app = await makeApp();
+    // The board only renders when at least one agent is installed (zero agents
+    // shows the Build-from-goal empty state by design).
+    agentStore.createAgent({
+      id: 'hello', name: 'hello', status: 'active', source: 'local', mcp: false,
+      nodes: [{ id: 'n', type: 'shell', command: 'echo hi', dependsOn: [] }],
+    }, 'cli');
+    // Seed an awaiting_user thread so the Needs-you zone shows a card.
+    const m = inboxStore.add({ priority: 'high', source: 'run-failure', title: 'markets-today failed', body: 'fetch-quotes exit 1', agentId: 'markets-today' });
+    inboxStore.updateStatus(m.id, 'awaiting_user');
+
+    const res = await get(app, '/');
+    expect(res.status).toBe(200);
+    // Live Pulse board (system tiles render even with zero signal agents).
+    expect(res.text).toContain('pulse-grid');
+    expect(res.text).toContain('id="pulse-tile-data"');
+    expect(res.text).toContain('_system-runs-today');
+    // Needs you strip.
+    expect(res.text).toContain('Needs you');
+    expect(res.text).toContain('markets-today failed');
+    expect(res.text).toContain('href="/inbox"');
+    // Collapsed activity.
+    expect(res.text).toContain('home-activity');
+    expect(res.text).toContain('Recent activity');
+    // The home does NOT show the board-level edit affordances (editable:false).
+    expect(res.text).not.toContain('id="pulse-edit-toggle"');
+  });
+
+  it('shows the "all clear" state when nothing is awaiting reply', async () => {
+    const app = await makeApp();
+    const res = await get(app, '/');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Inbox clear');
+  });
+});
+
+describe('GET /inbox/needs-you-count', () => {
+  it('returns 0 when nothing awaits, and the count once threads are awaiting_user', async () => {
+    const app = await makeApp();
+    const zero = await get(app, '/inbox/needs-you-count');
+    expect(zero.status).toBe(200);
+    expect(zero.body).toEqual({ count: 0 });
+
+    const a = inboxStore.add({ priority: 'medium', source: 'manual', title: 'a', body: 'x' });
+    const b = inboxStore.add({ priority: 'medium', source: 'manual', title: 'b', body: 'y' });
+    inboxStore.add({ priority: 'low', source: 'manual', title: 'open one', body: 'z' }); // stays open
+    inboxStore.updateStatus(a.id, 'awaiting_user');
+    inboxStore.updateStatus(b.id, 'awaiting_user');
+
+    const two = await get(app, '/inbox/needs-you-count');
+    expect(two.body).toEqual({ count: 2 });
+  });
+
+  it('is not shadowed by the inbox /:id route', async () => {
+    const app = await makeApp();
+    const res = await get(app, '/inbox/needs-you-count');
+    expect(res.status).toBe(200);
+    expect(res.type).toMatch(/json/);
+  });
+});

--- a/packages/dashboard/src/routes/inbox-count.ts
+++ b/packages/dashboard/src/routes/inbox-count.ts
@@ -1,0 +1,17 @@
+/**
+ * Lightweight count endpoint for the global inbox badge. Mounted BEFORE
+ * inboxRouter so `/inbox/needs-you-count` isn't shadowed by `/inbox/:id`.
+ * Returns the number of threads awaiting an operator reply so the nav badge
+ * can show "the inbox needs you" on every page without threading a count
+ * through every page's layout() render.
+ */
+import { Router, type Request, type Response } from 'express';
+import { getContext } from '../context.js';
+
+export const inboxCountRouter: Router = Router();
+
+inboxCountRouter.get('/inbox/needs-you-count', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const count = ctx.inboxStore ? ctx.inboxStore.countNeedsYou() : 0;
+  res.json({ count });
+});

--- a/packages/dashboard/src/routes/pulse.ts
+++ b/packages/dashboard/src/routes/pulse.ts
@@ -112,8 +112,20 @@ function buildSystemTiles(ctx: ReturnType<typeof getContext>): PulseTile[] {
 
 // ── Routes ───────────────────────────────────────────────────────────────
 
-pulseRouter.get('/pulse', (req: Request, res: Response) => {
-  const ctx = getContext(req.app.locals);
+/**
+ * Assemble the live Pulse board data: the 4 virtual system tiles + a tile per
+ * visible signal agent (two visibility gates) + the hidden count + dashboards
+ * and available packs. Shared by GET /pulse and the Mission Control home (`/`)
+ * so both render the identical board with zero divergence. Idempotent —
+ * `autoImportSignalExamples` only upserts examples not already installed.
+ */
+export function buildPulseBoardData(ctx: ReturnType<typeof getContext>): {
+  systemTiles: PulseTile[];
+  tiles: PulseTile[];
+  hiddenTiles: PulseTile[];
+  installedDashboards: ReturnType<NonNullable<ReturnType<typeof getContext>['dashboardsStore']>['listDashboards']>;
+  availablePacks: ReturnType<NonNullable<ReturnType<typeof getContext>['packsStore']>['listPacks']>;
+} {
   autoImportSignalExamples(ctx);
 
   const agents = ctx.agentStore.listAgents();
@@ -146,17 +158,15 @@ pulseRouter.get('/pulse', (req: Request, res: Response) => {
   // untouched (renderer falls back to signal.size / outputWidget.tileFit).
   attachLayoutHints(tiles, ctx.layoutHintsStore);
 
-  const flash = parsePulseFlash(req);
   const installedDashboards = ctx.dashboardsStore?.listDashboards() ?? [];
   const availablePacks = (ctx.packsStore?.listPacks() ?? []).filter((p) => p.installedAt === null);
-  res.type('html').send(renderPulsePage({
-    systemTiles,
-    tiles,
-    hiddenTiles,
-    flash,
-    installedDashboards,
-    availablePacks,
-  }));
+  return { systemTiles, tiles, hiddenTiles, installedDashboards, availablePacks };
+}
+
+pulseRouter.get('/pulse', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  const data = buildPulseBoardData(ctx);
+  res.type('html').send(renderPulsePage({ ...data, flash: parsePulseFlash(req) }));
 });
 
 function parsePulseFlash(req: Request): { kind: 'ok' | 'error' | 'info'; message: string } | undefined {

--- a/packages/dashboard/src/views/home-widgets.ts
+++ b/packages/dashboard/src/views/home-widgets.ts
@@ -159,7 +159,7 @@ function buildAgents(data: HomeWidgetData): SystemWidget {
   };
 }
 
-function buildRecentActivity(data: HomeWidgetData): SystemWidget {
+export function buildRecentActivity(data: HomeWidgetData): SystemWidget {
   const { recentRuns } = data;
   const page = data.activityPage ?? 1;
   const pageSize = data.activityPageSize ?? 10;

--- a/packages/dashboard/src/views/home.ts
+++ b/packages/dashboard/src/views/home.ts
@@ -1,72 +1,119 @@
 /**
- * Home page: widget-based dashboard using the shared container layout.
- * System widgets provide the same data as the old hand-coded layout, but
- * rendered through the OutputWidget system with drag-drop containers.
+ * Mission Control home (`/`) — the unified front door, ordered by attention:
+ *  1. "Needs you"   — the inbox's awaiting-user threads (count + preview + CTA)
+ *  2. "Live Pulse"  — the real Pulse board (system + agent signal tiles),
+ *                     reused read-only via renderPulseBoard({ editable: false })
+ *  3. "Recent activity" — the run feed, collapsed by default
+ *
+ * This replaces the old system-stat-only home (a strict subset of Pulse) so the
+ * two surfaces no longer duplicate, and surfaces the inbox — the most powerful
+ * surface — at the top of the front door.
  */
 
-import type { Agent, Run, RunStatus } from '@some-useful-agents/core';
-import { html, render, unsafeHtml, type SafeHtml } from './html.js';
+import type { InboxMessage } from '@some-useful-agents/core';
+import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
-import { buildHomeWidgets, renderHomeWidget } from './home-widgets.js';
-import type { HomeWidgetData } from './home-widgets.js';
+import { renderPulseBoard } from './pulse.js';
+import type { PulsePageInput } from './pulse-types.js';
+import { buildRecentActivity, renderHomeWidget, type HomeWidgetData } from './home-widgets.js';
 import { buildFromGoalButton, buildFromGoalModal } from './build-from-goal-modal.js';
-import { pageIntro } from './page-intro.js';
+import { formatAge } from './components.js';
 
-export { type HomeWidgetData as HomePageInput } from './home-widgets.js';
+export interface HomePageInput {
+  /** Live Pulse board data (from buildPulseBoardData). */
+  board: PulsePageInput;
+  /** Inbox "Needs you": count + a small preview of awaiting-user threads. */
+  needsYou: { count: number; top: InboxMessage[] };
+  /** Recent-activity feed data (reused HomeWidgetData subset). */
+  activity: HomeWidgetData;
+  agentCount: number;
+  availableDashboards?: Array<{ id: string; name: string }>;
+  flash?: { kind: 'ok' | 'error' | 'info'; message: string };
+}
 
-export function renderHomePage(input: HomeWidgetData): string {
-  const widgets = buildHomeWidgets(input);
+const PRIORITY_DOT: Record<string, string> = {
+  high: 'inbox-modal__priority--high',
+  medium: 'inbox-modal__priority--medium',
+  low: 'inbox-modal__priority--low',
+};
 
-  const allTileIds = widgets.map((w) => w.id);
-  const systemTileIds = allTileIds.slice(); // all are system widgets
-
-  const isEmpty = input.agents.length === 0;
-
-  const emptyState = html`
-    <div class="settings-empty" style="margin-top: var(--space-4);">
-      <h3 style="margin-top: 0;">No agents yet</h3>
-      <p class="dim">An agent is a named task sua can run \u2014 a shell command, an LLM prompt, or a chain of both. Describe what you want and let sua build it, or follow the guided tour.</p>
-      <p style="display: flex; gap: var(--space-3); justify-content: center; margin: 0;">
-        ${buildFromGoalButton({ variant: 'primary' })}
-        <a class="btn" href="/help/tutorial">Open tutorial</a>
-      </p>
-    </div>
+function needsYouCard(m: InboxMessage): SafeHtml {
+  return html`
+    <a class="home-needs__card" href="/inbox/${m.id}">
+      <span class="inbox-modal__priority ${PRIORITY_DOT[m.priority] ?? ''}" aria-hidden="true"></span>
+      <span class="home-needs__title">${m.title}</span>
+      <span class="home-needs__meta">
+        ${m.agentId ? html`<span class="mono">${m.agentId}</span> · ` : html``}${formatAge(new Date(m.createdAt).toISOString())}
+      </span>
+    </a>
   `;
+}
+
+function needsYouStrip(needsYou: HomePageInput['needsYou']): SafeHtml {
+  if (needsYou.count === 0) {
+    return html`
+      <section class="home-needs home-needs--clear">
+        <span class="home-needs__clear">✓ Inbox clear — nothing needs your reply.</span>
+        <a class="home-needs__open" href="/inbox">Open inbox →</a>
+      </section>
+    `;
+  }
+  return html`
+    <section class="home-needs">
+      <div class="home-needs__head">
+        <h2 class="home-needs__heading">Needs you <span class="badge badge--warn">${String(needsYou.count)}</span></h2>
+        <a class="home-needs__open" href="/inbox">Open inbox →</a>
+      </div>
+      <div class="home-needs__cards">
+        ${needsYou.top.map(needsYouCard) as unknown as SafeHtml[]}
+      </div>
+    </section>
+  `;
+}
+
+export function renderHomePage(input: HomePageInput): string {
+  const liveHeading = html`<h2 style="margin: 0;">Live Pulse</h2>`;
+
+  const board = input.agentCount === 0
+    ? html`
+      <div class="settings-empty" style="margin-top: var(--space-4);">
+        <h3 style="margin-top: 0;">No agents yet</h3>
+        <p class="dim">An agent is a named task sua can run — a shell command, an LLM prompt, or a chain of both. Describe what you want and let sua build it, or follow the guided tour.</p>
+        <p style="display: flex; gap: var(--space-3); justify-content: center; margin: 0;">
+          ${buildFromGoalButton({ variant: 'primary' })}
+          <a class="btn" href="/help/tutorial">Open tutorial</a>
+        </p>
+      </div>
+    `
+    : renderPulseBoard(input.board, { heading: liveHeading, editable: false });
+
+  const activityWidget = buildRecentActivity(input.activity);
 
   const body = html`
     <div style="display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-6);">
-      <h1 style="margin: 0;">Dashboard</h1>
+      <h1 style="margin: 0;">Home</h1>
       <span style="font-size: var(--font-size-sm); color: var(--color-text-muted);">
-        ${String(input.agents.length)} agents registered
+        ${String(input.agentCount)} agent${input.agentCount !== 1 ? 's' : ''} registered
       </span>
       <div style="margin-left: auto; display: flex; gap: var(--space-2);">
         ${buildFromGoalButton({ variant: 'primary' })}
         <a class="btn btn--ghost btn--sm" href="/packs">Browse packs</a>
-        <button type="button" class="btn btn--ghost btn--sm" id="home-edit-toggle">\u270E Edit layout</button>
-        <button type="button" class="btn btn--ghost btn--sm" id="home-add-container" style="display: none;">+ Add group</button>
       </div>
     </div>
 
-    ${pageIntro({
-      key: 'home',
-      text: 'Your at-a-glance home. Stat tiles summarize recent runs and scheduled work; rearrange them with Edit layout.',
-      learnMore: { href: 'https://github.com/gregmeyer/some-useful-agents/blob/main/docs/dashboard.md', label: 'Dashboard tour' },
-    })}
+    ${needsYouStrip(input.needsYou)}
 
-    ${isEmpty ? emptyState : html``}
+    ${board}
 
-    <div id="home-containers">
-      <section class="pulse-container" data-container-id="_default">
-        <div class="pulse-grid" data-container-id="_default">
-          ${widgets.map((w) => renderHomeWidget(w)) as unknown as SafeHtml[]}
-        </div>
-      </section>
-    </div>
-
-    ${unsafeHtml(`<script type="application/json" id="home-widget-data">${JSON.stringify({ allTileIds, systemTileIds })}</script>`)}
+    <details class="home-activity" style="margin-top: var(--space-6);">
+      <summary class="home-activity__summary">Recent activity</summary>
+      <div class="home-activity__body" style="margin-top: var(--space-3);">
+        ${renderHomeWidget(activityWidget)}
+      </div>
+    </details>
 
     ${buildFromGoalModal({ availableDashboards: input.availableDashboards })}
   `;
 
-  return render(layout({ title: 'Dashboard', activeNav: 'agents' }, body));
+  return render(layout({ title: 'Home', activeNav: 'agents', flash: input.flash }, body));
 }

--- a/packages/dashboard/src/views/inbox-badge.js.ts
+++ b/packages/dashboard/src/views/inbox-badge.js.ts
@@ -1,0 +1,25 @@
+/**
+ * Global inbox badge: polls the needs-you count and shows an amber pill on the
+ * Inbox nav link when threads are awaiting a reply. Lives in the layout bundle
+ * so it runs on every page. No global inbox SSE channel exists (the event bus
+ * is per-message), so a 30s poll is the minimal correct choice; live-update
+ * via SSE is a future enhancement.
+ */
+export const INBOX_BADGE_JS = `
+(function () {
+  var el = document.querySelector('[data-inbox-badge]');
+  if (!el) return;
+  function refresh() {
+    fetch('/inbox/needs-you-count', { credentials: 'same-origin' })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (d) {
+        if (!d || typeof d.count !== 'number') return;
+        if (d.count > 0) { el.textContent = String(d.count); el.hidden = false; }
+        else { el.textContent = ''; el.hidden = true; }
+      })
+      .catch(function () {});
+  }
+  refresh();
+  setInterval(refresh, 30000);
+})();
+`;

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -22,6 +22,7 @@ import { CSP_IMG_REPORT_JS } from './csp-img-report.js.js';
 import { WIDGET_IMG_FALLBACK_JS } from './widget-img-fallback.js.js';
 import { INSTALL_PACKS_MODAL_JS } from './install-packs-modal.js.js';
 import { INBOX_MODAL_JS } from './inbox-modal.js.js';
+import { INBOX_BADGE_JS } from './inbox-badge.js.js';
 import { ALLOWED_SUB_AGENTS_PICKLIST_JS } from './allowed-sub-agents-picklist.js.js';
 import { NODE_DISCOVERY_JS } from './node-discovery.js.js';
 import { footer } from './footer.js';
@@ -77,7 +78,7 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
 <header class="topbar">
   <a class="topbar__brand" href="/">sua</a>
   <nav class="topbar__nav">
-    <a href="/inbox" class="${opts.activeNav === 'inbox' ? 'is-active' : ''}">Inbox</a>
+    <a href="/inbox" class="${opts.activeNav === 'inbox' ? 'is-active' : ''}">Inbox<span class="nav-badge" data-inbox-badge hidden></span></a>
     <a href="/pulse" class="${opts.activeNav === 'pulse' ? 'is-active' : ''}">Pulse</a>
     <a href="/agents" class="${opts.activeNav === 'agents' || opts.activeNav === 'tools' || opts.activeNav === 'nodes' || opts.activeNav === 'runs' || opts.activeNav === 'packs' ? 'is-active' : ''}">Agents</a>
     <a href="/settings" class="${opts.activeNav === 'settings' ? 'is-active' : ''}">Settings</a>
@@ -92,7 +93,7 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
   ${body}
 </main>
 ${footer()}
-<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + PULSE_MASONRY_JS + HOME_LAYOUT_JS + DASHBOARDS_LAYOUT_JS + BUILD_FROM_GOAL_JS + IMPROVE_LAYOUT_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS + WIDGET_REPLAY_INPLACE_JS + WIDGET_COPY_JS + WIDGET_CAPTURE_JS + PAGE_INTRO_JS + ADD_TILE_MODAL_JS + CSP_ALLOW_JS + CSP_IMG_REPORT_JS + WIDGET_IMG_FALLBACK_JS + INSTALL_PACKS_MODAL_JS + INBOX_MODAL_JS + ALLOWED_SUB_AGENTS_PICKLIST_JS + NODE_DISCOVERY_JS)}</script>
+<script>${unsafeHtml(DASHBOARD_JS + TEMPLATE_PALETTE_JS + SUGGEST_IMPROVEMENTS_JS + PULSE_LAYOUT_JS + PULSE_MASONRY_JS + HOME_LAYOUT_JS + DASHBOARDS_LAYOUT_JS + BUILD_FROM_GOAL_JS + IMPROVE_LAYOUT_JS + OUTPUT_WIDGET_ACTIONS_JS + RUN_DETAIL_FILTER_JS + PULSE_CONFIGURE_JS + PULSE_REFRESH_JS + WIDGET_REPLAY_INPLACE_JS + WIDGET_COPY_JS + WIDGET_CAPTURE_JS + PAGE_INTRO_JS + ADD_TILE_MODAL_JS + CSP_ALLOW_JS + CSP_IMG_REPORT_JS + WIDGET_IMG_FALLBACK_JS + INSTALL_PACKS_MODAL_JS + INBOX_MODAL_JS + INBOX_BADGE_JS + ALLOWED_SUB_AGENTS_PICKLIST_JS + NODE_DISCOVERY_JS)}</script>
 </body>
 </html>`;
 }

--- a/packages/dashboard/src/views/pulse-board-extraction.test.ts
+++ b/packages/dashboard/src/views/pulse-board-extraction.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Regression: `renderPulseBoard` (the reusable board content the Mission
+ * Control home embeds) must be exactly what `/pulse` renders inside its layout,
+ * so the two surfaces never diverge. Also checks the `editable: false` variant
+ * (used on `/`) drops the board-level edit affordances but keeps the tiles.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderPulseBoard, renderPulsePage } from './pulse.js';
+import { html } from './html.js';
+import type { PulsePageInput } from './pulse-types.js';
+
+const EMPTY: PulsePageInput = { systemTiles: [], tiles: [], hiddenTiles: [] };
+
+describe('renderPulseBoard vs renderPulsePage', () => {
+  it('the page is just the board wrapped in the layout (board content is contained verbatim)', () => {
+    const board = renderPulseBoard(EMPTY).toString();
+    const page = renderPulsePage(EMPTY);
+    // The page must contain the entire board markup.
+    expect(page).toContain(board);
+    // Both carry the pulse JSON the client JS reads.
+    expect(board).toContain('id="pulse-tile-data"');
+    expect(page).toContain('id="pulse-template-registry"');
+    // The page adds the layout chrome the board lacks.
+    expect(board).not.toContain('<!DOCTYPE html>');
+    expect(page).toContain('<!DOCTYPE html>');
+  });
+
+  it('the default board is editable (Edit layout present); editable:false hides it', () => {
+    const editable = renderPulseBoard(EMPTY).toString();
+    const readOnly = renderPulseBoard(EMPTY, { editable: false }).toString();
+    expect(editable).toContain('id="pulse-edit-toggle"');
+    expect(readOnly).not.toContain('id="pulse-edit-toggle"');
+    // The tile grid is present in both.
+    expect(editable).toContain('pulse-grid');
+    expect(readOnly).toContain('pulse-grid');
+  });
+
+  it('a custom heading replaces the default <h1>Pulse</h1>', () => {
+    const custom = renderPulseBoard(EMPTY, { heading: html`<h2>Live Pulse</h2>` }).toString();
+    expect(custom).toContain('<h2>Live Pulse</h2>');
+    expect(custom).not.toContain('<h1 style="margin: 0;">Pulse</h1>');
+  });
+});

--- a/packages/dashboard/src/views/pulse.ts
+++ b/packages/dashboard/src/views/pulse.ts
@@ -182,9 +182,25 @@ function tileFooter(tile: PulseTile): SafeHtml {
 
 // ── Page ─────────────────────────────────────────────────────────────────
 
-export function renderPulsePage(input: PulsePageInput): string {
+/**
+ * The Pulse BOARD content — system + agent signal tiles, hidden-count restore,
+ * dashboards dropdown, and the JSON `<script>` blocks the pulse JS reads. NO
+ * `layout()` wrapper, so callers can compose it (e.g. the Mission Control home
+ * stacks it between a "Needs you" strip and a recent-activity section).
+ *
+ * `opts.heading` replaces the default `<h1>Pulse</h1>`. `opts.editable`
+ * (default true) gates the board-level arrangement affordances — Hide all /
+ * Improve layout / Edit layout / + Add group, the layout modal, and the Pulse
+ * page-intro. On the home it's false so the board stays glanceable and
+ * arrangement routes to `/pulse`; per-tile configure/hide/run controls are
+ * unaffected.
+ */
+export function renderPulseBoard(
+  input: PulsePageInput,
+  opts: { heading?: SafeHtml; editable?: boolean } = {},
+): SafeHtml {
+  const editable = opts.editable !== false;
   const { systemTiles, tiles, hiddenTiles } = input;
-  const allTileCount = systemTiles.length + tiles.length;
   const agentTileCount = tiles.length;
   const systemTileCount = systemTiles.length;
   const hiddenCount = hiddenTiles.length;
@@ -201,14 +217,15 @@ export function renderPulsePage(input: PulsePageInput): string {
     ? renderDashboardsDropdown({ options: dropdownOptions, activeHref: '/pulse' })
     : html``;
 
-  const body = html`
+  return html`
     <div style="display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-6);">
-      <h1 style="margin: 0;">Pulse</h1>
+      ${opts.heading ?? html`<h1 style="margin: 0;">Pulse</h1>`}
       <span style="font-size: var(--font-size-sm); color: var(--color-text-muted);">
         ${String(agentTileCount)} agent${agentTileCount !== 1 ? 's' : ''}${systemTileCount > 0 ? html` + ${String(systemTileCount)} system` : html``}${hiddenCount > 0 ? html` · ${String(hiddenCount)} hidden` : html``}
       </span>
       <div style="margin-left: auto; display: flex; align-items: center; gap: var(--space-2);">
         ${dropdownOptions.length > 1 ? dropdown : html``}
+        ${editable ? html`
         ${tiles.length > 0 ? html`
           <form method="POST" action="/pulse/hide-all" style="margin: 0; display: inline;" onsubmit="return confirm('Hide all ${String(tiles.length)} signal${tiles.length !== 1 ? 's' : ''} from Pulse? They\\'ll move to the hidden section and can be restored individually.');">
             <button type="submit" class="btn btn--ghost btn--sm" title="Move every visible tile to the hidden section. Useful before installing packs.">Hide all</button>
@@ -222,14 +239,15 @@ export function renderPulsePage(input: PulsePageInput): string {
         ${improveLayoutButton()}
         <button type="button" class="btn btn--ghost btn--sm" id="pulse-edit-toggle">\u270E Edit layout</button>
         <button type="button" class="btn btn--ghost btn--sm" id="pulse-add-container" style="display: none;">+ Add group</button>
+        ` : html``}
       </div>
     </div>
 
-    ${pageIntro({
+    ${editable ? pageIntro({
       key: 'pulse',
       text: 'Pulse is your live information radiator — each tile shows an agent\'s latest output. Drag to reorder, or use Improve layout to curate what shows.',
       learnMore: { href: 'https://github.com/gregmeyer/some-useful-agents/blob/main/docs/dashboard.md', label: 'Dashboard tour' },
-    })}
+    }) : html``}
 
     <div id="pulse-containers">
       <section class="pulse-container" data-container-id="_default">
@@ -250,13 +268,15 @@ export function renderPulsePage(input: PulsePageInput): string {
       </div>
     ` : html``}
 
-    ${improveLayoutModal()}
+    ${editable ? improveLayoutModal() : html``}
 
     ${dropdownOptions.length > 1 ? renderInstallPacksModal(input.availablePacks ?? []) : html``}
 
     ${unsafeHtml(`<script type="application/json" id="pulse-tile-data">${JSON.stringify({ allTileIds, systemTileIds })}</script>`)}
     ${unsafeHtml(`<script type="application/json" id="pulse-template-registry">${JSON.stringify(TEMPLATE_REGISTRY)}</script>`)}
   `;
+}
 
-  return render(layout({ title: 'Pulse', activeNav: 'pulse', flash: input.flash }, body));
+export function renderPulsePage(input: PulsePageInput): string {
+  return render(layout({ title: 'Pulse', activeNav: 'pulse', flash: input.flash }, renderPulseBoard(input)));
 }


### PR DESCRIPTION
## Why

The dashboard had three "home-like" surfaces that overlapped and buried the most powerful one:
- **`/` (Home)** rendered only the 4 system stat tiles — a strict subset of Pulse.
- **`/pulse`** rendered the same tiles **plus** agent signal tiles (so Home was a stripped Pulse).
- **`/inbox`** — the conversational control plane — was a plain nav link with no badge/count/preview.

## What — one front door

`/` is now the **single dashboard surface**, attention-ordered:
1. **Needs you** — inbox threads awaiting your reply (count + preview cards + **Open inbox →**), or "Inbox clear".
2. **Live Pulse board** — system + agent signal tiles, **fully editable here** (configure/hide, drag-reorder, Edit layout, Improve layout). The **dashboards dropdown** in the board header switches to named/pack dashboards (`/dashboards/:id`); "Default Dashboard" is this board.
3. **Recent activity** — collapsed run feed.

`/pulse` **collapsed into `/`**: `GET /pulse` 302-redirects to `/` (sub-routes — tile fragments, hide/show-all, layout planner — unchanged). Nav renames **Pulse → Home**. A global **Inbox badge** (from `GET /inbox/needs-you-count`) shows on every page.

> Built in two steps on this branch: (1) Mission Control home embedding the board; (2) collapsing `/pulse` in once it was clear we only need one surface — which also removed the awkward "editing bounces to /pulse" compromise from step 1.

## How

- `views/pulse.ts`: `renderPulseBoard(input, { heading?, editable? })` (board content, no layout); `renderPulsePage` removed.
- `routes/pulse.ts`: `buildPulseBoardData(ctx)` shared by `/` and the redirect; bare `GET /pulse` → redirect; signal/hide/show redirects → `/`; `parsePulseFlash` exported.
- `views/home.ts`: the 3-zone composition with the editable board.
- `core/inbox-store.ts`: `countNeedsYou()` / `listNeedsYou()`.
- Badge: `routes/inbox-count.ts` (`/inbox/needs-you-count`, mounted before `inboxRouter`) + `views/inbox-badge.js.ts` + nav badge + `.nav-badge` CSS.
- Nav/links: `layout.ts` Pulse→Home (`activeNav` union `'pulse'`→`'home'`); dashboards dropdown Default → `/`; not-found / install-packs-modal / help / tutorial repointed.

## Verification

- Full suite **2093 pass / 3 skip**. New/updated tests: home composition + editable board, `/inbox/needs-you-count`, `/pulse`→`/` redirect (route + dashboard nav), board-extraction, dashboards GET `/`, packs returnTo, not-found.
- **Live:** `/pulse` → `302 /`; `/` shows the editable board (`pulse-edit-toggle`, Improve layout) + needs-you + dashboards dropdown + collapsed activity; nav = **Inbox · Home · Agents · Settings · Help** (no Pulse); `/pulse/tile/:id` sub-route still 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)