### PR TITLE
fix(core): annotate node-timeout errors when the machine slept

### DIFF
--- a/.changeset/timeout-message-slept-machine.md
+++ b/.changeset/timeout-message-slept-machine.md
@@ -1,0 +1,17 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Clearer node-timeout errors when the machine slept.
+
+A node's wall-clock timer is suspended while the machine sleeps, so a 300s
+timeout could "fire" hours later and report a misleading "Timed out after 300s"
+on a run that never actually ran that long. The timeout message now detects when
+the elapsed wall-clock vastly exceeds the configured limit and annotates it
+("limit 300s, but 3.7h elapsed; the machine likely slept...") so run detail
+explains the gap instead of implying a true hang. Operator Stop (cancellation)
+keeps the bare message.

--- a/packages/core/src/node-spawner.test.ts
+++ b/packages/core/src/node-spawner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { appleFoundationModelsSpawner, buildProviderChain, claudeSpawner, codexSpawner, classifyLlmFailure, shouldFallback, spawnNodeReal, validateOutputContract, type SpawnResult } from './node-spawner.js';
+import { appleFoundationModelsSpawner, buildProviderChain, claudeSpawner, codexSpawner, classifyLlmFailure, shouldFallback, spawnNodeReal, timeoutError, validateOutputContract, type SpawnResult } from './node-spawner.js';
 
 function r(partial: Partial<SpawnResult>): SpawnResult {
   return {
@@ -441,5 +441,34 @@ describe('spawnNodeReal — unresolved tool node', () => {
   it('keeps "has no command" for a plain shell node with no tool', async () => {
     const res = await spawnNodeReal({ id: 'x', type: 'shell' }, {}, opts);
     expect(res.error).toBe('Shell node "x" has no command');
+  });
+});
+
+describe('timeoutError', () => {
+  it('returns the bare message for a cancellation (no elapsed)', () => {
+    expect(timeoutError(300)).toBe('Timed out after 300s');
+  });
+
+  it('returns the bare message when elapsed is near the limit', () => {
+    // 305s elapsed against a 300s limit — ordinary jitter, not a slept machine.
+    expect(timeoutError(300, 305_000)).toBe('Timed out after 300s');
+  });
+
+  it('returns the bare message when elapsed is over 2x but under +120s', () => {
+    // 60s limit, 150s elapsed: 2.5x the limit but only 90s past — not annotated.
+    expect(timeoutError(60, 150_000)).toBe('Timed out after 60s');
+  });
+
+  it('annotates the slept-machine case (224m against a 300s limit)', () => {
+    const msg = timeoutError(300, 224 * 60 * 1000);
+    expect(msg).toContain('limit 300s');
+    expect(msg).toContain('3.7h');
+    expect(msg).toContain('likely slept');
+  });
+
+  it('formats sub-hour elapsed in minutes', () => {
+    const msg = timeoutError(60, 40 * 60 * 1000);
+    expect(msg).toContain('40m');
+    expect(msg).not.toContain('h elapsed');
   });
 });

--- a/packages/core/src/node-spawner.ts
+++ b/packages/core/src/node-spawner.ts
@@ -1052,6 +1052,29 @@ function approximateExecSize(args: string[], env: Record<string, string>, stdinI
 }
 
 /**
+ * Build a node-timeout error message. When the actual wall-clock that elapsed
+ * (`elapsedMs`) vastly exceeds the configured limit, the timer was almost
+ * certainly suspended mid-run — the classic case is the laptop sleeping, which
+ * pauses Node's timers, so a 300s timeout can "fire" 4 hours later. The node
+ * did NOT run for that long, so we annotate instead of implying a true hang.
+ *
+ * `elapsedMs` is undefined for a cancellation (operator Stop), which reaches
+ * the same `killed` branch but isn't a real timeout — keep the bare message.
+ */
+export function timeoutError(timeoutSec: number, elapsedMs?: number): string {
+  const bare = `Timed out after ${timeoutSec}s`;
+  if (elapsedMs === undefined) return bare;
+  const elapsedSec = Math.round(elapsedMs / 1000);
+  // Trip only when elapsed is both a large multiple of the limit AND at least
+  // a couple minutes past it, so ordinary scheduling jitter never annotates.
+  if (elapsedSec <= timeoutSec * 2 || elapsedSec - timeoutSec < 120) return bare;
+  const elapsedHuman = elapsedSec >= 3600
+    ? `${(elapsedSec / 3600).toFixed(1)}h`
+    : `${Math.round(elapsedSec / 60)}m`;
+  return `Timed out — limit ${timeoutSec}s, but ${elapsedHuman} elapsed; the machine likely slept (timers suspend during sleep), so the node did not actually run that long.`;
+}
+
+/**
  * Low-level process spawn with timeout, exit-code categorization,
  * optional per-line progress callback, and result extraction.
  */
@@ -1063,6 +1086,10 @@ export async function spawnProcess(
   return new Promise<SpawnResult>((resolve) => {
     let child: ChildProcess;
     let killed = false;
+    // `timedOut` is set ONLY by the wall-clock timer (not by the cancellation
+    // signal, which also sets `killed`) so the close handler can tell a real
+    // timeout apart from an operator Stop and annotate the slept-machine case.
+    let timedOut = false;
     const stdinMode = opts.stdinInput !== undefined ? 'pipe' : 'ignore';
 
     const execSize = approximateExecSize(args, opts.env, opts.stdinInput);
@@ -1094,6 +1121,7 @@ export async function spawnProcess(
       resolve({ result: '', exitCode: 127, error: (err as Error).message, category: 'spawn_failure' });
       return;
     }
+    const spawnedAt = Date.now();
     // Report the freshly-spawned pid + start time so the executor can persist
     // them on the node_executions row. Fires before stdin write so a crash
     // between spawn() and the first stdout chunk still leaves a kill handle.
@@ -1130,6 +1158,7 @@ export async function spawnProcess(
 
     const timer = setTimeout(() => {
       killed = true;
+      timedOut = true;
       child.kill('SIGTERM');
       setTimeout(() => { if (!child.killed) child.kill('SIGKILL'); }, 5000);
     }, opts.timeoutSec * 1000);
@@ -1165,7 +1194,7 @@ export async function spawnProcess(
       const finalResult = opts.extractResult ? opts.extractResult(stdout) : stdout;
 
       if (killed) {
-        resolve({ result: finalResult, exitCode: 124, error: `Timed out after ${opts.timeoutSec}s`, category: 'timeout' });
+        resolve({ result: finalResult, exitCode: 124, error: timeoutError(opts.timeoutSec, timedOut ? Date.now() - spawnedAt : undefined), category: 'timeout' });
       } else if (code === 0) {
         resolve({ result: finalResult, exitCode: 0 });
       } else {


### PR DESCRIPTION
## What

When a node's wall-clock timeout fires, the error now distinguishes a true hang from a **slept machine**. Node's timers are suspended while the laptop sleeps, so a 300s timeout could "fire" hours later on a run that never actually ran that long — and report a misleading `Timed out after 300s`.

This was the "224m run" diagnosis from the last session: `ccusage-daily` + `churn-watcher` each showed a ~224m run that was just the laptop sleeping (scheduled 16:00Z, both ended ~19:44Z when timers resumed on wake).

## How

- `spawnProcess` records `spawnedAt` and a timer-only `timedOut` flag (distinct from the cancellation/abort path, which also sets `killed` — operator Stop should keep the bare message).
- New exported `timeoutError(timeoutSec, elapsedMs?)` annotates only when elapsed wall-clock is **both** >2x the limit **and** >=120s past it, so ordinary scheduling jitter never trips it:
  > Timed out — limit 300s, but 3.7h elapsed; the machine likely slept (timers suspend during sleep), so the node did not actually run that long.
- Sub-hour elapsed formats as minutes, >=1h as `N.Nh`.

## Tests

5 new `timeoutError` unit tests (bare on cancel, bare near-limit, bare under-threshold, annotated slept-machine, minute formatting). `node-spawner.test.ts` 64 pass; clean full build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)