### PR TITLE
fix(inbox): let triage see a whole run's output, not just the first 2KB

### DIFF
--- a/.changeset/triage-see-full-run-output.md
+++ b/.changeset/triage-see-full-run-output.md
@@ -1,0 +1,19 @@
+---
+"@some-useful-agents/core": patch
+"@some-useful-agents/cli": patch
+"@some-useful-agents/mcp-server": patch
+"@some-useful-agents/temporal-provider": patch
+"@some-useful-agents/dashboard": patch
+---
+
+Triage can now see a whole run's output, not just the first ~2KB.
+
+`FOCUS_AGENT_RUN` (the latest run output triage answers from) was capped at 2000
+chars. A verbose data agent — an MLB scoreboard is ~8KB, a full slate of 15
+games — got sliced off after ~4 entries, so triage genuinely couldn't see the
+row the operator asked about ("did the Mariners win?" with the Mariners game
+deep in the payload). The cap is now generous enough (12KB, 14KB total) that a
+full data payload reaches triage intact, still bounded so a pathological dump
+can't blow the prompt (it truncates with an "open the run" pointer). The triage
+kernel also tells it to read the whole payload before answering a data question,
+and to link the run rather than guess when the output is genuinely truncated.

--- a/agents/examples/inbox-triage/kernel.md
+++ b/agents/examples/inbox-triage/kernel.md
@@ -153,7 +153,14 @@ agent and paste the result — you already have it.
   it. Only ask the operator to run something when there is genuinely
   no run yet (FOCUS_AGENT_RUN empty).
 - When the latest run SUCCEEDED, you may confirm the outcome from its
-  output rather than asking the operator to verify.
+  output rather than asking the operator to verify. Read the WHOLE of
+  FOCUS_AGENT_RUN before answering a "did X happen / what was Y" data
+  question — the detail the operator wants (a specific team, row, or
+  ticker) is often deep in the payload, not near the top.
+- Only if FOCUS_AGENT_RUN ends with a "(truncated …)" marker AND the
+  specific detail asked about is genuinely not in the visible portion,
+  say the output was too large to fully load and link the run
+  (`/runs/<id>`) — do NOT guess a value you can't see.
 
 
 ════════════════════════════════════════════════════════════════

--- a/packages/dashboard/src/routes/inbox-catalog.ts
+++ b/packages/dashboard/src/routes/inbox-catalog.ts
@@ -445,8 +445,19 @@ export function extractAgentBuilderProviderPin(inputs: Record<string, string>): 
 /**
  * Distilled version of run-now-build.ts's run-output collector:
  * grab the latest completed run's result + the latest failed run's
- * error/output, cap at 3000 chars. Empty string when neither exists.
+ * error/output. This is triage's window into what an agent actually
+ * returned, so the caps must be generous enough that the operator's
+ * answer isn't past the cutoff: a data agent (an MLB scoreboard, a
+ * markets digest) emits verbose JSON — a full MLB slate is ~8KB — and
+ * a 2KB cap sliced off after ~4 games, so triage literally couldn't
+ * see the team the operator asked about. Empty string when neither
+ * run exists. Still bounded so a pathological multi-hundred-KB dump
+ * can't blow the triage prompt (it truncates + says so; triage can
+ * point the operator at the full run).
  */
+const RUN_RESULT_CAP = 12000;
+const RUN_SUMMARY_TOTAL_CAP = 14000;
+
 export function collectRunSummary(
   ctx: ReturnType<typeof getContext>,
   agentName: string,
@@ -456,7 +467,7 @@ export function collectRunSummary(
     const completed = ctx.runStore.listRuns({ agentName, status: 'completed', limit: 1 });
     if (completed.length > 0 && completed[0].result) {
       const raw = completed[0].result;
-      out = raw.length > 2000 ? raw.slice(0, 2000) + '\n...(truncated)' : raw;
+      out = raw.length > RUN_RESULT_CAP ? raw.slice(0, RUN_RESULT_CAP) + '\n...(truncated — open the run for the full output)' : raw;
     }
     const failed = ctx.runStore.listRuns({ agentName, status: 'failed', limit: 1 });
     if (failed.length > 0) {
@@ -467,13 +478,13 @@ export function collectRunSummary(
         const parts = [
           `\n\nMOST RECENT RUN FAILED (${f.id.slice(0, 8)}):`,
           f.error ? `Error: ${f.error}` : '',
-          f.result ? `Output: ${f.result.slice(0, 1000)}` : '',
+          f.result ? `Output: ${f.result.slice(0, 2000)}` : '',
         ].filter(Boolean);
         out += parts.join('\n');
       }
     }
   } catch { /* swallow */ }
-  return out.length > 3000 ? out.slice(0, 3000) + '\n...(truncated)' : out;
+  return out.length > RUN_SUMMARY_TOTAL_CAP ? out.slice(0, RUN_SUMMARY_TOTAL_CAP) + '\n...(truncated — open the run for the full output)' : out;
 }
 
 export function deriveRunFailureReason(

--- a/packages/dashboard/src/routes/inbox-run-summary.test.ts
+++ b/packages/dashboard/src/routes/inbox-run-summary.test.ts
@@ -1,0 +1,59 @@
+/**
+ * collectRunSummary is triage's window into what an agent returned (fed as
+ * FOCUS_AGENT_RUN). The cap must be generous enough that a verbose data payload
+ * (a full MLB scoreboard is ~8KB) reaches triage intact — a 2KB cap sliced off
+ * after ~4 games, so triage couldn't see the team the operator asked about.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { RunStore } from '@some-useful-agents/core';
+import { collectRunSummary } from './inbox-catalog.js';
+
+let dir: string;
+let runStore: RunStore;
+
+function setup() {
+  dir = mkdtempSync(join(tmpdir(), 'sua-run-summary-'));
+  runStore = new RunStore(join(dir, 'runs.db'));
+  return { runStore } as never as ReturnType<typeof import('../context.js').getContext>;
+}
+
+afterEach(() => {
+  try { runStore.close(); } catch { /* ignore */ }
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('collectRunSummary', () => {
+  it('surfaces data ~7.4KB deep in a verbose result (past the old 2KB cap)', () => {
+    const ctx = setup();
+    // Mimic the mlb-scoreboard payload: a big JSON blob with the answer deep in.
+    const result = 'x'.repeat(7400) + '"home_team": "Seattle Mariners", "home_score": 5' + 'y'.repeat(800);
+    runStore.createRun({
+      id: 'run-1', agentName: 'mlb-scoreboard', status: 'completed',
+      startedAt: new Date().toISOString(), completedAt: new Date().toISOString(),
+      triggeredBy: 'dashboard', result,
+    });
+    const out = collectRunSummary(ctx, 'mlb-scoreboard');
+    expect(out).toContain('Seattle Mariners');
+    expect(out).not.toContain('(truncated');
+  });
+
+  it('truncates a pathologically huge result and points at the run', () => {
+    const ctx = setup();
+    runStore.createRun({
+      id: 'run-2', agentName: 'firehose', status: 'completed',
+      startedAt: new Date().toISOString(), completedAt: new Date().toISOString(),
+      triggeredBy: 'dashboard', result: 'z'.repeat(50_000),
+    });
+    const out = collectRunSummary(ctx, 'firehose');
+    expect(out).toContain('(truncated');
+    expect(out.length).toBeLessThan(15_000);
+  });
+
+  it('returns empty string when the agent has no runs', () => {
+    const ctx = setup();
+    expect(collectRunSummary(ctx, 'nonexistent')).toBe('');
+  });
+});


### PR DESCRIPTION
## The bug

On [this thread](http://127.0.0.1:3000/inbox/d2cb3653-a423-4ca7-be4f-87177076f492) triage ran `mlb-scoreboard`, but when the operator asked *"did the Mariners win?"* it answered:

> The Mariners row is cut off in the result excerpt I can see here… I can only see the truncated excerpt embedded into this thread… my view cuts off in game 4.

## Root cause

`FOCUS_AGENT_RUN` — the latest run output triage answers from — is built by `collectRunSummary`, which capped the result at **2000 chars**. The scoreboard payload is **8381 chars** (15 games of verbose JSON) and "Seattle / Mariners" sits at byte **~7391** — well past the cap. 2000 chars ≈ 3.6 games, which is exactly triage's "cuts off at game 4." So triage literally never received the row it was asked about.

## Fix

- `collectRunSummary` cap raised to **12KB** (14KB total, named constants) — enough for a full data payload (MLB slate, markets digest) to reach triage intact, still bounded so a pathological multi-hundred-KB dump can't blow the prompt. The truncation marker now points at the run (`open the run for the full output`).
- Kernel (`REPORTING A RUN OUTCOME`): tells triage to read the **whole** `FOCUS_AGENT_RUN` before answering a "did X happen / what was Y" data question (the detail is often deep in the payload), and — only when the output is genuinely truncated — to link the run rather than guess.

## Dogfooded live

Replied *"did they win?"* on the reported thread. Triage now answers from the full scoreboard:

> Yes — the **Seattle Mariners won**, beating the **Los Angeles Angels 8-3** on June 30, 2026. Seattle broke it open with **5 runs in the 6th** and finished with **13 hits**.

## Tests

New `inbox-run-summary.test.ts`: surfaces data 7.4KB-deep (past the old cap), truncates a 50KB dump with the pointer, empty when no runs. 669 dashboard tests pass; clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)