### PR TITLE
feat(dashboard): add "Editorial Paper" appearance theme

### DIFF
--- a/.changeset/editorial-paper-theme.md
+++ b/.changeset/editorial-paper-theme.md
@@ -1,0 +1,14 @@
+---
+"@some-useful-agents/core": minor
+"@some-useful-agents/cli": minor
+"@some-useful-agents/mcp-server": minor
+"@some-useful-agents/temporal-provider": minor
+"@some-useful-agents/dashboard": minor
+---
+
+Add "Editorial Paper" dashboard theme.
+
+A new widget theme in Settings → Appearance: warm cream paper, an editorial
+serif typeface, and a muted, earthy accent palette (terracotta / pine / ochre /
+forest). Unlike the other dark widget themes, Editorial is light-based — the
+picker applies it on the light base so the whole surface reads like paper.

--- a/packages/dashboard/src/assets/themes.css
+++ b/packages/dashboard/src/assets/themes.css
@@ -68,3 +68,35 @@
   --shadow-md: 0 4px 12px rgb(0 0 0 / 0.5);
   --shadow-focus: 0 0 0 3px rgba(168, 85, 247, 0.3);
 }
+
+/* ── Editorial Paper ── */
+/* Warm cream paper, editorial serif type, muted earthy accents. Light-based:
+   the appearance picker also sets data-theme="light" so the page base is light,
+   and these overrides give it the paper/serif character. */
+[data-widget-theme="editorial"] {
+  --font-sans: "Charter", "Iowan Old Style", Georgia, "Times New Roman", serif;
+  --color-bg: #f4eede;
+  --color-surface: #fffdf8;
+  --color-surface-raised: #fbf5e8;
+  --color-border: #e0d5c0;
+  --color-border-strong: #cdbfa4;
+  --color-text: #241f18;
+  --color-text-muted: #6f6655;
+  --color-text-subtle: #948a76;
+  --color-primary: #2f6f6a;
+  --color-primary-hover: #255a55;
+  --color-primary-soft: rgba(47, 111, 106, 0.12);
+  --color-ok: #4a7c59;
+  --color-ok-soft: rgba(74, 124, 89, 0.12);
+  --color-warn: #b07d26;
+  --color-warn-soft: rgba(193, 137, 45, 0.14);
+  --color-warn-border: rgba(176, 125, 38, 0.30);
+  --color-err: #a23b28;
+  --color-err-soft: rgba(162, 59, 40, 0.12);
+  --color-info: #40607a;
+  --color-info-soft: rgba(64, 96, 122, 0.12);
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --shadow-focus: 0 0 0 3px rgba(47, 111, 106, 0.22);
+}

--- a/packages/dashboard/src/views/settings-appearance.ts
+++ b/packages/dashboard/src/views/settings-appearance.ts
@@ -65,6 +65,12 @@ export function renderSettingsAppearance(): SafeHtml {
               document.documentElement.setAttribute('data-theme', 'light');
               localStorage.setItem('sua-theme', 'light');
               document.body.removeAttribute('data-widget-theme');
+            } else if (id === 'editorial') {
+              // Editorial is light-based: use the light base AND the widget overrides.
+              localStorage.setItem(THEME_KEY, 'editorial');
+              document.documentElement.setAttribute('data-theme', 'light');
+              localStorage.setItem('sua-theme', 'light');
+              document.body.setAttribute('data-widget-theme', 'editorial');
             } else {
               localStorage.setItem(THEME_KEY, id);
               document.body.setAttribute('data-widget-theme', id);

--- a/packages/dashboard/src/views/themes.ts
+++ b/packages/dashboard/src/views/themes.ts
@@ -41,4 +41,10 @@ export const THEMES: WidgetTheme[] = [
     description: 'Purple accent, true black',
     preview: { bg: '#0a0a0a', surface: '#171717', accent: '#a855f7', text: '#fafafa' },
   },
+  {
+    id: 'editorial',
+    name: 'Editorial Paper',
+    description: 'Warm cream paper, serif type, muted earthy accents',
+    preview: { bg: '#f4eede', surface: '#fffdf8', accent: '#b5533a', text: '#241f18' },
+  },
 ];


### PR DESCRIPTION
## What

Adds a new theme to **Settings → Appearance**: **Editorial Paper** — warm cream paper, an editorial serif typeface, and a muted earthy accent palette (terracotta / pine / ochre / forest). A deliberate alternative to the existing dark/neon widget themes.

## How it works

Unlike the other widget themes (which are dark and blend with the dark base), Editorial is **light-based**. The picker applies it as `data-theme="light"` (light base) **plus** `data-widget-theme="editorial"` (the paper/serif overrides), and persists both `sua-theme=light` and `sua-widget-theme=editorial`. The existing on-load logic in `layout.ts` already restores that combination — **no layout change needed**.

## Changes

- `views/themes.ts` — new theme entry + preview swatch
- `assets/themes.css` — `[data-widget-theme="editorial"]` overrides (paper bg, serif `--font-sans`, earthy accents, softer radii)
- `views/settings-appearance.ts` — picker branch to apply it light-based
- `.changeset/editorial-paper-theme.md` — changeset (all five packages, minor)

## Verification

- `tsc --noEmit` clean; full `npm run build` (tsc + copy-assets) passes
- Theme present in compiled `dist/views/themes.js` and copied `dist/assets/themes.css`

Cut fresh from current `main` (post-#542); #542 touched none of these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)