### PR TITLE
feat(dashboard): inbox-first home — Ask sua CTA + global needs-you top-bar toast

### DIFF
--- a/.changeset/home-ask-sua-cta.md
+++ b/.changeset/home-ask-sua-cta.md
@@ -6,11 +6,17 @@
 "@some-useful-agents/dashboard": patch
 ---
 
-Home: replace the leftover header buttons with an inbox-first "Ask sua" CTA.
+Home: inbox-first "Ask sua" CTA + a global top-bar "needs you" toast.
 
 The unified home had three competing action clusters in the upper-right — the old
 "Build from goal" / "Browse packs" header buttons, the Needs-you strip's "Open
-inbox", and the board's own controls. The header buttons (carried over from the
-stat-only home) are replaced by a single primary **Ask sua →** that opens a fresh
-inbox thread, aligning the home's primary action with its inbox-anchored layout.
-Build-from-goal still lives on /agents and the no-agents empty state.
+inbox", and the board's own controls. Now:
+
+- The header buttons are replaced by a single primary **Ask sua →** that opens a
+  fresh inbox thread (`POST /inbox/new`). Build-from-goal still lives on /agents
+  and the no-agents empty state.
+- The "needs you" signal moves off the home body into a global **top-bar toast**
+  ("N need your reply →") shown in the top-bar empty space on every page whenever
+  inbox threads await a reply (count from `/inbox/needs-you-count`). This removes
+  the redundant "Open inbox" callout and tightens the home's vertical — the page
+  now leads straight into the board.

--- a/.changeset/home-ask-sua-cta.md
+++ b/.changeset/home-ask-sua-cta.md
@@ -1,0 +1,16 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Home: replace the leftover header buttons with an inbox-first "Ask sua" CTA.
+
+The unified home had three competing action clusters in the upper-right — the old
+"Build from goal" / "Browse packs" header buttons, the Needs-you strip's "Open
+inbox", and the board's own controls. The header buttons (carried over from the
+stat-only home) are replaced by a single primary **Ask sua →** that opens a fresh
+inbox thread, aligning the home's primary action with its inbox-anchored layout.
+Build-from-goal still lives on /agents and the no-agents empty state.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -14,26 +14,30 @@ The top bar leads with the daily-driver surfaces: `sua · Inbox · Agents · Set
 
 ## `/` — Mission Control home
 
-The unified front door, ordered by attention. Three zones, top to bottom:
+The single dashboard surface. Top to bottom:
 
-- **Needs you** — the inbox's threads awaiting your reply (a count + up to four
-  preview cards + an **Open inbox →** CTA). When nothing's waiting it collapses
-  to a slim "Inbox clear" line. This surfaces the inbox — the conversational
-  control plane — at the front door instead of leaving it a quiet nav link.
+- **Ask sua →** — the primary CTA in the header opens a fresh inbox thread
+  (`POST /inbox/new`), so the home's main action is "ask sua to run, build, fix,
+  or look something up." (Distinct from the top-bar toast, which is for reviewing
+  what's already waiting.) With no agents installed the page is the
+  Build-from-goal empty state instead.
 - **Live Pulse** — the live board (system metric tiles + per-agent signal
   tiles), fully editable here: configure/hide tiles, drag to reorder, Edit
   layout, Improve layout. The **dashboards dropdown** in the board header
   switches to named/pack dashboards (`/dashboards/:id`); "Default Dashboard"
-  is this home board. With no agents installed this becomes the Build-from-goal
-  empty state.
+  is this home board.
 - **Recent activity** — the paginated run feed, collapsed by default.
 
 This replaced the old system-stat-only home (a strict subset of Pulse) AND the
 separate `/pulse` page — there's now **one** dashboard surface. `/pulse` 302-
 redirects to `/`; its sub-routes (tile fragments, hide/show-all, layout planner)
-are unchanged. A global **Inbox badge** in the nav (amber pill, count from
-`/inbox/needs-you-count`, polled ~30s) shows on every page so you always know
-when the inbox needs you.
+are unchanged.
+
+The **"needs you" signal lives in the top bar**, not on the home: an amber
+**"N need your reply →"** toast appears in the top-bar empty space (on every
+page) whenever inbox threads are awaiting your reply — count from
+`/inbox/needs-you-count`, polled ~30s, hidden when zero. Click it to go to the
+inbox.
 
 ## `/agents` — Agents list
 

--- a/packages/dashboard/src/assets/components.css
+++ b/packages/dashboard/src/assets/components.css
@@ -43,23 +43,31 @@
   font-weight: var(--weight-semibold);
 }
 
-/* Global inbox "needs you" badge on the Inbox nav link. Populated client-side
-   (inbox-badge.js); hidden when the count is zero. */
-.nav-badge {
-  display: inline-block;
-  margin-left: var(--space-1);
-  min-width: 1.1em;
-  padding: 0 0.35em;
+/* Global "needs you" toast in the top-bar empty space. Populated client-side
+   (inbox-badge.js); hidden when the count is zero. margin-left:auto centers it
+   in the free space between the nav and the theme toggle. */
+.topbar__needs {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-3);
   border-radius: var(--radius-sm);
   background: var(--color-warn-soft);
   color: var(--color-warn);
-  font-size: var(--font-size-xs);
-  font-weight: var(--weight-semibold);
-  line-height: 1.5;
-  text-align: center;
-  vertical-align: middle;
+  font-size: var(--font-size-sm);
+  font-weight: var(--weight-medium);
+  text-decoration: none;
+  white-space: nowrap;
 }
-.nav-badge[hidden] { display: none; }
+.topbar__needs:hover { filter: brightness(1.12); }
+.topbar__needs[hidden] { display: none; }
+.topbar__needs-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-warn);
+}
 
 .topbar__theme-toggle {
   margin-left: auto;

--- a/packages/dashboard/src/assets/screens.css
+++ b/packages/dashboard/src/assets/screens.css
@@ -3871,75 +3871,9 @@ body.pulse-edit-mode .pulse-tile__resize-handle:hover::after {
 }
 
 /* ── Mission Control home (/) ─────────────────────────────────────────────
-   The unified front door: a "Needs you" inbox strip, the live Pulse board,
-   and a collapsed recent-activity section. Reuses badge--warn + the inbox
-   priority dots so it inherits the design system. */
-.home-needs {
-  margin-bottom: var(--space-6);
-  padding: var(--space-4);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  background: var(--color-surface);
-}
-.home-needs--clear {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
-  padding: var(--space-3) var(--space-4);
-  color: var(--color-text-muted);
-  font-size: var(--font-size-sm);
-}
-.home-needs__head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
-  margin-bottom: var(--space-3);
-}
-.home-needs__heading {
-  margin: 0;
-  font-size: var(--font-size-md);
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-.home-needs__open {
-  font-size: var(--font-size-sm);
-  font-weight: var(--weight-medium);
-  white-space: nowrap;
-}
-.home-needs__cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-  gap: var(--space-2);
-}
-.home-needs__card {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-2) var(--space-3);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  background: var(--color-surface-raised);
-  color: var(--color-text);
-  text-decoration: none;
-  min-width: 0;
-}
-.home-needs__card:hover { border-color: var(--color-border-strong); }
-.home-needs__title {
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-weight: var(--weight-medium);
-}
-.home-needs__meta {
-  flex-shrink: 0;
-  font-size: var(--font-size-xs);
-  color: var(--color-text-muted);
-}
+   The unified dashboard: the editable board + a collapsed recent-activity
+   section. (The "needs you" signal is the global top-bar toast, .topbar__needs
+   in components.css.) */
 .home-activity__summary {
   cursor: pointer;
   font-weight: var(--weight-semibold);

--- a/packages/dashboard/src/index.ts
+++ b/packages/dashboard/src/index.ts
@@ -219,10 +219,8 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
         // Live Pulse board — the same data /pulse renders.
         const board = buildPulseBoardData(ctx);
 
-        // Inbox "Needs you" — count for the badge-adjacent header + a small preview.
-        const needsYou = ctx.inboxStore
-          ? { count: ctx.inboxStore.countNeedsYou(), top: ctx.inboxStore.listNeedsYou(4) }
-          : { count: 0, top: [] };
+        // The inbox "needs you" signal lives in the global top-bar toast
+        // (driven by /inbox/needs-you-count), not in the home body.
 
         const availableDashboards = ctx.dashboardsStore
           ? ctx.dashboardsStore.listDashboards().filter((d) => !d.packId).map((d) => ({ id: d.id, name: d.name }))
@@ -230,7 +228,6 @@ export function buildDashboardApp(ctx: DashboardContext): Application {
 
         res.type('html').send(renderHomePage({
           board,
-          needsYou,
           activity: {
             agents,
             recentRuns: recentResult.rows,

--- a/packages/dashboard/src/routes/home-mission-control.test.ts
+++ b/packages/dashboard/src/routes/home-mission-control.test.ts
@@ -112,6 +112,12 @@ describe('GET / — Mission Control home', () => {
     // The home is now the single dashboard surface — the board is editable here
     // (/pulse collapsed into /).
     expect(res.text).toContain('id="pulse-edit-toggle"');
+    // Primary CTA is inbox-first ("Ask sua" → new thread), not the old
+    // Build-from-goal / Browse-packs header buttons.
+    expect(res.text).toContain('action="/inbox/new"');
+    expect(res.text).toContain('Ask sua');
+    expect(res.text).not.toContain('Browse packs');
+    expect(res.text).not.toContain('id="build-from-goal-btn"');
   });
 
   it('GET /pulse redirects to / (the board lives at the root now)', async () => {

--- a/packages/dashboard/src/routes/home-mission-control.test.ts
+++ b/packages/dashboard/src/routes/home-mission-control.test.ts
@@ -1,8 +1,8 @@
 /**
  * Mission Control home (`/`) + the global inbox badge count endpoint.
- * Verifies the unified front door composes the three zones (Needs you / live
- * Pulse board / collapsed activity) and that /inbox/needs-you-count drives the
- * nav badge.
+ * Verifies the unified front door (editable board + collapsed activity + the
+ * inbox-first Ask-sua CTA) and that /inbox/needs-you-count drives the global
+ * top-bar needs-you toast.
  */
 import { describe, it, expect, afterEach } from 'vitest';
 import request from 'supertest';
@@ -84,7 +84,7 @@ const get = (app: ReturnType<typeof buildDashboardApp>, path: string) =>
   request(app).get(path).set('Host', `127.0.0.1:${PORT}`).set('Cookie', COOKIE);
 
 describe('GET / — Mission Control home', () => {
-  it('renders the live Pulse board, the Needs-you strip, and collapsed activity', async () => {
+  it('renders the editable board, the Ask-sua CTA, and collapsed activity', async () => {
     const app = await makeApp();
     // The board only renders when at least one agent is installed (zero agents
     // shows the Build-from-goal empty state by design).
@@ -92,32 +92,26 @@ describe('GET / — Mission Control home', () => {
       id: 'hello', name: 'hello', status: 'active', source: 'local', mcp: false,
       nodes: [{ id: 'n', type: 'shell', command: 'echo hi', dependsOn: [] }],
     }, 'cli');
-    // Seed an awaiting_user thread so the Needs-you zone shows a card.
-    const m = inboxStore.add({ priority: 'high', source: 'run-failure', title: 'markets-today failed', body: 'fetch-quotes exit 1', agentId: 'markets-today' });
-    inboxStore.updateStatus(m.id, 'awaiting_user');
-
     const res = await get(app, '/');
     expect(res.status).toBe(200);
     // Live Pulse board (system tiles render even with zero signal agents).
     expect(res.text).toContain('pulse-grid');
     expect(res.text).toContain('id="pulse-tile-data"');
     expect(res.text).toContain('_system-runs-today');
-    // Needs you strip.
-    expect(res.text).toContain('Needs you');
-    expect(res.text).toContain('markets-today failed');
-    expect(res.text).toContain('href="/inbox"');
     // Collapsed activity.
     expect(res.text).toContain('home-activity');
     expect(res.text).toContain('Recent activity');
-    // The home is now the single dashboard surface — the board is editable here
-    // (/pulse collapsed into /).
+    // The home is the single dashboard surface — the board is editable here.
     expect(res.text).toContain('id="pulse-edit-toggle"');
     // Primary CTA is inbox-first ("Ask sua" → new thread), not the old
     // Build-from-goal / Browse-packs header buttons.
     expect(res.text).toContain('action="/inbox/new"');
     expect(res.text).toContain('Ask sua');
     expect(res.text).not.toContain('Browse packs');
-    expect(res.text).not.toContain('id="build-from-goal-btn"');
+    // The "needs you" signal moved to the global top-bar toast (driven by JS
+    // from /inbox/needs-you-count); the home body no longer has a needs-you strip.
+    expect(res.text).toContain('data-inbox-toast');
+    expect(res.text).not.toContain('home-needs__card');
   });
 
   it('GET /pulse redirects to / (the board lives at the root now)', async () => {
@@ -128,11 +122,14 @@ describe('GET / — Mission Control home', () => {
     expect(res.headers.location).toBe('/');
   });
 
-  it('shows the "all clear" state when nothing is awaiting reply', async () => {
+  it('renders the global top-bar needs-you toast (hidden until JS fills the count)', async () => {
     const app = await makeApp();
     const res = await get(app, '/');
     expect(res.status).toBe(200);
-    expect(res.text).toContain('Inbox clear');
+    // Toast element present on every page; server renders it hidden, the
+    // inbox-badge JS reveals it from /inbox/needs-you-count.
+    expect(res.text).toMatch(/class="topbar__needs"[^>]*data-inbox-toast[^>]*hidden/);
+    expect(res.text).toContain('data-inbox-count');
   });
 });
 

--- a/packages/dashboard/src/views/home.ts
+++ b/packages/dashboard/src/views/home.ts
@@ -95,10 +95,11 @@ export function renderHomePage(input: HomePageInput): string {
       <span style="font-size: var(--font-size-sm); color: var(--color-text-muted);">
         ${String(input.agentCount)} agent${input.agentCount !== 1 ? 's' : ''} registered
       </span>
-      <div style="margin-left: auto; display: flex; gap: var(--space-2);">
-        ${buildFromGoalButton({ variant: 'primary' })}
-        <a class="btn btn--ghost btn--sm" href="/packs">Browse packs</a>
-      </div>
+      ${input.agentCount === 0 ? html`` : html`
+        <form method="POST" action="/inbox/new" style="margin: 0 0 0 auto;">
+          <button type="submit" class="btn btn--primary btn--sm" title="Start a new inbox thread — ask sua to run, build, fix, or look something up">Ask sua →</button>
+        </form>
+      `}
     </div>
 
     ${needsYouStrip(input.needsYou)}
@@ -112,7 +113,7 @@ export function renderHomePage(input: HomePageInput): string {
       </div>
     </details>
 
-    ${buildFromGoalModal({ availableDashboards: input.availableDashboards })}
+    ${input.agentCount === 0 ? buildFromGoalModal({ availableDashboards: input.availableDashboards }) : html``}
   `;
 
   return render(layout({ title: 'Home', activeNav: 'home', flash: input.flash }, body));

--- a/packages/dashboard/src/views/home.ts
+++ b/packages/dashboard/src/views/home.ts
@@ -1,74 +1,29 @@
 /**
- * Mission Control home (`/`) — the unified front door, ordered by attention:
- *  1. "Needs you"   — the inbox's awaiting-user threads (count + preview + CTA)
- *  2. "Live Pulse"  — the real Pulse board (system + agent signal tiles),
- *                     reused read-only via renderPulseBoard({ editable: false })
- *  3. "Recent activity" — the run feed, collapsed by default
+ * Mission Control home (`/`) — the unified dashboard front door:
+ *  - a primary "Ask sua" CTA that opens a fresh inbox thread
+ *  - the live Pulse board (system + agent signal tiles, fully editable)
+ *  - a collapsed "Recent activity" run feed
  *
- * This replaces the old system-stat-only home (a strict subset of Pulse) so the
- * two surfaces no longer duplicate, and surfaces the inbox — the most powerful
- * surface — at the top of the front door.
+ * The "needs you" inbox signal lives globally in the top-bar toast (see
+ * layout.ts + inbox-badge.js), not in a vertical strip here — so the home
+ * leads straight into the board.
  */
 
-import type { InboxMessage } from '@some-useful-agents/core';
 import { html, render, type SafeHtml } from './html.js';
 import { layout } from './layout.js';
 import { renderPulseBoard } from './pulse.js';
 import type { PulsePageInput } from './pulse-types.js';
 import { buildRecentActivity, renderHomeWidget, type HomeWidgetData } from './home-widgets.js';
 import { buildFromGoalButton, buildFromGoalModal } from './build-from-goal-modal.js';
-import { formatAge } from './components.js';
 
 export interface HomePageInput {
   /** Live Pulse board data (from buildPulseBoardData). */
   board: PulsePageInput;
-  /** Inbox "Needs you": count + a small preview of awaiting-user threads. */
-  needsYou: { count: number; top: InboxMessage[] };
   /** Recent-activity feed data (reused HomeWidgetData subset). */
   activity: HomeWidgetData;
   agentCount: number;
   availableDashboards?: Array<{ id: string; name: string }>;
   flash?: { kind: 'ok' | 'error' | 'info'; message: string };
-}
-
-const PRIORITY_DOT: Record<string, string> = {
-  high: 'inbox-modal__priority--high',
-  medium: 'inbox-modal__priority--medium',
-  low: 'inbox-modal__priority--low',
-};
-
-function needsYouCard(m: InboxMessage): SafeHtml {
-  return html`
-    <a class="home-needs__card" href="/inbox/${m.id}">
-      <span class="inbox-modal__priority ${PRIORITY_DOT[m.priority] ?? ''}" aria-hidden="true"></span>
-      <span class="home-needs__title">${m.title}</span>
-      <span class="home-needs__meta">
-        ${m.agentId ? html`<span class="mono">${m.agentId}</span> · ` : html``}${formatAge(new Date(m.createdAt).toISOString())}
-      </span>
-    </a>
-  `;
-}
-
-function needsYouStrip(needsYou: HomePageInput['needsYou']): SafeHtml {
-  if (needsYou.count === 0) {
-    return html`
-      <section class="home-needs home-needs--clear">
-        <span class="home-needs__clear">✓ Inbox clear — nothing needs your reply.</span>
-        <a class="home-needs__open" href="/inbox">Open inbox →</a>
-      </section>
-    `;
-  }
-  return html`
-    <section class="home-needs">
-      <div class="home-needs__head">
-        <h2 class="home-needs__heading">Needs you <span class="badge badge--warn">${String(needsYou.count)}</span></h2>
-        <a class="home-needs__open" href="/inbox">Open inbox →</a>
-      </div>
-      <div class="home-needs__cards">
-        ${needsYou.top.map(needsYouCard) as unknown as SafeHtml[]}
-      </div>
-    </section>
-  `;
 }
 
 export function renderHomePage(input: HomePageInput): string {
@@ -101,8 +56,6 @@ export function renderHomePage(input: HomePageInput): string {
         </form>
       `}
     </div>
-
-    ${needsYouStrip(input.needsYou)}
 
     ${board}
 

--- a/packages/dashboard/src/views/inbox-badge.js.ts
+++ b/packages/dashboard/src/views/inbox-badge.js.ts
@@ -1,21 +1,22 @@
 /**
- * Global inbox badge: polls the needs-you count and shows an amber pill on the
- * Inbox nav link when threads are awaiting a reply. Lives in the layout bundle
- * so it runs on every page. No global inbox SSE channel exists (the event bus
- * is per-message), so a 30s poll is the minimal correct choice; live-update
- * via SSE is a future enhancement.
+ * Global "needs you" toast in the top bar: polls the inbox needs-you count and
+ * reveals an amber pill ("N need your reply →") in the top-bar empty space when
+ * threads are awaiting a reply. Lives in the layout bundle so it runs on every
+ * page. No global inbox SSE channel exists (the event bus is per-message), so a
+ * 30s poll is the minimal correct choice; live-update via SSE is a future step.
  */
 export const INBOX_BADGE_JS = `
 (function () {
-  var el = document.querySelector('[data-inbox-badge]');
-  if (!el) return;
+  var toast = document.querySelector('[data-inbox-toast]');
+  var countEl = document.querySelector('[data-inbox-count]');
+  if (!toast || !countEl) return;
   function refresh() {
     fetch('/inbox/needs-you-count', { credentials: 'same-origin' })
       .then(function (r) { return r.ok ? r.json() : null; })
       .then(function (d) {
         if (!d || typeof d.count !== 'number') return;
-        if (d.count > 0) { el.textContent = String(d.count); el.hidden = false; }
-        else { el.textContent = ''; el.hidden = true; }
+        if (d.count > 0) { countEl.textContent = String(d.count); toast.hidden = false; }
+        else { toast.hidden = true; }
       })
       .catch(function () {});
   }

--- a/packages/dashboard/src/views/layout.ts
+++ b/packages/dashboard/src/views/layout.ts
@@ -78,11 +78,16 @@ export function layout(opts: LayoutOptions, body: SafeHtml): SafeHtml {
 <header class="topbar">
   <a class="topbar__brand ${opts.activeNav === 'home' ? 'is-active' : ''}" href="/">sua</a>
   <nav class="topbar__nav">
-    <a href="/inbox" class="${opts.activeNav === 'inbox' ? 'is-active' : ''}">Inbox<span class="nav-badge" data-inbox-badge hidden></span></a>
+    <a href="/inbox" class="${opts.activeNav === 'inbox' ? 'is-active' : ''}">Inbox</a>
     <a href="/agents" class="${opts.activeNav === 'agents' || opts.activeNav === 'tools' || opts.activeNav === 'nodes' || opts.activeNav === 'runs' || opts.activeNav === 'packs' ? 'is-active' : ''}">Agents</a>
     <a href="/settings" class="${opts.activeNav === 'settings' ? 'is-active' : ''}">Settings</a>
     <a href="/help" class="${opts.activeNav === 'help' ? 'is-active' : ''}">Help</a>
   </nav>
+  <a class="topbar__needs" data-inbox-toast href="/inbox" hidden>
+    <span class="topbar__needs-dot" aria-hidden="true"></span>
+    <span data-inbox-count></span>&nbsp;need your reply
+    <span aria-hidden="true">→</span>
+  </a>
   <button class="topbar__theme-toggle" onclick="(function(){var h=document.documentElement;var c=h.getAttribute('data-theme');var n=c==='light'?null:'light';if(n)h.setAttribute('data-theme',n);else h.removeAttribute('data-theme');localStorage.setItem('sua-theme',n||'dark');})();" aria-label="Toggle theme">
     <span class="topbar__theme-icon"></span>
   </button>


### PR DESCRIPTION
## Why

On the unified home, the upper-right had competing callouts: **Build from goal** / **Browse packs** (leftovers from the stat-only home), the Needs-you strip's **Open inbox →**, and the board's controls. "Open inbox" and a build button both fought with the board, and "Open inbox" + "Ask sua" were two buttons doing the same go-to-the-inbox job.

## What

1. **Ask sua →** — the home's single primary CTA (header). POSTs to `/inbox/new` and drops you into a fresh thread. Build-from-goal moves to `/agents` + the no-agents empty state; "Browse packs" removed (reachable via the dashboards dropdown + `/packs`).
2. **Global "needs you" top-bar toast** — the "what needs review" signal moves off the home body into the **top-bar empty space**: an amber **"N need your reply →"** pill, on every page, shown only when inbox threads await a reply (count from `/inbox/needs-you-count`, polled ~30s, hidden at zero). Replaces the small nav-word badge.
3. **Drop the home Needs-you strip** — removes the redundant "Open inbox" callout and tightens the vertical; the home now leads straight into the board.

Net home: `Home · N agents · [Ask sua →]` → editable board → collapsed activity, with the needs-you toast living globally in the top bar.

## Verification

- `tsc` clean; full suite **2093 pass / 3 skip**. Tests: home asserts Ask-sua CTA + `data-inbox-toast` present + no `home-needs__card` / Browse packs; top-bar toast rendered hidden; count endpoint unchanged.
- Live: top bar carries the toast (hidden at count 0); home header shows only **Ask sua →**; no needs-you strip; board editable; `/pulse`→`302 /` still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)