### PR TITLE
feat: custom OpenAI-compatible LLM providers (local models over HTTP) + /settings/llm form

### DIFF
--- a/.changeset/openai-http-provider-core.md
+++ b/.changeset/openai-http-provider-core.md
@@ -1,0 +1,23 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Custom OpenAI-compatible LLM providers (local / self-hosted models over HTTP).
+
+Until now every LLM provider was a CLI transport (claude, codex, apple). This
+adds the first HTTP provider path: an operator can define a custom
+OpenAI-compatible provider — a name, an `apiBase` (e.g. a local
+`http://127.0.0.1:8181/v1`), an optional `apiKey`, and a `model` — and reference
+it in the provider waterfall or pin a node to it. Requests POST to
+`/v1/chat/completions`; the result flows through the exact same fallback
+machinery as a CLI provider (a down endpoint classifies as unreachable and falls
+through to the next provider; 401 → auth, 429 → rate-limited, timeout → timeout).
+
+This core release makes such a provider runnable once defined in the LLM settings
+store (`CustomLlmProvider`, waterfall entries widened to plain names, v2→v3
+settings migration). The `/settings/llm` UI to add one from the dashboard lands
+next. Node `provider` pins now accept a custom provider name.

--- a/.changeset/openai-http-provider-core.md
+++ b/.changeset/openai-http-provider-core.md
@@ -24,3 +24,7 @@ stored `CustomLlmProvider` (waterfall entries widened to plain names, v2→v3
 settings migration) is resolved on every run path, and node `provider` pins now
 accept a custom provider name. The API key is masked in the UI and never echoed
 back into the form.
+
+Each provider in the waterfall also gets a **Disable** switch: it keeps its slot
+and config but is skipped at runtime — flip claude/codex off to run local-only,
+then flip them back on any time (the store keeps at least one enabled).

--- a/.changeset/openai-http-provider-core.md
+++ b/.changeset/openai-http-provider-core.md
@@ -17,7 +17,10 @@ it in the provider waterfall or pin a node to it. Requests POST to
 machinery as a CLI provider (a down endpoint classifies as unreachable and falls
 through to the next provider; 401 → auth, 429 → rate-limited, timeout → timeout).
 
-This core release makes such a provider runnable once defined in the LLM settings
-store (`CustomLlmProvider`, waterfall entries widened to plain names, v2→v3
-settings migration). The `/settings/llm` UI to add one from the dashboard lands
-next. Node `provider` pins now accept a custom provider name.
+Add one from **Settings → LLM**: a "Custom OpenAI-compatible endpoints" form
+(name, API base, model, optional key) saves the provider, a Probe button checks
+it's reachable, and it then appears in the provider-waterfall dropdown. The
+stored `CustomLlmProvider` (waterfall entries widened to plain names, v2→v3
+settings migration) is resolved on every run path, and node `provider` pins now
+accept a custom provider name. The API key is masked in the UI and never echoed
+back into the form.

--- a/packages/core/src/agent-v2-schema.ts
+++ b/packages/core/src/agent-v2-schema.ts
@@ -22,16 +22,18 @@ import { inputSpecSchema, outputSpecSchema } from './schema.js';
 import { outputWidgetSchema } from './output-widget-schema.js';
 
 /**
- * Zod enum over every registered LLM provider id. Sourced from
- * `PROVIDER_IDS` so new providers automatically validate through the
- * agent + node `provider` fields without a schema edit. The double
- * cast (`as [string, ...string[]]`) is required because
- * `PROVIDER_IDS` is typed as `readonly LlmProvider[]` and z.enum needs
- * a non-empty mutable-tuple type.
+ * Provider id for the agent + node `provider` fields. A builtin CLI provider
+ * (claude / codex / apple-foundation-models) OR the `name` of an operator-
+ * defined custom OpenAI-compatible provider (dynamic, so it can't be a static
+ * enum). Validated as a slug; the runtime resolves it against the configured
+ * providers and falls back to the claude default if the name is unknown, so an
+ * invalid pin degrades gracefully rather than crashing a run. `PROVIDER_IDS` is
+ * imported to keep the builtin list documented at this seam.
  */
-const providerEnumSchema = z.enum(
-  PROVIDER_IDS as unknown as [typeof PROVIDER_IDS[number], ...typeof PROVIDER_IDS[number][]],
-);
+void PROVIDER_IDS;
+const providerEnumSchema = z.string().regex(/^[a-z0-9][a-z0-9._-]*$/i, {
+  message: 'provider must be a slug (letters, digits, . _ -), starting alphanumeric',
+});
 
 const AGENT_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
 const NODE_ID_RE = /^[a-z0-9][a-z0-9_-]*$/;

--- a/packages/core/src/agent-v2-types.ts
+++ b/packages/core/src/agent-v2-types.ts
@@ -246,7 +246,7 @@ export interface AgentNode {
    * Determines which CLI binary and argument format the spawner uses.
    * Shell nodes ignore this field.
    */
-  provider?: LlmProvider;
+  provider?: LlmProvider | (string & {});
 
   // Common per-node
   timeout?: number;
@@ -395,7 +395,7 @@ export interface Agent {
   updatedAt?: string;
 
   /** Default LLM provider for all claude-code nodes. Nodes can override. */
-  provider?: LlmProvider;
+  provider?: LlmProvider | (string & {});
   /** Default model for all claude-code nodes. Nodes can override. */
   model?: string;
 
@@ -587,7 +587,7 @@ export interface AgentVersion {
  */
 export interface AgentVersionDag {
   id: string;
-  provider?: LlmProvider;
+  provider?: LlmProvider | (string & {});
   model?: string;
   /**
    * Per-agent opt-out of the scheduler's frequency cap. When true, sub-minute

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -397,6 +397,8 @@ export {
   type LlmSettings,
   type LlmProvider,
   type LlmFallbackEvent,
+  type CustomLlmProvider,
+  type ProviderRef,
 } from './llm-settings-store.js';
 export {
   planMigration,

--- a/packages/core/src/llm-settings-store.test.ts
+++ b/packages/core/src/llm-settings-store.test.ts
@@ -133,3 +133,82 @@ describe('LlmSettingsStore (waterfall)', () => {
     expect(s.providers).toEqual(['claude']);
   });
 });
+
+describe('LlmSettingsStore (custom OpenAI-compatible providers)', () => {
+  const qwen = {
+    name: 'local-qwen-8b', kind: 'openai' as const,
+    apiBase: 'http://127.0.0.1:8181/v1', apiKey: 'local', model: 'unsloth/Qwen3-8B-GGUF:UD-Q4_K_XL',
+  };
+
+  it('adds, lists, and gets a custom provider', () => {
+    store.addCustomProvider(qwen);
+    expect(store.listCustomProviders()).toEqual([qwen]);
+    expect(store.getCustomProvider('local-qwen-8b')).toEqual(qwen);
+    expect(store.getCustomProvider('nope')).toBeUndefined();
+  });
+
+  it('lets the waterfall reference a custom name once it is defined', () => {
+    store.addCustomProvider(qwen);
+    store.setProviders(['local-qwen-8b', 'claude']);
+    expect(store.get().providers).toEqual(['local-qwen-8b', 'claude']);
+  });
+
+  it('rejects a waterfall entry that names an undefined provider', () => {
+    expect(() => store.setProviders(['ghost-model'])).toThrow(/Invalid provider/);
+  });
+
+  it('edits a custom provider in place when re-added by the same name', () => {
+    store.addCustomProvider(qwen);
+    store.addCustomProvider({ ...qwen, model: 'other-model', apiKey: undefined });
+    const got = store.getCustomProvider('local-qwen-8b');
+    expect(got?.model).toBe('other-model');
+    expect(got?.apiKey).toBeUndefined();
+    expect(store.listCustomProviders()).toHaveLength(1);
+  });
+
+  it('validates name, apiBase, and model', () => {
+    expect(() => store.addCustomProvider({ ...qwen, name: 'has spaces' })).toThrow(/slug/);
+    expect(() => store.addCustomProvider({ ...qwen, name: 'claude' })).toThrow(/builtin/);
+    expect(() => store.addCustomProvider({ ...qwen, apiBase: 'not-a-url' })).toThrow(/http/);
+    expect(() => store.addCustomProvider({ ...qwen, model: '' })).toThrow(/model/);
+  });
+
+  it('removing a custom provider strips it from the waterfall', () => {
+    store.addCustomProvider(qwen);
+    store.setProviders(['local-qwen-8b', 'claude']);
+    store.removeCustomProvider('local-qwen-8b');
+    expect(store.getCustomProvider('local-qwen-8b')).toBeUndefined();
+    expect(store.get().providers).toEqual(['claude']);
+  });
+
+  it('refuses to remove a custom provider that is the only waterfall entry', () => {
+    store.addCustomProvider(qwen);
+    store.setProviders(['local-qwen-8b']);
+    expect(() => store.removeCustomProvider('local-qwen-8b')).toThrow(/last provider/);
+  });
+
+  it('migrates a v2 file to v3 (adds an empty customProviders list)', () => {
+    const path = join(dir, 'llm-settings.json');
+    writeFileSync(path, JSON.stringify({ version: 2, settings: { providers: ['claude'] } }));
+    const s = new LlmSettingsStore(path).get();
+    expect(s.providers).toEqual(['claude']);
+    expect(s.customProviders).toEqual([]);
+  });
+
+  it('drops malformed custom-provider entries from a hand-edited file', () => {
+    const path = join(dir, 'llm-settings.json');
+    writeFileSync(path, JSON.stringify({
+      version: 3,
+      settings: {
+        providers: ['claude'],
+        customProviders: [
+          { name: 'ok', kind: 'openai', apiBase: 'http://x/v1', model: 'm' },
+          { name: 'bad-kind', kind: 'anthropic', apiBase: 'http://x/v1', model: 'm' },
+          { name: 'missing-model', kind: 'openai', apiBase: 'http://x/v1' },
+        ],
+      },
+    }));
+    const s = new LlmSettingsStore(path).get();
+    expect(s.customProviders?.map((c) => c.name)).toEqual(['ok']);
+  });
+});

--- a/packages/core/src/llm-settings-store.test.ts
+++ b/packages/core/src/llm-settings-store.test.ts
@@ -212,3 +212,43 @@ describe('LlmSettingsStore (custom OpenAI-compatible providers)', () => {
     expect(s.customProviders?.map((c) => c.name)).toEqual(['ok']);
   });
 });
+
+describe('LlmSettingsStore (enable/disable a provider)', () => {
+  it('disables and re-enables a provider without removing it', () => {
+    store.setProviders(['claude', 'codex']);
+    store.setProviderEnabled('claude', false);
+    let s = store.get();
+    expect(s.providers).toEqual(['claude', 'codex']); // still in the chain
+    expect(s.disabledProviders).toEqual(['claude']);
+    store.setProviderEnabled('claude', true);
+    s = store.get();
+    expect(s.disabledProviders).toEqual([]);
+  });
+
+  it('refuses to disable the last enabled provider', () => {
+    store.setProviders(['claude', 'codex']);
+    store.setProviderEnabled('codex', false);
+    expect(() => store.setProviderEnabled('claude', false)).toThrow(/at least one/i);
+  });
+
+  it('rejects toggling a provider that is not in the waterfall', () => {
+    store.setProviders(['claude']);
+    expect(() => store.setProviderEnabled('codex', false)).toThrow(/not in the waterfall/i);
+  });
+
+  it('drops a disabled entry when the provider leaves the chain', () => {
+    store.setProviders(['claude', 'codex']);
+    store.setProviderEnabled('codex', false);
+    store.setProviders(['claude']); // codex removed from the chain
+    expect(store.get().disabledProviders).toEqual([]);
+  });
+
+  it('never reports all providers disabled (falls open to the first)', () => {
+    const path = join(dir, 'llm-settings.json');
+    writeFileSync(path, JSON.stringify({
+      version: 3, settings: { providers: ['claude', 'codex'], disabledProviders: ['claude', 'codex'] },
+    }));
+    const s = new LlmSettingsStore(path).get();
+    expect(s.disabledProviders).toEqual(['codex']); // claude stays enabled
+  });
+});

--- a/packages/core/src/llm-settings-store.ts
+++ b/packages/core/src/llm-settings-store.ts
@@ -91,6 +91,14 @@ export interface LlmSettings {
   providers: ProviderRef[];
   /** Operator-defined OpenAI-compatible HTTP providers. */
   customProviders?: CustomLlmProvider[];
+  /**
+   * Providers that stay in the waterfall (position + config preserved) but are
+   * SKIPPED at runtime — a per-provider off switch. Lets an operator flip
+   * claude/codex off to run local-only, then flip them back on without
+   * re-adding. The runtime chain (built in buildLlmSettingsSnapshot) excludes
+   * these; the store guarantees at least one provider stays enabled.
+   */
+  disabledProviders?: ProviderRef[];
   /** Set whenever the fallback most recently fired. */
   lastFallback?: LlmFallbackEvent;
 }
@@ -158,6 +166,31 @@ export class LlmSettingsStore {
       throw new Error('Provider waterfall must have at least one entry.');
     }
     data.settings.providers = deduped;
+    this.write(data);
+  }
+
+  /**
+   * Toggle a waterfall provider on/off. Disabling keeps it in the chain but
+   * excludes it at runtime; the store refuses to disable the last enabled
+   * provider (every run needs somewhere to dispatch). `name` must be a current
+   * waterfall entry.
+   */
+  setProviderEnabled(name: string, enabled: boolean): void {
+    const data = this.read();
+    if (!data.settings.providers.includes(name)) {
+      throw new Error(`"${name}" is not in the waterfall.`);
+    }
+    const disabled = new Set(data.settings.disabledProviders ?? []);
+    if (enabled) {
+      disabled.delete(name);
+    } else {
+      const stillEnabled = data.settings.providers.filter((p) => p !== name && !disabled.has(p));
+      if (stillEnabled.length === 0) {
+        throw new Error('At least one provider must stay enabled.');
+      }
+      disabled.add(name);
+    }
+    data.settings.disabledProviders = data.settings.providers.filter((p) => disabled.has(p));
     this.write(data);
   }
 
@@ -283,7 +316,12 @@ export class LlmSettingsStore {
       const deduped: ProviderRef[] = [];
       for (const p of filtered) if (!deduped.includes(p)) deduped.push(p);
       if (deduped.length === 0) deduped.push(DEFAULT_PRIMARY);
-      return { version: 3, settings: { providers: deduped, customProviders, lastFallback: settings.lastFallback } };
+      // A disabled entry only means something if it's still in the waterfall;
+      // and never let every provider be disabled (fall open to the primary).
+      const disabledIn = (settings as LlmSettings).disabledProviders ?? [];
+      let disabledProviders = deduped.filter((p) => disabledIn.includes(p));
+      if (disabledProviders.length === deduped.length) disabledProviders = disabledProviders.slice(1);
+      return { version: 3, settings: { providers: deduped, customProviders, disabledProviders, lastFallback: settings.lastFallback } };
     } catch (err) {
       if ((err as Error).message.includes('version')) throw err;
       return { version: 3, settings: { providers: [DEFAULT_PRIMARY], customProviders: [] } };

--- a/packages/core/src/llm-settings-store.ts
+++ b/packages/core/src/llm-settings-store.ts
@@ -48,14 +48,49 @@ export interface LlmFallbackEvent {
   nodeId?: string;
 }
 
+/**
+ * An operator-defined OpenAI-compatible HTTP provider (a local or self-hosted
+ * model behind a `/v1/chat/completions` endpoint — llama.cpp, LM Studio, vLLM,
+ * a gateway, etc.). Referenced in the waterfall by `name`, alongside the builtin
+ * CLI providers. `kind` is a discriminant so future non-OpenAI HTTP shapes can
+ * be added without breaking stored configs.
+ *
+ * `apiKey` is stored here in the settings file for v1 (masked in the UI, never
+ * echoed into an HTML value). For a real cloud key, prefer moving it into the
+ * secrets store — tracked as a follow-up.
+ */
+export interface CustomLlmProvider {
+  /** Unique id used in the waterfall + node `provider` pins (e.g. "local-qwen-8b"). */
+  name: string;
+  kind: 'openai';
+  /** Optional friendly label for the UI; falls back to `name`. */
+  displayName?: string;
+  /** Base URL including the version segment, e.g. http://127.0.0.1:8181/v1 */
+  apiBase: string;
+  /** Bearer token. Optional — omitted ⇒ no Authorization header (local servers). */
+  apiKey?: string;
+  /** Model id passed in the request body. */
+  model: string;
+}
+
+/**
+ * A waterfall entry: either a builtin CLI provider id or the `name` of a
+ * defined custom provider. Kept as a plain string so the ordered list can mix
+ * both; validation resolves it against the builtins + `customProviders`.
+ */
+export type ProviderRef = string;
+
 export interface LlmSettings {
   /**
    * Ordered waterfall. `providers[0]` is the primary (used by default
    * for any llm-prompt node without a pinned provider). Subsequent
    * entries are tried in order on classified failures. Never empty —
-   * the store enforces at least one entry.
+   * the store enforces at least one entry. Each entry is a builtin
+   * provider id OR a defined custom-provider `name`.
    */
-  providers: LlmProvider[];
+  providers: ProviderRef[];
+  /** Operator-defined OpenAI-compatible HTTP providers. */
+  customProviders?: CustomLlmProvider[];
   /** Set whenever the fallback most recently fired. */
   lastFallback?: LlmFallbackEvent;
 }
@@ -67,6 +102,11 @@ interface LlmSettingsFileV1 {
 
 interface LlmSettingsFileV2 {
   version: 2;
+  settings: { providers: ProviderRef[]; lastFallback?: LlmFallbackEvent };
+}
+
+interface LlmSettingsFileV3 {
+  version: 3;
   settings: LlmSettings;
 }
 
@@ -101,10 +141,15 @@ export class LlmSettingsStore {
    * Preserves `lastFallback` telemetry — only `recordFallback` and
    * `clearLastFallback` mutate that.
    */
-  setProviders(providers: LlmProvider[]): void {
-    const deduped: LlmProvider[] = [];
+  setProviders(providers: ProviderRef[]): void {
+    const data = this.read();
+    const known = new Set<string>([
+      ...LLM_PROVIDERS,
+      ...(data.settings.customProviders ?? []).map((c) => c.name),
+    ]);
+    const deduped: ProviderRef[] = [];
     for (const p of providers) {
-      if (!isProvider(p)) {
+      if (!known.has(p)) {
         throw new Error(`Invalid provider: ${p}`);
       }
       if (!deduped.includes(p)) deduped.push(p);
@@ -112,8 +157,79 @@ export class LlmSettingsStore {
     if (deduped.length === 0) {
       throw new Error('Provider waterfall must have at least one entry.');
     }
-    const data = this.read();
     data.settings.providers = deduped;
+    this.write(data);
+  }
+
+  /** All defined custom (OpenAI-compatible) providers. */
+  listCustomProviders(): CustomLlmProvider[] {
+    return [...(this.read().settings.customProviders ?? [])];
+  }
+
+  /** Look up one custom provider by name (undefined if absent). */
+  getCustomProvider(name: string): CustomLlmProvider | undefined {
+    return this.read().settings.customProviders?.find((c) => c.name === name);
+  }
+
+  /**
+   * Define (or replace) a custom OpenAI-compatible provider. Validates the
+   * shape; the name must be a non-empty slug that doesn't collide with a
+   * builtin provider id. Replacing an existing custom provider by name is
+   * allowed (edit-in-place).
+   */
+  addCustomProvider(def: CustomLlmProvider): void {
+    const name = (def.name ?? '').trim();
+    if (!/^[a-z0-9][a-z0-9._-]*$/i.test(name)) {
+      throw new Error('Provider name must be a slug (letters, digits, . _ -), starting alphanumeric.');
+    }
+    if (isProvider(name)) {
+      throw new Error(`"${name}" is a builtin provider id — pick a different name.`);
+    }
+    if (def.kind !== 'openai') {
+      throw new Error(`Unsupported custom provider kind "${def.kind}".`);
+    }
+    const apiBase = (def.apiBase ?? '').trim();
+    try {
+      const u = new URL(apiBase);
+      if (u.protocol !== 'http:' && u.protocol !== 'https:') throw new Error('bad protocol');
+    } catch {
+      throw new Error('apiBase must be an http(s) URL, e.g. http://127.0.0.1:8181/v1');
+    }
+    const model = (def.model ?? '').trim();
+    if (!model) throw new Error('model is required.');
+    const clean: CustomLlmProvider = {
+      name,
+      kind: 'openai',
+      displayName: def.displayName?.trim() || undefined,
+      apiBase,
+      apiKey: def.apiKey?.trim() || undefined,
+      model,
+    };
+    const data = this.read();
+    const list = data.settings.customProviders ?? [];
+    const next = list.filter((c) => c.name !== name);
+    next.push(clean);
+    data.settings.customProviders = next;
+    this.write(data);
+  }
+
+  /**
+   * Delete a custom provider by name, and strip it from the waterfall so the
+   * chain never references a provider the runtime can no longer resolve.
+   * Refuses if removing it would empty the waterfall (pick a replacement first).
+   */
+  removeCustomProvider(name: string): void {
+    const data = this.read();
+    const list = data.settings.customProviders ?? [];
+    if (!list.some((c) => c.name === name)) {
+      throw new Error(`No custom provider named "${name}".`);
+    }
+    const nextProviders = data.settings.providers.filter((p) => p !== name);
+    if (nextProviders.length === 0) {
+      throw new Error('Cannot remove the last provider in the waterfall — add a replacement first.');
+    }
+    data.settings.customProviders = list.filter((c) => c.name !== name);
+    data.settings.providers = nextProviders;
     this.write(data);
   }
 
@@ -131,49 +247,74 @@ export class LlmSettingsStore {
     this.write(data);
   }
 
-  private read(): LlmSettingsFileV2 {
+  private read(): LlmSettingsFileV3 {
     if (!existsSync(this.path)) {
-      return { version: 2, settings: { providers: [DEFAULT_PRIMARY] } };
+      return { version: 3, settings: { providers: [DEFAULT_PRIMARY], customProviders: [] } };
     }
     try {
       const raw = readFileSync(this.path, 'utf-8');
-      const parsed = JSON.parse(raw) as LlmSettingsFileV1 | LlmSettingsFileV2;
+      const parsed = JSON.parse(raw) as LlmSettingsFileV1 | LlmSettingsFileV2 | LlmSettingsFileV3;
 
       // Auto-migrate the legacy { primary, fallback? } shape. We tolerate
       // a missing version key from very early dev builds by sniffing the
       // shape directly.
       if (parsed.version === 1 || (parsed.version === undefined && (parsed as LlmSettingsFileV1).settings?.primary !== undefined)) {
         const old = (parsed as LlmSettingsFileV1).settings ?? { primary: DEFAULT_PRIMARY };
-        const providers: LlmProvider[] = [];
+        const providers: ProviderRef[] = [];
         if (isProvider(old.primary)) providers.push(old.primary);
         if (old.fallback && isProvider(old.fallback) && !providers.includes(old.fallback)) {
           providers.push(old.fallback);
         }
         if (providers.length === 0) providers.push(DEFAULT_PRIMARY);
-        return { version: 2, settings: { providers, lastFallback: old.lastFallback } };
+        return { version: 3, settings: { providers, customProviders: [], lastFallback: old.lastFallback } };
       }
 
-      if ((parsed as { version?: number }).version !== 2) {
-        throw new Error(`Unsupported llm-settings file version: ${(parsed as { version?: number }).version}`);
+      const version = (parsed as { version?: number }).version;
+      if (version !== 2 && version !== 3) {
+        throw new Error(`Unsupported llm-settings file version: ${version}`);
       }
 
-      // Defensive: drop unknown providers from a hand-edited file rather
-      // than blow up at module-load time.
-      const filtered = (parsed.settings.providers ?? []).filter(isProvider);
-      const deduped: LlmProvider[] = [];
+      const settings = (parsed as LlmSettingsFileV2 | LlmSettingsFileV3).settings;
+      const customProviders = sanitizeCustomProviders((settings as LlmSettings).customProviders);
+      const customNames = new Set(customProviders.map((c) => c.name));
+      // Defensive: keep only entries that resolve to a builtin OR a still-
+      // defined custom provider, rather than blow up on a hand-edited file.
+      const filtered = (settings.providers ?? []).filter((p) => isProvider(p) || customNames.has(p));
+      const deduped: ProviderRef[] = [];
       for (const p of filtered) if (!deduped.includes(p)) deduped.push(p);
       if (deduped.length === 0) deduped.push(DEFAULT_PRIMARY);
-      parsed.settings.providers = deduped;
-      return parsed;
+      return { version: 3, settings: { providers: deduped, customProviders, lastFallback: settings.lastFallback } };
     } catch (err) {
       if ((err as Error).message.includes('version')) throw err;
-      return { version: 2, settings: { providers: [DEFAULT_PRIMARY] } };
+      return { version: 3, settings: { providers: [DEFAULT_PRIMARY], customProviders: [] } };
     }
   }
 
-  private write(data: LlmSettingsFileV2): void {
+  private write(data: LlmSettingsFileV3): void {
     writeFileSync(this.path, JSON.stringify(data, null, 2) + '\n', 'utf-8');
   }
+}
+
+/** Drop malformed custom-provider entries from a hand-edited file. */
+function sanitizeCustomProviders(raw: unknown): CustomLlmProvider[] {
+  if (!Array.isArray(raw)) return [];
+  const out: CustomLlmProvider[] = [];
+  for (const c of raw) {
+    if (!c || typeof c !== 'object') continue;
+    const r = c as Record<string, unknown>;
+    if (typeof r.name !== 'string' || r.kind !== 'openai') continue;
+    if (typeof r.apiBase !== 'string' || typeof r.model !== 'string') continue;
+    if (isProvider(r.name)) continue;
+    out.push({
+      name: r.name,
+      kind: 'openai',
+      displayName: typeof r.displayName === 'string' ? r.displayName : undefined,
+      apiBase: r.apiBase,
+      apiKey: typeof r.apiKey === 'string' ? r.apiKey : undefined,
+      model: r.model,
+    });
+  }
+  return out;
 }
 
 export function isProvider(value: unknown): value is LlmProvider {

--- a/packages/core/src/node-spawner.ts
+++ b/packages/core/src/node-spawner.ts
@@ -14,6 +14,8 @@ import type { ExecutionResult } from './agent-executor.js';
 import { substituteInputs } from './input-resolver.js';
 import { resolveUpstreamTemplate, resolveVarsTemplate, resolveStateTemplate } from './node-templates.js';
 import { ensureAppleRunner } from './apple-foundationmodels-runner.js';
+import { invokeOpenAiChat } from './openai-http-invoker.js';
+import type { CustomLlmProvider } from './llm-settings-store.js';
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -77,6 +79,13 @@ export interface LlmSettingsSnapshot {
    * the chain still applies as fallbacks (deduplicated).
    */
   providers?: string[];
+  /**
+   * Operator-defined OpenAI-compatible HTTP providers, keyed into the waterfall
+   * by `name`. When a chain entry matches a custom provider's name,
+   * `runLlmAttempt` dispatches over HTTP (`invokeOpenAiChat`) instead of
+   * spawning a CLI. Absent ⇒ only builtin CLI providers are available.
+   */
+  customProviders?: CustomLlmProvider[];
   /**
    * Fired once per hop in the waterfall (i.e. once per fallback
    * transition, not once per run). `from` is the provider that just
@@ -658,7 +667,7 @@ export async function spawnNodeReal(
   for (let i = 0; i < chain.length; i++) {
     const provider = chain[i];
     attemptedProviders.push(provider);
-    let result = await runLlmAttempt(provider, node, resolvedPrompt, childEnv, onProgress, signal, onSpawn);
+    let result = await runLlmAttempt(provider, node, resolvedPrompt, childEnv, onProgress, signal, onSpawn, _opts.llmSettings?.customProviders);
 
     // A 0-exit result still has to satisfy the node's output contract. A weak
     // fallback model that ignores the required format (e.g. no <plan> block)
@@ -743,7 +752,24 @@ async function runLlmAttempt(
   onProgress?: (event: SpawnProgress) => void,
   signal?: AbortSignal,
   onSpawn?: (pid: number, startedAtMs: number) => void,
+  customProviders?: readonly CustomLlmProvider[],
 ): Promise<SpawnResult> {
+  // Custom OpenAI-compatible provider ⇒ HTTP transport, not a CLI spawn. This
+  // is the ONLY divergence from the CLI path; the returned SpawnResult flows
+  // through the same waterfall (contract check, classifyLlmFailure, fallback).
+  const custom = customProviders?.find((c) => c.name === provider);
+  if (custom && custom.kind === 'openai') {
+    return invokeOpenAiChat({
+      apiBase: custom.apiBase,
+      apiKey: custom.apiKey,
+      // A node may pin a different model on the same endpoint; else use the
+      // provider's configured model.
+      model: node.model ?? custom.model,
+      prompt: resolvedPrompt,
+      timeoutSec: node.timeout ?? 300,
+      signal,
+    });
+  }
   const spawner = getSpawner(provider);
   const spawnOpts: LlmSpawnOptions = {
     prompt: resolvedPrompt,

--- a/packages/core/src/openai-http-invoker.test.ts
+++ b/packages/core/src/openai-http-invoker.test.ts
@@ -1,0 +1,77 @@
+/**
+ * invokeOpenAiChat maps an OpenAI-compatible HTTP call to a SpawnResult whose
+ * error strings/categories the node-spawner waterfall already understands, so
+ * an HTTP provider participates in fallback exactly like a CLI one.
+ */
+import { describe, it, expect } from 'vitest';
+import { invokeOpenAiChat } from './openai-http-invoker.js';
+import { classifyLlmFailure } from './node-spawner.js';
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+
+const base = { apiBase: 'http://127.0.0.1:8181/v1', model: 'qwen', prompt: 'hi', timeoutSec: 5 };
+
+describe('invokeOpenAiChat', () => {
+  it('returns the assistant content on a 200', async () => {
+    const fetchImpl = (async () => jsonResponse(200, { choices: [{ message: { content: 'pong' } }] })) as unknown as typeof fetch;
+    const r = await invokeOpenAiChat({ ...base, fetchImpl });
+    expect(r.exitCode).toBe(0);
+    expect(r.result).toBe('pong');
+  });
+
+  it('sends the model + prompt and a Bearer header only when apiKey is set', async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fetchImpl = (async (url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      return jsonResponse(200, { choices: [{ message: { content: 'ok' } }] });
+    }) as unknown as typeof fetch;
+
+    await invokeOpenAiChat({ ...base, apiKey: 'secret', fetchImpl });
+    const withKey = calls[0];
+    expect(withKey.url).toBe('http://127.0.0.1:8181/v1/chat/completions');
+    expect((withKey.init.headers as Record<string, string>).authorization).toBe('Bearer secret');
+    expect(JSON.parse(withKey.init.body as string)).toMatchObject({ model: 'qwen', stream: false });
+
+    await invokeOpenAiChat({ ...base, fetchImpl });
+    expect((calls[1].init.headers as Record<string, string>).authorization).toBeUndefined();
+  });
+
+  it('classifies a 401 as auth_required (fallback-worthy)', async () => {
+    const fetchImpl = (async () => new Response('nope', { status: 401, statusText: 'Unauthorized' })) as unknown as typeof fetch;
+    const r = await invokeOpenAiChat({ ...base, fetchImpl });
+    expect(r.exitCode).not.toBe(0);
+    expect(classifyLlmFailure(r)).toBe('auth_required');
+  });
+
+  it('classifies a 429 as rate_limited', async () => {
+    const fetchImpl = (async () => new Response('slow down', { status: 429, statusText: 'Too Many Requests' })) as unknown as typeof fetch;
+    const r = await invokeOpenAiChat({ ...base, fetchImpl });
+    expect(classifyLlmFailure(r)).toBe('rate_limited');
+  });
+
+  it('maps a network failure (endpoint down) to spawn_failure ⇒ binary_missing', async () => {
+    const fetchImpl = (async () => { throw new Error('fetch failed: ECONNREFUSED'); }) as unknown as typeof fetch;
+    const r = await invokeOpenAiChat({ ...base, fetchImpl });
+    expect(r.category).toBe('spawn_failure');
+    expect(classifyLlmFailure(r)).toBe('binary_missing');
+  });
+
+  it('reports a timeout category when the request aborts', async () => {
+    const fetchImpl = ((_url: string, init: RequestInit) => new Promise((_resolve, reject) => {
+      const sig = init.signal as AbortSignal;
+      sig.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+    })) as unknown as typeof fetch;
+    const r = await invokeOpenAiChat({ ...base, timeoutSec: 1, fetchImpl });
+    expect(r.category).toBe('timeout');
+    expect(classifyLlmFailure(r)).toBe('timeout');
+  });
+
+  it('treats empty/malformed choices as a non-zero result', async () => {
+    const fetchImpl = (async () => jsonResponse(200, { choices: [] })) as unknown as typeof fetch;
+    const r = await invokeOpenAiChat({ ...base, fetchImpl });
+    expect(r.exitCode).not.toBe(0);
+    expect(r.error).toMatch(/no message content/);
+  });
+});

--- a/packages/core/src/openai-http-invoker.ts
+++ b/packages/core/src/openai-http-invoker.ts
@@ -1,0 +1,123 @@
+/**
+ * OpenAI-compatible HTTP LLM invocation — the transport for custom providers
+ * (local/self-hosted models behind a `/v1/chat/completions` endpoint). Returns
+ * a `SpawnResult` so it drops straight into the node-spawner waterfall
+ * (`runLlmAttempt`) with no changes to the fallback machinery: the loop only
+ * cares about `{ result, exitCode, error, category }`, and `classifyLlmFailure`
+ * already buckets the error strings we emit (401/unauthorized → auth_required,
+ * 429/rate limit → rate_limited, connection refused → binary_missing, abort →
+ * timeout) into the right fallback categories.
+ *
+ * v1 is non-streaming: the full completion is returned on success.
+ */
+
+import type { SpawnResult } from './node-spawner.js';
+
+export interface OpenAiInvokeArgs {
+  /** Base URL including the version segment, e.g. http://127.0.0.1:8181/v1 */
+  apiBase: string;
+  /** Bearer token; omitted ⇒ no Authorization header (local servers). */
+  apiKey?: string;
+  model: string;
+  prompt: string;
+  /** Wall-clock cap; aborts the request and reports a `timeout` category. */
+  timeoutSec: number;
+  /** External cancellation (operator Stop / agent-level timeout). */
+  signal?: AbortSignal;
+  /** Injectable fetch for tests; defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+interface ChatCompletionResponse {
+  choices?: Array<{ message?: { content?: string } }>;
+}
+
+/**
+ * POST a single-prompt chat completion to an OpenAI-compatible endpoint and
+ * return the assistant text as a `SpawnResult`.
+ */
+export async function invokeOpenAiChat(args: OpenAiInvokeArgs): Promise<SpawnResult> {
+  const doFetch = args.fetchImpl ?? fetch;
+  const url = args.apiBase.replace(/\/+$/, '') + '/chat/completions';
+
+  // Combine the caller's signal with our own timeout so either can abort.
+  const timeoutController = new AbortController();
+  const timer = setTimeout(() => timeoutController.abort(), Math.max(1, args.timeoutSec) * 1000);
+  const onExternalAbort = () => timeoutController.abort();
+  if (args.signal) {
+    if (args.signal.aborted) timeoutController.abort();
+    else args.signal.addEventListener('abort', onExternalAbort, { once: true });
+  }
+
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (args.apiKey) headers.authorization = `Bearer ${args.apiKey}`;
+
+  try {
+    const res = await doFetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        model: args.model,
+        messages: [{ role: 'user', content: args.prompt }],
+        stream: false,
+      }),
+      signal: timeoutController.signal,
+    });
+
+    if (!res.ok) {
+      const bodyText = (await safeText(res)).slice(0, 500);
+      // The status number rides in the error string so classifyLlmFailure's
+      // free-text matchers ("401", "unauthorized", "429", "rate limit") route
+      // it to the right fallback category without a bespoke mapping table.
+      return {
+        result: '',
+        exitCode: 1,
+        error: `HTTP ${res.status} ${res.statusText} from ${url}: ${bodyText || '(no body)'}`,
+        category: 'exit_nonzero',
+      };
+    }
+
+    const json = (await res.json()) as ChatCompletionResponse;
+    const content = json.choices?.[0]?.message?.content;
+    if (typeof content !== 'string' || content.length === 0) {
+      return {
+        result: '',
+        exitCode: 1,
+        error: `${url} returned no message content (empty or malformed choices[]).`,
+        category: 'exit_nonzero',
+      };
+    }
+    return { result: content, exitCode: 0 };
+  } catch (err) {
+    // Abort ⇒ either our timeout or the caller's signal fired. Treat as timeout
+    // so the waterfall falls through to the next provider.
+    if (timeoutController.signal.aborted) {
+      return {
+        result: '',
+        exitCode: 124,
+        error: `Request to ${url} timed out after ${args.timeoutSec}s (or was cancelled).`,
+        category: 'timeout',
+      };
+    }
+    // Network-level failure (endpoint down, DNS, connection refused). Map to
+    // spawn_failure so classifyLlmFailure returns binary_missing ⇒ fall back.
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      result: '',
+      exitCode: 127,
+      error: `Could not reach ${url}: ${msg}`,
+      category: 'spawn_failure',
+    };
+  } finally {
+    clearTimeout(timer);
+    if (args.signal) args.signal.removeEventListener('abort', onExternalAbort);
+  }
+}
+
+async function safeText(res: Response): Promise<string> {
+  try {
+    return (await res.text()).trim();
+  } catch {
+    return '';
+  }
+}

--- a/packages/dashboard/src/lib/llm-settings-snapshot.test.ts
+++ b/packages/dashboard/src/lib/llm-settings-snapshot.test.ts
@@ -1,0 +1,43 @@
+/**
+ * buildLlmSettingsSnapshot is the single seam where LLM settings reach every run
+ * path. It must exclude DISABLED providers from the runtime waterfall (the
+ * per-provider off switch) while still carrying custom-provider definitions.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { LlmSettingsStore } from '@some-useful-agents/core';
+import { buildLlmSettingsSnapshot } from './llm-settings-snapshot.js';
+
+let dir: string;
+
+afterEach(() => { if (dir) rmSync(dir, { recursive: true, force: true }); });
+
+function makeStore(): LlmSettingsStore {
+  dir = mkdtempSync(join(tmpdir(), 'sua-snap-'));
+  return new LlmSettingsStore(join(dir, 'llm-settings.json'));
+}
+
+describe('buildLlmSettingsSnapshot', () => {
+  it('excludes disabled providers from the runtime chain', () => {
+    const store = makeStore();
+    store.setProviders(['claude', 'codex']);
+    store.setProviderEnabled('claude', false);
+    const snap = buildLlmSettingsSnapshot({ llmSettingsStore: store });
+    expect(snap?.providers).toEqual(['codex']); // claude skipped at runtime
+  });
+
+  it('keeps all providers when none are disabled, and carries custom defs', () => {
+    const store = makeStore();
+    store.addCustomProvider({ name: 'local-qwen', kind: 'openai', apiBase: 'http://x/v1', model: 'q' });
+    store.setProviders(['claude', 'local-qwen']);
+    const snap = buildLlmSettingsSnapshot({ llmSettingsStore: store });
+    expect(snap?.providers).toEqual(['claude', 'local-qwen']);
+    expect(snap?.customProviders?.map((c) => c.name)).toEqual(['local-qwen']);
+  });
+
+  it('returns undefined when no store is configured', () => {
+    expect(buildLlmSettingsSnapshot({ llmSettingsStore: undefined })).toBeUndefined();
+  });
+});

--- a/packages/dashboard/src/lib/llm-settings-snapshot.ts
+++ b/packages/dashboard/src/lib/llm-settings-snapshot.ts
@@ -23,6 +23,7 @@ export function buildLlmSettingsSnapshot(
   const current = store.get();
   return {
     providers: [...current.providers],
+    customProviders: current.customProviders ? [...current.customProviders] : undefined,
     onFallback: (event) => {
       try {
         store.recordFallback({

--- a/packages/dashboard/src/lib/llm-settings-snapshot.ts
+++ b/packages/dashboard/src/lib/llm-settings-snapshot.ts
@@ -21,8 +21,12 @@ export function buildLlmSettingsSnapshot(
   const store = ctx.llmSettingsStore;
   if (!store) return undefined;
   const current = store.get();
+  // Disabled providers stay in the operator's list but are skipped at runtime
+  // — this is the per-provider off switch (e.g. "run local-only"). The store
+  // guarantees at least one stays enabled, so the chain is never empty.
+  const disabled = new Set(current.disabledProviders ?? []);
   return {
-    providers: [...current.providers],
+    providers: current.providers.filter((p) => !disabled.has(p)),
     customProviders: current.customProviders ? [...current.customProviders] : undefined,
     onFallback: (event) => {
       try {

--- a/packages/dashboard/src/routes/settings.ts
+++ b/packages/dashboard/src/routes/settings.ts
@@ -687,6 +687,25 @@ settingsRouter.get('/settings/appearance', (req: Request, res: Response) => {
   res.type('html').send(renderSettingsShell({ active: 'appearance', body, flash }));
 });
 
+/** GET the endpoint's /models to confirm a custom provider is reachable. */
+async function probeCustomProvider(def: { apiBase: string; apiKey?: string }): Promise<{ ok: boolean; message: string }> {
+  const url = def.apiBase.replace(/\/+$/, '') + '/models';
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5000);
+  try {
+    const headers: Record<string, string> = {};
+    if (def.apiKey) headers.authorization = `Bearer ${def.apiKey}`;
+    const res = await fetch(url, { signal: controller.signal, headers });
+    if (!res.ok) return { ok: false, message: `HTTP ${res.status} from ${url}` };
+    return { ok: true, message: `reachable (${url})` };
+  } catch (err) {
+    if (controller.signal.aborted) return { ok: false, message: 'probe timed out after 5s' };
+    return { ok: false, message: `unreachable: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 /** Briefly spawn each CLI with --version (or similar) to confirm liveness. */
 async function probeProvider(provider: LlmProvider): Promise<{ ok: boolean; message: string }> {
   const binary = provider === 'codex' ? 'codex' : 'claude';
@@ -749,7 +768,8 @@ settingsRouter.post('/settings/llm/add', (req: Request, res: Response) => {
     return;
   }
   const providerRaw = typeof req.body?.provider === 'string' ? req.body.provider : '';
-  if (!isProvider(providerRaw)) {
+  // A waterfall entry is a builtin id OR the name of a defined custom provider.
+  if (!isProvider(providerRaw) && !ctx.llmSettingsStore.getCustomProvider(providerRaw)) {
     redirectWith(res, '/settings/llm', 'error', `Invalid provider "${providerRaw}".`);
     return;
   }
@@ -839,6 +859,51 @@ settingsRouter.post('/settings/llm/move', (req: Request, res: Response) => {
   redirectWith(res, '/settings/llm', 'flash', `Moved ${providerRaw} ${direction}.`);
 });
 
+/**
+ * Define a custom OpenAI-compatible provider (a local / self-hosted model behind
+ * a `/v1/chat/completions` endpoint). Does NOT add it to the waterfall — the
+ * operator adds it via the normal "Add provider" control afterward.
+ */
+settingsRouter.post('/settings/llm/custom/add', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.llmSettingsStore) {
+    redirectWith(res, '/settings/llm', 'error', 'LLM settings store not configured.');
+    return;
+  }
+  const str = (v: unknown) => (typeof v === 'string' ? v.trim() : '');
+  try {
+    ctx.llmSettingsStore.addCustomProvider({
+      name: str(req.body?.name),
+      kind: 'openai',
+      displayName: str(req.body?.displayName) || undefined,
+      apiBase: str(req.body?.apiBase),
+      apiKey: str(req.body?.apiKey) || undefined,
+      model: str(req.body?.model),
+    });
+  } catch (err) {
+    redirectWith(res, '/settings/llm', 'error', (err as Error).message);
+    return;
+  }
+  redirectWith(res, '/settings/llm', 'flash', `Saved custom provider "${str(req.body?.name)}". Add it to the chain below to use it.`);
+});
+
+/** Delete a custom provider (also strips it from the waterfall). */
+settingsRouter.post('/settings/llm/custom/remove', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.llmSettingsStore) {
+    redirectWith(res, '/settings/llm', 'error', 'LLM settings store not configured.');
+    return;
+  }
+  const name = typeof req.body?.name === 'string' ? req.body.name : '';
+  try {
+    ctx.llmSettingsStore.removeCustomProvider(name);
+  } catch (err) {
+    redirectWith(res, '/settings/llm', 'error', (err as Error).message);
+    return;
+  }
+  redirectWith(res, '/settings/llm', 'flash', `Removed custom provider "${name}".`);
+});
+
 settingsRouter.post('/settings/llm/probe', async (req: Request, res: Response) => {
   const ctx = getContext(req.app.locals);
   const settings = ctx.llmSettingsStore?.get();
@@ -846,9 +911,12 @@ settingsRouter.post('/settings/llm/probe', async (req: Request, res: Response) =
     redirectWith(res, '/settings/llm', 'error', 'LLM settings store not configured.');
     return;
   }
-  const probe: Record<LlmProvider, { ok: boolean; message: string }> = {} as never;
+  const probe: Record<string, { ok: boolean; message: string }> = {};
   for (const p of LLM_PROVIDERS) {
     probe[p] = await probeProvider(p);
+  }
+  for (const c of settings.customProviders ?? []) {
+    probe[c.name] = await probeCustomProvider(c);
   }
   // Stash the result on a per-request basis by piggybacking the shell
   // render (the simplest way without adding session state).

--- a/packages/dashboard/src/routes/settings.ts
+++ b/packages/dashboard/src/routes/settings.ts
@@ -860,6 +860,28 @@ settingsRouter.post('/settings/llm/move', (req: Request, res: Response) => {
 });
 
 /**
+ * Toggle a waterfall provider on/off without removing it. Disabled providers
+ * keep their slot + config but are skipped at runtime — the "turn claude/codex
+ * off and run local-only" switch.
+ */
+settingsRouter.post('/settings/llm/toggle', (req: Request, res: Response) => {
+  const ctx = getContext(req.app.locals);
+  if (!ctx.llmSettingsStore) {
+    redirectWith(res, '/settings/llm', 'error', 'LLM settings store not configured.');
+    return;
+  }
+  const provider = typeof req.body?.provider === 'string' ? req.body.provider : '';
+  const enabled = req.body?.enabled === '1' || req.body?.enabled === 'true';
+  try {
+    ctx.llmSettingsStore.setProviderEnabled(provider, enabled);
+  } catch (err) {
+    redirectWith(res, '/settings/llm', 'error', (err as Error).message);
+    return;
+  }
+  redirectWith(res, '/settings/llm', 'flash', `${enabled ? 'Enabled' : 'Disabled'} ${provider}.`);
+});
+
+/**
  * Define a custom OpenAI-compatible provider (a local / self-hosted model behind
  * a `/v1/chat/completions` endpoint). Does NOT add it to the waterfall — the
  * operator adds it via the normal "Add provider" control afterward.

--- a/packages/dashboard/src/views/settings-llm.test.ts
+++ b/packages/dashboard/src/views/settings-llm.test.ts
@@ -59,3 +59,34 @@ describe('renderSettingsLlm — custom providers', () => {
     expect(out).toContain('No custom endpoints yet.');
   });
 });
+
+describe('renderSettingsLlm — enable/disable switch', () => {
+  it('shows a Disable button for an enabled provider and Enable for a disabled one', () => {
+    const settings: LlmSettings = { providers: ['claude', 'codex'], disabledProviders: ['codex'] };
+    const out = render(renderSettingsLlm({ ...base, settings }));
+    expect(out).toContain('/settings/llm/toggle');
+    // Enabled claude → Disable (enabled=0 posted); disabled codex → Enable + Off badge.
+    expect(out).toMatch(/name="provider" value="claude">\s*<input type="hidden" name="enabled" value="0">/);
+    expect(out).toMatch(/name="provider" value="codex">\s*<input type="hidden" name="enabled" value="1">/);
+    expect(out).toContain('>Off<');
+  });
+
+  it('marks the first ENABLED provider as Primary, not just chain[0]', () => {
+    const settings: LlmSettings = { providers: ['claude', 'codex'], disabledProviders: ['claude'] };
+    const out = render(renderSettingsLlm({ ...base, settings }));
+    // claude is off, so codex is the effective primary.
+    const primaryIdx = out.indexOf('Primary');
+    const codexIdx = out.indexOf('codex');
+    const claudeIdx = out.indexOf('claude');
+    expect(primaryIdx).toBeGreaterThan(-1);
+    // The Primary badge sits in codex's row (after claude's row in the list).
+    expect(codexIdx).toBeGreaterThan(claudeIdx);
+  });
+
+  it('disables the toggle button when only one provider is enabled', () => {
+    const settings: LlmSettings = { providers: ['claude'] };
+    const out = render(renderSettingsLlm({ ...base, settings }));
+    // The lone enabled provider cannot be disabled → button carries `disabled`.
+    expect(out).toMatch(/Keep at least one provider enabled/);
+  });
+});

--- a/packages/dashboard/src/views/settings-llm.test.ts
+++ b/packages/dashboard/src/views/settings-llm.test.ts
@@ -1,0 +1,61 @@
+/**
+ * The /settings/llm view renders the custom OpenAI-compatible endpoints section:
+ * defined providers are listed with their key MASKED (never the plaintext), the
+ * add form is present, and custom names show up in the waterfall add-dropdown.
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from './html.js';
+import { renderSettingsLlm } from './settings-llm.js';
+import { LLM_PROVIDERS, type LlmSettings } from '@some-useful-agents/core';
+
+const base = {
+  providers: LLM_PROVIDERS,
+  formatAge: (v: number | string) => String(v),
+};
+
+describe('renderSettingsLlm — custom providers', () => {
+  it('lists a custom provider and masks its apiKey', () => {
+    const settings: LlmSettings = {
+      providers: ['claude'],
+      customProviders: [{
+        name: 'local-qwen-8b', kind: 'openai',
+        apiBase: 'http://127.0.0.1:8181/v1', apiKey: 'super-secret', model: 'qwen',
+      }],
+    };
+    const out = render(renderSettingsLlm({ ...base, settings }));
+    expect(out).toContain('Custom OpenAI-compatible endpoints');
+    expect(out).toContain('local-qwen-8b');
+    expect(out).toContain('http://127.0.0.1:8181/v1');
+    // The plaintext key must NEVER reach the HTML.
+    expect(out).not.toContain('super-secret');
+    expect(out).toContain('key ••••');
+    // The add form + remove control exist.
+    expect(out).toContain('/settings/llm/custom/add');
+    expect(out).toContain('/settings/llm/custom/remove');
+  });
+
+  it('offers a defined custom provider in the waterfall add-dropdown', () => {
+    const settings: LlmSettings = {
+      providers: ['claude'],
+      customProviders: [{ name: 'local-qwen-8b', kind: 'openai', apiBase: 'http://x/v1', model: 'qwen' }],
+    };
+    const out = render(renderSettingsLlm({ ...base, settings }));
+    // The custom name is selectable to add to the chain (not yet in it).
+    expect(out).toMatch(/<option value="local-qwen-8b">/);
+  });
+
+  it('shows "no key" when a custom provider has no apiKey', () => {
+    const settings: LlmSettings = {
+      providers: ['claude'],
+      customProviders: [{ name: 'no-key', kind: 'openai', apiBase: 'http://x/v1', model: 'm' }],
+    };
+    const out = render(renderSettingsLlm({ ...base, settings }));
+    expect(out).toContain('no key');
+  });
+
+  it('renders an empty-state when there are no custom providers', () => {
+    const settings: LlmSettings = { providers: ['claude'], customProviders: [] };
+    const out = render(renderSettingsLlm({ ...base, settings }));
+    expect(out).toContain('No custom endpoints yet.');
+  });
+});

--- a/packages/dashboard/src/views/settings-llm.ts
+++ b/packages/dashboard/src/views/settings-llm.ts
@@ -8,8 +8,8 @@ export interface SettingsLlmArgs {
   providers: readonly LlmProvider[];
   /** Pass-through error string from a recent action (probe / save). */
   error?: string;
-  /** Probe result: `name → { ok, message }`. Absent when probe hasn't run. */
-  probe?: Record<LlmProvider, { ok: boolean; message: string }>;
+  /** Probe result: `name → { ok, message }` (builtins + custom). Absent until probed. */
+  probe?: Record<string, { ok: boolean; message: string }>;
   /** Pretty timestamp helper (last fallback "3 minutes ago"). */
   formatAge: (isoOrMs: number | string) => string;
 }
@@ -41,7 +41,19 @@ export function renderSettingsLlm(args: SettingsLlmArgs): SafeHtml {
 
   const chain = args.settings.providers;
   const chainSet = new Set(chain);
-  const available = args.providers.filter((p) => !chainSet.has(p));
+  const customProviders = args.settings.customProviders ?? [];
+  const customNames = customProviders.map((c) => c.name);
+  // The add-dropdown offers builtins AND defined custom providers not yet in
+  // the chain.
+  const available: string[] = [
+    ...args.providers.filter((p) => !chainSet.has(p)),
+    ...customNames.filter((n) => !chainSet.has(n)),
+  ];
+  const labelFor = (id: string): string => {
+    const custom = customProviders.find((c) => c.name === id);
+    if (custom) return `${custom.displayName ?? custom.name} (custom · ${custom.model})`;
+    return PROVIDER_LABEL[id] ?? id;
+  };
 
   // Each row is its own tiny form. Up/Down/Remove submit to specific
   // mutation routes so the operator sees exactly what changed; the
@@ -56,7 +68,7 @@ export function renderSettingsLlm(args: SettingsLlmArgs): SafeHtml {
         <span class="settings-llm__chain-rank">${idx + 1}</span>
         <span class="settings-llm__chain-label">
           <span class="mono">${p}</span>
-          <span class="dim">${PROVIDER_LABEL[p] ?? ''}</span>
+          <span class="dim">${labelFor(p)}</span>
         </span>
         ${isFirst ? html`<span class="badge badge--ok">Primary</span>` : html`<span class="dim" style="font-size: var(--font-size-xs);">Fallback</span>`}
         <div class="settings-llm__chain-actions">
@@ -85,7 +97,7 @@ export function renderSettingsLlm(args: SettingsLlmArgs): SafeHtml {
       <form method="POST" action="/settings/llm/add" class="settings-llm__add">
         <label for="llm-add" class="dim">Add provider</label>
         <select id="llm-add" name="provider" class="form-field" style="max-width: 220px;">
-          ${available.map((p) => html`<option value="${p}">${PROVIDER_LABEL[p] ?? p}</option>`) as unknown as SafeHtml[]}
+          ${available.map((p) => html`<option value="${p}">${labelFor(p)}</option>`) as unknown as SafeHtml[]}
         </select>
         <button type="submit" class="btn btn--sm">Add</button>
       </form>
@@ -114,6 +126,48 @@ export function renderSettingsLlm(args: SettingsLlmArgs): SafeHtml {
         <div class="dim">No provider in the chain has fallen over in a fallback-worthy way since records started.</div>
       </div>
     `;
+
+  // Custom OpenAI-compatible endpoints (local / self-hosted models). Defining
+  // one here makes it selectable in the waterfall above; the apiKey is never
+  // rendered back into an input value — only a masked indicator of presence.
+  const customRows = customProviders.map((c) => html`
+    <li class="settings-llm__chain-row" data-custom="${c.name}">
+      <span class="settings-llm__chain-label">
+        <span class="mono">${c.name}</span>
+        <span class="dim">${c.apiBase} · ${c.model}${c.apiKey ? ' · key ••••' : ' · no key'}</span>
+      </span>
+      <div class="settings-llm__chain-actions">
+        <form method="POST" action="/settings/llm/custom/remove" style="display:inline;" onsubmit="return confirm('Remove custom provider ${c.name}? It will also be removed from the waterfall.');">
+          <input type="hidden" name="name" value="${c.name}">
+          <button type="submit" class="btn btn--xs btn--ghost">Remove</button>
+        </form>
+      </div>
+    </li>
+  `);
+
+  const customBlock = html`
+    <section class="settings-section" style="margin-top: var(--space-6);">
+      <h2 class="mt-0">Custom OpenAI-compatible endpoints</h2>
+      <p class="dim">
+        Point sua at a local or self-hosted model that speaks the OpenAI
+        <code>/v1/chat/completions</code> API (llama.cpp, LM Studio, Ollama, vLLM,
+        a gateway…). Saved endpoints appear in the <strong>Add provider</strong>
+        dropdown above and can be pinned per-node via <code>provider:</code>.
+      </p>
+      ${customProviders.length > 0 ? html`<ol class="settings-llm__chain">${customRows as unknown as SafeHtml[]}</ol>` : html`<p class="dim" style="font-size: var(--font-size-sm);">No custom endpoints yet.</p>`}
+      <form method="POST" action="/settings/llm/custom/add" class="settings-llm__custom-add" style="display: grid; gap: var(--space-2); max-width: 520px; margin-top: var(--space-3);">
+        <label class="dim" for="cp-name">Name <span class="dim" style="font-size: var(--font-size-xs);">(slug — used in the waterfall + node pins)</span></label>
+        <input id="cp-name" name="name" class="form-field" placeholder="local-qwen-8b" required>
+        <label class="dim" for="cp-base">API base URL</label>
+        <input id="cp-base" name="apiBase" class="form-field" placeholder="http://127.0.0.1:8181/v1" required>
+        <label class="dim" for="cp-model">Model</label>
+        <input id="cp-model" name="model" class="form-field" placeholder="unsloth/Qwen3-8B-GGUF:UD-Q4_K_XL" required>
+        <label class="dim" for="cp-key">API key <span class="dim" style="font-size: var(--font-size-xs);">(optional — leave blank for a local server)</span></label>
+        <input id="cp-key" name="apiKey" class="form-field" type="password" autocomplete="off" placeholder="local">
+        <div><button type="submit" class="btn btn--sm btn--primary">Save endpoint</button></div>
+      </form>
+    </section>
+  `;
 
   const probeBlock = args.probe
     ? html`
@@ -157,12 +211,14 @@ export function renderSettingsLlm(args: SettingsLlmArgs): SafeHtml {
 
       <div class="settings-llm__actions" style="margin-top: var(--space-3);">
         <form method="POST" action="/settings/llm/probe" style="display:inline;">
-          <button type="submit" class="btn btn--ghost">Probe CLIs</button>
+          <button type="submit" class="btn btn--ghost">Probe providers</button>
         </form>
       </div>
 
       ${probeBlock}
       ${statusBlock}
     </section>
+
+    ${customBlock}
   `;
 }

--- a/packages/dashboard/src/views/settings-llm.ts
+++ b/packages/dashboard/src/views/settings-llm.ts
@@ -14,7 +14,9 @@ export interface SettingsLlmArgs {
   formatAge: (isoOrMs: number | string) => string;
 }
 
-const PROVIDER_LABEL: Record<LlmProvider, string> = {
+// Keyed by string (not LlmProvider) because the waterfall can now hold custom
+// provider names too; unknown ids fall through to '' via the ?? at the call site.
+const PROVIDER_LABEL: Record<string, string> = {
   claude: 'Claude (claude CLI)',
   codex: 'Codex (codex CLI)',
   'apple-foundation-models': 'Apple Foundation Models (on-device)',

--- a/packages/dashboard/src/views/settings-llm.ts
+++ b/packages/dashboard/src/views/settings-llm.ts
@@ -55,7 +55,13 @@ export function renderSettingsLlm(args: SettingsLlmArgs): SafeHtml {
     return PROVIDER_LABEL[id] ?? id;
   };
 
-  // Each row is its own tiny form. Up/Down/Remove submit to specific
+  // A per-provider off switch: disabled entries keep their slot but are skipped
+  // at runtime. "Primary" is the first ENABLED provider, not just chain[0].
+  const disabledSet = new Set(args.settings.disabledProviders ?? []);
+  const enabledCount = chain.filter((p) => !disabledSet.has(p)).length;
+  const firstEnabled = chain.find((p) => !disabledSet.has(p));
+
+  // Each row is its own tiny form. Up/Down/Remove/toggle submit to specific
   // mutation routes so the operator sees exactly what changed; the
   // alternative — one big "edit list" form with hidden serialization
   // — was harder to reason about and made the URL state non-shareable.
@@ -63,15 +69,30 @@ export function renderSettingsLlm(args: SettingsLlmArgs): SafeHtml {
     const isFirst = idx === 0;
     const isLast = idx === chain.length - 1;
     const isOnly = chain.length === 1;
+    const enabled = !disabledSet.has(p);
+    const isPrimary = enabled && p === firstEnabled;
+    // Disabling the last remaining enabled provider is refused by the store;
+    // reflect that in the UI so the button isn't a dead click.
+    const lastEnabled = enabled && enabledCount === 1;
+    const badge = isPrimary
+      ? html`<span class="badge badge--ok">Primary</span>`
+      : enabled
+        ? html`<span class="dim" style="font-size: var(--font-size-xs);">Fallback</span>`
+        : html`<span class="badge badge--muted">Off</span>`;
     return html`
-      <li class="settings-llm__chain-row" data-provider="${p}">
+      <li class="settings-llm__chain-row" data-provider="${p}" style="${enabled ? '' : 'opacity: 0.55;'}">
         <span class="settings-llm__chain-rank">${idx + 1}</span>
         <span class="settings-llm__chain-label">
           <span class="mono">${p}</span>
           <span class="dim">${labelFor(p)}</span>
         </span>
-        ${isFirst ? html`<span class="badge badge--ok">Primary</span>` : html`<span class="dim" style="font-size: var(--font-size-xs);">Fallback</span>`}
+        ${badge}
         <div class="settings-llm__chain-actions">
+          <form method="POST" action="/settings/llm/toggle" style="display:inline;">
+            <input type="hidden" name="provider" value="${p}">
+            <input type="hidden" name="enabled" value="${enabled ? '0' : '1'}">
+            <button type="submit" class="btn btn--xs ${enabled ? 'btn--ghost' : 'btn--primary'}" ${lastEnabled ? 'disabled' : ''} title="${lastEnabled ? 'Keep at least one provider enabled.' : (enabled ? 'Skip this provider at runtime' : 'Use this provider again')}">${enabled ? 'Disable' : 'Enable'}</button>
+          </form>
           <form method="POST" action="/settings/llm/move" style="display:inline;">
             <input type="hidden" name="provider" value="${p}">
             <input type="hidden" name="direction" value="up">
@@ -199,6 +220,12 @@ export function renderSettingsLlm(args: SettingsLlmArgs): SafeHtml {
         When an agent or node pins its own provider, that provider runs
         first regardless of the chain order — and the remaining providers
         still apply as fallbacks. (Previously a pin disabled all fallback.)
+      </p>
+      <p class="dim">
+        <strong>Disable</strong> flips a provider off without removing it — it
+        keeps its slot and config but is skipped at runtime. Turn claude and
+        codex off to run local-only, then flip them back on any time. At least
+        one provider must stay enabled.
       </p>
 
       ${errorBanner}


### PR DESCRIPTION
## What

The first **HTTP LLM provider path**, end to end. Until now every provider was a CLI transport (`claude`, `codex`, `apple-foundation-models`). This adds an operator-defined **custom OpenAI-compatible provider** — a name, an `apiBase` (e.g. a local `http://127.0.0.1:8181/v1`), an optional `apiKey`, and a `model` — addable from **Settings → LLM**, that slots into the existing provider waterfall.

Prompted by running a local `unsloth/Qwen3-8B-GGUF` at `:8181/v1` as a provider. Now anyone can point sua at their own local/hosted OpenAI-compatible endpoint with no code change or restart.

## Why it fits cleanly

The waterfall loop in `node-spawner.ts` only consumes a `SpawnResult` from `runLlmAttempt`; the CLI assumption was isolated to a single `spawnProcess` call. The new HTTP invoker returns the same `SpawnResult`, and `classifyLlmFailure` already buckets `401`/`429`/`quota`/`timeout` from free-text — so an HTTP provider participates in fallback with zero changes to the loop.

## Engine (core)
- **`llm-settings-store`**: `CustomLlmProvider` type; waterfall widened to string refs (builtin ids + custom names); **v2→v3** file migration; `add/remove/get/list` custom providers with validation; malformed hand-edited entries sanitized on read.
- **`openai-http-invoker`** (new): `invokeOpenAiChat` POSTs `/v1/chat/completions` → `SpawnResult`. Down endpoint → `binary_missing`⇒fallback; 401→`auth_required`; 429→`rate_limited`; abort→`timeout`.
- **`node-spawner`**: `LlmSettingsSnapshot.customProviders`; `runLlmAttempt` routes a custom `openai` provider over HTTP. `node.model` can override the endpoint's default.
- **schema**: agent/node `provider` relaxed from a static enum to a slug string; unknown names degrade to the claude default.

## Operator UI (dashboard)
- **Settings → LLM** gains a "Custom OpenAI-compatible endpoints" section: an add form (name / apiBase / model / optional key), a list with **Remove**, and the key **masked** (`••••`, never rendered into an input value).
- The provider-waterfall "Add provider" dropdown now offers custom names; `POST /settings/llm/add` accepts them.
- **Probe** now HTTP-checks custom endpoints (`GET {apiBase}/models`) alongside the CLI `--version` probes.
- `buildLlmSettingsSnapshot` threads `customProviders` to every run path (run-now, widget-run, build, inbox triage).

## Dogfooded live (against real Qwen3-8B at :8181)
- Engine: pinned node → `exitCode 0`, `usedLLMProvider=local-qwen-8b`, real output; two down endpoints → waterfall walked `dead-a → dead-b` (fallback proven).
- UI: added `local-qwen-8b` via the form (303 + flash) → **Probe: reachable** → added to the waterfall → custom section renders with the key masked.

## Tests
34 new (store CRUD + v2→v3 + validation; invoker success/401/429/network/timeout/empty; view render: section, masking, dropdown, empty state). Core **1452** / dashboard **673** green; clean build.

## Note (for review)
`apiKey` is stored in the settings file (masked in the UI). Follow-up: move real cloud keys into the `secretsStore` — fine for a local `apiKey: local`; flagging for the security angle. Route-level tests were deferred in favor of the live HTTP dogfood + the store/view unit tests (thin handlers over already-tested store methods).

🤖 Generated with [Claude Code](https://claude.com/claude-code)