### PR TITLE
feat(inbox): triage can resolve a thread it has fully handled

### DIFF
--- a/.changeset/triage-resolve-thread.md
+++ b/.changeset/triage-resolve-thread.md
@@ -1,0 +1,18 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Triage can now resolve a thread it has fully handled.
+
+When a thread is done — the operator says "thanks, that's all", or the request is
+fully answered with nothing left to run or diagnose — triage can close it itself
+with a new `resolve-thread` action instead of telling the operator to click
+Resolve. It sets the thread status to `resolved` synchronously (no agent runs),
+posts a short acknowledgment, and is excluded from the auto-follow-up trigger so
+closing a thread never spawns another triage turn. The kernel teaches strict
+guardrails: never resolve while a question is pending, an action is still
+running, or a reported problem hasn't actually been addressed.

--- a/agents/examples/inbox-triage/kernel.md
+++ b/agents/examples/inbox-triage/kernel.md
@@ -393,6 +393,46 @@ like agent-editor) and the operator confirms one write at a time.
   CTA using the id from the action result.
 
 ════════════════════════════════════════════════════════════════
+RESOLVING A THREAD — close it out when you're truly done
+════════════════════════════════════════════════════════════════
+
+When a thread is fully handled and there is NOTHING left to run,
+diagnose, or ask, close it yourself with a `resolve-thread` action
+instead of telling the operator to "click Resolve". It sets the
+thread status to resolved synchronously (no agent runs).
+
+Resolve when ALL of these hold:
+- The operator's request is fully satisfied OR their latest message
+  is a closure/acknowledgment ("thanks", "got it", "that's all",
+  "nvm").
+- Nothing is pending: no action is running, no run to inspect, no
+  follow-up you still owe.
+- You are NOT asking the operator a question in this same turn.
+
+Do NOT resolve when:
+- You asked a clarifying question (leave it awaiting the reply).
+- An action you proposed is still running or needs approval.
+- The operator reported a problem you haven't actually addressed —
+  diagnosing or running something is the job, not closing the thread.
+
+- Shape: `{ "type": "resolve-thread", "rationale": "one line on why it's done" }`.
+  No agentId, no inputs. Pair it with a short `recommendation` that
+  acknowledges the close (the operator sees both). Propose at most one
+  resolve-thread, and nothing after it.
+
+Example (operator said "thanks, that's all" — acknowledge and close):
+
+<plan>
+{
+  "messageId": "{{inputs.MESSAGE_ID}}",
+  "recommendation": "Glad that sorted it — closing this out. Reply any time to reopen.",
+  "actions": [
+    { "type": "resolve-thread", "rationale": "Operator confirmed done; nothing left to run." }
+  ]
+}
+</plan>
+
+════════════════════════════════════════════════════════════════
 OUTPUT FORMAT — exact shape, single <plan>...</plan> block
 ════════════════════════════════════════════════════════════════
 

--- a/packages/core/src/inbox-store.ts
+++ b/packages/core/src/inbox-store.ts
@@ -92,9 +92,12 @@ export interface InboxActionMeta {
    * the agent. `show-widget` summons the agent's LATEST COMPLETED run's output
    * widget inline WITHOUT dispatching — a read-only snapshot that resolves
    * `proposed → completed` by pointing `runId` at that latest run, so the
-   * existing inline-widget render path displays it.
+   * existing inline-widget render path displays it. `resolve` closes the thread
+   * (sets its status to `resolved`) WITHOUT dispatching any agent — triage's way
+   * of ending a thread it has fully handled instead of telling the operator to
+   * click Resolve. `agentId` is the sentinel `_resolve-thread` (no real agent).
    */
-  mode?: 'run' | 'show-widget';
+  mode?: 'run' | 'show-widget' | 'resolve';
   /**
    * When true, approving this run first grants `permissions.inboxRunnable`
    * to `agentId` (a one-click "Enable & run"). Set by the dashboard when

--- a/packages/dashboard/src/routes/inbox-engine.ts
+++ b/packages/dashboard/src/routes/inbox-engine.ts
@@ -1106,6 +1106,9 @@ export function atLeastOneActionExecuted(
     // count as "something ran" (else it would trigger a follow-up triage turn,
     // risking a show→refire→show loop).
     if (m?.mode === 'show-widget') continue;
+    // resolve-thread closes the thread; it's not an outcome to summarize, so it
+    // must not trigger a follow-up triage turn.
+    if (m?.mode === 'resolve') continue;
     if (m && (m.status === 'completed' || m.status === 'failed')) return true;
   }
   return false;
@@ -1480,6 +1483,9 @@ export async function runTriageAgent(
     // Enter when there are runnable sub-agents OR the plan summons a widget
     // (show-widget is read-only and isn't gated on the run allowlist, so it
     // works on threads with no runnable agents, e.g. a manual "show me X").
+    // When a resolve-thread action closes the thread, skip the awaiting_user
+    // status update below so the `resolved` status sticks.
+    let threadResolved = false;
     const rawActionList = Array.isArray(parsed.actions) ? parsed.actions : [];
     const planHasShowWidget = rawActionList.some(
       (a) => a && typeof a === 'object' && (a as { type?: unknown }).type === 'show-widget',
@@ -1490,7 +1496,12 @@ export async function runTriageAgent(
     const planHasDashboardEditor = rawActionList.some(
       (a) => a && typeof a === 'object' && (a as { type?: unknown }).type === 'dashboard-editor',
     );
-    if (allowlist.length > 0 || planHasShowWidget || planHasDashboardEditor) {
+    // resolve-thread runs nothing (not allowlist-gated) but must still enter the
+    // action block on a thread with no runnable agents (e.g. "thanks, we're done").
+    const planHasResolve = rawActionList.some(
+      (a) => a && typeof a === 'object' && (a as { type?: unknown }).type === 'resolve-thread',
+    );
+    if (allowlist.length > 0 || planHasShowWidget || planHasDashboardEditor || planHasResolve) {
       const { accepted, rejected, deferred } = parseProposedActions(parsed.actions, allowlist, candidates);
       const dedupedAccepted: InboxActionMeta[] = [];
       for (const action of accepted) {
@@ -1522,7 +1533,9 @@ export async function runTriageAgent(
         const body = action.rationale
           ?? (action.mode === 'show-widget'
             ? `Show the latest output from \`${action.agentId}\`.`
-            : `Run agent \`${action.agentId}\`.`);
+            : action.mode === 'resolve'
+              ? 'Resolve this thread — nothing left to run or diagnose.'
+              : `Run agent \`${action.agentId}\`.`);
         const actionResp = ctx.inboxStore.addResponse(messageId, 'action', body, JSON.stringify(action));
         publishInboxEvent(ctx, messageId, 'action:created', {
           responseId: actionResp.id,
@@ -1531,6 +1544,32 @@ export async function runTriageAgent(
           inputs: action.inputs,
           createdAt: actionResp.createdAt,
         });
+        // resolve-thread closes the thread synchronously (no dispatch): mark the
+        // action completed and set the thread status to `resolved`. `break` —
+        // the thread is closed, so any remaining proposed actions this turn are
+        // moot. `threadResolved` suppresses the awaiting_user update below.
+        if (action.mode === 'resolve') {
+          const now = Date.now();
+          const resolvedMeta: InboxActionMeta = {
+            ...action,
+            status: 'completed',
+            resultSummary: action.rationale ? `Resolved: ${action.rationale}` : 'Resolved by triage.',
+            startedAt: now,
+            endedAt: now,
+          };
+          if (ctx.inboxStore.transitionActionStatus(actionResp.id, 'proposed', JSON.stringify(resolvedMeta))) {
+            publishInboxEvent(ctx, messageId, 'action:status', {
+              responseId: actionResp.id,
+              status: 'completed',
+              agentId: action.agentId,
+              resultSummary: resolvedMeta.resultSummary,
+              endedAt: now,
+            });
+          }
+          try { ctx.inboxStore.updateStatus(messageId, 'resolved'); } catch { /* ignore */ }
+          threadResolved = true;
+          break;
+        }
         // show-widget resolves synchronously to the agent's latest completed
         // run (read-only, no dispatch) → proposed → completed/failed in one
         // step. No `running` phase (a zero-latency lookup), and NO refire (it's
@@ -1615,9 +1654,13 @@ export async function runTriageAgent(
       }
     }
 
-    try {
-      ctx.inboxStore.updateStatus(messageId, 'awaiting_user', { recommendation: rec, triageRunId: runId });
-    } catch { /* ignore */ }
+    // A resolve-thread action already set the thread to `resolved`; don't stomp
+    // it back to awaiting_user.
+    if (!threadResolved) {
+      try {
+        ctx.inboxStore.updateStatus(messageId, 'awaiting_user', { recommendation: rec, triageRunId: runId });
+      } catch { /* ignore */ }
+    }
     // A turn completed cleanly — the thread isn't in a crash loop, so refund
     // the auto-retry budget for any future transient failure.
     resetTriageCrashRetries(ctx, messageId);

--- a/packages/dashboard/src/routes/inbox-plan.ts
+++ b/packages/dashboard/src/routes/inbox-plan.ts
@@ -18,6 +18,13 @@ import {
  */
 const MAX_TRIAGE_CRASH_RETRIES = 1;
 
+/**
+ * Sentinel agentId for a `resolve-thread` action. It isn't a real agent — the
+ * engine handles it by setting the thread status to `resolved` — so it must not
+ * collide with any installed agent id. Exported so the engine can recognize it.
+ */
+export const RESOLVE_THREAD_AGENT_ID = '_resolve-thread';
+
 export function hasMatchingFailedAction(
   ctx: ReturnType<typeof getContext>,
   messageId: string,
@@ -30,6 +37,9 @@ export function hasMatchingFailedAction(
   // is exactly the change that unblocks a "no completed run yet" failure). Never
   // treat a show-widget as a stale-failed match.
   if (candidate.mode === 'show-widget') return false;
+  // A resolve-thread action has no inputs and never "fails" in a way a retry
+  // would fix — never let the stale-failed guard block it.
+  if (candidate.mode === 'resolve') return false;
   const candidateInputs = stableStringifyInputs(candidate.inputs);
   // When the target agent was edited AFTER a failure, that failure is stale —
   // the operator fixing the agent is exactly the "something changed that would
@@ -185,6 +195,23 @@ export function parseProposedActions(
     // no dispatch). Not gated on the run allowlist — any INSTALLED agent is
     // fair game (the engine's dedup loop rejects uninstalled ones, where it has
     // agentStore access). No inputs (the agent isn't run).
+    // `resolve-thread` closes the thread — no agent, no dispatch. The engine
+    // sets the thread status to `resolved` synchronously. Not allowlist-gated
+    // (it runs nothing). Sentinel agentId so downstream code never treats it as
+    // a real agent.
+    if (type === 'resolve-thread') {
+      accepted.push({
+        kind: 'action',
+        mode: 'resolve',
+        status: 'proposed',
+        agentId: RESOLVE_THREAD_AGENT_ID,
+        inputs: {},
+        rationale: rationaleRaw || undefined,
+        effect: 'write',
+        ctaLabel: 'Resolve',
+      });
+      continue;
+    }
     if (type === 'show-widget') {
       if (!agentId) {
         rejected.push({ agentId: '<unknown>', reason: 'show-widget missing agentId' });

--- a/packages/dashboard/src/routes/inbox-resolve-thread.test.ts
+++ b/packages/dashboard/src/routes/inbox-resolve-thread.test.ts
@@ -1,0 +1,87 @@
+/**
+ * resolve-thread action: triage can CLOSE a thread it has fully handled instead
+ * of telling the operator to click Resolve. The parser accepts `resolve-thread`
+ * (no agent, no dispatch), and the engine excludes it from the refire trigger so
+ * closing a thread never spawns a follow-up turn.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { AgentStore, InboxStore, RunStore, type InboxActionMeta } from '@some-useful-agents/core';
+import { parseProposedActions, hasMatchingFailedAction, RESOLVE_THREAD_AGENT_ID } from './inbox-plan.js';
+import { atLeastOneActionExecuted } from './inbox-engine.js';
+
+let dir: string;
+let agentStore: AgentStore;
+let inboxStore: InboxStore;
+let runStore: RunStore;
+
+function setup() {
+  dir = mkdtempSync(join(tmpdir(), 'sua-resolve-thread-'));
+  const db = join(dir, 'runs.db');
+  agentStore = new AgentStore(db);
+  inboxStore = new InboxStore(db);
+  runStore = new RunStore(db);
+  return { agentStore, inboxStore, runStore } as never as ReturnType<typeof import('../context.js').getContext>;
+}
+
+afterEach(() => {
+  try { agentStore.close(); } catch { /* ignore */ }
+  try { inboxStore.close(); } catch { /* ignore */ }
+  try { runStore.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('parseProposedActions — resolve-thread', () => {
+  it('accepts a resolve-thread action (no agent, no allowlist gating)', () => {
+    const { accepted, rejected } = parseProposedActions(
+      [{ type: 'resolve-thread', rationale: 'Operator said thanks; nothing left.' }],
+      [], // empty allowlist — resolve runs nothing, so it still parses
+    );
+    expect(rejected).toHaveLength(0);
+    expect(accepted).toHaveLength(1);
+    expect(accepted[0].mode).toBe('resolve');
+    expect(accepted[0].agentId).toBe(RESOLVE_THREAD_AGENT_ID);
+    expect(accepted[0].effect).toBe('write');
+    expect(accepted[0].rationale).toContain('nothing left');
+  });
+});
+
+describe('hasMatchingFailedAction — resolve is never blocked', () => {
+  it('returns false for a resolve action even after a prior failed resolve', () => {
+    const ctx = setup();
+    const msg = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const failedResolve: InboxActionMeta = {
+      kind: 'action', mode: 'resolve', status: 'failed', agentId: RESOLVE_THREAD_AGENT_ID, inputs: {},
+    };
+    inboxStore.addResponse(msg.id, 'action', 'resolve', JSON.stringify(failedResolve));
+    const candidate: InboxActionMeta = {
+      kind: 'action', mode: 'resolve', status: 'proposed', agentId: RESOLVE_THREAD_AGENT_ID, inputs: {},
+    };
+    expect(hasMatchingFailedAction(ctx, msg.id, candidate)).toBe(false);
+  });
+});
+
+describe('atLeastOneActionExecuted — resolve does not trigger a refire', () => {
+  it('excludes a completed resolve action', () => {
+    const ctx = setup();
+    const msg = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const resolved: InboxActionMeta = {
+      kind: 'action', mode: 'resolve', status: 'completed', agentId: RESOLVE_THREAD_AGENT_ID, inputs: {},
+      resultSummary: 'Resolved by triage.',
+    };
+    inboxStore.addResponse(msg.id, 'action', 'resolve', JSON.stringify(resolved));
+    expect(atLeastOneActionExecuted(ctx, msg.id)).toBe(false);
+  });
+
+  it('still counts a completed run-agent action', () => {
+    const ctx = setup();
+    const msg = inboxStore.add({ priority: 'medium', source: 'manual', title: 't', body: 'b' });
+    const ran: InboxActionMeta = {
+      kind: 'action', status: 'completed', agentId: 'some-agent', inputs: {}, runId: 'r1',
+    };
+    inboxStore.addResponse(msg.id, 'action', 'run', JSON.stringify(ran));
+    expect(atLeastOneActionExecuted(ctx, msg.id)).toBe(true);
+  });
+});

--- a/packages/dashboard/src/views/inbox-detail.ts
+++ b/packages/dashboard/src/views/inbox-detail.ts
@@ -604,8 +604,8 @@ function renderActionEntry(r: InboxResponse, currentTargetYaml?: string, inlineW
       <div class="inbox-msg__avatar inbox-msg__avatar--action">Act</div>
       <div class="inbox-msg__body">
         <div class="inbox-msg__meta">
-          <span class="inbox-msg__meta-name">${meta.mode === 'show-widget' ? 'Widget' : 'Triage proposed'}</span>
-          ${meta.mode === 'show-widget' ? html`` : html`<span class="inbox-action__status">${statusLabel}</span>`}
+          <span class="inbox-msg__meta-name">${meta.mode === 'show-widget' ? 'Widget' : meta.mode === 'resolve' ? 'Triage resolved' : 'Triage proposed'}</span>
+          ${meta.mode === 'show-widget' || meta.mode === 'resolve' ? html`` : html`<span class="inbox-action__status">${statusLabel}</span>`}
           <span>${formatAge(new Date(r.createdAt).toISOString())}</span>
         </div>
         <div class="inbox-action__card">
@@ -614,7 +614,9 @@ function renderActionEntry(r: InboxResponse, currentTargetYaml?: string, inlineW
               ? html`${meta.inputs.op === 'create' ? 'Create dashboard' : 'Add tile'} · <span class="mono">${meta.inputs.DASHBOARD ?? ''}</span>${meta.inputs.AGENT_ID ? html` · <span class="mono">${meta.inputs.AGENT_ID}</span>` : html``}`
               : meta.mode === 'show-widget'
                 ? html`Latest <span class="mono">${meta.agentId}</span> output`
-                : html`Run agent <span class="mono">${meta.agentId}</span>`}
+                : meta.mode === 'resolve'
+                  ? html`Resolved this thread`
+                  : html`Run agent <span class="mono">${meta.agentId}</span>`}
             ${meta.runId ? html` · <a href="/runs/${meta.runId}" class="mono">run ${meta.runId.slice(0, 8)}</a>` : html``}
           </div>
           ${meta.rationale ? html`<div class="inbox-action__rationale">${mdBody(meta.rationale)}</div>` : html``}
@@ -658,6 +660,10 @@ function renderActionStatusBody(meta: InboxActionMeta, inlineWidget?: SafeHtml):
       `;
     case 'completed': {
       const hasInlineWidget = !!inlineWidget;
+      // resolve-thread has no run chrome — just a quiet confirmation.
+      if (meta.mode === 'resolve') {
+        return html`<div class="inbox-action__result inbox-action__result--ok"><span class="badge badge--ok">Resolved</span></div>`;
+      }
       // show-widget is a read-only snapshot — drop the run chrome (duration,
       // "Completed" badge, raw-result preview) and show just the widget.
       if (meta.mode === 'show-widget') {


### PR DESCRIPTION
## What

Triage couldn't close a thread — the best it could do was tell you *"click Resolve on this thread now to clear it."* (Exactly what it said on the demo thread.) Now triage can resolve a thread itself when it's genuinely done.

## How

A new `resolve-thread` action, modeled on the existing control actions (`show-widget`, `dashboard-editor`):

- **core** — `InboxActionMeta.mode` gains `'resolve'` (sentinel `agentId` `_resolve-thread`; no agent runs).
- **parser** (`inbox-plan`) — accepts `{ "type": "resolve-thread", "rationale": "…" }`. Not allowlist-gated (it dispatches nothing) and never blocked by the failed-action dedup guard.
- **engine** (`inbox-engine`) — `planHasResolve` lets it through on threads with no runnable agents; executes synchronously (action → `completed`, thread → `resolved`), `break`s the action loop, suppresses the trailing `awaiting_user` update so the `resolved` status sticks, and is excluded from `atLeastOneActionExecuted` so closing a thread never spawns a follow-up triage turn.
- **render** (`inbox-detail`) — a "Triage resolved" / "Resolved this thread" card with a green **Resolved** badge, no Run button.
- **kernel** — a `RESOLVING A THREAD` section with strict guardrails: resolve only when the request is fully satisfied / acknowledged and nothing is pending; **never** resolve while a question is pending, an action is running, or a reported problem hasn't actually been addressed.

## Dogfooded live

Replied *"Thanks, that was just a demo — please close this thread out."* to an `awaiting_user` thread. Triage emitted a `resolve-thread` action, posted *"Closing this out now. Reply any time if you want to reopen it."*, and the thread flipped to **resolved** (verified the card renders "Triage resolved" + the Resolved badge). Reopen still works via reply.

## Tests

New `inbox-resolve-thread.test.ts` covers the parser branch, the failed-action-guard exclusion, and the refire exclusion (resolve doesn't count as an executed action; a run-agent still does). Full dashboard + core suite green; clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)